### PR TITLE
Reals form an ordered ring

### DIFF
--- a/library/algebra/ordered_ring.lean
+++ b/library/algebra/ordered_ring.lean
@@ -11,7 +11,7 @@ of "linear_ordered_comm_ring". This development is modeled after Isabelle's libr
 import algebra.ordered_group algebra.ring
 open eq eq.ops
 
-namespace algebra
+namespace algebra 
 
 variable {A : Type}
 
@@ -197,7 +197,8 @@ definition ordered_ring.to_ordered_semiring [instance] [coercion] [reducible] [s
   mul_le_mul_of_nonneg_left  := @ordered_ring.mul_le_mul_of_nonneg_left A s,
   mul_le_mul_of_nonneg_right := @ordered_ring.mul_le_mul_of_nonneg_right A s,
   mul_lt_mul_of_pos_left     := @ordered_ring.mul_lt_mul_of_pos_left A s,
-  mul_lt_mul_of_pos_right    := @ordered_ring.mul_lt_mul_of_pos_right A s ⦄
+  mul_lt_mul_of_pos_right    := @ordered_ring.mul_lt_mul_of_pos_right A s,
+  lt_of_add_lt_add_left      := @lt_of_add_lt_add_left A s⦄
 
 section
   variable [s : ordered_ring A]
@@ -262,7 +263,8 @@ end
 
 -- TODO: we can eliminate mul_pos_of_pos, but now it is not worth the effort to redeclare the
 -- class instance
-structure linear_ordered_ring [class] (A : Type) extends ordered_ring A, linear_strong_order_pair A
+structure linear_ordered_ring [class] (A : Type) extends ordered_ring A, linear_strong_order_pair A :=
+  (zero_lt_one : lt zero one)
 
 -- print fields linear_ordered_semiring
 
@@ -279,7 +281,8 @@ definition linear_ordered_ring.to_linear_ordered_semiring [instance] [coercion] 
   mul_le_mul_of_nonneg_right := @mul_le_mul_of_nonneg_right A s,
   mul_lt_mul_of_pos_left     := @mul_lt_mul_of_pos_left A s,
   mul_lt_mul_of_pos_right    := @mul_lt_mul_of_pos_right A s,
-  le_total                   := linear_ordered_ring.le_total ⦄
+  le_total                   := linear_ordered_ring.le_total,
+  lt_of_add_lt_add_left      := @lt_of_add_lt_add_left A s ⦄
 
 structure linear_ordered_comm_ring [class] (A : Type) extends linear_ordered_ring A, comm_monoid A
 
@@ -336,7 +339,7 @@ section
     (assume H : a ≤ 0, mul_nonneg_of_nonpos_of_nonpos H H)
 
   theorem zero_le_one : 0 ≤ (1:A) := one_mul 1 ▸ mul_self_nonneg 1
-  theorem zero_lt_one : 0 < (1:A) := lt_of_le_of_ne zero_le_one zero_ne_one
+  theorem zero_lt_one : 0 < (1:A) := linear_ordered_ring.zero_lt_one A 
 
   theorem pos_and_pos_or_neg_and_neg_of_mul_pos {a b : A} (Hab : a * b > 0) :
     (a > 0 ∧ b > 0) ∨ (a < 0 ∧ b < 0) :=

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -224,8 +224,7 @@ lt.intro
         ... = 0 + nat.succ (nat.succ n * m + n)        : zero_add))
 
 
