### PR TITLE
fix(bin/linja): don't double-decode Popen output

### DIFF
--- a/bin/linja.in
+++ b/bin/linja.in
@@ -185,8 +185,6 @@ class FlycheckItemList:
         tmpBuffer = ""
         ignore = True
         for line in text.splitlines():
-            # I had to add the following line to avoid a crash on Python 3.4 for Windows
-            line = line.decode("utf-8")
             if line.startswith(g_flycheck_header):
                 tmpBuffer = tmpBuffer + line + "\n"
                 ignore = False


### PR DESCRIPTION
After 8ca3ee48, `text` is always a `str` instance, which provokes an `AttributeError` in Python 3.
