### PR TITLE
migrate real theorems from algebra

### DIFF
--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -71,8 +71,7 @@ section linear_ordered_field
     iff.intro
     (assume H : 1 < a / b,
       calc
-        b   = b           : refl
-        ... < b * (a / b) : lt_mul_of_gt_one_right Hb H
+        b   < b * (a / b) : lt_mul_of_gt_one_right Hb H
         ... = a           : mul_div_cancel' Hb')
     (assume H : b < a,
       have Hbinv : 1 / b > 0, from  div_pos_of_pos Hb, calc

--- a/library/data/data.md
+++ b/library/data/data.md
@@ -15,6 +15,7 @@ Basic types:
 * [int](int/int.md) : the integers
 * [rat](rat/rat.md) : the rationals
 * [pnat](pnat.lean) : the positive natural numbers
+* [real](real.lean) : the real numbers 
 
 Constructors:
 

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -103,6 +103,7 @@ theorem factor_lemma_2 (a b c d : ℚ) : (a + b) + (c + d) = (a + c) + (d + b) :
 
 --------------------------------------
 -- define cauchy sequences and equivalence. show equivalence actually is one
+namespace s
 
 notation `seq` := ℕ+ → ℚ
 
@@ -885,6 +886,24 @@ theorem zero_nequiv_one : ¬ zero ≡ one :=
   end
 
 ---------------------------------------------
+-- constant sequences
+
+definition const (a : ℚ) : seq := λ n, a
+
+theorem const_reg (a : ℚ) : regular (const a) :=
+  begin
+    intros,
+    rewrite [↑const, rat.sub_self, abs_zero],
+    apply add_invs_nonneg
+  end
+
+theorem add_consts (a b : ℚ) : sadd (const a) (const b) ≡ const (a + b) :=
+  begin
+    rewrite [↑sadd, ↑const],
+    apply equiv.refl
+  end
+
+---------------------------------------------
 -- create the type of regular sequences and lift theorems
 
 record reg_seq : Type :=
@@ -967,10 +986,16 @@ theorem r_distrib (s t u : reg_seq) : requiv (s * (t + u)) (s * t + s * u) :=
 theorem r_zero_nequiv_one : ¬ requiv r_zero r_one :=
   zero_nequiv_one
 
+definition r_const (a : ℚ) : reg_seq := reg_seq.mk (const a) (const_reg a)
+
+theorem r_add_consts (a b : ℚ) : requiv (r_const a + r_const b) (r_const (a + b)) := add_consts a b
+
+end s
 ----------------------------------------------
 -- take quotients to get ℝ and show it's a comm ring
 
 namespace real
+open s
 definition real := quot reg_seq.to_setoid
 notation `ℝ` := real
 
@@ -1053,5 +1078,15 @@ definition comm_ring [reducible] : algebra.comm_ring ℝ :=
     apply distrib_l,
     apply mul_comm
   end
+
+definition const (a : ℚ) : ℝ := quot.mk (s.r_const a)
+
+theorem add_consts (a b : ℚ) : const a + const b = const (a + b) :=
+  quot.sound (s.r_add_consts a b)
+
+theorem sub_consts (a b : ℚ) : const a + -const b = const (a - b) := !add_consts
+
+theorem add_half_const (n : ℕ+) : const (2 * n)⁻¹ + const (2 * n)⁻¹ = const (n⁻¹) :=
+  by rewrite [add_consts, pnat.add_halves]
 
 end real

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -1058,7 +1058,7 @@ theorem zero_ne_one : ¬ zero = one :=
   take H : zero = one,
   absurd (quot.exact H) (r_zero_nequiv_one)
 
-definition comm_ring [reducible] : algebra.comm_ring ℝ :=
+protected definition comm_ring [reducible] : algebra.comm_ring ℝ :=
   begin
     fapply algebra.comm_ring.mk,
     exact add,

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -606,6 +606,7 @@ end s
 
 
 namespace real
+open [classes] s
 
 definition inv (x : ℝ) : ℝ := quot.lift_on x (λ a, quot.mk (s.r_inv a))
            (λ a b H, quot.sound (s.r_inv_well_defined H))

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -651,9 +651,12 @@ theorem dec_lt : decidable_rel lt :=
     apply prop_decidable
   end
 
-open [classes] algebra
-definition linear_ordered_field [instance] : algebra.discrete_linear_ordered_field ℝ :=
-  ⦃ algebra.discrete_linear_ordered_field, comm_ring, ordered_ring,
+section migrate_algebra
+  open [classes] algebra
+
+  protected definition discrete_linear_ordered_field [reducible] :
+      algebra.discrete_linear_ordered_field ℝ :=
+  ⦃ algebra.discrete_linear_ordered_field, real.comm_ring, real.ordered_ring,
     le_total := le_total,
     mul_inv_cancel := mul_inv,
     inv_mul_cancel := inv_mul,
@@ -662,5 +665,20 @@ definition linear_ordered_field [instance] : algebra.discrete_linear_ordered_fie
     le_iff_lt_or_eq := le_iff_lt_or_eq,
     decidable_lt := dec_lt
    ⦄
+
+  local attribute real.comm_ring [instance]
+  local attribute real.ordered_ring [instance]
+  local attribute real.discrete_linear_ordered_field [instance]
+
+  definition abs (n : ℝ) : ℝ := algebra.abs n
+  definition sign (n : ℝ) : ℝ := algebra.sign n
+
+  definition max (a b : ℝ) : ℝ := algebra.max a b
+  definition min (a b : ℝ) : ℝ := algebra.min a b
+
+  migrate from algebra with real
+    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, abs → abs, sign → sign, dvd → dvd,
+      divide → divide, max → max, min → min
+end migrate_algebra
 
 end real

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -1022,6 +1022,14 @@ infix `<` := lt
 
 definition le (x y : ℝ) := quot.lift_on₂ x y (λ a b, s.r_le a b) s.r_le_well_defined
 infix `≤` := le
+infix `<=` := le
+
+definition gt [reducible] (a b : ℝ) := lt b a
+definition ge [reducible] (a b : ℝ) := le b a
+
+infix >= := real.ge
+infix ≥  := real.ge
+infix >  := real.gt
 
 definition sep (x y : ℝ) := quot.lift_on₂ x y (λ a b, s.r_sep a b) s.r_sep_well_defined
 infix `≢` : 50 := sep
@@ -1056,13 +1064,13 @@ theorem not_sep_self (x : ℝ) : ¬ x ≢ x :=
 theorem not_lt_self (x : ℝ) : ¬ x < x :=
   quot.induction_on x (λ s, s.r_not_lt_self s)
 
-theorem le_of_lt (x y : ℝ) : x < y → x ≤ y :=
+theorem le_of_lt {x y : ℝ} : x < y → x ≤ y :=
   quot.induction_on₂ x y (λ s t H', s.r_le_of_lt H')
 
-theorem lt_of_le_of_lt (x y z : ℝ) : x ≤ y → y < z → x < z :=
+theorem lt_of_le_of_lt {x y z : ℝ} : x ≤ y → y < z → x < z :=
   quot.induction_on₃ x y z (λ s t u H H', s.r_lt_of_le_of_lt H H')
 
-theorem lt_of_lt_of_le (x y z : ℝ) : x < y → y ≤ z → x < z :=
+theorem lt_of_lt_of_le {x y z : ℝ} : x < y → y ≤ z → x < z :=
   quot.induction_on₃ x y z (λ s t u H H', s.r_lt_of_lt_of_le H H')
 
 theorem add_lt_add_left_var (x y z : ℝ) : x < y → z + x < z + y :=
@@ -1083,11 +1091,11 @@ theorem le_of_lt_or_eq (x y : ℝ) : x < y ∨ x = y → x ≤ y :=
         apply (or.inr (quot.exact H'))
       end)))
 
