### PR TITLE
making library for finite sets more robust

### DIFF
--- a/library/data/finset/basic.lean
+++ b/library/data/finset/basic.lean
@@ -463,6 +463,12 @@ quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h₁ h₂, h₁ a h₂)
 theorem subset_of_forall {s₁ s₂ : finset A} : (∀x, x ∈ s₁ → x ∈ s₂) → s₁ ⊆ s₂ :=
 quot.induction_on₂ s₁ s₂ (λ l₁ l₂ H, H)
 
+theorem subset_insert [h : decidable_eq A] (s : finset A) (a : A) : s ⊆ insert a s :=
+subset_of_forall (take x, assume H : x ∈ s, mem_insert_of_mem _ H)
+
+theorem eq_of_subset_of_subset {s₁ s₂ : finset A} (H₁ : s₁ ⊆ s₂) (H₂ : s₂ ⊆ s₁) : s₁ = s₂ :=
+ext (take x, iff.intro (assume H, mem_of_subset_of_mem H₁ H) (assume H, mem_of_subset_of_mem H₂ H))
+
 /- upto -/
 section upto
 definition upto (n : nat) : finset nat :=

--- a/library/data/finset/basic.lean
+++ b/library/data/finset/basic.lean
@@ -460,6 +460,9 @@ quot.induction_on₃ s₁ s₂ s₃ (λ l₁ l₂ l₃ h₁ h₂, list.sub.trans
 theorem mem_of_subset_of_mem {s₁ s₂ : finset A} {a : A} : s₁ ⊆ s₂ → a ∈ s₁ → a ∈ s₂ :=
 quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h₁ h₂, h₁ a h₂)
 
+theorem subset_of_forall {s₁ s₂ : finset A} : (∀x, x ∈ s₁ → x ∈ s₂) → s₁ ⊆ s₂ :=
+quot.induction_on₂ s₁ s₂ (λ l₁ l₂ H, H)
+
 /- upto -/
 section upto
 definition upto (n : nat) : finset nat :=

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -10,96 +10,117 @@ open list quot subtype decidable perm function
 
 namespace finset
 
-/- map -/
-section map
+/- image (corresponds to map on list) -/
+section image
 variables {A B : Type}
 variable [h : decidable_eq B]
 include h
 
-definition map (f : A → B) (s : finset A) : finset B :=
+definition image (f : A → B) (s : finset A) : finset B :=
 quot.lift_on s
   (λ l, to_finset (list.map f (elt_of l)))
   (λ l₁ l₂ p, quot.sound (perm_erase_dup_of_perm (perm_map _ p)))
 
-theorem map_empty (f : A → B) : map f ∅ = ∅ :=
+theorem image_empty (f : A → B) : image f ∅ = ∅ :=
 rfl
-end map
+
+theorem mem_image_of_mem (f : A → B) {s : finset A} {a : A} : a ∈ s → f a ∈ image f s :=
+quot.induction_on s (take l, assume H : a ∈ elt_of l, mem_to_finset (mem_map f H))
+
+theorem exists_of_mem_image {f : A → B} {s : finset A} {b : B} :
+  b ∈ image f s → ∃a, a ∈ s ∧ f a = b :=
+quot.induction_on s
+  (take l, assume H : b ∈ erase_dup (list.map f (elt_of l)),
+    exists_of_mem_map (mem_of_mem_erase_dup H))
+
+theorem mem_image_iff (f : A → B) {s : finset A} {y : B} : y ∈ image f s ↔ ∃x, x ∈ s ∧ f x = y :=
+iff.intro exists_of_mem_image
+  (assume H,
+    obtain x (H1 : x ∈ s ∧ f x = y), from H,
+    eq.subst (and.right H1) (mem_image_of_mem f (and.left H1)))
+
+theorem mem_image_eq (f : A → B) {s : finset A} {y : B} : y ∈ image f s = ∃x, x ∈ s ∧ f x = y :=
+propext (mem_image_iff f)
+end image
 
 /- filter and set-builder notation -/
 section filter