-theorem zero_lt_one : (0 : ℤ) < 1 :=
-  by rewrite [↑lt, zero_add]; apply le.refl
+theorem zero_lt_one : (0 : ℤ) < 1 := trivial
 
 theorem not_le_of_gt {a b : ℤ} (H : a < b) : ¬ b ≤ a :=
   assume Hba,

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -34,6 +34,7 @@ int.cases_on a (take n H, exists.intro n rfl) (take n' H, false.elim H)
 private theorem nonneg_or_nonneg_neg (a : ℤ) : nonneg a ∨ nonneg (-a) :=
 int.cases_on a (take n, or.inl trivial) (take n, or.inr trivial)
 
+
 theorem le.intro {a b : ℤ} {n : ℕ} (H : a + n = b) : a ≤ b :=
 have H1 : b - a = n, from (eq_add_neg_of_add_eq (!add.comm ▸ H))⁻¹,
 have H2 : nonneg n, from true.intro,
@@ -189,6 +190,12 @@ have H2 : c + a + n = c + b, from
       ... = c + b : {Hn},
 le.intro H2
 
+theorem add_lt_add_left {a b : ℤ} (H : a < b) (c : ℤ) : c + a < c + b :=
+let H' := le_of_lt H in 
+(iff.mp' (lt_iff_le_and_ne _ _)) (and.intro (add_le_add_left H' _)
+                                  (take Heq, let Heq' := add_left_cancel Heq in
+                                   !lt.irrefl (Heq' ▸ H)))
+
 theorem mul_nonneg {a b : ℤ} (Ha : 0 ≤ a) (Hb : 0 ≤ b) : 0 ≤ a * b :=
 obtain (n : ℕ) (Hn : 0 + n = a), from le.elim Ha,
 obtain (m : ℕ) (Hm : 0 + m = b), from le.elim Hb,
@@ -216,6 +223,27 @@ lt.intro
         ... = of_nat (nat.succ (nat.succ n * m + n))   : nat.add_succ
         ... = 0 + nat.succ (nat.succ n * m + n)        : zero_add))
 
+
+theorem zero_lt_one : (0 : ℤ) < 1 :=
+  by rewrite [↑lt, zero_add]; apply le.refl
+
+theorem not_le_of_gt {a b : ℤ} (H : a < b) : ¬ b ≤ a :=
+  assume Hba,
+  let Heq := le.antisymm (le_of_lt H) Hba in 
+  !lt.irrefl (Heq ▸ H) 
+
+theorem lt_of_lt_of_le {a b c : ℤ} (Hab : a < b) (Hbc : b ≤ c) : a < c :=
+  let Hab' := le_of_lt Hab in
+  let Hac := le.trans Hab' Hbc in
+  (iff.mp' !lt_iff_le_and_ne) (and.intro Hac
+    (assume Heq, not_le_of_gt (Heq ▸ Hab) Hbc))
+
+theorem lt_of_le_of_lt  {a b c : ℤ} (Hab : a ≤ b) (Hbc : b < c) : a < c :=
+  let Hbc' := le_of_lt Hbc in
+  let Hac := le.trans Hab Hbc' in
+  (iff.mp' !lt_iff_le_and_ne) (and.intro Hac
+    (assume Heq, not_le_of_gt (Heq⁻¹ ▸ Hbc) Hab))
+
 section migrate_algebra
   open [classes] algebra
 
@@ -227,13 +255,18 @@ section migrate_algebra
     le_trans         := @le.trans,
     le_antisymm      := @le.antisymm,
     lt               := lt,
-    lt_iff_le_and_ne := lt_iff_le_and_ne,
+    le_of_lt         := @le_of_lt,
+    lt_irrefl        := lt.irrefl,
+    lt_of_lt_of_le   := @lt_of_lt_of_le,
+    lt_of_le_of_lt   := @lt_of_le_of_lt,
     add_le_add_left  := @add_le_add_left,
     mul_nonneg       := @mul_nonneg,
     mul_pos          := @mul_pos,
     le_iff_lt_or_eq  := le_iff_lt_or_eq,
     le_total         := le.total,
-    zero_ne_one      := zero_ne_one⦄
+    zero_ne_one      := zero_ne_one,
+    zero_lt_one      := zero_lt_one,
+    add_lt_add_left  := @add_lt_add_left⦄
 
   protected definition decidable_linear_ordered_comm_ring [reducible] :
     algebra.decidable_linear_ordered_comm_ring int :=

--- a/library/data/nat/order.lean
+++ b/library/data/nat/order.lean
@@ -90,6 +90,10 @@ le.intro (add.cancel_left
       k + (n + l)  = k + n + l : add.assoc
                ... = k + m     : Hl))
 
