### PR TITLE
work on finsets

### DIFF
--- a/library/data/data.md
+++ b/library/data/data.md
@@ -20,9 +20,17 @@ Constructors:
 * [prod](prod.lean) : cartesian product
 * [sum](sum.lean)
 * [sigma](sigma.lean) : the dependent product
+* [uprod](uprod.lean) : unordered pairs
 * [option](option.lean)
 * [subtype](subtype.lean)
 * [quotient](quotient/quotient.md)
+* [squash](squash.lean) : propositional truncation
 * [list](list/list.md)
+* [finset](finset/finset.md) : finite sets
 * [set](set/set.md)
 * [vector](vector.lean)
+
+Types with extra information:
+
+* [fintype](fintype.lean) : finite types
+* [encodable](encodable.lean) : types with a coding to nat

--- a/library/data/default.lean
+++ b/library/data/default.lean
@@ -5,5 +5,5 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Module: data.default
 Author: Jeremy Avigad
 -/
-import .empty .unit .bool .num .string .nat .int
-import .prod .sum .sigma .option .subtype .quotient .list .set
+import .empty .unit .bool .num .string .nat .int .fintype
+import .prod .sum .sigma .option .subtype .quotient .list .finset .set

--- a/library/data/finset/bigop.lean
+++ b/library/data/finset/bigop.lean
@@ -1,18 +1,16 @@
 /-
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
-Module: data.finset
 Author: Leonardo de Moura
 
-Big operator for finite sets
+Big operator for finite sets.
 -/
 import algebra.group data.finset.basic data.list.bigop
 open algebra finset function binary quot subtype
 
 namespace finset
 variables {A B : Type}
-variable  [g : comm_group B]
+variable  [g : comm_monoid B]
 include g
 
 definition bigop (s : finset A) (f : A → B) : B :=

--- a/library/data/finset/bigop.lean
+++ b/library/data/finset/bigop.lean
@@ -32,7 +32,10 @@ theorem bigop_insert_of_not_mem (f : A → B) {a : A} {s : finset A} : a ∉ s �
 quot.induction_on s
   (λ l nainl, list.bigop_insert_of_not_mem f nainl)
 
-theorem bigop_union (f : A → B) {s₁ s₂ : finset A} : disjoint s₁ s₂ → bigop (s₁ ∪ s₂) f = bigop s₁ f * bigop s₂ f :=
-quot.induction_on₂ s₁ s₂
-  (λ l₁ l₂ d, list.bigop_union f d)
+theorem bigop_union (f : A → B) {s₁ s₂ : finset A} (disj : s₁ ∩ s₂ = ∅) :
+bigop (s₁ ∪ s₂) f = bigop s₁ f * bigop s₂ f :=
+have H1 : disjoint s₁ s₂ → bigop (s₁ ∪ s₂) f = bigop s₁ f * bigop s₂ f, from
+  quot.induction_on₂ s₁ s₂
+    (λ l₁ l₂ d, list.bigop_union f d),
+H1 (disjoint_of_inter_empty disj)
 end finset

--- a/library/data/finset/card.lean
+++ b/library/data/finset/card.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Cardinality calculations for finite sets.
+-/
+import data.finset.comb
+open nat eq.ops
+
+namespace finset
+
+variable {A : Type}
+variable [deceq : decidable_eq A]
+include deceq
+
+theorem card_add_card (s₁ s₂ : finset A) : card s₁ + card s₂ = card (s₁ ∪ s₂) + card (s₁ ∩ s₂) :=
+finset.induction_on s₂
+  (show card s₁ + card ∅ = card (s₁ ∪ ∅) + card (s₁ ∩ ∅),
+    by rewrite [union_empty, card_empty, inter_empty])
+  (take s₂ a,
+    assume ans2: a ∉ s₂,
+    assume IH : card s₁ + card s₂ = card (s₁ ∪ s₂) + card (s₁ ∩ s₂),
+    show card s₁ + card (insert a s₂) = card (s₁ ∪ (insert a s₂)) + card (s₁ ∩ (insert a s₂)),
+    from decidable.by_cases
+      (assume as1 : a ∈ s₁,
+        assert H : a ∉ s₁ ∩ s₂, from assume H', ans2 (mem_of_mem_inter_right H'),
+        begin
+          rewrite [card_insert_of_not_mem ans2, union.comm, -insert_union, union.comm],
+          rewrite [insert_union, insert_eq_of_mem as1, insert_eq, inter.distrib_left, inter.comm],
+          rewrite [singleton_inter_of_mem as1, -insert_eq, card_insert_of_not_mem H, -*add.assoc],
+          rewrite IH
+        end)
+      (assume ans1 : a ∉ s₁,
+        assert H : a ∉ s₁ ∪ s₂, from assume H',
+          or.elim (mem_or_mem_of_mem_union H') (assume as1, ans1 as1) (assume as2, ans2 as2),
+        begin
+          rewrite [card_insert_of_not_mem ans2, union.comm, -insert_union, union.comm],
+          rewrite [card_insert_of_not_mem H, insert_eq, inter.distrib_left, inter.comm],
+          rewrite [singleton_inter_of_not_mem ans1, empty_union, add.right_comm],
+          rewrite [-add.assoc, IH]
+        end))
+
+theorem card_union (s₁ s₂ : finset A) : card (s₁ ∪ s₂) = card s₁ + card s₂ - card (s₁ ∩ s₂) :=
+calc
+  card (s₁ ∪ s₂) = card (s₁ ∪ s₂) + card (s₁ ∩ s₂) - card (s₁ ∩ s₂) : add_sub_cancel
+             ... = card s₁ + card s₂ - card (s₁ ∩ s₂)               : card_add_card
+
+theorem card_union_of_disjoint {s₁ s₂ : finset A} (H : disjoint s₁ s₂) :
+  card (s₁ ∪ s₂) = card s₁ + card s₂ :=
+by rewrite [card_union, ↑disjoint at H, inter_empty_of_disjoint H]
+
+theorem card_le_card_of_subset {s₁ s₂ : finset A} (H : s₁ ⊆ s₂) : card s₁ ≤ card s₂ :=
+have H1 : disjoint s₁ (s₂ \ s₁),
+  from disjoint.intro (take x, assume H1 H2, not_mem_of_mem_diff H2 H1),
+calc
+  card s₂ = card (s₁ ∪ (s₂ \ s₁))    : union_diff_cancel H
+      ... = card s₁ + card (s₂ \ s₁) : card_union_of_disjoint H1
+      ... ≥ card s₁                  : le_add_right
+
+end finset

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -1,16 +1,16 @@
 /-
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
+Author: Leonardo de Moura, Jeremy Avigad
 
