### PR TITLE
small changes

### DIFF
--- a/hott/core.hlean
+++ b/hott/core.hlean
@@ -1,0 +1,11 @@
+/-
+Copyright (c) 2015 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Module: core
+Authors: Floris van Doorn
+
+The core of the HoTT library
+-/
+
+import types

--- a/hott/hott.md
+++ b/hott/hott.md
@@ -14,6 +14,8 @@ Lean's homotopy type theory kernel is a version of Martin-Löf Type Theory with:
 * a non-cumulative hierarchy of universes, `Type 0`, `Type 1`, ... 
 * inductively defined types
 
+Note that there is no proof-irrelevant or impredicative universe.
+
 By default, the univalence axiom is declared on initialization.
 
 See also the [standard library](../library/library.md).

--- a/hott/init/path.hlean
+++ b/hott/init/path.hlean
@@ -498,6 +498,7 @@ namespace eq
 
   -- Transporting in a pulled back fibration.
   -- TODO: P can probably be implicit
+  -- rename: tr_compose
   definition transport_compose (P : B → Type) (f : A → B) (p : x = y) (z : P (f x)) :
     transport (P ∘ f) p z  =  transport P (ap f p) z :=
   eq.rec_on p idp

--- a/hott/init/reserved_notation.hlean
+++ b/hott/init/reserved_notation.hlean
@@ -97,7 +97,7 @@ reserve infixl `++`:65
 reserve infixr `::`:65
 
 -- Yet another trick to anotate an expression with a type
-definition is_typeof (A : Type) (a : A) : A := a
+abbreviation is_typeof (A : Type) (a : A) : A := a
 
 notation `typeof` t `:` T  := is_typeof T t
 notation `(` t `:` T `)`  := is_typeof T t

--- a/hott/types/default.hlean
+++ b/hott/types/default.hlean
@@ -1,0 +1,11 @@
+/-
+Copyright (c) 2015 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Module: types.default
+Authors: Floris van Doorn
+
+The core of the HoTT library
+-/
+
+import .sigma .prod .pi .equiv .fiber .eq .trunc .arrow .pointed

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -321,7 +321,7 @@ namespace sigma
 
   section
   definition is_equiv_sigma_rec [instance] (C : (Σa, B a) → Type)
-    : is_equiv (@sigma.rec _ _ C) :=
+    : is_equiv (sigma.rec : (Πa b, C ⟨a, b⟩) → Πab, C ab) :=
   adjointify _ (λ g a b, g ⟨a, b⟩)
                (λ g, proof eq_of_homotopy (λu, destruct u (λa b, idp)) qed)
                (λ f, refl f)

--- a/hott/types/types.md
+++ b/hott/types/types.md
@@ -12,4 +12,4 @@ Various datatypes.
 * [fiber](fiber.hlean)
 * [equiv](equiv.hlean)
 * [pointed](pointed.hlean)
-* [W](W.hlean)
+* [W](W.hlean) (not loaded by default)

--- a/library/init/reserved_notation.lean
+++ b/library/init/reserved_notation.lean
@@ -94,7 +94,7 @@ reserve infixl `++`:65
 reserve infixr `::`:65
 
 -- Yet another trick to anotate an expression with a type
-definition is_typeof (A : Type) (a : A) : A := a
+abbreviation is_typeof (A : Type) (a : A) : A := a
 
 notation `typeof` t `:` T  := is_typeof T t
 notation `(` t `:` T `)`  := is_typeof T t


### PR DESCRIPTION
I made `is_typeof` an abbreviation instead of a definition in both libraries. Then we can insert them anywhere without affecting anything else (the change in `sigma.hlean` would otherwise break when `is_equiv_sigma_rec` was used as instance)
I also added `core.hlean`, which imports the core part of the library.
