### PR TITLE
Maintenance in reals

### DIFF
--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -71,8 +71,7 @@ section linear_ordered_field
     iff.intro
     (assume H : 1 < a / b,
       calc
-        b   = b           : refl
-        ... < b * (a / b) : lt_mul_of_gt_one_right Hb H
+        b   < b * (a / b) : lt_mul_of_gt_one_right Hb H
         ... = a           : mul_div_cancel' Hb')
     (assume H : b < a,
       have Hbinv : 1 / b > 0, from  div_pos_of_pos Hb, calc

--- a/library/data/data.md
+++ b/library/data/data.md
@@ -15,6 +15,7 @@ Basic types:
 * [int](int/int.md) : the integers
 * [rat](rat/rat.md) : the rationals
 * [pnat](pnat.lean) : the positive natural numbers
+* [real](real.lean) : the real numbers 
 
 Constructors:
 

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -103,6 +103,7 @@ theorem factor_lemma_2 (a b c d : ℚ) : (a + b) + (c + d) = (a + c) + (d + b) :
 
 --------------------------------------
 -- define cauchy sequences and equivalence. show equivalence actually is one
+namespace s
 
 notation `seq` := ℕ+ → ℚ
 
@@ -885,6 +886,24 @@ theorem zero_nequiv_one : ¬ zero ≡ one :=
   end
 
 ---------------------------------------------
+-- constant sequences
+
+definition const (a : ℚ) : seq := λ n, a
+
+theorem const_reg (a : ℚ) : regular (const a) :=
+  begin
+    intros,
+    rewrite [↑const, rat.sub_self, abs_zero],
+    apply add_invs_nonneg
+  end
+
+theorem add_consts (a b : ℚ) : sadd (const a) (const b) ≡ const (a + b) :=
+  begin
+    rewrite [↑sadd, ↑const],
+    apply equiv.refl
+  end
+
+---------------------------------------------
 -- create the type of regular sequences and lift theorems
 
 record reg_seq : Type :=
@@ -967,10 +986,16 @@ theorem r_distrib (s t u : reg_seq) : requiv (s * (t + u)) (s * t + s * u) :=
 theorem r_zero_nequiv_one : ¬ requiv r_zero r_one :=
   zero_nequiv_one
 
+definition r_const (a : ℚ) : reg_seq := reg_seq.mk (const a) (const_reg a)
+
+theorem r_add_consts (a b : ℚ) : requiv (r_const a + r_const b) (r_const (a + b)) := add_consts a b
+
+end s
 ----------------------------------------------
 -- take quotients to get ℝ and show it's a comm ring
 
 namespace real
+open s
 definition real := quot reg_seq.to_setoid
 notation `ℝ` := real
 
@@ -1053,5 +1078,15 @@ definition comm_ring [reducible] : algebra.comm_ring ℝ :=
     apply distrib_l,
     apply mul_comm
   end
+
+definition const (a : ℚ) : ℝ := quot.mk (s.r_const a)
+
+theorem add_consts (a b : ℚ) : const a + const b = const (a + b) :=
+  quot.sound (s.r_add_consts a b)
+
+theorem sub_consts (a b : ℚ) : const a + -const b = const (a - b) := !add_consts
+
+theorem add_half_const (n : ℕ+) : const (2 * n)⁻¹ + const (2 * n)⁻¹ = const (n⁻¹) :=
+  by rewrite [add_consts, pnat.add_halves]
 
 end real

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -606,6 +606,7 @@ end s
 
 
 namespace real
+open [classes] s
 
 definition inv (x : ℝ) : ℝ := quot.lift_on x (λ a, quot.mk (s.r_inv a))
            (λ a b H, quot.sound (s.r_inv_well_defined H))


### PR DESCRIPTION
There are various things left to do in the reals, including embedding the rationals. This was done haphazardly before the proof of completeness; I've moved some of the relevant definitions and theorems in order to do it earlier.

This created some minor issues (rewrite was getting confused between +, \* defined on R and +, \* inferred from algebra), so I figured it was time to migrate theorems from algebra to R. This is not done yet, and I'll be traveling for the next couple weeks. This commit is so Jeremy can make changes to min/max in algebra without interfering with my changes. I'll clean things up when I get back to Pittsburgh!
