### PR TITLE
add theorems from Haitao and more

### DIFF
--- a/library/algebra/function.lean
+++ b/library/algebra/function.lean
@@ -37,7 +37,7 @@ definition dcompose [reducible] [unfold-f] {B : A → Type} {C : Π {x : A}, B x
   (f : Π {x : A} (y : B x), C y) (g : Πx, B x) : Πx, C (g x) :=
 λx, f (g x)
 
-definition flip [reducible] [unfold-f] {C : A → B → Type} (f : Πx y, C x y) : Πy x, C x y :=
+definition swap [reducible] [unfold-f] {C : A → B → Type} (f : Πx y, C x y) : Πy x, C x y :=
 λy x, f x y
 
 definition app [reducible] {B : A → Type} (f : Πx, B x) (x : A) : B x :=

--- a/library/algebra/group.lean
+++ b/library/algebra/group.lean
@@ -257,11 +257,19 @@ section group
   theorem mul_right_cancel {a b c : A} (H : a * b = c * b) : a = c :=
   by rewrite [-mul_inv_cancel_right a b, H, mul_inv_cancel_right]
 
-  definition group.to_left_cancel_semigroup [instance] [coercion] [reducible] : left_cancel_semigroup A :=
+  theorem mul_eq_one_of_mul_eq_one {a b : A} (H : b * a = 1) : a * b = 1 :=
+  by rewrite [-inv_eq_of_mul_eq_one H, mul.left_inv]
+
+  theorem mul_eq_one_iff_mul_eq_one (a b : A) : a * b = 1 ↔ b * a = 1 :=
+  iff.intro !mul_eq_one_of_mul_eq_one !mul_eq_one_of_mul_eq_one
+
+  definition group.to_left_cancel_semigroup [instance] [coercion] [reducible] :
+    left_cancel_semigroup A :=
   ⦃ left_cancel_semigroup, s,
     mul_left_cancel := @mul_left_cancel A s ⦄
 
-  definition group.to_right_cancel_semigroup [instance] [coercion] [reducible] : right_cancel_semigroup A :=
+  definition group.to_right_cancel_semigroup [instance] [coercion] [reducible] :
+    right_cancel_semigroup A :=
   ⦃ right_cancel_semigroup, s,
     mul_right_cancel := @mul_right_cancel A s ⦄
 

--- a/library/data/finset/bigops.lean
+++ b/library/data/finset/bigops.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2015 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Jeremy Avigad
+Author: Jeremy Avigad, Haitao Zhang
 
 Finite unions and intersections on finsets.
 
@@ -64,7 +64,7 @@ section deceqA
   include deceqA
   theorem Union_insert_of_mem (f : A → finset B) {a : A} {s : finset A} (H : a ∈ s) :
     Union (insert a s) f = Union s f := algebra.Prod_insert_of_mem f H
-  theorem Union_insert_of_not_mem (f : A → finset B) {a : A} {s : finset A} (H : a ∉ s) :
+  private theorem Union_insert_of_not_mem (f : A → finset B) {a : A} {s : finset A} (H : a ∉ s) :
     Union (insert a s) f = f a ∪ Union s f := algebra.Prod_insert_of_not_mem f H
   theorem Union_union (f : A → finset B) {s₁ s₂ : finset A} (disj : s₁ ∩ s₂ = ∅) :
     Union (s₁ ∪ s₂) f = Union s₁ f ∪ Union s₂ f := algebra.Prod_union f disj
@@ -92,6 +92,31 @@ section deceqA
   theorem mem_Union_eq (s : finset A) (f : A → finset B) (b : B) :
     b ∈ (⋃ x ∈ s, f x) = (∃ x, x ∈ s ∧ b ∈ f x ) :=
   propext !mem_Union_iff
+
+  theorem Union_insert (f : A → finset B) {a : A} {s : finset A} :
+    Union (insert a s) f = f a ∪ Union s f :=
+  decidable.by_cases
+    (assume Pin : a ∈ s,
+      begin
+        rewrite [Union_insert_of_mem f Pin],
+        apply ext,
+        intro x,
+        apply iff.intro,
+          exact mem_union_r,
+          rewrite [mem_union_eq],
+          intro Por,
+          exact or.elim Por
+            (assume Pl, begin
+              rewrite mem_Union_eq, exact (exists.intro a (and.intro Pin Pl)) end)
+            (assume Pr, Pr)
+      end)
+    (assume H : a ∉ s, !Union_insert_of_not_mem H)
+
+  lemma image_eq_Union_index_image (s : finset A) (f : A → finset B) :
+    Union s f = Union (image f s) function.id :=
+      finset.induction_on s
+        (by rewrite Union_empty)
+        (take s1 a Pa IH, by rewrite [image_insert, *Union_insert, IH])
 end deceqA
 
 end union

--- a/library/data/finset/card.lean
+++ b/library/data/finset/card.lean
@@ -118,7 +118,7 @@ finset.induction_on s
         f a ∩ (⋃ (x : A) ∈ s', f x) = (⋃ (x : A) ∈ s', f a ∩ f x)  : inter_Union
                                 ... = (⋃ (x : A) ∈ s', ∅)          : Union_ext H7
                                 ... = ∅                            : Union_empty',
-    by rewrite [Union_insert_of_not_mem _ H, Sum_insert_of_not_mem _ H,
+    by rewrite [Union_insert, Sum_insert_of_not_mem _ H,
                 card_union_of_disjoint H8, H6])
 end deceqB
 

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -23,6 +23,10 @@ theorem map_id : ∀ l : list A, map id l = l
 | []      := rfl
 | (x::xs) := begin rewrite [map_cons, map_id] end
 
+theorem map_id' {f : A → A} (H : ∀x, f x = x) : ∀ l : list A, map f l = l
+| []      := rfl
+| (x::xs) := begin rewrite [map_cons, H, map_id'] end
+
 theorem map_map (g : B → C) (f : A → B) : ∀ l, map g (map f l) = map (g ∘ f) l
 | []       := rfl
 | (a :: l) :=

--- a/library/data/list/set.lean
+++ b/library/data/list/set.lean
@@ -283,12 +283,12 @@ theorem nodup_map {f : A → B} (inj : has_left_inverse f) : ∀ {l : list A}, n
   assert ndmfxs : nodup (map f xs), from nodup_map ndxs,
   assert nfxinm : f x ∉ map f xs,   from
     λ ab : f x ∈ map f xs,
-      obtain (finv : B → A) (isinv : finv ∘ f = id), from inj,
+      obtain (finv : B → A) (isinv : left_inverse finv f), from inj,
       assert finvfxin : finv (f x) ∈ map finv (map f xs), from mem_map finv ab,
       assert xinxs : x ∈ xs,
         begin
-          rewrite [map_map at finvfxin, isinv at finvfxin, left_inv_eq isinv at finvfxin],
-          rewrite [map_id at finvfxin],
+          rewrite [map_map at finvfxin, isinv at finvfxin],
+          krewrite [map_id' isinv at finvfxin],
           exact finvfxin
         end,
       absurd xinxs nxinxs,

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -24,6 +24,11 @@ funext (take x, propext (H x))
 definition subset (a b : set X) := ∀⦃x⦄, x ∈ a → x ∈ b
 infix `⊆` := subset
 
+theorem subset.refl (a : set X) : a ⊆ a := take x, assume H, H
+
+theorem subset.trans (a b c : set X) (subab : a ⊆ b) (subbc : b ⊆ c) : a ⊆ c :=
+take x, assume ax, subbc (subab ax)
+
 /- bounded quantification -/
 
 abbreviation bounded_forall (a : set X) (P : X → Prop) := ∀⦃x⦄, x ∈ a → P x

--- a/library/data/set/map.lean
+++ b/library/data/set/map.lean
@@ -37,7 +37,8 @@ take x, assume Ha : x ∈ a, eq.trans (H₁ Ha) (H₂ Ha)
 
 protected theorem equiv.is_equivalence {X Y : Type} (a : set X) (b : set Y) :
   equivalence (@map.equiv X Y a b) :=
-mk_equivalence (@map.equiv X Y a b) (@equiv.refl X Y a b) (@equiv.symm X Y a b) (@equiv.trans X Y a b)
+mk_equivalence (@map.equiv X Y a b) (@equiv.refl X Y a b) (@equiv.symm X Y a b)
+    (@equiv.trans X Y a b)
 
 /- compose -/
 
@@ -73,7 +74,8 @@ theorem surjective_of_equiv {f1 f2 : map a b} (H1 : f1 ~ f2) (H2 : map.surjectiv
   map.surjective f2 :=
 surj_on_of_eq_on H1 H2
 
-theorem surjective_compose {g : map b c} {f : map a b} (Hg : map.surjective g) (Hf: map.surjective f) :
+theorem surjective_compose {g : map b c} {f : map a b} (Hg : map.surjective g)
+    (Hf: map.surjective f) :
   map.surjective (g ∘ f) :=
 surj_on_compose Hg Hf
 
@@ -109,7 +111,8 @@ theorem injective_of_left_inverse {g : map b a} {f : map a b} (H : map.left_inve
 inj_on_of_left_inv_on H
 
 theorem left_inverse_compose {f' : map b a} {g' : map c b} {g : map b c} {f : map a b}
-    (Hf : map.left_inverse f' f) (Hg : map.left_inverse g' g) : map.left_inverse (f' ∘ g') (g ∘ f) :=
+    (Hf : map.left_inverse f' f) (Hg : map.left_inverse g' g) :
+  map.left_inverse (f' ∘ g') (g ∘ f) :=
 left_inv_on_compose (mapsto f) Hf Hg
 
 /- right inverse -/
@@ -125,12 +128,23 @@ theorem right_inverse_of_equiv_right {g : map b a} {f1 f2 : map a b} (eqf : f1 ~
   (H : map.right_inverse g f1) : map.right_inverse g f2 :=
 map.left_inverse_of_equiv_left eqf H
 
+theorem right_inverse_of_injective_of_left_inverse {f : map a b} {g : map b a}
+    (injf : map.injective f) (lfg : map.left_inverse f g) :
+  map.right_inverse f g :=
+right_inv_on_of_inj_on_of_left_inv_on (mapsto f) (mapsto g) injf lfg
+
 theorem surjective_of_right_inverse {g : map b a} {f : map a b} (H : map.right_inverse g f) :
   map.surjective f :=
 surj_on_of_right_inv_on (mapsto g) H
 
+theorem left_inverse_of_surjective_of_right_inverse {f : map a b} {g : map b a}
+    (surjf : map.surjective f) (rfg : map.right_inverse f g) :
+  map.left_inverse f g :=
+left_inv_on_of_surj_on_right_inv_on surjf rfg
+
 theorem right_inverse_compose {f' : map b a} {g' : map c b} {g : map b c} {f : map a b}
-    (Hf : map.right_inverse f' f) (Hg : map.right_inverse g' g) : map.right_inverse (f' ∘ g') (g ∘ f) :=
+    (Hf : map.right_inverse f' f) (Hg : map.right_inverse g' g) :
+  map.right_inverse (f' ∘ g') (g ∘ f) :=
 map.left_inverse_compose Hg Hf
 
 theorem equiv_of_map.left_inverse_of_right_inverse {g1 g2 : map b a} {f : map a b}
@@ -143,7 +157,8 @@ eq_on_of_left_inv_of_right_inv (mapsto g2) H1 H2
 protected definition is_inverse (g : map b a) (f : map a b) : Prop :=
 map.left_inverse g f ∧ map.right_inverse g f
 
-theorem bijective_of_is_inverse {g : map b a} {f : map a b} (H : map.is_inverse g f) : map.bijective f :=
+theorem bijective_of_is_inverse {g : map b a} {f : map a b} (H : map.is_inverse g f) :
+  map.bijective f :=
 and.intro
   (injective_of_left_inverse (and.left H))
   (surjective_of_right_inverse (and.right H))

--- a/library/logic/axioms/examples/leftinv_of_inj.lean
+++ b/library/logic/axioms/examples/leftinv_of_inj.lean
@@ -19,13 +19,13 @@ theorem has_left_inverse_of_injective {A B : Type} {f : A → B} : nonempty A �
 assume h : nonempty A,
 assume inj  : ∀ a₁ a₂, f a₁ = f a₂ → a₁ = a₂,
 let  finv : B → A := mk_left_inv f in
-have linv : finv ∘ f = id, from
-  funext (λ a,
+have linv : left_inverse finv f, from
+  λ a,
     assert ex : ∃ a₁ : A, f a₁ = f a, from exists.intro a rfl,
     assert h₁ : f (some ex) = f a,    from !some_spec,
     begin
       esimp [mk_left_inv, compose, id],
       rewrite [dif_pos ex],
       exact (!inj h₁)
-    end),
+    end,
 exists.intro finv linv

--- a/library/logic/cast.lean
+++ b/library/logic/cast.lean
@@ -121,6 +121,12 @@ section
   H₂ (pi_eq H)
 end
 
+-- function extensionality wrt heterogeneous equality
+theorem hfunext {A : Type} {B : A → Type} {B' : A → Type} {f : Π x, B x} {g : Π x, B' x}
+                (H : ∀ a, f a == g a) : f == g :=
+let HH : B = B' := (funext (λ x, heq.type_eq (H x))) in
+  cast_to_heq (funext (λ a, heq.to_eq (heq.trans (cast_app HH f a) (H a))))
+
 section
   variables {A : Type} {B : A → Type} {C : Πa, B a → Type} {D : Πa b, C a b → Type}
             {E : Πa b c, D a b c → Type} {F : Type}

--- a/library/logic/connectives.lean
+++ b/library/logic/connectives.lean
@@ -114,15 +114,15 @@ propext
   (iff.intro (λ Pl a b, Pl (and.intro a b))
   (λ Pr Pand, Pr (and.left Pand) (and.right Pand)))
 
-theorem and_eq_right {a b : Prop} (Ha : a) : (a ∧ b) = b :=
-propext (iff.intro
+theorem and_iff_right {a b : Prop} (Ha : a) : (a ∧ b) ↔ b :=
+iff.intro
   (assume Hab, and.elim_right Hab)
-  (assume Hb, and.intro Ha Hb))
+  (assume Hb, and.intro Ha Hb)
 
-theorem and_eq_left {a b : Prop} (Hb : b) : (a ∧ b) = a :=
-propext (iff.intro
+theorem and_iff_left {a b : Prop} (Hb : b) : (a ∧ b) ↔ a :=
+iff.intro
   (assume Hab, and.elim_left Hab)
-  (assume Ha, and.intro Ha Hb))
+  (assume Ha, and.intro Ha Hb)
 
 /- or -/
 

--- a/library/logic/connectives.lean
+++ b/library/logic/connectives.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2014 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Jeremy Avigad, Leonardo de Moura
+Authors: Jeremy Avigad, Leonardo de Moura, Haitao Zhang
 
 The propositional connectives. See also init.datatypes and init.logic.
 -/
@@ -40,6 +40,9 @@ theorem not.intro (H : a → false) : ¬a := H
 
 theorem not_not_intro (Ha : a) : ¬¬a :=
 assume Hna : ¬a, absurd Ha Hna
+
+theorem not_imp_not_of_imp {a b : Prop} : (a → b) → ¬b → ¬a :=
+assume Pimp Pnb Pa, absurd (Pimp Pa) Pnb
 
 theorem not_not_of_not_implies (H : ¬(a → b)) : ¬¬a :=
 assume Hna : ¬a, absurd (assume Ha : a, absurd Ha Hna) H
@@ -105,6 +108,21 @@ iff.intro (assume H, and.left H) (assume H, false.elim H)
 
 theorem and_self (a : Prop) : a ∧ a ↔ a :=
 iff.intro (assume H, and.left H) (assume H, and.intro H H)
+
+theorem and_imp_eq (a b c : Prop) : (a ∧ b → c) = (a → b → c) :=
+propext
+  (iff.intro (λ Pl a b, Pl (and.intro a b))
+  (λ Pr Pand, Pr (and.left Pand) (and.right Pand)))
+
+theorem and_eq_right {a b : Prop} (Ha : a) : (a ∧ b) = b :=
+propext (iff.intro
+  (assume Hab, and.elim_right Hab)
+  (assume Hb, and.intro Ha Hb))
+
+theorem and_eq_left {a b : Prop} (Hb : b) : (a ∧ b) = a :=
+propext (iff.intro
+  (assume Hab, and.elim_left Hab)
+  (assume Ha, and.intro Ha Hb))
 
 /- or -/
 

--- a/library/logic/identities.lean
+++ b/library/logic/identities.lean
@@ -94,19 +94,30 @@ assume H, by_contradiction (assume Hna : ¬a,
   have Hnna : ¬¬a, from not_not_of_not_implies (mt H Hna),
   absurd (not_not_elim Hnna) Hna)
 
-theorem forall_not_of_not_exists {A : Type} {P : A → Prop} [D : ∀x, decidable (P x)]
-    (H : ¬∃x, P x) : ∀x, ¬P x :=
-take x, or.elim (em (P x))
-  (assume Hp : P x,   absurd (exists.intro x Hp) H)
-  (assume Hn : ¬P x, Hn)
+theorem forall_not_of_not_exists {A : Type} {p : A → Prop} [D : ∀x, decidable (p x)]
+  (H : ¬∃x, p x) : ∀x, ¬p x :=
+take x, or.elim (em (p x))
+  (assume Hp : p x,   absurd (exists.intro x Hp) H)
+  (assume Hnp : ¬p x, Hnp)
 
-theorem exists_not_of_not_forall {A : Type} {P : A → Prop} [D : ∀x, decidable (P x)]
-    [D' : decidable (∃x, ¬P x)] (H : ¬∀x, P x) :
-  ∃x, ¬P x :=
-@by_contradiction _ D' (assume H1 : ¬∃x, ¬P x,
-  have H2 : ∀x, ¬¬P x, from @forall_not_of_not_exists _ _ (take x, decidable_not) H1,
-  have H3 : ∀x, P x, from take x, @not_not_elim _ (D x) (H2 x),
-  absurd H3 H)
+theorem forall_of_not_exists_not {A : Type} {p : A → Prop} [D : decidable_pred p] :
+  ¬(∃ x, ¬p x) → ∀ x, p x :=
+assume Hne, take x, by_contradiction (assume Hnp : ¬ p x, Hne (exists.intro x Hnp))
+
+theorem exists_not_of_not_forall {A : Type} {p : A → Prop} [D : ∀x, decidable (p x)]
+    [D' : decidable (∃x, ¬p x)] (H : ¬∀x, p x) :
+  ∃x, ¬p x :=
+by_contradiction
+  (assume H1 : ¬∃x, ¬p x,
+    have H2 : ∀x, ¬¬p x, from forall_not_of_not_exists H1,
+    have H3 : ∀x, p x, from take x, not_not_elim (H2 x),
+    absurd H3 H)
+
+theorem exists_of_not_forall_not {A : Type} {p : A → Prop} [D : ∀x, decidable (p x)]
+    [D' : decidable (∃x, ¬¬p x)] (H : ¬∀x, ¬ p x) :
+  ∃x, p x :=
+obtain x (H : ¬¬ p x), from exists_not_of_not_forall H,
+exists.intro x (not_not_elim H)
 
 theorem ne_self_iff_false {A : Type} (a : A) : (a ≠ a) ↔ false :=
 iff.intro

--- a/tests/lean/run/fun.lean
+++ b/tests/lean/run/fun.lean
@@ -11,10 +11,10 @@ check typeof id : num → num
 
 constant h : num → bool → num
 
-check flip h
-check flip h ff num.zero
+check swap h
+check swap h ff num.zero
 
-check typeof flip h ff num.zero : num
+check typeof swap h ff num.zero : num
 
 constant f1 : num → num → bool
 constant f2 : bool → num

--- a/tests/lean/run/tut_104.lean
+++ b/tests/lean/run/tut_104.lean
@@ -4,7 +4,6 @@ section
 open set
 variables {A B : Type}
 set_option pp.beta false
-definition bijective (f : A → B) := injective f ∧ surjective f
 
 lemma injective_eq_inj_on_univ₁ (f : A → B) : injective f = inj_on f univ :=
   begin
@@ -13,7 +12,7 @@ lemma injective_eq_inj_on_univ₁ (f : A → B) : injective f = inj_on f univ :=
     apply iff.intro,
       intro Pl a1 a2,
         rewrite *true_imp,
-        exact Pl a1 a2,
+        exact @Pl a1 a2,
       intro Pr a1 a2,
       exact Pr trivial trivial
   end
@@ -25,7 +24,7 @@ lemma injective_eq_inj_on_univ₂ (f : A → B) : injective f = inj_on f univ :=
     apply iff.intro,
       intro Pl a1 a2,
         rewrite *(propext !true_imp),
-        exact Pl a1 a2,
+        exact @Pl a1 a2,
       intro Pr a1 a2,
       exact Pr trivial trivial
   end


### PR DESCRIPTION
I started working in Haitao's "extras". There is a lot there! 

@hthz, I will keep going over the next couple of change. I will send you notes about what I changed (mostly renaming, and stating theorems with iff instead of =). I have also cloned your repository, and I will make my version compatible with the changes I am making.

@leodemoura, note, I made algebra/function less reliant on function extensionality. For example, it is a lot more useful to say `∀x, f (g x) = x` instead of `f ∘ g = id`. Similarly, in lists, 

```
theorem map_id' {f : A → A} (H : ∀x, f x = x) : ∀ l : list A, map f l = l
```

is generally more useful than

```
theorem map_id : ∀ l : list A, map id l = l
```

if we are trying to avoid function extensionality.
