### PR TITLE
implement min and max

### DIFF
--- a/library/algebra/group_power.lean
+++ b/library/algebra/group_power.lean
@@ -96,38 +96,38 @@ open nat int algebra
 
 definition ipow (a : A) : ℤ → A
 | (of_nat n) := a^n
-| -[n +1]    := (a^(nat.succ n))⁻¹
+| -[1+n]     := (a^(nat.succ n))⁻¹
 
 private lemma ipow_add_aux (a : A) (m n : nat) :
-  ipow a ((of_nat m) + -[n +1]) = ipow a (of_nat m) * ipow a (-[n +1]) :=
+  ipow a ((of_nat m) + -[1+n]) = ipow a (of_nat m) * ipow a (-[1+n]) :=
 or.elim (nat.lt_or_ge m (nat.succ n))
   (assume H : (#nat m < nat.succ n),
     assert H1 : (#nat nat.succ n - m > nat.zero), from nat.sub_pos_of_lt H,
     calc
-      ipow a ((of_nat m) + -[n +1]) = ipow a (sub_nat_nat m (nat.succ n)) : rfl
-        ... = ipow a (-[nat.pred (nat.sub (nat.succ n) m) +1])            : {sub_nat_nat_of_lt H}
+      ipow a ((of_nat m) + -[1+n]) = ipow a (sub_nat_nat m (nat.succ n))  : rfl
+        ... = ipow a (-[1+ nat.pred (nat.sub (nat.succ n) m)])            : {sub_nat_nat_of_lt H}
         ... = (pow a (nat.succ (nat.pred (nat.sub (nat.succ n) m))))⁻¹    : rfl
         ... = (pow a (nat.succ n) * (pow a m)⁻¹)⁻¹                        :
                 by rewrite [nat.succ_pred_of_pos H1, pow_sub a (nat.le_of_lt H)]
         ... = pow a m * (pow a (nat.succ n))⁻¹                            :
                 by rewrite [mul_inv, inv_inv]
-        ... = ipow a (of_nat m) * ipow a (-[n +1])                        : rfl)
+        ... = ipow a (of_nat m) * ipow a (-[1+n])                         : rfl)
   (assume H : (#nat m ≥ nat.succ n),
     calc
-      ipow a ((of_nat m) + -[n +1]) = ipow a (sub_nat_nat m (nat.succ n)) : rfl
+      ipow a ((of_nat m) + -[1+n]) = ipow a (sub_nat_nat m (nat.succ n))  : rfl
         ... = ipow a (#nat m - nat.succ n)                                : {sub_nat_nat_of_ge H}
         ... = pow a m * (pow a (nat.succ n))⁻¹                            : pow_sub a H
-        ... = ipow a (of_nat m) * ipow a (-[n +1])                        : rfl)
+        ... = ipow a (of_nat m) * ipow a (-[1+n])                         : rfl)
 
 theorem ipow_add (a : A) : ∀i j : int, ipow a (i + j) = ipow a i * ipow a j
 | (of_nat m) (of_nat n) := !pow_add
-| (of_nat m) -[n +1]    := !ipow_add_aux
-| -[ m+1]    (of_nat n) := by rewrite [int.add.comm, ipow_add_aux, ↑ipow, -*inv_pow, pow_inv_comm]
-| -[ m+1]    -[n+1]     :=
+| (of_nat m) -[1+n]     := !ipow_add_aux
+| -[1+m]     (of_nat n) := by rewrite [int.add.comm, ipow_add_aux, ↑ipow, -*inv_pow, pow_inv_comm]
+| -[1+m]     -[1+n]     :=
   calc
-    ipow a (-[ m+1] + -[n+1]) = (a^(#nat nat.succ m + nat.succ n))⁻¹ : rfl
+    ipow a (-[1+m] + -[1+n]) = (a^(#nat nat.succ m + nat.succ n))⁻¹ : rfl
       ... = (a^(nat.succ m))⁻¹ * (a^(nat.succ n))⁻¹ : by rewrite [pow_add, pow_comm, mul_inv]
-      ... = ipow a (-[ m+1]) * ipow a (-[n+1])      : rfl
+      ... = ipow a (-[1+m]) * ipow a (-[1+n])       : rfl
 
 theorem ipow_comm (a : A) (i j : ℤ) : ipow a i * ipow a j = ipow a j * ipow a i :=
 by rewrite [-*ipow_add, int.add.comm]

--- a/library/algebra/order.lean
+++ b/library/algebra/order.lean
@@ -301,8 +301,7 @@ definition strong_order_pair.to_order_pair [trans-instance] [coercion] [reducibl
   lt_irrefl := lt_irrefl',
   le_of_lt := le_of_lt',
   lt_of_le_of_lt := lt_of_le_of_lt',
-  lt_of_lt_of_le := lt_of_lt_of_le'
-⦄
+  lt_of_lt_of_le := lt_of_lt_of_le' ⦄
 
 /- linear orders -/
 
@@ -313,7 +312,7 @@ structure linear_strong_order_pair [class] (A : Type) extends strong_order_pair 
 
 definition linear_strong_order_pair.to_linear_order_pair [trans-instance] [coercion] [reducible]
     [s : linear_strong_order_pair A] : linear_order_pair A :=
-⦃ linear_order_pair, s, strong_order_pair.to_order_pair⦄
+⦃ linear_order_pair, s, strong_order_pair.to_order_pair ⦄
 
 section
   variable [s : linear_strong_order_pair A]
@@ -450,48 +449,24 @@ section
     le_max_right := le_dlo_max_right,
     max_le := dlo_max_le ⦄
 
-/-
-  definition max (a b : A) : A :=
-  if a < b then b else a
+  /- These don't require decidability, but it is not clear whether it is worth breaking out
+     a new class, linearly_ordered_lattice. Currently nat is the only instance that doesn't
+     use decidable_linear_order (because max and min are defined separately, in init),
+     so we simply reprove these theorems there. -/
 
-  definition min (a b : A) : A :=
-  if a < b then a else b
-
-  theorem max_a_a (a : A) : a = max a a :=
-  eq.rec_on !if_t_t rfl
-
-  theorem max.eq_right {a b : A} (H : a < b) : max a b = b :=
-  if_pos H
-
-  theorem max.eq_left {a b : A} (H : ¬ a < b) : max a b = a :=
-  if_neg H
-
-  theorem max.right_eq {a b : A} (H : a < b) : b = max a b :=
-  eq.rec_on (max.eq_right H) rfl
-
-  theorem max.left_eq {a b : A} (H : ¬ a < b) : a = max a b :=
-  eq.rec_on (max.eq_left H) rfl
-
-  theorem max.left (a b : A) : a ≤ max a b :=
+  theorem lt_min {a b c : A} (H₁ : a < b) (H₂ : a < c) : a < min b c :=
   by_cases
-    (λ h : a < b,   le_of_lt (eq.rec_on (max.right_eq h) h))
-    (λ h : ¬ a < b, eq.rec_on (max.eq_left h) !le.refl)
+    (assume H : b ≤ c, by rewrite (min_eq_left H); apply H₁)
+    (assume H : ¬ b ≤ c,
+      assert H' : c ≤ b, from le_of_lt (lt_of_not_ge H),
+      by rewrite (min_eq_right H'); apply H₂)
 
-  theorem eq_or_lt_of_not_lt (H : ¬ a < b) : a = b ∨ b < a :=
-  have H' : b = a ∨ b < a, from or.swap (lt_or_eq_of_le (le_of_not_gt H)),
-  or.elim H'
-    (take H'' : b = a, or.inl (symm H''))
-    (take H'' : b < a, or.inr H'')
-
-  theorem max.right (a b : A) : b ≤ max a b :=
+  theorem max_lt {a b c : A} (H₁ : a < c) (H₂ : b < c) : max a b < c :=
   by_cases
-    (λ h : a < b,   eq.rec_on (max.eq_right h) !le.refl)
-    (λ h : ¬ a < b, or.rec_on (eq_or_lt_of_not_lt h)
-      (λ heq, eq.rec_on heq (eq.rec_on (max_a_a a) !le.refl))
-      (λ h : b < a,
-        have aux : a = max a b, from max.left_eq (lt.asymm h),
-        eq.rec_on aux (le_of_lt h)))
--/
+    (assume H : a ≤ b, by rewrite (max_eq_right H); apply H₂)
+    (assume H : ¬ a ≤ b,
+      assert H' : b ≤ a, from le_of_lt (lt_of_not_ge H),
+      by rewrite (max_eq_left H'); apply H₁)
 end
 
 end algebra

--- a/library/algebra/ordered_group.lean
+++ b/library/algebra/ordered_group.lean
@@ -476,6 +476,41 @@ section
 
   theorem max_eq_neg_min_neg_neg : max a b = - min (-a) (-b) :=
   by rewrite [min_neg_neg, neg_neg]
+
+  /- absolute value -/
+  variables {a b c}
+
+  definition abs (a : A) : A := max a (-a)
+
+  theorem abs_of_nonneg (H : a ≥ 0) : abs a = a :=
+  have H' : -a ≤ a, from le.trans (neg_nonpos_of_nonneg H) H,
+  max_eq_left H'
+
+  theorem abs_of_pos (H : a > 0) : abs a = a :=
+  abs_of_nonneg (le_of_lt H)
+
+  theorem abs_of_nonpos (H : a ≤ 0) : abs a = -a :=
+  have H' : a ≤ -a, from le.trans H (neg_nonneg_of_nonpos H),
+  max_eq_right H'
+
+  theorem abs_of_neg (H : a < 0) : abs a = -a := abs_of_nonpos (le_of_lt H)
+
+  theorem abs_zero : abs 0 = (0:A) := abs_of_nonneg (le.refl _)
+
+  theorem abs_neg (a : A) : abs (-a) = abs a :=
+  by rewrite [↑abs, max.comm, neg_neg]
+
+  theorem abs_pos_of_pos (H : a > 0) : abs a > 0 :=
+  by rewrite (abs_of_pos H); exact H
+
+  theorem abs_pos_of_neg (H : a < 0) : abs a > 0 :=
+  !abs_neg ▸ abs_pos_of_pos (neg_pos_of_neg H)
+
+  theorem abs_sub (a b : A) : abs (a - b) = abs (b - a) :=
+  by rewrite [-neg_sub, abs_neg]
+
+  theorem ne_zero_of_abs_ne_zero {a : A} (H : abs a ≠ 0) : a ≠ 0 :=
+   assume Ha, H (Ha⁻¹ ▸ abs_zero)
 end
 
 /- linear ordered group with decidable order -/
@@ -513,28 +548,6 @@ section
       have H2: a < 0, from H ▸ neg_neg_of_pos H1,
       absurd H1 (lt.asymm H2))
 
-  definition abs (a : A) : A := if 0 ≤ a then a else -a
-
-  theorem abs_of_nonneg (H : a ≥ 0) : abs a = a := if_pos H
-
-  theorem abs_of_pos (H : a > 0) : abs a = a := if_pos (le_of_lt H)
-
-  theorem abs_of_neg (H : a < 0) : abs a = -a := if_neg (not_le_of_gt H)
-
-  theorem abs_zero : abs 0 = (0:A) := abs_of_nonneg (le.refl _)
-
-  theorem abs_of_nonpos (H : a ≤ 0) : abs a = -a :=
-  decidable.by_cases
-    (assume H1 : a = 0, by rewrite [H1, abs_zero, neg_zero])
-    (assume H1 : a ≠ 0,
-      have H2 : a < 0, from lt_of_le_of_ne H H1,
-      abs_of_neg H2)
-
-  theorem abs_neg (a : A) : abs (-a) = abs a :=
-  or.elim (le.total 0 a)
-    (assume H1 : 0 ≤ a, by rewrite [abs_of_nonpos (neg_nonpos_of_nonneg H1), neg_neg, abs_of_nonneg H1])
-    (assume H1 : a ≤ 0, by rewrite [abs_of_nonneg (neg_nonneg_of_nonpos H1), abs_of_nonpos H1])
-
   theorem abs_nonneg (a : A) : abs a ≥ 0 :=
   or.elim (le.total 0 a)
     (assume H : 0 ≤ a, by rewrite (abs_of_nonneg H); exact H)
@@ -561,17 +574,8 @@ section
   theorem abs_eq_zero_iff_eq_zero (a : A) : abs a = 0 ↔ a = 0 :=
   iff.intro eq_zero_of_abs_eq_zero (assume H, congr_arg abs H ⬝ !abs_zero)
 
-  theorem abs_pos_of_pos (H : a > 0) : abs a > 0 :=
-  by rewrite (abs_of_pos H); exact H
-
-  theorem abs_pos_of_neg (H : a < 0) : abs a > 0 :=
-  !abs_neg ▸ abs_pos_of_pos (neg_pos_of_neg H)
-
   theorem abs_pos_of_ne_zero (H : a ≠ 0) : abs a > 0 :=
   or.elim (lt_or_gt_of_ne H) abs_pos_of_neg abs_pos_of_pos
-
-  theorem abs_sub (a b : A) : abs (a - b) = abs (b - a) :=
-  by rewrite [-neg_sub, abs_neg]
 
   theorem abs.by_cases {P : A → Prop} {a : A} (H1 : P a) (H2 : P (-a)) : P (abs a) :=
   or.elim (le.total 0 a)
@@ -583,9 +587,6 @@ section
 
   theorem abs_lt_of_lt_of_neg_lt (H1 : a < b) (H2 : -a < b) : abs a < b :=
   abs.by_cases H1 H2
-
-  theorem ne_zero_of_abs_ne_zero {a : A} (H : abs a ≠ 0) : a ≠ 0 :=
-   assume Ha, H (Ha⁻¹ ▸ abs_zero)
 
   -- the triangle inequality
   section
@@ -636,7 +637,6 @@ section
           abs (a + b) = abs (-a + -b)   : by rewrite [-abs_neg, neg_add]
               ... ≤ abs (-a) + abs (-b) : aux2 H5
               ... = abs a + abs b       : by rewrite *abs_neg)
-  end
 
   theorem abs_sub_abs_le_abs_sub (a b : A) : abs a - abs b ≤ abs (a - b) :=
   have H1 : abs a - abs b + abs b ≤ abs (a - b) + abs b, from
@@ -656,5 +656,6 @@ section
       apply le.refl
     end
   end
+end
 
 end algebra

--- a/library/algebra/ordered_ring.lean
+++ b/library/algebra/ordered_ring.lean
@@ -97,7 +97,6 @@ section
     rewrite zero_mul at  H,
     exact H
   end
-
 end
 
 structure linear_ordered_semiring [class] (A : Type)
@@ -185,7 +184,8 @@ section
       not_le_of_gt (mul_pos H2 H1) H)
 end
 
-structure ordered_ring [class] (A : Type) extends ring A, ordered_comm_group A, zero_ne_one_class A :=
+structure ordered_ring [class] (A : Type)
+    extends ring A, ordered_comm_group A, zero_ne_one_class A :=
 (mul_nonneg : ∀a b, le zero a → le zero b → le zero (mul a b))
 (mul_pos : ∀a b, lt zero a → lt zero b → lt zero (mul a b))
 
@@ -225,7 +225,8 @@ begin
   exact (iff.mp !sub_pos_iff_lt H2)
 end
 
-definition ordered_ring.to_ordered_semiring [trans-instance] [coercion] [reducible] [s : ordered_ring A] :
+definition ordered_ring.to_ordered_semiring [trans-instance] [coercion] [reducible]
+    [s : ordered_ring A] :
   ordered_semiring A :=
 ⦃ ordered_semiring, s,
   mul_zero                   := mul_zero,
@@ -302,10 +303,9 @@ end
 
 -- TODO: we can eliminate mul_pos_of_pos, but now it is not worth the effort to redeclare the
 -- class instance
-structure linear_ordered_ring [class] (A : Type) extends ordered_ring A, linear_strong_order_pair A :=
+structure linear_ordered_ring [class] (A : Type)
+    extends ordered_ring A, linear_strong_order_pair A :=
   (zero_lt_one : lt zero one)
-
--- print fields linear_ordered_semiring
 
 definition linear_ordered_ring.to_linear_ordered_semiring [trans-instance] [coercion] [reducible]
     [s : linear_ordered_ring A] :

--- a/library/data/fin.lean
+++ b/library/data/fin.lean
@@ -9,11 +9,12 @@ import data.list.basic data.finset.basic data.fintype.card algebra.group
 open eq.ops nat function list finset fintype
 
 structure fin (n : nat) := (val : nat) (is_lt : val < n)
-attribute fin.val [coercion]
 
 definition less_than [reducible] := fin
 
 namespace fin
+
+attribute fin.val [coercion]
 
 section def_equal
 variable {n : nat}

--- a/library/data/int/basic.lean
+++ b/library/data/int/basic.lean
@@ -39,11 +39,12 @@ inductive int : Type :=
 | neg_succ_of_nat : nat → int
 
 notation `ℤ` := int
-attribute int.of_nat [coercion]
 definition int.of_num [coercion] [reducible] [constructor] (n : num) : ℤ :=
 int.of_nat (nat.of_num n)
 
 namespace int
+
+attribute int.of_nat [coercion]
 
 /- definitions of basic functions -/
 

--- a/library/data/int/basic.lean
+++ b/library/data/int/basic.lean
@@ -85,7 +85,7 @@ definition mul (a b : ℤ) : ℤ :=
 
 /- notation -/
 
-notation `-[` n `+1]` := int.neg_succ_of_nat n    -- for pretty-printing output
+notation `-[1+` n `]` := int.neg_succ_of_nat n    -- for pretty-printing output
 prefix - := int.neg
 infix +  := int.add
 infix *  := int.mul
@@ -101,7 +101,7 @@ iff.intro of_nat.inj !congr_arg
 theorem neg_succ_of_nat.inj {m n : ℕ} (H : neg_succ_of_nat m = neg_succ_of_nat n) : m = n :=
 by injection H; assumption
 
-theorem neg_succ_of_nat_eq (n : ℕ) : -[n +1] = -(n + 1) := rfl
+theorem neg_succ_of_nat_eq (n : ℕ) : -[1+ n] = -(n + 1) := rfl
 
 definition has_decidable_eq [instance] : decidable_eq ℤ :=
 take a b,
@@ -641,7 +641,7 @@ have H1 : m = (#nat m - n + n), from (nat.sub_add_cancel H)⁻¹,
 have H2 : m = (#nat m - n) + n, from congr_arg of_nat H1,
 (sub_eq_of_eq_add H2)⁻¹
 
-theorem neg_succ_of_nat_eq' (m : ℕ) : -[m +1] = -m - 1 :=
+theorem neg_succ_of_nat_eq' (m : ℕ) : -[1+ m] = -m - 1 :=
 by rewrite [neg_succ_of_nat_eq, of_nat_add, neg_add]
 
 definition succ (a : ℤ) := a + (nat.succ zero)

--- a/library/data/int/div.lean
+++ b/library/data/int/div.lean
@@ -21,7 +21,7 @@ definition divide (a b : ℤ) : ℤ :=
 sign b *
   (match a with
     | of_nat m := #nat m div (nat_abs b)
-    | -[ m +1] := -[ (#nat m div (nat_abs b)) +1]
+    | -[1+m]   := -[1+ (#nat m div (nat_abs b))]
   end)
 notation a div b := divide a b
 
@@ -37,17 +37,17 @@ nat.cases_on n
   (take n, by rewrite [↑divide, sign_of_succ, one_mul])
 
 theorem neg_succ_of_nat_div (m : nat) {b : ℤ} (H : b > 0) :
-  -[m +1] div b = -(m div b + 1) :=
+  -[1+m] div b = -(m div b + 1) :=
 calc
-  -[m +1] div b = sign b * _              : rfl
-     ... = -[(#nat m div (nat_abs b)) +1] : by rewrite [sign_of_pos H, one_mul]
+  -[1+m] div b = sign b * _               : rfl
+     ... = -[1+(#nat m div (nat_abs b))]  : by rewrite [sign_of_pos H, one_mul]
      ... = -(m div b + 1)                 : by rewrite [↑divide, sign_of_pos H, one_mul]
 
 theorem div_neg (a b : ℤ) : a div -b = -(a div b) :=
 by rewrite [↑divide, sign_neg, neg_mul_eq_neg_mul, nat_abs_neg]
 
 theorem div_of_neg_of_pos {a b : ℤ} (Ha : a < 0) (Hb : b > 0) : a div b = -((-a - 1) div b + 1) :=
-obtain m (H1 : a = -[m +1]), from exists_eq_neg_succ_of_nat Ha,
+obtain m (H1 : a = -[1+m]), from exists_eq_neg_succ_of_nat Ha,
 calc
   a div b = -(m div b + 1)       : by rewrite [H1, neg_succ_of_nat_div _ Hb]
       ... = -((-a -1) div b + 1) : by rewrite [H1, neg_succ_of_nat_eq', neg_sub, sub_neg_eq_add,
@@ -100,12 +100,12 @@ int.cases_on a
           m div n = #nat m div n : of_nat_div
               ... = 0            : nat.div_eq_zero_of_lt (lt_of_of_nat_lt_of_nat H))
       (take n,
-        assume H : m < -[ n +1],
-        have H1 : ¬(m < -[ n +1]), from dec_trivial,
+        assume H : m < -[1+n],
+        have H1 : ¬(m < -[1+n]), from dec_trivial,
         absurd H H1))
   (take m,
-    assume H : 0 ≤ -[ m +1],
-    have H1 : ¬ (0 ≤ -[ m +1]), from dec_trivial,
+    assume H : 0 ≤ -[1+m],
+    have H1 : ¬ (0 ≤ -[1+m]), from dec_trivial,
     absurd H H1)
 
 theorem div_eq_zero_of_lt_abs {a b : ℤ} (H1 : 0 ≤ a) (H2 : a < abs b) : a div b = 0 :=
@@ -134,14 +134,14 @@ Hm⁻¹ ▸ (calc
 private theorem add_mul_div_self_aux2 {a : ℤ} {k : ℕ} (n : ℕ)
     (H1 : a < 0) (H2 : #nat k > 0) :
   (a + n * k) div k = a div k + n :=
-obtain m (Hm : a = -[m +1]), from exists_eq_neg_succ_of_nat H1,
+obtain m (Hm : a = -[1+m]), from exists_eq_neg_succ_of_nat H1,
 or.elim (nat.lt_or_ge m (#nat n * k))
   (assume m_lt_nk : #nat m < n * k,
     have H3 : #nat (m + 1 ≤ n * k), from nat.succ_le_of_lt m_lt_nk,
     have H4 : #nat m div k + 1 ≤ n,
       from nat.succ_le_of_lt (nat.div_lt_of_lt_mul m_lt_nk),
     Hm⁻¹ ▸ (calc
-      (-[m +1] + n * k) div k = (n * k - (m + 1)) div k : by rewrite [add.comm, neg_succ_of_nat_eq]
+      (-[1+m] + n * k) div k = (n * k - (m + 1)) div k : by rewrite [add.comm, neg_succ_of_nat_eq]
         ... = ((#nat n * k) - (#nat m + 1)) div k       : rfl
         ... = (#nat n * k - (m + 1)) div k              : {(of_nat_sub H3)⁻¹}
         ... = #nat (n * k - (m + 1)) div k              : of_nat_div
@@ -152,11 +152,11 @@ or.elim (nat.lt_or_ge m (#nat n * k))
         ... = n - (#nat m div k + 1)                    : of_nat_sub H4
         ... = -(m div k + 1) + n                        :
                   by rewrite [add.comm, -sub_eq_add_neg, of_nat_add, of_nat_div]
-        ... = -[m +1] div k + n                         :
+        ... = -[1+m] div k + n                         :
                   neg_succ_of_nat_div m (of_nat_lt_of_nat_of_lt H2)))
   (assume nk_le_m : #nat n * k ≤ m,
     eq.symm (Hm⁻¹ ▸ (calc
-      -[m +1] div k + n = -(m div k + 1) + n              :
+      -[1+m] div k + n = -(m div k + 1) + n              :
                   neg_succ_of_nat_div m (of_nat_lt_of_nat_of_lt H2)
         ... = -((#nat m div k) + 1) + n                   : of_nat_div
         ... = -((#nat (m - n * k + n * k) div k) + 1) + n : nat.sub_add_cancel nk_le_m
@@ -164,13 +164,13 @@ or.elim (nat.lt_or_ge m (#nat n * k))
         ... = -((#nat m - n * k) div k + 1)               :
                    by rewrite [of_nat_add, *neg_add, add.right_comm, neg_add_cancel_right,
                                of_nat_div]
-        ... = -[(#nat m - n * k) +1] div k                :
+        ... = -[1+(#nat m - n * k)] div k                 :
                    neg_succ_of_nat_div _ (of_nat_lt_of_nat_of_lt H2)
         ... = -((#nat m - n * k) + 1) div k               : rfl
         ... = -(m - (#nat n * k) + 1) div k               : of_nat_sub nk_le_m
         ... = (-(m + 1) + n * k) div k                    :
                    by rewrite [sub_eq_add_neg, -*add.assoc, *neg_add, neg_neg, add.right_comm]
-        ... = (-[m +1] + n * k) div k                     : rfl)))
+        ... = (-[1+m] + n * k) div k                      : rfl)))
 
 private theorem add_mul_div_self_aux3 (a : ℤ) {b c : ℤ} (H1 : b ≥ 0) (H2 : c > 0) :
     (a + b * c) div c = a div c + b :=
@@ -236,9 +236,9 @@ calc
       ... = (#nat m mod n)  : sub_eq_of_eq_add H
 
 theorem neg_succ_of_nat_mod (m : ℕ) {b : ℤ} (bpos : b > 0) :
-  -[m +1] mod b = b - 1 - m mod b :=
+  -[1+m] mod b = b - 1 - m mod b :=
 calc
-  -[m +1] mod b = -(m + 1) - -[m +1] div b * b : rfl
+  -[1+m] mod b = -(m + 1) - -[1+m] div b * b : rfl
     ... = -(m + 1) - -(m div b + 1) * b        : neg_succ_of_nat_div _ bpos
     ... = -m + -1 + (b + m div b * b)          :
               by rewrite [neg_add, -neg_mul_eq_neg_mul, sub_neg_eq_add, mul.right_distrib,
@@ -300,7 +300,7 @@ have H2 : a mod (abs b) ≥ 0, from
       have H3 : 1 + m mod (abs b) ≤ (abs b),
         from (!add.comm ▸ add_one_le_of_lt (of_nat_mod_abs_lt m H)),
       calc
-        -[ m +1] mod (abs b) = abs b - 1 - m mod (abs b) : neg_succ_of_nat_mod _ H1
+        -[1+m] mod (abs b) = abs b - 1 - m mod (abs b) : neg_succ_of_nat_mod _ H1
           ... = abs b - (1 + m mod (abs b))    : by rewrite [*sub_eq_add_neg, neg_add, add.assoc]
           ... ≥ 0                              : iff.mp' !sub_nonneg_iff_le H3),
 !mod_abs ▸ H2
@@ -314,7 +314,7 @@ have H2 : a mod (abs b) < abs b, from
       have H3 : abs b ≠ 0, from assume H', H (eq_zero_of_abs_eq_zero H'),
       have H4 : 1 + m mod (abs b) > 0, from add_pos_of_pos_of_nonneg dec_trivial (mod_nonneg _ H3),
       calc
-        -[ m +1] mod (abs b) = abs b - 1 - m mod (abs b) : neg_succ_of_nat_mod _ H1
+        -[1+m] mod (abs b) = abs b - 1 - m mod (abs b) : neg_succ_of_nat_mod _ H1
           ... = abs b - (1 + m mod (abs b))      : by rewrite [*sub_eq_add_neg, neg_add, add.assoc]
           ... < abs b                            : sub_lt_self _ H4),
 !mod_abs ▸ H2

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -281,7 +281,6 @@ section migrate_algebra
   show decidable (b ≤ a), from _
   definition decidable_gt [instance] (a b : ℤ) : decidable (a > b) :=
   show decidable (b < a), from _
-
   definition min : ℤ → ℤ → ℤ := algebra.min
   definition max : ℤ → ℤ → ℤ := algebra.max
   definition abs : ℤ → ℤ := algebra.abs
@@ -294,7 +293,6 @@ section migrate_algebra
   attribute le.trans ge.trans lt.trans gt.trans [trans]
   attribute lt_of_lt_of_le lt_of_le_of_lt gt_of_gt_of_ge gt_of_ge_of_gt [trans]
 end migrate_algebra
-
 
 /- more facts specific to int -/
 

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -363,7 +363,7 @@ theorem lt_of_le_sub_one {a b : ℤ} (H : a ≤ b - 1) : a < b :=
 theorem sign_of_succ (n : nat) : sign (nat.succ n) = 1 :=
 sign_of_pos (of_nat_pos !nat.succ_pos)
 
-theorem exists_eq_neg_succ_of_nat {a : ℤ} : a < 0 → ∃m : ℕ, a = -[m +1] :=
+theorem exists_eq_neg_succ_of_nat {a : ℤ} : a < 0 → ∃m : ℕ, a = -[1+m] :=
 int.cases_on a
   (take m H, absurd (of_nat_nonneg m : 0 ≤ m) (not_le_of_gt H))
   (take m H, exists.intro m rfl)

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -281,15 +281,19 @@ section migrate_algebra
   show decidable (b ≤ a), from _
   definition decidable_gt [instance] (a b : ℤ) : decidable (a > b) :=
   show decidable (b < a), from _
-  definition sign : ∀a : ℤ, ℤ := algebra.sign
+  definition min : ℤ → ℤ → ℤ := algebra.min
+  definition max : ℤ → ℤ → ℤ := algebra.max
   definition abs : ℤ → ℤ := algebra.abs
+  definition sign : ℤ → ℤ := algebra.sign
 
   migrate from algebra with int
-  replacing has_le.ge → ge, has_lt.gt → gt, sign → sign, abs → abs, dvd → dvd, sub → sub
+  replacing has_le.ge → ge, has_lt.gt → gt, dvd → dvd, sub → sub, min → min, max → max,
+            abs → abs, sign → sign
 
   attribute le.trans ge.trans lt.trans gt.trans [trans]
   attribute lt_of_lt_of_le lt_of_le_of_lt gt_of_gt_of_ge gt_of_ge_of_gt [trans]
 end migrate_algebra
+
 
 /- more facts specific to int -/
 

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -281,6 +281,7 @@ section migrate_algebra
   show decidable (b ≤ a), from _
   definition decidable_gt [instance] (a b : ℤ) : decidable (a > b) :=
   show decidable (b < a), from _
+
   definition min : ℤ → ℤ → ℤ := algebra.min
   definition max : ℤ → ℤ → ℤ := algebra.max
   definition abs : ℤ → ℤ := algebra.abs

--- a/library/data/nat/order.lean
+++ b/library/data/nat/order.lean
@@ -446,4 +446,30 @@ decidable.by_cases
     assert H' : b ≤ a, from le_of_lt (lt_of_not_ge H),
     by rewrite (max_eq_left H'); apply H₁)
 
+theorem min_add_add_left (a b c : ℕ) : min (a + b) (a + c) = a + min b c :=
+decidable.by_cases
+  (assume H : b ≤ c,
+    assert H1 : a + b ≤ a + c, from add_le_add_left H _,
+    by rewrite [min_eq_left H, min_eq_left H1])
+  (assume H : ¬ b ≤ c,
+    assert H' : c ≤ b, from le_of_lt (lt_of_not_ge H),
+    assert H1 : a + c ≤ a + b, from add_le_add_left H' _,
+    by rewrite [min_eq_right H', min_eq_right H1])
+
+theorem min_add_add_right (a b c : ℕ) : min (a + c) (b + c) = min a b + c :=
+by rewrite [add.comm a c, add.comm b c, add.comm _ c]; apply min_add_add_left
+
+theorem max_add_add_left (a b c : ℕ) : max (a + b) (a + c) = a + max b c :=
+decidable.by_cases
+  (assume H : b ≤ c,
+    assert H1 : a + b ≤ a + c, from add_le_add_left H _,
+    by rewrite [max_eq_right H, max_eq_right H1])
+  (assume H : ¬ b ≤ c,
+    assert H' : c ≤ b, from le_of_lt (lt_of_not_ge H),
+    assert H1 : a + c ≤ a + b, from add_le_add_left H' _,
+    by rewrite [max_eq_left H', max_eq_left H1])
+
+theorem max_add_add_right (a b c : ℕ) : max (a + c) (b + c) = max a b + c :=
+by rewrite [add.comm a c, add.comm b c, add.comm _ c]; apply max_add_add_left
+
 end nat

--- a/library/data/pnat.lean
+++ b/library/data/pnat.lean
@@ -73,11 +73,11 @@ theorem max_right (a b : ℕ+) : max a b ≥ b := !le_max_right
 theorem max_left (a b : ℕ+) : max a b ≥ a := !le_max_left
 
 theorem max_eq_right {a b : ℕ+} (H : a < b) : max a b = b :=
-  have Hnat : nat.max a~ b~ = b~, from nat.max_eq_right H,
+  have Hnat : nat.max a~ b~ = b~, from nat.max_eq_right' H,
   pnat.eq Hnat
 
 theorem max_eq_left {a b : ℕ+} (H : ¬ a < b) : max a b = a :=
-  have Hnat : nat.max a~ b~ = a~, from nat.max_eq_left H,
+  have Hnat : nat.max a~ b~ = a~, from nat.max_eq_left' H,
   pnat.eq Hnat
 
 theorem le_of_lt {a b : ℕ+} (H : a < b) : a ≤ b := nat.le_of_lt H

--- a/library/data/rat/basic.lean
+++ b/library/data/rat/basic.lean
@@ -105,9 +105,9 @@ theorem of_int.inj {a b : ℤ} : of_int a ≡ of_int b → a = b :=
 by rewrite [↑of_int, ↑equiv, *mul_one]; intros; assumption
 
 definition inv : prerat → prerat
-| inv (prerat.mk nat.zero d dp) := zero
+| inv (prerat.mk nat.zero d dp)     := zero
 | inv (prerat.mk (nat.succ n) d dp) := prerat.mk d (nat.succ n) !of_nat_succ_pos
-| inv (prerat.mk -[n +1] d dp) := prerat.mk (-d) (nat.succ n) !of_nat_succ_pos
+| inv (prerat.mk -[1+n] d dp)       := prerat.mk (-d) (nat.succ n) !of_nat_succ_pos
 
 theorem equiv_zero_of_num_eq_zero {a : prerat} (H : num a = 0) : a ≡ zero :=
 by rewrite [↑equiv, H, ↑zero, ↑num, ↑of_int, *zero_mul]
@@ -132,9 +132,9 @@ obtain (n' : nat) (Hn' : n = of_nat n'), from exists_eq_of_nat (le_of_lt np),
 have H1 : (#nat n' > nat.zero), from lt_of_of_nat_lt_of_nat (Hn' ▸ np),
 obtain (k : nat) (Hk : n' = nat.succ k), from nat.exists_eq_succ_of_lt H1,
 have H2 : -d * n = -d * nat.succ k, by rewrite [Hn', Hk],
-have H3 : inv (mk -[k +1] d dp) ≡ mk (-d) n np, from H2,
-have H4 : -[k +1] = -n, from calc
-  -[k +1] = -(nat.succ k) : rfl
+have H3 : inv (mk -[1+k] d dp) ≡ mk (-d) n np, from H2,
+have H4 : -[1+k] = -n, from calc
+  -[1+k] = -(nat.succ k) : rfl
       ... = -n            : by rewrite [Hk⁻¹, Hn'],
 H4 ▸ H3
 
@@ -298,13 +298,15 @@ theorem reduce_eq_reduce : ∀{a b : prerat}, a ≡ b → reduce a = reduce b
   decidable.by_cases
     (assume anz : an = 0,
       have H' : bn * ad = 0, by rewrite [-H, anz, zero_mul],
-      assert bnz : bn = 0, from or_resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero H') (ne_of_gt adpos),
+      assert bnz : bn = 0,
+        from or_resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero H') (ne_of_gt adpos),
       by rewrite [↑reduce, if_pos anz, if_pos bnz])
     (assume annz : an ≠ 0,
       assert bnnz : bn ≠ 0, from
         assume bnz,
         have H' : an * bd = 0, by rewrite [H, bnz, zero_mul],
-        have anz : an = 0, from or_resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero H') (ne_of_gt bdpos),
+        have anz : an = 0,
+          from or_resolve_left (eq_zero_or_eq_zero_of_mul_eq_zero H') (ne_of_gt bdpos),
         show false, from annz anz,
       begin
         rewrite [↑reduce, if_neg annz, if_neg bnnz],
@@ -395,7 +397,7 @@ calc
                   ... = of_int a - of_int b         : {of_int_neg b}
 
 theorem of_int.inj {a b : ℤ} (H : of_int a = of_int b) : a = b :=
-sorry
+prerat.of_int.inj (quot.exact H)
 
 theorem of_nat_eq (a : ℕ) : of_nat a = of_int (int.of_nat a) := rfl
 

--- a/library/data/rat/order.lean
+++ b/library/data/rat/order.lean
@@ -276,10 +276,6 @@ theorem lt_of_le_of_lt  (Hab : a ≤ b) (Hbc : b < c) : a < c :=
     (assume Heq, not_le_of_gt (Heq⁻¹ ▸ Hbc) Hab))
 
 theorem zero_lt_one : (0 : ℚ) < 1 := trivial
---  begin
---    rewrite [↑lt, sub_zero],
---    apply sorry
---  end
 
 theorem add_lt_add_left (H : a < b) (c : ℚ) : c + a < c + b :=
 let H' := le_of_lt H in
@@ -298,10 +294,10 @@ section migrate_algebra
     le_trans         := @le.trans,
     le_antisymm      := @le.antisymm,
     le_total         := @le.total,
-    le_of_lt                   := @le_of_lt, --sorry,
-    lt_irrefl                  := lt_irrefl,
-    lt_of_lt_of_le             := @lt_of_lt_of_le,
-    lt_of_le_of_lt             := @lt_of_le_of_lt,
+    le_of_lt         := @le_of_lt,
+    lt_irrefl        := lt_irrefl,
+    lt_of_lt_of_le   := @lt_of_lt_of_le,
+    lt_of_le_of_lt   := @lt_of_le_of_lt,
     le_iff_lt_or_eq  := @le_iff_lt_or_eq,
     add_le_add_left  := @add_le_add_left,
     mul_nonneg       := @mul_nonneg,
@@ -312,17 +308,16 @@ section migrate_algebra
 
   local attribute rat.discrete_field [instance]
   local attribute rat.discrete_linear_ordered_field [instance]
-  definition abs (n : rat) : rat := algebra.abs n
-  definition sign (n : rat) : rat := algebra.sign n
+  definition min : ℚ → ℚ → ℚ := algebra.min
+  definition max : ℚ → ℚ → ℚ := algebra.max
+  definition abs : ℚ → ℚ := algebra.abs
+  definition sign : ℚ → ℚ := algebra.sign
 
-  definition max (a b : rat) : rat := algebra.max a b
-  definition min (a b : rat) : rat := algebra.min a b
-  --set_option migrate.trace true
   migrate from algebra with rat
-    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, abs → abs, sign → sign, dvd → dvd,
-      divide → divide, max → max, min → min
+    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, dvd → dvd,
+              divide → divide, max → max, min → min, abs → abs, sign → sign
 
-attribute le.trans lt.trans lt_of_lt_of_le lt_of_le_of_lt ge.trans gt.trans gt_of_gt_of_ge
+  attribute le.trans lt.trans lt_of_lt_of_le lt_of_le_of_lt ge.trans gt.trans gt_of_gt_of_ge
                    gt_of_ge_of_gt [trans]
 
 end migrate_algebra

--- a/library/init/nat.lean
+++ b/library/init/nat.lean
@@ -5,7 +5,6 @@ Authors: Floris van Doorn, Leonardo de Moura
 -/
 prelude
 import init.wf init.tactic init.num
-
 open eq.ops decidable or
 
 namespace nat
@@ -39,7 +38,6 @@ namespace nat
 
   notation a - b := sub a b
   notation a * b := mul a b
-
 
   /- properties of ℕ -/
 
@@ -226,17 +224,18 @@ namespace nat
   theorem max_self (a : ℕ) : max a a = a :=
   eq.rec_on !if_t_t rfl
 
-  theorem max_eq_right {a b : ℕ} (H : a < b) : max a b = b :=
+  theorem max_eq_right' {a b : ℕ} (H : a < b) : max a b = b :=
   if_pos H
 
-  theorem max_eq_left {a b : ℕ} (H : ¬ a < b) : max a b = a :=
+  -- different versions will be defined in algebra
+  theorem max_eq_left' {a b : ℕ} (H : ¬ a < b) : max a b = a :=
   if_neg H
 
   theorem eq_max_right {a b : ℕ} (H : a < b) : b = max a b :=
-  eq.rec_on (max_eq_right H) rfl
+  eq.rec_on (max_eq_right' H) rfl
 
   theorem eq_max_left {a b : ℕ} (H : ¬ a < b) : a = max a b :=
-  eq.rec_on (max_eq_left H) rfl
+  eq.rec_on (max_eq_left' H) rfl
 
   theorem le_max_left (a b : ℕ) : a ≤ max a b :=
   by_cases


### PR DESCRIPTION
I implemented a `lattice` class in algebra, and other subclasses, to define `min` and `max`. There are theorems relating them to an additive group structure, but I still have to prove theorems for ordered rings, e.g. `max (a * b) (a * c) = a * max b c` when `a >= 0`.

The types `nat`, `int`, `rat`, and `real` are instances, so we have `min` and `max` for all of them uniformly. Handling `nat` was a little tricky, because `min` and `max` are defined in `init`, so we cannot use the generic definitions from algebra.

I also got rid of an unused class in `order.lean`.

@htzh These should include at least some of theorems you wanted for min and max. Please let me know if there are others you need.

@fpvandoorn Unfortunately, this makes the standard library diverge from the hott library. It would be really tedious to track all the changes and make them again in hott. Perhaps when we are both back in Pittsburgh and the concrete number types in the standard library have settled, we can do another port? I think the concrete number types are close to settling down. (A note for the port: I renamed the theorems `max_eq_right` and `max_eq_left` in `init/nat` to `max_eq_right'` and `max_eq_left'`, because those theorems mean something slightly different (and more natural) in the algebra.)

@rlewis1988 I defined `abs a b := max a (-a)` which is also valid constructively, and I moved a number of theorems to a class that can be instantiated constructively. One thing I could not prove was `abs a b >= 0`, even though that is true of the constructive reals. I also don't know how to prove the triangle inequality constructively in a general algebraic setting. We should talk about this, and find a good constructive axiomatization, to which we can instantiate the reals.