+theorem lt_of_add_lt_add_left {k n m : ℕ} (H : k + n < k + m) : n < m :=
+let H' := le_of_lt H in
+lt_of_le_and_ne (le_of_add_le_add_left H') (assume Heq, !lt.irrefl (Heq ▸ H))
+
 theorem add_lt_add_left {n m : ℕ} (H : n < m) (k : ℕ) : k + n < k + m :=
 lt_of_succ_le (!add_succ ▸ add_le_add_left (succ_le_of_lt H) k)
 
@@ -157,7 +161,12 @@ section migrate_algebra
     le_antisymm                := @le.antisymm,
     le_total                   := @le.total,
     le_iff_lt_or_eq            := @le_iff_lt_or_eq,
-    lt_iff_le_and_ne           := lt_iff_le_and_ne,
+    le_of_lt                   := @le_of_lt,
+    lt_irrefl                  := @lt.irrefl,
+    lt_of_lt_of_le             := @lt_of_lt_of_le,
+    lt_of_le_of_lt             := @lt_of_le_of_lt,
+    lt_of_add_lt_add_left      := @lt_of_add_lt_add_left,
+    add_lt_add_left            := @add_lt_add_left,
     add_le_add_left            := @add_le_add_left,
     le_of_add_le_add_left      := @le_of_add_le_add_left,
     zero_ne_one                := ne.symm (succ_ne_zero zero),

--- a/library/data/rat/order.lean
+++ b/library/data/rat/order.lean
@@ -10,7 +10,7 @@ import data.int algebra.ordered_field .basic
 open quot eq.ops
 
 /- the ordering on representations -/
-
+ 
 namespace prerat
 section int_notation
 open int
@@ -66,7 +66,7 @@ assume H', ne_of_gt H (num_eq_zero_of_equiv_zero H')
 theorem pos_of_nonneg_of_ne_zero (H1 : nonneg a) (H2 : ¬ a ≡ zero) : pos a :=
 have H3 : num a ≠ 0,
   from assume H' : num a = 0, H2 (equiv_zero_of_num_eq_zero H'),
-lt_of_le_of_ne H1 (ne.symm H3)
+  lt_of_le_of_ne H1 (ne.symm H3)
 
 theorem nonneg_mul (H1 : nonneg a) (H2 : nonneg b) : nonneg (mul a b) :=
 mul_nonneg H1 H2
@@ -204,6 +204,9 @@ or.elim (nonneg_total (b - a))
   (assume H, or.inl H)
   (assume H, or.inr (!neg_sub ▸ H))
 