-  variables {A : Type} [deceq : decidable_eq A]
-  include deceq
-  variables (p : A → Prop) [decp : decidable_pred p] (s : finset A) {x : A}
-  include decp
+variables {A : Type} [deceq : decidable_eq A]
+include deceq
+variables (p : A → Prop) [decp : decidable_pred p] (s : finset A) {x : A}
+include decp
 
-  definition filter : finset A :=
-  quot.lift_on s
-    (λl, to_finset_of_nodup
-      (list.filter p (subtype.elt_of l))
-      (list.nodup_filter p (subtype.has_property l)))
-    (λ l₁ l₂ u, quot.sound (perm.perm_filter u))
+definition filter : finset A :=
+quot.lift_on s
+  (λl, to_finset_of_nodup
+    (list.filter p (subtype.elt_of l))
+    (list.nodup_filter p (subtype.has_property l)))
+  (λ l₁ l₂ u, quot.sound (perm.perm_filter u))
 
-  notation `{` binders ∈ s `|` r:(scoped:1 p, filter p s) `}` := r
+notation `{` binders ∈ s `|` r:(scoped:1 p, filter p s) `}` := r
 
-  theorem filter_empty : filter p ∅ = ∅ := rfl
+theorem filter_empty : filter p ∅ = ∅ := rfl
 
-  variables {p s}
+variables {p s}
 
-  theorem of_mem_filter : x ∈ filter p s → p x :=
-  quot.induction_on s (take l, list.of_mem_filter)
+theorem of_mem_filter : x ∈ filter p s → p x :=
+quot.induction_on s (take l, list.of_mem_filter)
 
-  theorem mem_of_mem_filter : x ∈ filter p s → x ∈ s :=
-  quot.induction_on s (take l, list.mem_of_mem_filter)
+theorem mem_of_mem_filter : x ∈ filter p s → x ∈ s :=
+quot.induction_on s (take l, list.mem_of_mem_filter)
 
-  theorem mem_filter_of_mem {x : A} : x ∈ s → p x → x ∈ filter p s :=
-  quot.induction_on s (take l, list.mem_filter_of_mem)
+theorem mem_filter_of_mem {x : A} : x ∈ s → p x → x ∈ filter p s :=
+quot.induction_on s (take l, list.mem_filter_of_mem)
 
-  variables (p s)
+variables (p s)
 
-  theorem mem_filter_eq : x ∈ filter p s = (x ∈ s ∧ p x) :=
-  propext (iff.intro
-    (assume H, and.intro (mem_of_mem_filter H) (of_mem_filter H))
-    (assume H, mem_filter_of_mem (and.left H) (and.right H)))
+theorem mem_filter_iff : x ∈ filter p s ↔ x ∈ s ∧ p x :=
+iff.intro
+  (assume H, and.intro (mem_of_mem_filter H) (of_mem_filter H))
+  (assume H, mem_filter_of_mem (and.left H) (and.right H))
+
+theorem mem_filter_eq : x ∈ filter p s = (x ∈ s ∧ p x) :=
+propext !mem_filter_iff
 end filter
 
 /- set difference -/
 section diff
-  variables {A : Type} [deceq : decidable_eq A]
-  include deceq
+variables {A : Type} [deceq : decidable_eq A]
+include deceq
 