-Module: data.finset
-Author: Leonardo de Moura
-
-Combinators for finite sets
+Combinators for finite sets.
 -/
 import data.finset.basic logic.identities
 open list quot subtype decidable perm function
 
 namespace finset
+
+/- map -/
 section map
 variables {A B : Type}
 variable [h : decidable_eq B]
@@ -25,12 +25,94 @@ theorem map_empty (f : A → B) : map f ∅ = ∅ :=
 rfl
 end map
 
+/- filter and set-builder notation -/
+section filter
+  variables {A : Type} [deceq : decidable_eq A]
+  include deceq
+  variables (p : A → Prop) [decp : decidable_pred p] (s : finset A) {x : A}
+  include decp
+
+  definition filter : finset A :=
+  quot.lift_on s
+    (λl, to_finset_of_nodup
+      (list.filter p (subtype.elt_of l))
+      (list.nodup_filter p (subtype.has_property l)))
+    (λ l₁ l₂ u, quot.sound (perm.perm_filter u))
+
+  notation `{` binders ∈ s `|` r:(scoped:1 p, filter p s) `}` := r
+
+  theorem filter_empty : filter p ∅ = ∅ := rfl
+
+  variables {p s}
+
+  theorem of_mem_filter : x ∈ filter p s → p x :=
+  quot.induction_on s (take l, list.of_mem_filter)
+
+  theorem mem_of_mem_filter : x ∈ filter p s → x ∈ s :=
+  quot.induction_on s (take l, list.mem_of_mem_filter)
+
+  theorem mem_filter_of_mem {x : A} : x ∈ s → p x → x ∈ filter p s :=
+  quot.induction_on s (take l, list.mem_filter_of_mem)
+
+  variables (p s)
+
+  theorem mem_filter_eq : x ∈ filter p s = (x ∈ s ∧ p x) :=
+  propext (iff.intro
+    (assume H, and.intro (mem_of_mem_filter H) (of_mem_filter H))
+    (assume H, mem_filter_of_mem (and.left H) (and.right H)))
+end filter
+
+/- set difference -/
+section diff
+  variables {A : Type} [deceq : decidable_eq A]
+  include deceq
+
+  definition diff (s t : finset A) : finset A := {x ∈ s | x ∉ t}
+  infix `\`:70 := diff
+
+  theorem mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∈ s :=
+  mem_of_mem_filter H
+
+  theorem not_mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∉ t :=
+  of_mem_filter H
+
+  theorem mem_diff {s t : finset A} {x : A} (H1 : x ∈ s) (H2 : x ∉ t) : x ∈ s \ t :=
+  mem_filter_of_mem H1 H2
+
+  theorem mem_diff_iff (s t : finset A) (x : A) : x ∈ s \ t ↔ x ∈ s ∧ x ∉ t :=
+  iff.intro
+    (assume H, and.intro (mem_of_mem_diff H) (not_mem_of_mem_diff H))
+    (assume H, mem_diff (and.left H) (and.right H))
+
+  theorem mem_diff_eq (s t : finset A) (x : A) : x ∈ s \ t = (x ∈ s ∧ x ∉ t) :=
+  propext !mem_diff_iff
+
+  theorem union_diff_cancel {s t : finset A} (H : s ⊆ t) : s ∪ (t \ s) = t :=
+  ext (take x, iff.intro
+    (assume H1 : x ∈ s ∪ (t \ s),
+      or.elim (mem_or_mem_of_mem_union H1)
+        (assume H2 : x ∈ s, mem_of_subset_of_mem H H2)
+        (assume H2 : x ∈ t \ s, mem_of_mem_diff H2))
+    (assume H1 : x ∈ t,
+      decidable.by_cases
+        (assume H2 : x ∈ s, mem_union_left _ H2)
+        (assume H2 : x ∉ s, mem_union_right _ (mem_diff H1 H2))))
+
+  theorem diff_union_cancel {s t : finset A} (H : s ⊆ t) : (t \ s) ∪ s = t :=
+  eq.subst !union.comm (!union_diff_cancel H)
+end diff
+
+/- all -/
 section all
 variables {A : Type}
 definition all (s : finset A) (p : A → Prop) : Prop :=
 quot.lift_on s
   (λ l, all (elt_of l) p)
   (λ l₁ l₂ p, foldr_eq_of_perm (λ a₁ a₂ q, propext !and.left_comm) p true)
+
+-- notation for bounded quantifiers
+notation `forallb` binders `∈` a `,` r:(scoped:1 P, P) := all a r
+notation `∀₀` binders `∈` a `,` r:(scoped:1 P, P) := all a r
 
 theorem all_empty (p : A → Prop) : all ∅ p = true :=
 rfl

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -148,38 +148,38 @@ theorem all_inter_of_all_right {p : A → Prop} {s₁ : finset A} (s₂ : finset
 quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h, list.all_inter_of_all_right _ h)
 end all
 
-section cross_product
+section product
 variables {A B : Type}
-definition cross_product (s₁ : finset A) (s₂ : finset B) : finset (A × B) :=
+definition product (s₁ : finset A) (s₂ : finset B) : finset (A × B) :=
 quot.lift_on₂ s₁ s₂
   (λ l₁ l₂,
-    to_finset_of_nodup (list.cross_product (elt_of l₁) (elt_of l₂))
-                       (nodup_cross_product (has_property l₁) (has_property l₂)))
-  (λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound (perm_cross_product p₁ p₂))
+    to_finset_of_nodup (list.product (elt_of l₁) (elt_of l₂))
+                       (nodup_product (has_property l₁) (has_property l₂)))
+  (λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound (perm_product p₁ p₂))
 
-infix * := cross_product
+infix * := product
 
-theorem empty_cross_product (s : finset B) : @empty A * s = ∅ :=
+theorem empty_product (s : finset B) : @empty A * s = ∅ :=
 quot.induction_on s (λ l, rfl)
 
-theorem mem_cross_product {a : A} {b : B} {s₁ : finset A} {s₂ : finset B}
+theorem mem_product {a : A} {b : B} {s₁ : finset A} {s₂ : finset B}
         : a ∈ s₁ → b ∈ s₂ → (a, b) ∈ s₁ * s₂ :=
-quot.induction_on₂ s₁ s₂ (λ l₁ l₂ i₁ i₂, list.mem_cross_product i₁ i₂)
+quot.induction_on₂ s₁ s₂ (λ l₁ l₂ i₁ i₂, list.mem_product i₁ i₂)
 
-theorem mem_of_mem_cross_product_left {a : A} {b : B} {s₁ : finset A} {s₂ : finset B}
+theorem mem_of_mem_product_left {a : A} {b : B} {s₁ : finset A} {s₂ : finset B}
         : (a, b) ∈ s₁ * s₂ → a ∈ s₁ :=
-quot.induction_on₂ s₁ s₂ (λ l₁ l₂ i, list.mem_of_mem_cross_product_left i)
+quot.induction_on₂ s₁ s₂ (λ l₁ l₂ i, list.mem_of_mem_product_left i)
 
-theorem mem_of_mem_cross_product_right {a : A} {b : B} {s₁ : finset A} {s₂ : finset B}
+theorem mem_of_mem_product_right {a : A} {b : B} {s₁ : finset A} {s₂ : finset B}
         : (a, b) ∈ s₁ * s₂ → b ∈ s₂ :=
-quot.induction_on₂ s₁ s₂ (λ l₁ l₂ i, list.mem_of_mem_cross_product_right i)
+quot.induction_on₂ s₁ s₂ (λ l₁ l₂ i, list.mem_of_mem_product_right i)
 
-theorem cross_product_empty (s : finset A) : s * @empty B = ∅ :=
+theorem product_empty (s : finset A) : s * @empty B = ∅ :=
 ext (λ p,
   match p with
   | (a, b) := iff.intro
-     (λ i, absurd (mem_of_mem_cross_product_right i) !not_mem_empty)
+     (λ i, absurd (mem_of_mem_product_right i) !not_mem_empty)
      (λ i, absurd i !not_mem_empty)
   end)
-end cross_product
+end product
 end finset

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -153,7 +153,7 @@ variables {A B : Type}
 definition product (s₁ : finset A) (s₂ : finset B) : finset (A × B) :=
 quot.lift_on₂ s₁ s₂
   (λ l₁ l₂,
-    to_finset_of_nodup (list.product (elt_of l₁) (elt_of l₂))
+    to_finset_of_nodup (product (elt_of l₁) (elt_of l₂))
                        (nodup_product (has_property l₁) (has_property l₂)))
   (λ v₁ v₂ w₁ w₂ p₁ p₂, quot.sound (perm_product p₁ p₂))
 

--- a/library/data/finset/default.lean
+++ b/library/data/finset/default.lean
@@ -1,10 +1,8 @@
 /-
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
-Module: data.finset
 Author: Leonardo de Moura
 
-Finite sets
+Finite sets.
 -/
-import data.finset.basic data.finset.comb data.finset.bigop
+import data.finset.basic data.finset.comb data.finset.card data.finset.bigop

--- a/library/data/fintype.lean
+++ b/library/data/fintype.lean
@@ -1,10 +1,9 @@
 /-
 Copyright (c) 2015 Leonardo de Moura. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
 Authors: Leonardo de Moura
 
-Finite type (type class)
+Finite type (type class).
 -/
 import data.list data.bool
 open list bool unit decidable option function
@@ -26,11 +25,11 @@ fintype.mk [ff, tt]
 definition fintype_product [instance] {A B : Type} : Π [h₁ : fintype A] [h₂ : fintype B], fintype (A × B)
 | (fintype.mk e₁ u₁ c₁) (fintype.mk e₂ u₂ c₂) :=
   fintype.mk
-    (cross_product e₁ e₂)
-    (nodup_cross_product u₁ u₂)
+    (product e₁ e₂)
+    (nodup_product u₁ u₂)
     (λ p,
       match p with
-      (a, b) := mem_cross_product (c₁ a) (c₂ b)
+      (a, b) := mem_product (c₁ a) (c₂ b)
       end)
 
 /- auxiliary function for finding 'a' s.t. f a ≠ g a -/

--- a/library/data/list/basic.lean
+++ b/library/data/list/basic.lean
@@ -162,11 +162,11 @@ definition mem : T → list T → Prop
 notation e ∈ s := mem e s
 notation e ∉ s := ¬ e ∈ s
 
-theorem mem_nil (x : T) : x ∈ [] ↔ false :=
+theorem mem_nil_iff (x : T) : x ∈ [] ↔ false :=
 iff.rfl
 
 theorem not_mem_nil (x : T) : x ∉ [] :=
-iff.mp !mem_nil
+iff.mp !mem_nil_iff
 
 theorem mem_cons (x : T) (l : list T) : x ∈ x :: l :=
 or.inl rfl
@@ -230,7 +230,7 @@ local attribute mem [reducible]
 local attribute append [reducible]
 theorem mem_split {x : T} {l : list T} : x ∈ l → ∃s t : list T, l = s ++ (x::t) :=
 list.induction_on l
-  (take H : x ∈ [], false.elim (iff.elim_left !mem_nil H))
+  (take H : x ∈ [], false.elim (iff.elim_left !mem_nil_iff H))
   (take y l,
     assume IH : x ∈ l → ∃s t : list T, l = s ++ (x::t),
     assume H : x ∈ y::l,
@@ -252,7 +252,7 @@ assume ainl₂, mem_append_of_mem_or_mem (or.inr ainl₂)
 
 definition decidable_mem [instance] [H : decidable_eq T] (x : T) (l : list T) : decidable (x ∈ l) :=
 list.rec_on l
-  (decidable.inr (not_of_iff_false !mem_nil))
+  (decidable.inr (not_of_iff_false !mem_nil_iff))
   (take (h : T) (l : list T) (iH : decidable (x ∈ l)),
     show decidable (x ∈ h::l), from
     decidable.rec_on iH
@@ -289,7 +289,7 @@ definition sublist (l₁ l₂ : list T) := ∀ ⦃a : T⦄, a ∈ l₁ → a ∈
 infix `⊆`:50 := sublist
 
 theorem nil_sub (l : list T) : [] ⊆ l :=
-λ b i, false.elim (iff.mp (mem_nil b) i)
+λ b i, false.elim (iff.mp (mem_nil_iff b) i)
 
 theorem sub.refl (l : list T) : l ⊆ l :=
 λ b i, i

--- a/library/data/list/bigop.lean
+++ b/library/data/list/bigop.lean
@@ -12,7 +12,7 @@ open algebra function binary quot
 
 namespace list
 variables {A B : Type}
-variable  [g : group B]
+variable  [g : monoid B]
 include g
 
 definition mulf (f : A → B) : B → A → B :=
@@ -58,7 +58,7 @@ end list
 namespace list
 open perm
 variables {A B : Type}
-variable  [g : comm_group B]
+variable  [g : comm_monoid B]
 include g
 
 theorem mulf_rcomm (f : A → B) : right_commutative (mulf f) :=

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -269,20 +269,20 @@ definition flat (l : list (list A)) : list A :=
 foldl append nil l
 
 /- cross product -/
-section cross_product
+section product
 
-definition cross_product : list A → list B → list (A × B)
+definition product : list A → list B → list (A × B)
 | []      l₂ := []
-| (a::l₁) l₂ := map (λ b, (a, b)) l₂ ++ cross_product l₁ l₂
+| (a::l₁) l₂ := map (λ b, (a, b)) l₂ ++ product l₁ l₂
 
-theorem nil_cross_product (l : list B) : cross_product (@nil A) l = []
+theorem nil_product (l : list B) : product (@nil A) l = []
 
-theorem cross_product_cons (a : A) (l₁ : list A) (l₂ : list B)
-        : cross_product (a::l₁) l₂ = map (λ b, (a, b)) l₂ ++ cross_product l₁ l₂
+theorem product_cons (a : A) (l₁ : list A) (l₂ : list B)
+        : product (a::l₁) l₂ = map (λ b, (a, b)) l₂ ++ product l₁ l₂
 
-theorem cross_product_nil : ∀ (l : list A), cross_product l (@nil B) = []
+theorem product_nil : ∀ (l : list A), product l (@nil B) = []
 | []     := rfl
-| (a::l) := by rewrite [cross_product_cons, map_nil, cross_product_nil]
+| (a::l) := by rewrite [product_cons, map_nil, product_nil]
 
 theorem eq_of_mem_map_pair₁  {a₁ a : A} {b₁ : B} {l : list B} : (a₁, b₁) ∈ map (λ b, (a, b)) l → a₁ = a :=
 assume ain,
@@ -296,7 +296,7 @@ assert h₁ : pr2 (a₁, b₁) ∈ map pr2 (map (λ b, (a, b)) l), from mem_map 
 assert h₂ : b₁ ∈ map (λx, x) l, by rewrite [map_map at h₁, ↑pr2 at h₁]; exact h₁,
 by rewrite [map_id at h₂]; exact h₂
 
-theorem mem_cross_product {a : A} {b : B} : ∀ {l₁ l₂}, a ∈ l₁ → b ∈ l₂ → (a, b) ∈ cross_product l₁ l₂
+theorem mem_product {a : A} {b : B} : ∀ {l₁ l₂}, a ∈ l₁ → b ∈ l₂ → (a, b) ∈ product l₁ l₂
 | []      l₂ h₁ h₂ := absurd h₁ !not_mem_nil
 | (x::l₁) l₂ h₁ h₂ :=
   or.elim (eq_or_mem_of_mem_cons h₁)
@@ -304,29 +304,29 @@ theorem mem_cross_product {a : A} {b : B} : ∀ {l₁ l₂}, a ∈ l₁ → b �
       assert aux : (a, b) ∈ map (λ b, (a, b)) l₂, from mem_map _ h₂,
       by rewrite [-aeqx]; exact (mem_append_left _ aux))
     (λ ainl₁ : a ∈ l₁,
-      have inl₁l₂ : (a, b) ∈ cross_product l₁ l₂, from mem_cross_product ainl₁ h₂,
+      have inl₁l₂ : (a, b) ∈ product l₁ l₂, from mem_product ainl₁ h₂,
       mem_append_right _ inl₁l₂)
 
-theorem mem_of_mem_cross_product_left {a : A} {b : B} : ∀ {l₁ l₂}, (a, b) ∈ cross_product l₁ l₂ → a ∈ l₁
+theorem mem_of_mem_product_left {a : A} {b : B} : ∀ {l₁ l₂}, (a, b) ∈ product l₁ l₂ → a ∈ l₁
 | []      l₂ h := absurd h !not_mem_nil
 | (x::l₁) l₂ h :=
   or.elim (mem_or_mem_of_mem_append h)
     (λ ain : (a, b) ∈ map (λ b, (x, b)) l₂,
        assert aeqx : a = x, from eq_of_mem_map_pair₁ ain,
        by rewrite [aeqx]; exact !mem_cons)
-    (λ ain : (a, b) ∈ cross_product l₁ l₂,
-      have ainl₁ : a ∈ l₁, from mem_of_mem_cross_product_left ain,
+    (λ ain : (a, b) ∈ product l₁ l₂,
+      have ainl₁ : a ∈ l₁, from mem_of_mem_product_left ain,
       mem_cons_of_mem _ ainl₁)
 
-theorem mem_of_mem_cross_product_right {a : A} {b : B} : ∀ {l₁ l₂}, (a, b) ∈ cross_product l₁ l₂ → b ∈ l₂
+theorem mem_of_mem_product_right {a : A} {b : B} : ∀ {l₁ l₂}, (a, b) ∈ product l₁ l₂ → b ∈ l₂
 | []      l₂ h := absurd h !not_mem_nil
 | (x::l₁) l₂ h :=
   or.elim (mem_or_mem_of_mem_append h)
     (λ abin : (a, b) ∈ map (λ b, (x, b)) l₂,
       mem_of_mem_map_pair₁ abin)
-    (λ abin : (a, b) ∈ cross_product l₁ l₂,
-      mem_of_mem_cross_product_right abin)
-end cross_product
+    (λ abin : (a, b) ∈ product l₁ l₂,
+      mem_of_mem_product_right abin)
+end product
 end list
 
 attribute list.decidable_any [instance]

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -268,7 +268,7 @@ theorem zip_unzip : ∀ (l : list (A × B)), zip (pr₁ (unzip l)) (pr₂ (unzip
 definition flat (l : list (list A)) : list A :=
 foldl append nil l
 
-/- cross product -/
+/- product -/
 section product
 
 definition product : list A → list B → list (A × B)

--- a/library/data/list/default.lean
+++ b/library/data/list/default.lean
@@ -1,5 +1,7 @@
--- Copyright (c) 2014 Microsoft Corporation. All rights reserved.
--- Released under Apache 2.0 license as described in the file LICENSE.
--- Author: Jeremy Avigad
+/-
+Copyright (c) 2014 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+-/
 import data.list.basic data.list.comb data.list.set data.list.perm
 import data.list.bigop data.list.as_type

--- a/library/data/list/list.md
+++ b/library/data/list/list.md
@@ -1,7 +1,11 @@
 data.list
 =========
 
-Lists of elements of a fixed type. By default, `import list` imports
-everything here.
+List of elements of a fixed type. By default, `import list` imports everything here.
 
 [basic](basic.lean) : basic operations and properties
+[comb](comb.lean) : combinators and list constructions
+[set](set.lean) : set-like operations (these support the finset construction)
+[perm](perm.lean) : equivalence up to permutation (these support the finset construction)
+[bigop](bigop.lean) : "big" operations
+[as_type](as_type.lean) : treats a list as a type

--- a/library/data/list/perm.lean
+++ b/library/data/list/perm.lean
@@ -1,11 +1,9 @@
 /-
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
-Module: data.list.perm
 Author: Leonardo de Moura
 
-List permutations
+List permutations.
 -/
 import data.list.basic data.list.set
 open list setoid nat binary
@@ -752,4 +750,34 @@ list.induction_on l
 theorem perm_cross_product {l₁ l₂ : list A} {t₁ t₂ : list B} : l₁ ~ l₂ → t₁ ~ t₂ → (cross_product l₁ t₁) ~ (cross_product l₂ t₂) :=
 assume p₁ p₂, trans (perm_cross_product_left t₁ p₁) (perm_cross_product_right l₂ p₂)
 end cross_product
+
+/- filter -/
+theorem perm_filter {l₁ l₂ : list A} {p : A → Prop} [decp : decidable_pred p] :
+  l₁ ~ l₂ → (filter p l₁) ~ (filter p l₂) :=
+assume u, perm.induction_on u
+  perm.nil
+  (take x l₁' l₂',
+    assume u' : l₁' ~ l₂',
+    assume u'' : filter p l₁' ~ filter p l₂',
+    decidable.by_cases
+      (assume H : p x, by rewrite [*filter_cons_of_pos _ H]; apply perm.skip; apply u'')
+      (assume H : ¬ p x, by rewrite [*filter_cons_of_neg _ H]; apply u''))
+  (take x y l,
+    decidable.by_cases
+      (assume H1 : p x,
+        decidable.by_cases
+          (assume H2 : p y,
+             begin
+               rewrite [filter_cons_of_pos _ H1, *filter_cons_of_pos _ H2, filter_cons_of_pos _ H1],
+               apply perm.swap
+             end)
+          (assume H2 : ¬ p y,
+             by rewrite [filter_cons_of_pos _ H1, *filter_cons_of_neg _ H2, filter_cons_of_pos _ H1]))
+      (assume H1 : ¬ p x,
+        decidable.by_cases
+          (assume H2 : p y,
+             by rewrite [filter_cons_of_neg _ H1, *filter_cons_of_pos _ H2, filter_cons_of_neg _ H1])
+          (assume H2 : ¬ p y,
+             by rewrite [filter_cons_of_neg _ H1, *filter_cons_of_neg _ H2, filter_cons_of_neg _ H1])))
+    (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, trans r₁ r₂)
 end perm

--- a/library/data/list/perm.lean
+++ b/library/data/list/perm.lean
@@ -726,30 +726,30 @@ theorem perm_ext : ∀ {l₁ l₂ : list A}, nodup l₁ → nodup l₂ → (∀a
          ...  = a₂::t₂       : by rewrite t₂_eq
 end ext
 
-/- cross_product -/
-section cross_product
-theorem perm_cross_product_left {l₁ l₂ : list A} (t₁ : list B) : l₁ ~ l₂ → (cross_product l₁ t₁) ~ (cross_product l₂ t₁) :=
+/- product -/
+section product
+theorem perm_product_left {l₁ l₂ : list A} (t₁ : list B) : l₁ ~ l₂ → (product l₁ t₁) ~ (product l₂ t₁) :=
 assume p : l₁ ~ l₂, perm.induction_on p
   !perm.refl
   (λ x l₁ l₂ p r, perm_app !perm.refl r)
   (λ x y l,
     let m₁ := map (λ b, (x, b)) t₁ in
     let m₂ := map (λ b, (y, b)) t₁ in
-    let c  := cross_product l t₁ in
+    let c  := product l t₁ in
     calc m₂ ++ (m₁ ++ c) = (m₂ ++ m₁) ++ c  : by rewrite append.assoc
                      ... ~ (m₁ ++ m₂) ++ c  : perm_app !perm_app_comm !perm.refl
                      ... =  m₁ ++ (m₂ ++ c) : by rewrite append.assoc)
   (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, trans r₁ r₂)
 
-theorem perm_cross_product_right (l : list A) {t₁ t₂ : list B} : t₁ ~ t₂ → (cross_product l t₁) ~ (cross_product l t₂) :=
+theorem perm_product_right (l : list A) {t₁ t₂ : list B} : t₁ ~ t₂ → (product l t₁) ~ (product l t₂) :=
 list.induction_on l
-  (λ p, by rewrite [*nil_cross_product])
+  (λ p, by rewrite [*nil_product])
   (λ a t r p,
     perm_app (perm_map _ p) (r p))
 
-theorem perm_cross_product {l₁ l₂ : list A} {t₁ t₂ : list B} : l₁ ~ l₂ → t₁ ~ t₂ → (cross_product l₁ t₁) ~ (cross_product l₂ t₂) :=
-assume p₁ p₂, trans (perm_cross_product_left t₁ p₁) (perm_cross_product_right l₂ p₂)
-end cross_product
+theorem perm_product {l₁ l₂ : list A} {t₁ t₂ : list B} : l₁ ~ l₂ → t₁ ~ t₂ → (product l₁ t₁) ~ (product l₂ t₂) :=
+assume p₁ p₂, trans (perm_product_left t₁ p₁) (perm_product_right l₂ p₂)
+end product
 
 /- filter -/
 theorem perm_filter {l₁ l₂ : list A} {p : A → Prop} [decp : decidable_pred p] :

--- a/library/data/list/set.lean
+++ b/library/data/list/set.lean
@@ -635,6 +635,20 @@ assume ainl, by_cases
   (λ binl  : b ∈ l, by rewrite [insert_eq_of_mem binl]; exact ainl)
   (λ nbinl : b ∉ l, by rewrite [insert_eq_of_not_mem nbinl]; exact (mem_cons_of_mem _ ainl))
 
+theorem eq_or_mem_of_mem_insert {x a : A} {l : list A} (H : x ∈ insert a l) : x = a ∨ x ∈ l :=
+decidable.by_cases
+  (assume H3: a ∈ l, or.inr (insert_eq_of_mem H3 ▸ H))
+  (assume H3: a ∉ l,
+    have H4: x ∈ a :: l, from insert_eq_of_not_mem H3 ▸ H,
+    iff.mp !mem_cons_iff H4)
+
+theorem mem_insert_iff (x a : A) (l : list A) : x ∈ insert a l ↔ x = a ∨ x ∈ l :=
+iff.intro
+  (!eq_or_mem_of_mem_insert)
+  (assume H, or.elim H
+    (assume H' : x = a, H'⁻¹ ▸ !mem_insert)
+    (assume H' : x ∈ l, !mem_insert_of_mem H'))
+
 theorem nodup_insert (a : A) {l : list A} : nodup l → nodup (insert a l) :=
 assume n, by_cases
   (λ ainl  : a ∈ l, by rewrite [insert_eq_of_mem ainl]; exact n)

--- a/library/data/list/set.lean
+++ b/library/data/list/set.lean
@@ -1,8 +1,6 @@
 /-
 Copyright (c) 2015 Leonardo de Moura. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
-Module: data.list.set
 Authors: Leonardo de Moura
 
 Set-like operations on lists
@@ -396,12 +394,12 @@ definition decidable_nodup [instance] [h : decidable_eq A] : ∀ (l : list A), d
     end
   end
 
-theorem nodup_cross_product : ∀ {l₁ : list A} {l₂ : list B}, nodup l₁ → nodup l₂ → nodup (cross_product l₁ l₂)
+theorem nodup_product : ∀ {l₁ : list A} {l₂ : list B}, nodup l₁ → nodup l₂ → nodup (product l₁ l₂)
 | []      l₂ n₁ n₂ := nodup_nil
 | (a::l₁) l₂ n₁ n₂ :=
   have nainl₁ : a ∉ l₁,                      from not_mem_of_nodup_cons n₁,
   have n₃    : nodup l₁,                     from nodup_of_nodup_cons n₁,
-  have n₄    : nodup (cross_product l₁ l₂),  from nodup_cross_product n₃ n₂,
+  have n₄    : nodup (product l₁ l₂),  from nodup_product n₃ n₂,
   have dgen  : ∀ l, nodup l → nodup (map (λ b, (a, b)) l)
     | []     h := nodup_nil
     | (x::l) h :=
@@ -412,11 +410,11 @@ theorem nodup_cross_product : ∀ {l₁ : list A} {l₂ : list B}, nodup l₁ �
         assume pin, absurd (mem_of_mem_map_pair₁ pin) nxin,
       nodup_cons npin dm,
   have dm    : nodup (map (λ b, (a, b)) l₂), from dgen l₂ n₂,
-  have dsj   : disjoint (map (λ b, (a, b)) l₂) (cross_product l₁ l₂), from
+  have dsj   : disjoint (map (λ b, (a, b)) l₂) (product l₁ l₂), from
     λ p, match p with
          | (a₁, b₁) :=
-            λ (i₁ : (a₁, b₁) ∈ map (λ b, (a, b)) l₂) (i₂ : (a₁, b₁) ∈ cross_product l₁ l₂),
-              have a₁inl₁ : a₁ ∈ l₁, from mem_of_mem_cross_product_left i₂,
+            λ (i₁ : (a₁, b₁) ∈ map (λ b, (a, b)) l₂) (i₂ : (a₁, b₁) ∈ product l₁ l₂),
+              have a₁inl₁ : a₁ ∈ l₁, from mem_of_mem_product_left i₂,
               have a₁eqa : a₁ = a, from eq_of_mem_map_pair₁ i₁,
               absurd (a₁eqa ▸ a₁inl₁) nainl₁
          end,

--- a/library/data/list/set.lean
+++ b/library/data/list/set.lean
@@ -130,7 +130,7 @@ end erase
 section disjoint
 variable {A : Type}
 
-definition disjoint (l₁ l₂ : list A) : Prop := ∀ a, (a ∈ l₁ → a ∈ l₂ → false)
+definition disjoint (l₁ l₂ : list A) : Prop := ∀ ⦃a⦄, (a ∈ l₁ → a ∈ l₂ → false)
 
 lemma disjoint_left {l₁ l₂ : list A} : disjoint l₁ l₂ → ∀ {a}, a ∈ l₁ → a ∉ l₂ :=
 λ d a, d a

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -54,7 +54,7 @@ theorem mem_univ (x : T) : x ∈ univ := trivial
 definition inter [reducible] (a b : set T) : set T := λx, x ∈ a ∧ x ∈ b
 notation a ∩ b := inter a b
 
-theorem mem_inter (x : T) (a b : set T) : x ∈ a ∩ b ↔ (x ∈ a ∧ x ∈ b) := !iff.refl
+theorem mem_inter (x : T) (a b : set T) : x ∈ a ∩ b ↔ x ∈ a ∧ x ∈ b := !iff.refl
 
 theorem inter_self (a : set T) : a ∩ a = a :=
 setext (take x, !and_self)
@@ -76,7 +76,7 @@ setext (take x, !and.assoc)
 definition union [reducible] (a b : set T) : set T := λx, x ∈ a ∨ x ∈ b
 notation a ∪ b := union a b
 
-theorem mem_union (x : T) (a b : set T) : x ∈ a ∪ b ↔ (x ∈ a ∨ x ∈ b) := !iff.refl
+theorem mem_union (x : T) (a b : set T) : x ∈ a ∪ b ↔ x ∈ a ∨ x ∈ b := !iff.refl
 
 theorem union_self (a : set T) : a ∪ a = a :=
 setext (take x, !or_self)

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -8,116 +8,161 @@ Author: Jeremy Avigad, Leonardo de Moura
 import logic
 open eq.ops
 
-definition set [reducible] (T : Type) := T → Prop
+definition set [reducible] (X : Type) := X → Prop
 
 namespace set
 
-variable {T : Type}
+variable {X : Type}
 
 /- membership and subset -/
 
-definition mem [reducible] (x : T) (a : set T) := a x
-notation e ∈ a := mem e a
+definition mem [reducible] (x : X) (a : set X) := a x
+infix `∈` := mem
+notation a ∉ b := ¬ mem a b
 
-theorem setext {a b : set T} (H : ∀x, x ∈ a ↔ x ∈ b) : a = b :=
+theorem setext {a b : set X} (H : ∀x, x ∈ a ↔ x ∈ b) : a = b :=
 funext (take x, propext (H x))
 
-definition subset (a b : set T) := ∀⦃x⦄, x ∈ a → x ∈ b
+definition subset (a b : set X) := ∀⦃x⦄, x ∈ a → x ∈ b
 infix `⊆`:50 := subset
 
 /- bounded quantification -/
 
-abbreviation bounded_forall (a : set T) (P : T → Prop) := ∀⦃x⦄, x ∈ a → P x
+abbreviation bounded_forall (a : set X) (P : X → Prop) := ∀⦃x⦄, x ∈ a → P x
 notation `forallb` binders `∈` a `,` r:(scoped:1 P, P) := bounded_forall a r
 notation `∀₀` binders `∈` a `,` r:(scoped:1 P, P) := bounded_forall a r
 
-abbreviation bounded_exists (a : set T) (P : T → Prop) := ∃⦃x⦄, x ∈ a ∧ P x
+abbreviation bounded_exists (a : set X) (P : X → Prop) := ∃⦃x⦄, x ∈ a ∧ P x
 notation `existsb` binders `∈` a `,` r:(scoped:1 P, P) := bounded_exists a r
 notation `∃₀` binders `∈` a `,` r:(scoped:1 P, P) := bounded_exists a r
 
 /- empty set -/
 
-definition empty [reducible] : set T := λx, false
+definition empty [reducible] : set X := λx, false
 notation `∅` := empty
 
-theorem mem_empty (x : T) : ¬ (x ∈ ∅) :=
+theorem not_mem_empty (x : X) : ¬ (x ∈ ∅) :=
 assume H : x ∈ ∅, H
+
+theorem mem_empty_eq (x : X) : x ∈ ∅ = false := rfl
 
 /- universal set -/
 
-definition univ : set T := λx, true
+definition univ : set X := λx, true
 
-theorem mem_univ (x : T) : x ∈ univ := trivial
+theorem mem_univ (x : X) : x ∈ univ := trivial
 
-/- intersection -/
-
-definition inter [reducible] (a b : set T) : set T := λx, x ∈ a ∧ x ∈ b
-notation a ∩ b := inter a b
-
-theorem mem_inter (x : T) (a b : set T) : x ∈ a ∩ b ↔ x ∈ a ∧ x ∈ b := !iff.refl
-
-theorem inter_self (a : set T) : a ∩ a = a :=
-setext (take x, !and_self)
-
-theorem inter_empty (a : set T) : a ∩ ∅ = ∅ :=
-setext (take x, !and_false)
-
-theorem empty_inter (a : set T) : ∅ ∩ a = ∅ :=
-setext (take x, !false_and)
-
-theorem inter.comm (a b : set T) : a ∩ b = b ∩ a :=
-setext (take x, !and.comm)
-
-theorem inter.assoc (a b c : set T) : (a ∩ b) ∩ c = a ∩ (b ∩ c) :=
-setext (take x, !and.assoc)
+theorem mem_univ_eq (x : X) : x ∈ univ = true := rfl
 
 /- union -/
 
-definition union [reducible] (a b : set T) : set T := λx, x ∈ a ∨ x ∈ b
+definition union [reducible] (a b : set X) : set X := λx, x ∈ a ∨ x ∈ b
 notation a ∪ b := union a b
 
-theorem mem_union (x : T) (a b : set T) : x ∈ a ∪ b ↔ x ∈ a ∨ x ∈ b := !iff.refl
+theorem mem_union (x : X) (a b : set X) : x ∈ a ∪ b ↔ x ∈ a ∨ x ∈ b := !iff.refl
 
-theorem union_self (a : set T) : a ∪ a = a :=
+theorem mem_union_eq (x : X) (a b : set X) : x ∈ a ∪ b = (x ∈ a ∨ x ∈ b) := rfl
+
+theorem union_self (a : set X) : a ∪ a = a :=
 setext (take x, !or_self)
 
-theorem union_empty (a : set T) : a ∪ ∅ = a :=
+theorem union_empty (a : set X) : a ∪ ∅ = a :=
 setext (take x, !or_false)
 
-theorem empty_union (a : set T) : ∅ ∪ a = a :=
+theorem empty_union (a : set X) : ∅ ∪ a = a :=
 setext (take x, !false_or)
 
-theorem union.comm (a b : set T) : a ∪ b = b ∪ a :=
+theorem union.comm (a b : set X) : a ∪ b = b ∪ a :=
 setext (take x, or.comm)
 
-theorem union_assoc (a b c : set T) : (a ∪ b) ∪ c = a ∪ (b ∪ c) :=
+theorem union_assoc (a b c : set X) : (a ∪ b) ∪ c = a ∪ (b ∪ c) :=
 setext (take x, or.assoc)
+
+/- intersection -/
+
+definition inter [reducible] (a b : set X) : set X := λx, x ∈ a ∧ x ∈ b
+notation a ∩ b := inter a b
+
+theorem mem_inter (x : X) (a b : set X) : x ∈ a ∩ b ↔ x ∈ a ∧ x ∈ b := !iff.refl
+
+theorem mem_inter_eq (x : X) (a b : set X) : x ∈ a ∩ b = (x ∈ a ∧ x ∈ b) := rfl
+
+theorem inter_self (a : set X) : a ∩ a = a :=
+setext (take x, !and_self)
+
+theorem inter_empty (a : set X) : a ∩ ∅ = ∅ :=
+setext (take x, !and_false)
+
+theorem empty_inter (a : set X) : ∅ ∩ a = ∅ :=
+setext (take x, !false_and)
+
+theorem inter.comm (a b : set X) : a ∩ b = b ∩ a :=
+setext (take x, !and.comm)
+
+theorem inter.assoc (a b c : set X) : (a ∩ b) ∩ c = a ∩ (b ∩ c) :=
+setext (take x, !and.assoc)
+
+/- distributivity laws -/
+
+theorem inter.distrib_left (s t u : set X) : s ∩ (t ∪ u) = (s ∩ t) ∪ (s ∩ u) :=
+setext (take x, !and.distrib_left)
+
+theorem inter.distrib_right (s t u : set X) : (s ∪ t) ∩ u = (s ∩ u) ∪ (t ∩ u) :=
+setext (take x, !and.distrib_right)
+
+theorem union.distrib_left (s t u : set X) : s ∪ (t ∩ u) = (s ∪ t) ∩ (s ∪ u) :=
+setext (take x, !or.distrib_left)
+
+theorem union.distrib_right (s t u : set X) : (s ∩ t) ∪ u = (s ∪ u) ∩ (t ∪ u) :=
+setext (take x, !or.distrib_right)
 
 /- set-builder notation -/
 
--- {x : T | P}
-definition set_of (P : T → Prop) : set T := P
+-- {x : X | P}
+definition set_of (P : X → Prop) : set X := P
 notation `{` binders `|` r:(scoped:1 P, set_of P) `}` := r
 
+-- {x ∈ s | P}
+definition filter (P : X → Prop) (s : set X) : set X := λx, x ∈ s ∧ P x
+notation `{` binders ∈ s `|` r:(scoped:1 p, filter p s) `}` := r
+
 -- {[x, y, z]} or ⦃x, y, z⦄
-definition insert (x : T) (a : set T) : set T := {y : T | y = x ∨ y ∈ a}
+definition insert (x : X) (a : set X) : set X := {y : X | y = x ∨ y ∈ a}
 notation `{[`:max a:(foldr `,` (x b, insert x b) ∅) `]}`:0 := a
 notation `⦃` a:(foldr `,` (x b, insert x b) ∅) `⦄` := a
+
+/- set difference -/
+
+definition diff (s t : set X) : set X := {x ∈ s | x ∉ t}
+infix `\`:70 := diff
+
+theorem mem_of_mem_diff {s t : set X} {x : X} (H : x ∈ s \ t) : x ∈ s :=
+and.left H
+
+theorem not_mem_of_mem_diff {s t : set X} {x : X} (H : x ∈ s \ t) : x ∉ t :=
+and.right H
+
+theorem mem_diff {s t : set X} {x : X} (H1 : x ∈ s) (H2 : x ∉ t) : x ∈ s \ t :=
+and.intro H1 H2
+
+theorem mem_diff_iff (s t : set X) (x : X) : x ∈ s \ t ↔ x ∈ s ∧ x ∉ t := !iff.refl
+
+theorem mem_diff_eq (s t : set X) (x : X) : x ∈ s \ t = (x ∈ s ∧ x ∉ t) := rfl
 
 /- large unions -/
 
 section
   variables {I : Type}
   variable a : set I
-  variable b : I → set T
-  variable C : set (set T)
+  variable b : I → set X
+  variable C : set (set X)
 
-  definition Inter  : set T := {x : T | ∀i, x ∈ b i}
-  definition bInter : set T := {x : T | ∀₀ i ∈ a, x ∈ b i}
-  definition sInter : set T := {x : T | ∀₀ c ∈ C, x ∈ c}
-  definition Union  : set T := {x : T | ∃i, x ∈ b i}
-  definition bUnion : set T := {x : T | ∃₀ i ∈ a, x ∈ b i}
-  definition sUnion : set T := {x : T | ∃₀ c ∈ C, x ∈ c}
+  definition Inter  : set X := {x : X | ∀i, x ∈ b i}
+  definition bInter : set X := {x : X | ∀₀ i ∈ a, x ∈ b i}
+  definition sInter : set X := {x : X | ∀₀ c ∈ C, x ∈ c}
+  definition Union  : set X := {x : X | ∃i, x ∈ b i}
+  definition bUnion : set X := {x : X | ∃₀ i ∈ a, x ∈ b i}
+  definition sUnion : set X := {x : X | ∃₀ c ∈ C, x ∈ c}
 
   -- TODO: need notation for these
 end

--- a/library/data/set/function.lean
+++ b/library/data/set/function.lean
@@ -41,7 +41,7 @@ theorem in_image {f : X → Y} {a : set X} {x : X} {y : Y}
   (H1 : x ∈ a) (H2 : f x = y) : y ∈ f '[a] :=
 exists.intro x (and.intro H1 H2)
 
-lemma image_compose (f : Y → X) (g : X → Y) (a : set X) : (f ∘ g) '[a] = f '[g '[a]] :=
+lemma image_compose (f : Y → Z) (g : X → Y) (a : set X) : (f ∘ g) '[a] = f '[g '[a]] :=
 setext (take z,
   iff.intro
     (assume Hz : z ∈ (f ∘ g) '[a],

--- a/library/logic/connectives.lean
+++ b/library/logic/connectives.lean
@@ -1,12 +1,11 @@
 /-
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
-Module: logic.connectives
 Authors: Jeremy Avigad, Leonardo de Moura
 
 The propositional connectives. See also init.datatypes and init.logic.
 -/
+open eq.ops
 
 variables {a b c d : Prop}
 
@@ -177,6 +176,34 @@ theorem or_self (a : Prop) : a ∨ a ↔ a :=
 iff.intro
   (assume H, or.elim H (assume H1, H1) (assume H1, H1))
   (assume H, or.inl H)
+
+/- distributivity -/
+
+theorem and.distrib_left (a b c : Prop) : a ∧ (b ∨ c) ↔ (a ∧ b) ∨ (a ∧ c) :=
+iff.intro
+  (assume H, or.elim (and.right H)
+    (assume Hb : b, or.inl (and.intro (and.left H) Hb))
+    (assume Hc : c, or.inr (and.intro (and.left H) Hc)))
+  (assume H, or.elim H
+    (assume Hab, and.intro (and.left Hab) (or.inl (and.right Hab)))
+    (assume Hac, and.intro (and.left Hac) (or.inr (and.right Hac))))
+
+theorem and.distrib_right (a b c : Prop) : (a ∨ b) ∧ c ↔ (a ∧ c) ∨ (b ∧ c) :=
+propext (!and.comm) ▸ propext (!and.comm) ▸ propext (!and.comm) ▸ !and.distrib_left
+
+theorem or.distrib_left (a b c : Prop) : a ∨ (b ∧ c) ↔ (a ∨ b) ∧ (a ∨ c) :=
+iff.intro
+  (assume H, or.elim H
+    (assume Ha, and.intro (or.inl Ha) (or.inl Ha))
+    (assume Hbc, and.intro (or.inr (and.left Hbc)) (or.inr (and.right Hbc))))
+  (assume H, or.elim (and.left H)
+    (assume Ha, or.inl Ha)
+    (assume Hb, or.elim (and.right H)
+      (assume Ha, or.inl Ha)
+      (assume Hc, or.inr (and.intro Hb Hc))))
+
+theorem or.distrib_right (a b c : Prop) : (a ∧ b) ∨ c ↔ (a ∨ c) ∧ (b ∨ c) :=
+propext (!or.comm) ▸ propext (!or.comm) ▸ propext (!or.comm) ▸ !or.distrib_left
 
 /- iff -/
 

--- a/src/emacs/lean-input.el
+++ b/src/emacs/lean-input.el
@@ -309,6 +309,7 @@ order for the change to take effect."
   ("ex"  . ("∃"))
   ("exn" . ("∄"))
   ("0"   . ("∅"))
+  ("empty"   . ("∅"))
   ("C"   . ("∁"))
 
   ;; Corners, ceilings and floors.


### PR DESCRIPTION
Various additions, such as filter, "set-builder" notation, and basic facts about cardinality.

@htzh: some of this should be of interest to you.

Still needed:
- the "exists" operator
- functions (inj_on, surj_on, etc., as on set)
- if f is injective on s, f `[ s ] has the same cardinality as s
- more identities (e.g. as in the Isabelle library)
- make sure finset and set parallel each other
- powers on monoids and groups
- sums on additive commutative monoids, products on commutative monoids

I'll keep working on this.

@leodemoura: Question: we have "erase" on lists and sets to delete an element. Would "delete" be a better name?