-section migrate_reals
-open [classes] algebra
+section migrate_algebra
+  open [classes] algebra
 
-definition ordered_ring [reducible]  : algebra.ordered_ring ℝ :=
-  ⦃ algebra.ordered_ring, comm_ring,
+  protected definition ordered_ring [reducible]  : algebra.ordered_ring ℝ :=
+  ⦃ algebra.ordered_ring, real.comm_ring,
     le_refl := le.refl,
     le_trans := le.trans,
     mul_pos := mul_gt_zero_of_gt_zero,
@@ -1096,16 +1104,27 @@ definition ordered_ring [reducible]  : algebra.ordered_ring ℝ :=
     add_le_add_left := add_le_add_of_le_right,
     le_antisymm := eq_of_le_of_ge,
     lt_irrefl := not_lt_self,
-    lt_of_le_of_lt := lt_of_le_of_lt,
-    lt_of_lt_of_le := lt_of_lt_of_le,
-    le_of_lt := le_of_lt,
+    lt_of_le_of_lt := @lt_of_le_of_lt,
+    lt_of_lt_of_le := @lt_of_lt_of_le,
+    le_of_lt := @le_of_lt,
     add_lt_add_left := add_lt_add_left
   ⦄
-local attribute real.ordered_ring [instance]
---set_option migrate.trace true
-migrate from algebra with real
 
-end migrate_reals
+  local attribute real.comm_ring [instance]
+  local attribute real.ordered_ring [instance]
+
+  definition sub (a b : ℝ) : ℝ := algebra.sub a b
+  infix - := real.sub
+  definition dvd (a b : ℝ) : Prop := algebra.dvd a b
+  notation a ∣ b := real.dvd a b
+
+  migrate from algebra with real
+    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, dvd → dvd, divide → divide
+
+  attribute le.trans lt.trans lt_of_lt_of_le lt_of_le_of_lt ge.trans gt.trans gt_of_gt_of_ge
+                   gt_of_ge_of_gt [trans]
+end migrate_algebra
+
 theorem const_le_const_of_le (a b : ℚ) : a ≤ b → const a ≤ const b :=
   s.r_const_le_const_of_le
 
@@ -1113,6 +1132,3 @@ theorem le_of_const_le_const (a b : ℚ) : const a ≤ const b → a ≤ b :=
   s.r_le_of_const_le_const
 
 end real
-
---print prefix real
---check @real.lt


### PR DESCRIPTION
I hope I did this right: I pulled from @rlewis1988, and added a commit. So this pull request includes his commits.

The migrate went smoothly. There are two things that were finicky:
- I had to remember to declare the previous instances with each successive migrate.
- I had to remember to make sure to have local definitions of each definition in algebra. 

For example, I had trouble because gt and ge were not defined in real. The migrate silently tried to use rat.gt and rat.ge and didn't tell me there was a problem. @leodemoura plans to improve migrate so that the second point won't be an issue. (I am not sure there is a good solution to the first, but it is not so bad.)

The good news is that modulo the finickiness, the migrate worked beautifully. The files all compile very quickly now on my laptop: basic, order, division, and complete require 2, 4, 6, and 1 seconds, respectively.

Rob, I did not define the coercions from numerals (so I used "zero" and "one" for real 0 and 1).

Also, a small thing: I have been following the convention that any arguments that appear in a hypothesis to a theorem are made implicit, for example, `le_of_lt {x y : real} (H : x < y) : x <= y`. I changed this in `le_of_lt` and two surrounding theorems, so that they agree with the instances in algebra, nat, int, etc. But I did not check through your files to see if there are other arguments that should also be made implicit.