-  definition diff (s t : finset A) : finset A := {x ∈ s | x ∉ t}
-  infix `\`:70 := diff
+definition diff (s t : finset A) : finset A := {x ∈ s | x ∉ t}
+infix `\`:70 := diff
 
-  theorem mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∈ s :=
-  mem_of_mem_filter H
+theorem mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∈ s :=
+mem_of_mem_filter H
 
-  theorem not_mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∉ t :=
-  of_mem_filter H
+theorem not_mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∉ t :=
+of_mem_filter H
 
-  theorem mem_diff {s t : finset A} {x : A} (H1 : x ∈ s) (H2 : x ∉ t) : x ∈ s \ t :=
-  mem_filter_of_mem H1 H2
+theorem mem_diff {s t : finset A} {x : A} (H1 : x ∈ s) (H2 : x ∉ t) : x ∈ s \ t :=
+mem_filter_of_mem H1 H2
 
-  theorem mem_diff_iff (s t : finset A) (x : A) : x ∈ s \ t ↔ x ∈ s ∧ x ∉ t :=
-  iff.intro
-    (assume H, and.intro (mem_of_mem_diff H) (not_mem_of_mem_diff H))
-    (assume H, mem_diff (and.left H) (and.right H))
+theorem mem_diff_iff (s t : finset A) (x : A) : x ∈ s \ t ↔ x ∈ s ∧ x ∉ t :=
+iff.intro
+  (assume H, and.intro (mem_of_mem_diff H) (not_mem_of_mem_diff H))
+  (assume H, mem_diff (and.left H) (and.right H))
 
-  theorem mem_diff_eq (s t : finset A) (x : A) : x ∈ s \ t = (x ∈ s ∧ x ∉ t) :=
-  propext !mem_diff_iff
+theorem mem_diff_eq (s t : finset A) (x : A) : x ∈ s \ t = (x ∈ s ∧ x ∉ t) :=
+propext !mem_diff_iff
 
-  theorem union_diff_cancel {s t : finset A} (H : s ⊆ t) : s ∪ (t \ s) = t :=
-  ext (take x, iff.intro
-    (assume H1 : x ∈ s ∪ (t \ s),
-      or.elim (mem_or_mem_of_mem_union H1)
-        (assume H2 : x ∈ s, mem_of_subset_of_mem H H2)
-        (assume H2 : x ∈ t \ s, mem_of_mem_diff H2))
-    (assume H1 : x ∈ t,
-      decidable.by_cases
-        (assume H2 : x ∈ s, mem_union_left _ H2)
-        (assume H2 : x ∉ s, mem_union_right _ (mem_diff H1 H2))))
+theorem union_diff_cancel {s t : finset A} (H : s ⊆ t) : s ∪ (t \ s) = t :=
+ext (take x, iff.intro
+  (assume H1 : x ∈ s ∪ (t \ s),
+    or.elim (mem_or_mem_of_mem_union H1)
+      (assume H2 : x ∈ s, mem_of_subset_of_mem H H2)
+      (assume H2 : x ∈ t \ s, mem_of_mem_diff H2))
+  (assume H1 : x ∈ t,
+    decidable.by_cases
+      (assume H2 : x ∈ s, mem_union_left _ H2)
+      (assume H2 : x ∉ s, mem_union_right _ (mem_diff H1 H2))))
 
-  theorem diff_union_cancel {s t : finset A} (H : s ⊆ t) : (t \ s) ∪ s = t :=
-  eq.subst !union.comm (!union_diff_cancel H)
+theorem diff_union_cancel {s t : finset A} (H : s ⊆ t) : (t \ s) ∪ s = t :=
+eq.subst !union.comm (!union_diff_cancel H)
 end diff
 
 /- all -/
@@ -119,7 +140,14 @@ quot.induction_on s (λ l i h, list.of_mem_of_all i h)
 theorem forall_of_all {p : A → Prop} {s : finset A} (H : all s p) : ∀{a}, a ∈ s → p a :=
 λ a H', of_mem_of_all H' H
 
-definition decidable_all (p : A → Prop) [h : decidable_pred p] (s : finset A) : decidable (all s p) :=
+theorem all_of_forall {p : A → Prop} {s : finset A} : (∀a, a ∈ s → p a) → all s p :=
+quot.induction_on s (λ l H, list.all_of_forall H)
+
+theorem all_iff_forall (p : A → Prop) (s : finset A) : all s p ↔ (∀a, a ∈ s → p a) :=
+iff.intro forall_of_all all_of_forall
+
+definition decidable_all [instance] (p : A → Prop) [h : decidable_pred p] (s : finset A) :
+  decidable (all s p) :=
 quot.rec_on_subsingleton s (λ l, list.decidable_all p (elt_of l))
 
 theorem all_implies {p q : A → Prop} {s : finset A} : all s p → (∀ x, p x → q x) → all s q :=
@@ -148,6 +176,14 @@ quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h, list.all_inter_of_all_left _ h)
 
 theorem all_inter_of_all_right {p : A → Prop} {s₁ : finset A} (s₂ : finset A) : all s₂ p → all (s₁ ∩ s₂) p :=
 quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h, list.all_inter_of_all_right _ h)
+
+theorem subset_iff_all (s t : finset A) : s ⊆ t ↔ all s (λ x, x ∈ t) :=
+iff.intro
+  (assume H : s ⊆ t, all_of_forall (take x, assume H1, mem_of_subset_of_mem H H1))
+  (assume H : all s (λ x, x ∈ t), subset_of_forall (take x, assume H1 : x ∈ s, of_mem_of_all H1 H))
+
+definition decidable_subset [instance] (s t : finset A) : decidable (s ⊆ t) :=
+decidable_of_decidable_of_iff _ (iff.symm !subset_iff_all)
 end all
 
 /- any -/
@@ -166,6 +202,13 @@ quot.induction_on s (λ l H, list.exists_of_any H)
 theorem any_of_mem {p : A → Prop} {s : finset A} {a : A} : a ∈ s → p a → any s p :=
 quot.induction_on s (λ l H1 H2, list.any_of_mem H1 H2)
 
+theorem any_of_exists {p : A → Prop} {s : finset A} (H : ∃a, a ∈ s ∧ p a) : any s p :=
+obtain a H', from H,
+any_of_mem (and.left H') (and.right H')
+
+theorem any_iff_exists (p : A → Prop) (s : finset A) : any s p ↔ (∃a, a ∈ s ∧ p a) :=
+iff.intro exists_of_any any_of_exists
+
 theorem any_of_insert [h : decidable_eq A] {p : A → Prop} (s : finset A) {a : A} (H : p a) :
   any (insert a s) p :=
 any_of_mem (mem_insert a s) H
@@ -175,13 +218,9 @@ theorem any_of_insert_right [h : decidable_eq A] {p : A → Prop} {s : finset A}
 obtain b (H' : b ∈ s ∧ p b), from exists_of_any H,
 any_of_mem (mem_insert_of_mem a (and.left H')) (and.right H')
 
-theorem any_of_exists {p : A → Prop} {s : finset A} (H : ∃a, a ∈ s ∧ p a) : any s p :=
-obtain a H', from H,
-any_of_mem (and.left H') (and.right H')
-
-definition decidable_any (p : A → Prop) [h : decidable_pred p] (s : finset A) : decidable (any s p) :=
+definition decidable_any [instance] (p : A → Prop) [h : decidable_pred p] (s : finset A) :
+  decidable (any s p) :=
 quot.rec_on_subsingleton s (λ l, list.decidable_any p (elt_of l))
-
 end any
 
 section product

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -110,15 +110,17 @@ quot.lift_on s
   (λ l, all (elt_of l) p)
   (λ l₁ l₂ p, foldr_eq_of_perm (λ a₁ a₂ q, propext !and.left_comm) p true)
 
--- notation for bounded quantifiers
-notation `forallb` binders `∈` a `,` r:(scoped:1 P, P) := all a r
-notation `∀₀` binders `∈` a `,` r:(scoped:1 P, P) := all a r
-
 theorem all_empty (p : A → Prop) : all ∅ p = true :=
 rfl
 
 theorem of_mem_of_all {p : A → Prop} {a : A} {s : finset A} : a ∈ s → all s p → p a :=
 quot.induction_on s (λ l i h, list.of_mem_of_all i h)
+
+theorem forall_of_all {p : A → Prop} {s : finset A} (H : all s p) : ∀{a}, a ∈ s → p a :=
+λ a H', of_mem_of_all H' H
+
+definition decidable_all (p : A → Prop) [h : decidable_pred p] (s : finset A) : decidable (all s p) :=
+quot.rec_on_subsingleton s (λ l, list.decidable_all p (elt_of l))
 
 theorem all_implies {p q : A → Prop} {s : finset A} : all s p → (∀ x, p x → q x) → all s q :=
 quot.induction_on s (λ l h₁ h₂, list.all_implies h₁ h₂)
@@ -147,6 +149,40 @@ quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h, list.all_inter_of_all_left _ h)
 theorem all_inter_of_all_right {p : A → Prop} {s₁ : finset A} (s₂ : finset A) : all s₂ p → all (s₁ ∩ s₂) p :=
 quot.induction_on₂ s₁ s₂ (λ l₁ l₂ h, list.all_inter_of_all_right _ h)
 end all
+
+/- any -/
+section any
+variables {A : Type}
+definition any (s : finset A) (p : A → Prop) : Prop :=
+quot.lift_on s
+  (λ l, any (elt_of l) p)
+  (λ l₁ l₂ p, foldr_eq_of_perm (λ a₁ a₂ q, propext !or.left_comm) p false)
+
+theorem any_empty (p : A → Prop) : any ∅ p = false := rfl
+
+theorem exists_of_any {p : A → Prop} {s : finset A} : any s p → ∃a, a ∈ s ∧ p a :=
+quot.induction_on s (λ l H, list.exists_of_any H)
+
+theorem any_of_mem {p : A → Prop} {s : finset A} {a : A} : a ∈ s → p a → any s p :=
+quot.induction_on s (λ l H1 H2, list.any_of_mem H1 H2)
+
+theorem any_of_insert [h : decidable_eq A] {p : A → Prop} (s : finset A) {a : A} (H : p a) :
+  any (insert a s) p :=
+any_of_mem (mem_insert a s) H
+
+theorem any_of_insert_right [h : decidable_eq A] {p : A → Prop} {s : finset A} (a : A) (H : any s p) :
+  any (insert a s) p :=
+obtain b (H' : b ∈ s ∧ p b), from exists_of_any H,
+any_of_mem (mem_insert_of_mem a (and.left H')) (and.right H')
+
+theorem any_of_exists {p : A → Prop} {s : finset A} (H : ∃a, a ∈ s ∧ p a) : any s p :=
+obtain a H', from H,
+any_of_mem (and.left H') (and.right H')
+
+definition decidable_any (p : A → Prop) [h : decidable_pred p] (s : finset A) : decidable (any s p) :=
+quot.rec_on_subsingleton s (λ l, list.decidable_any p (elt_of l))
+
+end any
 
 section product
 variables {A B : Type}

--- a/library/data/finset/finset.md
+++ b/library/data/finset/finset.md
@@ -1,0 +1,9 @@
+data.finset
+===========
+
+Finite sets. By default, `import list` imports everything here.
+
+[basic](basic.lean) : basic operations and properties
+[comb](comb.lean) : combinators and list constructions
+[card](card.lean) : cardinality
+[bigop](bigop.lean) : "big" operations

--- a/library/data/finset/to_set.lean
+++ b/library/data/finset/to_set.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Interactions between finset and set.
+-/
+import data.finset.comb data.set.function
+open nat eq.ops set
+
+namespace finset
+
+variable {A : Type}
+variable [deceq : decidable_eq A]
+include deceq
+
+definition to_set (s : finset A) : set A := λx, x ∈ s
+abbreviation ts := to_set   -- until coercion is working
+
+variables (s t : finset A) (x : A)
+
+/- operations -/
+
+theorem mem_to_set_empty : (x ∈ ts ∅) = (x ∈ ∅) := rfl
+theorem to_set_empty : ts ∅ = ∅ := rfl
+
+theorem mem_to_set_univ [h : fintype A] : (x ∈ ts univ) = (x ∈ set.univ) :=
+  propext (iff.intro (assume H, trivial) (assume H, !mem_univ))
+theorem to_set_univ [h : fintype A] : ts univ = set.univ := funext (λ x, !mem_to_set_univ)
+
+theorem mem_to_set_union : (x ∈ ts (s ∪ t)) = (x ∈ ts s ∪ ts t) := !finset.mem_union_eq
+theorem to_set_union : ts (s ∪ t) = ts s ∪ ts t := funext (λ x, !mem_to_set_union)
+
+theorem mem_to_set_inter : (x ∈ ts (s ∩ t)) = (x ∈ ts s ∩ ts t) := !finset.mem_inter_eq
+theorem to_set_inter : ts (s ∩ t) = ts s ∩ ts t := funext (λ x, !mem_to_set_inter)
+
+theorem mem_to_set_diff : (x ∈ ts (s \ t)) = (x ∈ ts s \ ts t) := !finset.mem_diff_eq
+theorem to_set_diff : ts (s \ t) = ts s \ ts t := funext (λ x, !mem_to_set_diff)
+
+theorem mem_to_set_filter (p : A → Prop) [h : decidable_pred p] :
+  (x ∈ ts (finset.filter p s)) = (x ∈ set.filter p (ts s)) := !finset.mem_filter_eq
+theorem to_set_filter (p : A → Prop) [h : decidable_pred p] :
+  ts (finset.filter p s) = set.filter p (ts s) := funext (λ x, !mem_to_set_filter)
+
+theorem mem_to_set_image {B : Type} [h : decidable_eq B] (f : A → B) {s : finset A} {y : B} :
+  (y ∈ ts (finset.image f s)) = (y ∈ set.image f (ts s)) := !finset.mem_image_eq
+theorem to_set_image {B : Type} [h : decidable_eq B] (f : A → B) (s : finset A) :
+  ts (finset.image f s) = set.image f (ts s) := funext (λ x, !mem_to_set_image)
+
+/- relations -/
+
+theorem mem_eq_mem_to_set : (x ∈ s) = (x ∈ ts s) := rfl
+
+definition decidable_mem_to_set [instance] (x s) : decidable (x ∈ ts s) :=
+decidable_of_decidable_of_eq _ !mem_eq_mem_to_set
+
+theorem eq_eq_to_set_eq : (s = t) = (ts s = ts t) :=
+propext (iff.intro
+  (assume H, H ▸ rfl)
+  (assume H, ext (take x, by rewrite [mem_eq_mem_to_set s, H])))
+
+definition decidable_to_set_eq [instance] (s t : finset A) : decidable (ts s = ts t) :=
+decidable_of_decidable_of_eq _ !eq_eq_to_set_eq
+
+theorem subset_eq_to_set_subset (s t : finset A) : (s ⊆ t) = (ts s ⊆ ts t) :=
+propext (iff.intro
+  (assume H, take x xs, mem_of_subset_of_mem H xs)
+  (assume H, subset_of_forall H))
+
+definition decidable_to_set_subset (s t : finset A) : decidable (ts s ⊆ ts t) :=
+decidable_of_decidable_of_eq _ !subset_eq_to_set_subset
+
+/- bounded quantifiers -/
+
+definition decidable_bounded_forall (s : finset A) (p : A → Prop) [h : decidable_pred p] :
+  decidable (∀₀ x ∈ ts s, p x) :=
+decidable_of_decidable_of_iff _ !all_iff_forall
+
+definition decidable_bounded_exists (s : finset A) (p : A → Prop) [h : decidable_pred p] :
+  decidable (∃₀ x ∈ ts s, p x) :=
+decidable_of_decidable_of_iff _ !any_iff_exists
+
+end finset

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -1,11 +1,9 @@
 /-
 Copyright (c) 2015 Leonardo de Moura. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-
-Module: data.list.comb
 Authors: Leonardo de Moura
 
-List combinators
+List combinators.
 -/
 import data.list.basic
 open nat prod decidable function helper_tactics
@@ -42,6 +40,16 @@ theorem mem_map {A B : Type} (f : A → B) : ∀ {a l}, a ∈ l → f a ∈ map 
 | a (x::xs) i := or.elim (eq_or_mem_of_mem_cons i)
    (λ aeqx  : a = x, by rewrite [aeqx, map_cons]; apply mem_cons)
    (λ ainxs : a ∈ xs, or.inr (mem_map ainxs))
+
+theorem exists_of_mem_map {A B : Type} {f : A → B} {b : B} :
+    ∀{l}, b ∈ map f l → ∃a, a ∈ l ∧ f a = b
+| []     H := false.elim H
+| (c::l) H := or.elim (iff.mp !mem_cons_iff H)
+                (assume H1 : b = f c,
+                  exists.intro c (and.intro !mem_cons (eq.symm H1)))
+                (assume H1 : b ∈ map f l,
+                  obtain a (H : a ∈ l ∧ f a = b), from exists_of_mem_map H1,
+                  exists.intro a (and.intro (mem_cons_of_mem _ (and.left H)) (and.right H)))
 
 theorem eq_of_map_const {A B : Type} {b₁ b₂ : B} : ∀ {l : list A}, b₁ ∈ map (const A b₂) l → b₁ = b₂
 | []     h := absurd h !not_mem_nil
@@ -98,7 +106,7 @@ theorem mem_filter_of_mem {p : A → Prop} [h : decidable_pred p] {a : A} : ∀ 
     (λ aeqb : a = b, absurd (eq.rec_on aeqb pa) npb)
     (λ ainl : a ∈ l, by rewrite [filter_cons_of_neg _ npb]; exact (mem_filter_of_mem ainl pa)))
 
-theorem filter_subset {p : A → Prop} [h : decidable_pred p] (l : list A) : filter p l ⊆ l :=
+theorem filter_sub {p : A → Prop} [h : decidable_pred p] (l : list A) : filter p l ⊆ l :=
 λ a ain, mem_of_mem_filter ain
 
 theorem filter_append {p : A → Prop} [h : decidable_pred p] : ∀ (l₁ l₂ : list A), filter p (l₁++l₂) = filter p l₁ ++ filter p l₂

--- a/library/data/set/function.lean
+++ b/library/data/set/function.lean
@@ -96,6 +96,12 @@ assume  H1 : g (f x1) = g (f x2),
 have    H2 : f x1 = f x2, from Hg fx1b fx2b H1,
 show x1 = x2, from Hf x1a x2a H2
 
+theorem inj_on_of_inj_on_of_subset {f : X → Y} {a b : set X} (H1 : inj_on f b) (H2 : a ⊆ b) :
+  inj_on f a :=
+take x1 x2 : X, assume (x1a : x1 ∈ a) (x2a : x2 ∈ a),
+assume H : f x1 = f x2,
+show x1 = x2, from H1 (H2 x1a) (H2 x2a) H
+
 /- surjectivity -/
 
 definition surj_on [reducible] (f : X → Y) (a : set X) (b : set Y) : Prop := b ⊆ f '[a]

--- a/src/emacs/lean-input.el
+++ b/src/emacs/lean-input.el
@@ -257,6 +257,8 @@ order for the change to take effect."
   ("subn"  . ("⊄"))  ("supn"  . ("⊅"))
   ("sub="  . ("⊆"))  ("sup="  . ("⊇"))
   ("sub=n" . ("⊈"))  ("sup=n" . ("⊉"))
+  ("subeq"  . ("⊆")) ("supeq"  . ("⊇"))
+  ("subeqn" . ("⊈")) ("supeqn" . ("⊉"))
 
   ("squb"   . ("⊏"))  ("squp"   . ("⊐"))
   ("squb="  . ("⊑"))  ("squp="  . ("⊒"))
@@ -265,6 +267,7 @@ order for the change to take effect."
   ;; Set membership etc.
 
   ("member" . ,(lean-input-to-string-list "∈∉∊∋∌∍⋲⋳⋴⋵⋶⋷⋸⋹⋺⋻⋼⋽⋾⋿"))
+  ("mem" . ("∈"))
 
   ("inn" . ("∉"))
   ("nin" . ("∌"))


### PR DESCRIPTION
Still plodding along. We now have a number of conventional set constructions for finite sets, and can prove that they "implement" the set-theoretic versions. The file `data.finset.to_set` has the coercion from `finset` to `set` (when we can really coerce to set, we will not need to insert it manually), and coordination lemmas for the two domains.

The general idea is this:
- finitary versions of set-theoretic constructions (like union, intersection, image, ...) have to be implemented specifically for finsets to make them computable, but then we can prove that they meet the usual set-theoretic descriptions. This lets us relate the operations on finset to their set-theoretic counterparts.
- if `s` is a finset and `ts` is the coercion to set, `x ∈ s` and `x ∈ ts s` are definitionally the same. Thus for proving things about finsets, we can use general set-theoretic language to make the assertions, and use general set-theoretic facts to prove them. 

This is illustrated in the theorem `card_image_eq_of_inj_on` in `data.finset.card`, which asserts that an injective image of a finset has the same cardinality. Notice that `inj_on` is the predicate from the `set` library.

The hypothesis is that this will all work out smoothly.... We'll see.