+theorem le.by_cases {P : Prop} (a b : ℚ) (H : a ≤ b → P) (H2 : b ≤ a → P) : P := 
+  or.elim (!rat.le.total) H H2
+
 theorem lt_iff_le_and_ne (a b : ℚ) : a < b ↔ a ≤ b ∧ a ≠ b :=
 iff.intro
   (assume H : a < b,
@@ -242,6 +245,42 @@ have H : pos (a * b), from pos_mul (!sub_zero ▸ H1) (!sub_zero ▸ H2),
 definition decidable_lt [instance] : decidable_rel rat.lt :=
 take a b, decidable_pos (b - a)
 
+theorem le_of_lt  (H : a < b) : a ≤ b := iff.mp' !le_iff_lt_or_eq (or.inl H)
+
+theorem lt_irrefl (a : ℚ) : ¬ a < a := 
+  take Ha,
+  let Hand := (iff.mp !lt_iff_le_and_ne) Ha in 
+  (and.right Hand) rfl
+
+theorem not_le_of_gt (H : a < b) : ¬ b ≤ a :=
+  assume Hba,
+  let Heq := le.antisymm (le_of_lt H) Hba in 
+  !lt_irrefl (Heq ▸ H) 
+
+theorem lt_of_lt_of_le  (Hab : a < b) (Hbc : b ≤ c) : a < c := 
+  let Hab' := le_of_lt Hab in
+  let Hac := le.trans Hab' Hbc in
+  (iff.mp' !lt_iff_le_and_ne) (and.intro Hac
+    (assume Heq, not_le_of_gt (Heq ▸ Hab) Hbc))
+
+theorem lt_of_le_of_lt  (Hab : a ≤ b) (Hbc : b < c) : a < c :=
+  let Hbc' := le_of_lt Hbc in
+  let Hac := le.trans Hab Hbc' in
+  (iff.mp' !lt_iff_le_and_ne) (and.intro Hac
+    (assume Heq, not_le_of_gt (Heq⁻¹ ▸ Hbc) Hab))
+
+theorem zero_lt_one : (0 : ℚ) < 1 := trivial
+--  begin
+--    rewrite [↑lt, sub_zero],
+--    apply sorry
+--  end
+
+theorem add_lt_add_left (H : a < b) (c : ℚ) : c + a < c + b := 
+let H' := le_of_lt H in 
+(iff.mp' (lt_iff_le_and_ne _ _)) (and.intro (add_le_add_left H' _)
+                                  (take Heq, let Heq' := add_left_cancel Heq in
+                                   !lt_irrefl (Heq' ▸ H)))
+
 section migrate_algebra
   open [classes] algebra
 
@@ -253,12 +292,17 @@ section migrate_algebra
     le_trans         := @le.trans,
     le_antisymm      := @le.antisymm,
     le_total         := @le.total,
-    lt_iff_le_and_ne := @lt_iff_le_and_ne,
+    le_of_lt                   := @le_of_lt, --sorry,
+    lt_irrefl                  := lt_irrefl,
+    lt_of_lt_of_le             := @lt_of_lt_of_le,
+    lt_of_le_of_lt             := @lt_of_le_of_lt,
     le_iff_lt_or_eq  := @le_iff_lt_or_eq,
     add_le_add_left  := @add_le_add_left,
     mul_nonneg       := @mul_nonneg,
     mul_pos          := @mul_pos,
-    decidable_lt     := @decidable_lt⦄
+    decidable_lt     := @decidable_lt,
+    zero_lt_one      := zero_lt_one,
+    add_lt_add_left  := @add_lt_add_left⦄
 
   local attribute rat.discrete_field [instance]
   local attribute rat.discrete_linear_ordered_field [instance]

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -105,6 +105,8 @@ theorem inv_pos (n : ℕ+) : n⁻¹ > 0 := div_pos_of_pos !rat_of_pnat_is_pos
 
 theorem inv_le_one (n : ℕ+) : n⁻¹ ≤ (1 : ℚ) := sorry
 
+theorem inv_lt_one_of_gt {n : ℕ+} (H : n~ > 1) : n⁻¹ < (1 : ℚ) := sorry
+
 theorem pone_inv : pone⁻¹ = 1 := rfl -- ? Why is this rfl?
 
 theorem add_invs_nonneg (m n : ℕ+) : 0 ≤ m⁻¹ + n⁻¹ :=
@@ -114,9 +116,13 @@ theorem add_invs_nonneg (m n : ℕ+) : 0 ≤ m⁻¹ + n⁻¹ :=
     repeat apply inv_pos,
   end
 
-theorem half_shrink (n : ℕ+) : (2 * n)⁻¹ ≤ n⁻¹ := sorry
+theorem half_shrink_strong (n : ℕ+) : (2 * n)⁻¹ < n⁻¹ := sorry
+
+theorem half_shrink (n : ℕ+) : (2 * n)⁻¹ ≤ n⁻¹ := le_of_lt !half_shrink_strong
 
 theorem inv_ge_of_le {p q : ℕ+} (H : p ≤ q) : q⁻¹ ≤ p⁻¹ := sorry
+
+theorem ge_of_inv_le {p q : ℕ+} (H : p⁻¹ ≤ q⁻¹) : q < p := sorry
 
 theorem padd_halves (p : ℕ+) : (2 * p)⁻¹ + (2 * p)⁻¹ = p⁻¹ := sorry
 
@@ -145,6 +151,12 @@ theorem s_mul_assoc_lemma_3 (a b n : ℕ+) (p : ℚ) :
 
 theorem pnat.mul_le_mul_left (p q : ℕ+) : q ≤ p * q := sorry
 
+theorem one_lt_two : pone < 2 := sorry
+
+theorem pnat.lt_of_not_le {p q : ℕ+} (H : ¬ p ≤ q) : q < p := sorry
+
+theorem pnat.inv_cancel (p : ℕ+) : pnat.to_rat p * p⁻¹ = (1 : ℚ) := sorry
+
 -------------------------------------
 -- theorems to add to (ordered) field and/or rat
 
@@ -170,10 +182,17 @@ theorem add_sub_comm (a b c d : ℚ) : a + b - (c + d) = (a - c) + (b - d) := so
 
 theorem div_helper (a b : ℚ) : (1 / (a * b)) * a = 1 / b := sorry
 
-theorem abs_add_three (a b c : ℚ) : abs (a + b + c) ≤ abs a + abs b + abs c := sorry
+theorem abs_add_three (a b c : ℚ) : abs (a + b + c) ≤ abs a + abs b + abs c := 
+  begin
+    apply rat.le.trans,
+    apply abs_add_le_abs_add_abs,
+    apply rat.add_le_add_right,
+    apply abs_add_le_abs_add_abs
+  end
 
 theorem add_le_add_three (a b c d e f : ℚ) (H1 : a ≤ d) (H2 : b ≤ e) (H3 : c ≤ f) :
-        a + b + c ≤ d + e + f := sorry
+        a + b + c ≤ d + e + f :=
+  by repeat apply rat.add_le_add; repeat assumption
 
 theorem distrib_three_right (a b c d : ℚ) : (a + b + c) * d = a * d + b * d + c * d := sorry
 
@@ -182,6 +201,9 @@ theorem mul_le_mul_of_mul_div_le (a b c d : ℚ) : a * (b / c) ≤ d → b * a �
 definition pceil (a : ℚ) : ℕ+ := pnat.pos (ceil a + 1) (sorry)
 
 theorem pceil_helper {a : ℚ} {n : ℕ+} (H : pceil a ≤ n) : n⁻¹ ≤ 1 / a := sorry
+
+theorem inv_pceil_div (a b : ℚ) (Ha : a > 0) (Hb : b > 0) : (pceil (a / b))⁻¹ ≤ b / a := sorry
+
 
 theorem s_mul_assoc_lemma_4 {n : ℕ+} {ε q : ℚ} (Hε : ε > 0) (Hq : q > 0) (H : n ≥ pceil (q / ε)) :
         q * n⁻¹ ≤ ε :=
@@ -193,7 +215,6 @@ theorem s_mul_assoc_lemma_4 {n : ℕ+} {ε q : ℚ} (Hε : ε > 0) (Hq : q > 0) 
     assumption
   end
 
-theorem of_nat_add (a b : ℕ) : of_nat (a + b) = of_nat a + of_nat b := sorry -- did Jeremy add this?
 -------------------------------------
 -- small helper lemmas
 
@@ -210,6 +231,10 @@ theorem squeeze {a b : ℚ} (H : ∀ j : ℕ+, a ≤ b + j⁻¹ + j⁻¹ + j⁻�
     have Ha : a > b + j⁻¹ + j⁻¹ + j⁻¹, from lt.trans Hbj Hc,
     exact absurd !H (not_le_of_gt Ha)
   end
+
+
+theorem squeeze_2 {a b : ℚ} (H : ∀ ε : ℚ, ε > 0 → a ≥ b - ε) : a ≥ b := sorry
+
 
 theorem rewrite_helper (a b c d : ℚ) : a * b  - c * d = a * (b - d) + (a - c) * d :=
   sorry
@@ -690,7 +715,23 @@ theorem s_add_zero (s : seq) (H : regular s) : sadd s zero ≡ s :=
       apply add_invs_nonneg
     end
 
-theorem add_well_defined {s t u v : seq} (Hs : regular s) (Ht : regular t) (Hu : regular u)
+theorem neg_s_cancel (s : seq) (H : regular s) : sadd s (sneg s) ≡ zero :=
+  begin
+    apply equiv.trans,
+    rotate 3,
+    apply s_add_comm,
+    apply s_neg_cancel s H,
+    apply reg_add_reg,
+    apply H,
+    apply reg_neg_reg,
+    apply H,
+    apply reg_add_reg,
+    apply reg_neg_reg,
+    repeat apply H,
+    apply zero_is_reg
+  end
+
+theorem add_well_defined {s t u v : seq} (Hs : regular s) (Ht : regular t) (Hu : regular u) 
         (Hv : regular v) (Esu : s ≡ u) (Etv : t ≡ v) : sadd s t ≡ sadd u v :=
   begin
     rewrite [↑sadd, ↑equiv at *],
@@ -1020,6 +1061,20 @@ theorem s_mul_one {s : seq} (H : regular s) : smul s one ≡ s :=
     apply H
   end
 
+theorem zero_nequiv_one : ¬ zero ≡ one :=
+  begin
+    intro Hz,
+    rewrite [↑equiv at Hz, ↑zero at Hz, ↑one at Hz],
+    let H := Hz (2 * 2),
+    rewrite [rat.zero_sub at H, abs_neg at H, padd_halves at H],
+    have H' : pone⁻¹ ≤ 2⁻¹, from calc
+      pone⁻¹ = 1 : by rewrite -pone_inv
+      ... = abs 1 : abs_of_pos zero_lt_one
+      ... ≤ 2⁻¹ : H,
+    let H'' := ge_of_inv_le H', 
+    apply absurd (one_lt_two) (pnat.not_lt_of_le (pnat.le_of_lt H''))
+  end
+
 ---------------------------------------------
 -- create the type of regular sequences and lift theorems
 
@@ -1100,6 +1155,9 @@ theorem r_one_mul (s : reg_seq) : requiv (r_one * s) s :=
 theorem r_distrib (s t u : reg_seq) : requiv (s * (t + u)) (s * t + s * u) :=
   s_distrib (reg_seq.is_reg s) (reg_seq.is_reg t) (reg_seq.is_reg u)
 
+theorem r_zero_nequiv_one : ¬ requiv r_zero r_one :=
+  zero_nequiv_one 
+
 ----------------------------------------------
 -- take quotients to get ℝ and show it's a comm ring
 
@@ -1161,6 +1219,10 @@ theorem distrib (x y z : ℝ) : x * (y + z) = x * y + x * z :=
 
 theorem distrib_l (x y z : ℝ) : (x + y) * z = x * z + y * z :=
   by rewrite [mul_comm, distrib, {x * _}mul_comm, {y * _}mul_comm] -- this shouldn't be necessary
+
+theorem zero_ne_one : ¬ zero = one := 
+  take H : zero = one,
+  absurd (quot.exact H) (r_zero_nequiv_one)
 
 definition comm_ring [reducible] : algebra.comm_ring ℝ :=
   begin

--- a/library/data/real/default.lean
+++ b/library/data/real/default.lean
@@ -3,4 +3,4 @@ Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Robert Y. Lewis
 -/
-import .basic
+import .basic .order


### PR DESCRIPTION
The algebraic hierarchy before became nonconstructive very early: the reals did not even form an "order_pair" under the old definitions. I've modified things so that the reals form an ordered ring (so far), and updated the proofs that nat, int, and rat form the appropriate structures.
