### PR TITLE
prime factorization

### DIFF
--- a/library/algebra/algebra.md
+++ b/library/algebra/algebra.md
@@ -13,7 +13,9 @@ Algebraic structures.
 * [ring](ring.lean)
 * [ordered_group](ordered_group.lean)
 * [ordered_ring](ordered_ring.lean)
+* [ring_power](ring_power.lean) : power in ring structures
 * [field](field.lean)
 * [ordered_field](ordered_field.lean)
+
 * [category](category/category.md) : category theory
 

--- a/library/algebra/ordered_ring.lean
+++ b/library/algebra/ordered_ring.lean
@@ -19,7 +19,7 @@ definition absurd_a_lt_a {B : Type} {a : A} [s : strict_order A] (H : a < a) : B
 absurd H (lt.irrefl a)
 
 structure ordered_semiring [class] (A : Type)
-  extends semiring A, ordered_cancel_comm_monoid A, zero_ne_one_class A :=
+  extends semiring A, ordered_cancel_comm_monoid A :=
 (mul_le_mul_of_nonneg_left: ∀a b c, le a b → le zero c → le (mul c a) (mul c b))
 (mul_le_mul_of_nonneg_right: ∀a b c, le a b → le zero c → le (mul a c) (mul b c))
 (mul_lt_mul_of_pos_left: ∀a b c, lt a b → lt zero c → lt (mul c a) (mul c b))
@@ -100,12 +100,15 @@ section
 end
 
 structure linear_ordered_semiring [class] (A : Type)
-  extends ordered_semiring A, linear_strong_order_pair A
+  extends ordered_semiring A, linear_strong_order_pair A :=
+(zero_lt_one : lt zero one)
 
 section
   variable [s : linear_ordered_semiring A]
   variables {a b c : A}
   include s
+
+  theorem zero_lt_one : 0 < (1:A) := linear_ordered_semiring.zero_lt_one A
 
   theorem lt_of_mul_lt_mul_left (H : c * a < c * b) (Hc : c ≥ 0) : a < b :=
   lt_of_not_ge
@@ -378,7 +381,6 @@ section
     (assume H : a ≤ 0, mul_nonneg_of_nonpos_of_nonpos H H)
 
   theorem zero_le_one : 0 ≤ (1:A) := one_mul 1 ▸ mul_self_nonneg 1
-  theorem zero_lt_one : 0 < (1:A) := linear_ordered_ring.zero_lt_one A
 
   theorem pos_and_pos_or_neg_and_neg_of_mul_pos {a b : A} (Hab : a * b > 0) :
     (a > 0 ∧ b > 0) ∨ (a < 0 ∧ b < 0) :=

--- a/library/algebra/ring_power.lean
+++ b/library/algebra/ring_power.lean
@@ -1,0 +1,63 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Properties of the power operation in an ordered ring.
+
+(Right now, this file is just a stub. More soon.)
+-/
+import .group_power
+open nat
+
+namespace algebra
+
+variable {A : Type}
+
+section linear_ordered_semiring
+variable [s : linear_ordered_semiring A]
+include s
+
+theorem pow_pos_of_pos {x : A} (i : ℕ) (H : x > 0) : x^i > 0 :=
+begin
+  induction i with [j, ih],
+    {show (1 : A) > 0, from zero_lt_one},
+    {show x^(succ j) > 0, from mul_pos ih H}
+end
+
+theorem pow_nonneg_of_nonneg {x : A} (i : ℕ) (H : x ≥ 0) : x^i ≥ 0 :=
+begin
+  induction i with [j, ih],
+    {show (1 : A) ≥ 0, from le_of_lt zero_lt_one},
+    {show x^(succ j) ≥ 0, from mul_nonneg ih H}
+end
+
+theorem pow_le_pow_of_le {x y : A} (i : ℕ) (H₁ : 0 ≤ x) (H₂ : x ≤ y) : x^i ≤ y^i :=
+begin
+  induction i with [i, ih],
+    {rewrite *pow_zero, apply le.refl},
+  rewrite *pow_succ,
+  have H : 0 ≤ y^i, from pow_nonneg_of_nonneg i (le.trans H₁ H₂),
+  apply mul_le_mul ih H₂ H₁ H
+end
+
+theorem pow_ge_one {x : A} (i : ℕ) (xge1 : x ≥ 1) : x^i ≥ 1 :=
+assert H : x^i ≥ 1^i, from pow_le_pow_of_le i (le_of_lt zero_lt_one) xge1,
+by rewrite one_pow at H; exact H
+
+set_option formatter.hide_full_terms false
+
+theorem pow_gt_one {x : A} {i : ℕ} (xgt1 : x > 1) (ipos : i > 0) : x^i > 1 :=
+assert xpos : x > 0, from lt.trans zero_lt_one xgt1,
+begin
+  induction i with [i, ih],
+    {exfalso, exact !nat.lt.irrefl ipos},
+  have xige1 : x^i ≥ 1, from pow_ge_one _ (le_of_lt xgt1),
+  rewrite [pow_succ', -mul_one 1, ↑has_lt.gt],
+  apply mul_lt_mul xgt1 xige1 zero_lt_one,
+  apply le_of_lt xpos
+end
+
+end linear_ordered_semiring
+
+end algebra

--- a/library/data/nat/order.lean
+++ b/library/data/nat/order.lean
@@ -165,7 +165,7 @@ section migrate_algebra
     add_lt_add_left            := @add_lt_add_left,
     add_le_add_left            := @add_le_add_left,
     le_of_add_le_add_left      := @le_of_add_le_add_left,
-    zero_ne_one                := ne.symm (succ_ne_zero zero),
+    zero_lt_one                := zero_lt_succ 0,
     mul_le_mul_of_nonneg_left  := (take a b c H1 H2, mul_le_mul_left c H1),
     mul_le_mul_of_nonneg_right := (take a b c H1 H2, mul_le_mul_right c H1),
     mul_lt_mul_of_pos_left     := @mul_lt_mul_of_pos_left,
@@ -223,7 +223,6 @@ section migrate_algebra
 end migrate_algebra
 
 theorem zero_le_one : 0 ≤ 1 := dec_trivial
-theorem zero_lt_one : 0 < 1 := dec_trivial
 
 /- properties specific to nat -/
 

--- a/library/data/nat/order.lean
+++ b/library/data/nat/order.lean
@@ -472,4 +472,41 @@ decidable.by_cases
 theorem max_add_add_right (a b c : ℕ) : max (a + c) (b + c) = max a b + c :=
 by rewrite [add.comm a c, add.comm b c, add.comm _ c]; apply max_add_add_left
 
+/- greatest -/
+
+section greatest
+  variable (P : ℕ → Prop)
+  variable [decP : ∀ n, decidable (P n)]
+  include decP
+
+  -- returns the largest i < n satisfying P, or n if there is none.
+  definition greatest : ℕ → ℕ
+  | 0        := 0
+  | (succ n) := if P n then n else greatest n
+
+  theorem greatest_of_lt {i n : ℕ} (ltin : i < n) (Hi : P i) : P (greatest P n) :=
+  begin
+    induction n with [m, ih],
+      {exact absurd ltin !not_lt_zero},
+      {cases (decidable.em (P m)) with [Psm, Pnsm],
+        {rewrite [↑greatest, if_pos Psm]; exact Psm},
+        {rewrite [↑greatest, if_neg Pnsm],
+          have neim : i ≠ m, from assume H : i = m, absurd (H ▸ Hi) Pnsm,
+          have ltim : i < m, from lt_of_le_of_ne (le_of_lt_succ ltin) neim,
+          apply ih ltim}}
+  end
+
+  theorem le_greatest_of_lt {i n : ℕ} (ltin : i < n) (Hi : P i) : i ≤ greatest P n :=
+  begin
+    induction n with [m, ih],
+      {exact absurd ltin !not_lt_zero},
+      {cases (decidable.em (P m)) with [Psm, Pnsm],
+        {rewrite [↑greatest, if_pos Psm], apply le_of_lt_succ ltin},
+        {rewrite [↑greatest, if_neg Pnsm],
+          have neim : i ≠ m, from assume H : i = m, absurd (H ▸ Hi) Pnsm,
+          have ltim : i < m, from lt_of_le_of_ne (le_of_lt_succ ltin) neim,
+          apply ih ltim}}
+ end
+end greatest
+
 end nat

--- a/library/data/nat/power.lean
+++ b/library/data/nat/power.lean
@@ -5,7 +5,7 @@ Authors: Leonardo de Moura, Jeremy Avigad
 
 The power function on the natural numbers.
 -/
-import data.nat.basic data.nat.order data.nat.div data.nat.gcd algebra.group_power
+import data.nat.basic data.nat.order data.nat.div data.nat.gcd algebra.ring_power
 
 namespace nat
 
@@ -17,13 +17,32 @@ section migrate_algebra
   definition pow (a : ℕ) (n : ℕ) : ℕ := algebra.pow a n
   infix ^ := pow
 
+  theorem pow_le_pow_of_le {x y : ℕ} (i : ℕ) (H : x ≤ y) : x^i ≤ y^i :=
+  algebra.pow_le_pow_of_le i !zero_le H
+
   migrate from algebra with nat
     replacing dvd → dvd, has_le.ge → ge, has_lt.gt → gt, pow → pow
     hiding add_pos_of_pos_of_nonneg,  add_pos_of_nonneg_of_pos,
       add_eq_zero_iff_eq_zero_and_eq_zero_of_nonneg_of_nonneg, le_add_of_nonneg_of_le,
       le_add_of_le_of_nonneg, lt_add_of_nonneg_of_lt, lt_add_of_lt_of_nonneg,
-      lt_of_mul_lt_mul_left, lt_of_mul_lt_mul_right, pos_of_mul_pos_left, pos_of_mul_pos_right
+      lt_of_mul_lt_mul_left, lt_of_mul_lt_mul_right, pos_of_mul_pos_left, pos_of_mul_pos_right,
+      pow_nonneg_of_nonneg
 end migrate_algebra
+
+-- generalize to semirings?
+theorem le_pow_self {x : ℕ} (H : x > 1) : ∀ i, i ≤ x^i
+| 0        := !zero_le
+| (succ j) := have xpos : x > 0, from lt.trans zero_lt_one H,
+              have xjge1 : x^j ≥ 1, from succ_le_of_lt (pow_pos_of_pos _ xpos),
+              have xge2 : x ≥ 2, from succ_le_of_lt H,
+              calc
+                succ j = j + 1         : rfl
+                   ... ≤ x^j + 1       : add_le_add_right (le_pow_self j)
+                   ... ≤ x^j + x^j     : add_le_add_left xjge1
+                   ... = x^j * (1 + 1) : by rewrite [mul.left_distrib, *mul_one]
+                   ... = x^j * 2       : rfl
+                   ... ≤ x^j * x       : mul_le_mul_left _ xge2
+                   ... = x^(succ j)    : rfl
 
 -- TODO: eventually this will be subsumed under the algebraic theorems
 

--- a/library/theories/number_theory/bezout.lean
+++ b/library/theories/number_theory/bezout.lean
@@ -73,11 +73,15 @@ end
 
 end Bezout
 
+/-
+A sample application of Bezout's theorem, namely, an alternative proof that irreducible
+implies prime (dvd_or_dvd_of_prime_of_dvd_mul).
+-/
+
 namespace nat
 open int
 
-theorem dvd_or_dvd_of_dvd_mul_of_prime {p x y : ℕ} (pp : prime p) (H : p ∣ x * y) :
-  p ∣ x ∨ p ∣ y :=
+example {p x y : ℕ} (pp : prime p) (H : p ∣ x * y) : p ∣ x ∨ p ∣ y :=
 decidable.by_cases
   (assume Hpx : p ∣ x, or.inl Hpx)
   (assume Hnpx : ¬ p ∣ x,

--- a/library/theories/number_theory/number_theory.md
+++ b/library/theories/number_theory/number_theory.md
@@ -1,4 +1,6 @@
 theories.number_theory
 ======================
 
-* [bezout](bezout.lean)
+* [primes](primes.lean)
+* [bezout](bezout.lean) : Bezout's theorem
+* [prime_factorization](prime_factorization.lean) : prime divisors and multiplicity

--- a/library/theories/number_theory/prime_factorization.lean
+++ b/library/theories/number_theory/prime_factorization.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+
+Multiplicity and prime factors. We have:
+
+  mult p n        := the greatest power of p dividing n if p > 1 and n > 0, and 0 otherwise.
+  prime_factors n := the finite set of prime factors of n, assuming n > 0
+
+-/
+import data.nat data.finset .primes
+open eq.ops finset well_founded decidable
+
+namespace nat
+
+/- multiplicity -/
+
+theorem mult_rec_decreasing {p n : ℕ} (Hp : p > 1) (Hn : n > 0) : n div p < n :=
+have H' : n < n * p,
+ by rewrite [-mul_one n at {1}]; apply mul_lt_mul_of_pos_left Hp Hn,
+div_lt_of_lt_mul H'
+
+private definition mult.F (p : ℕ) (n : ℕ) (f: Π {m : ℕ}, m < n → ℕ) : ℕ :=
+if H : (p > 1 ∧ n > 0) ∧ p ∣ n then
+  succ (f (mult_rec_decreasing (and.left (and.left H)) (and.right (and.left H))))
+else 0
+
+definition mult (p n : ℕ) : ℕ := fix (mult.F p) n
+
+theorem mult_rec {p n : ℕ} (pgt1 : p > 1) (ngt0 : n > 0) (pdivn : p ∣ n) :
+  mult p n = succ (mult p (n div p)) :=
+have H : (p > 1 ∧ n > 0) ∧ p ∣ n, from and.intro (and.intro pgt1 ngt0) pdivn,
+eq.trans (well_founded.fix_eq (mult.F p) n) (dif_pos H)
+
+private theorem mult_base {p n : ℕ} (H : ¬ ((p > 1 ∧ n > 0) ∧ p ∣ n)) :
+  mult p n = 0 :=
+eq.trans (well_founded.fix_eq (mult.F p) n) (dif_neg H)
+
+theorem mult_zero_right (p : ℕ) : mult p 0 = 0 :=
+mult_base (assume H, !lt.irrefl (and.right (and.left H)))
+
+theorem mult_eq_zero_of_not_dvd {p n : ℕ} (H : ¬ p ∣ n) : mult p n = 0 :=
+mult_base (assume H', H (and.right H'))
+
+theorem mult_eq_zero_of_le_one {p : ℕ} (n : ℕ) (H : p ≤ 1) : mult p n = 0 :=
+mult_base (assume H', not_lt_of_ge H (and.left (and.left H')))
+
+theorem mult_zero_left (n : ℕ) : mult 0 n = 0 :=
+mult_eq_zero_of_le_one n !dec_trivial
+
+theorem mult_one_left (n : ℕ) : mult 1 n = 0 :=
+mult_eq_zero_of_le_one n !dec_trivial
+
+theorem mult_pos_of_dvd {p n : ℕ} (pgt1 : p > 1) (npos : n > 0) (pdvdn : p ∣ n) : mult p n > 0 :=
+by rewrite (mult_rec pgt1 npos pdvdn); apply succ_pos
+
+theorem not_dvd_of_mult_eq_zero {p n : ℕ} (pgt1 : p > 1) (npos : n > 0) (H : mult p n = 0) :
+  ¬ p ∣ n :=
+assume pdvdn : p ∣ n,
+ne_of_gt (mult_pos_of_dvd pgt1 npos pdvdn) H
+
+theorem dvd_of_mult_pos {p n : ℕ} (H : mult p n > 0) : p ∣ n :=
+by_contradiction (assume npdvdn : ¬ p ∣ n, ne_of_gt H (mult_eq_zero_of_not_dvd npdvdn))
+
+/- properties of mult -/
+
+theorem pow_mult_dvd (p n : ℕ) : p^(mult p n) ∣ n :=
+begin
+  induction n using nat.strong_induction_on with [n, ih],
+  cases eq_zero_or_pos n with [nz, npos],
+    {rewrite nz, apply dvd_zero},
+  cases le_or_gt p 1 with [ple1, pgt1],
+    {rewrite [!mult_eq_zero_of_le_one ple1, pow_zero], apply one_dvd},
+  cases (or.swap (em (p ∣ n))) with [pndvdn, pdvdn],
+    {rewrite [mult_eq_zero_of_not_dvd pndvdn, pow_zero], apply one_dvd},
+  show p ^ (mult p n) ∣ n, from dvd.elim pdvdn
+    (take n',
+      assume Hn' : n = p * n',
+      have ppos : p > 0, from lt.trans zero_lt_one pgt1,
+      assert ndivpeq : n div p = n', from !div_eq_of_eq_mul_right ppos Hn',
+      assert ndivplt : n' < n,
+        by rewrite -ndivpeq; apply mult_rec_decreasing pgt1 npos,
+      begin
+        rewrite [mult_rec pgt1 npos pdvdn, ndivpeq, pow_succ', Hn'],
+        apply mul_dvd_mul !dvd.refl,
+        apply ih _ ndivplt
+      end)
+end
+
+theorem mult_one_right (p : ℕ) : mult p 1 = 0:=
+assert H : p^(mult p 1) = 1, from eq_one_of_dvd_one !pow_mult_dvd,
+or.elim (le_or_gt p 1)
+  (assume H1 : p ≤ 1, by rewrite [!mult_eq_zero_of_le_one H1])
+  (assume H1 : p > 1,
+    by_contradiction
+      assume H2 : mult p 1 ≠ 0,
+      have H3 : mult p 1 > 0, from pos_of_ne_zero H2,
+      assert H4 : p^(mult p 1) > 1, from pow_gt_one H1 H3,
+      show false, by rewrite H at H4; apply !lt.irrefl H4)
+
+private theorem mult_pow_mul {p n : ℕ} (i : ℕ) (pgt1 : p > 1) (npos : n > 0) :
+  mult p (p^i * n) = i + mult p n :=
+begin
+  induction i with [i, ih],
+    rewrite [pow_zero, one_mul, zero_add],  -- strange: this fails with {brackets} around it
+  have ppos : p > 0, from lt.trans zero_lt_one pgt1,
+  have psin_pos : p^(succ i) * n > 0, from mul_pos (!pow_pos_of_pos ppos) npos,
+  have pdvd : p ∣ p^(succ i) * n, by rewrite [pow_succ', mul.assoc]; apply dvd_mul_right,
+  rewrite [mult_rec pgt1 psin_pos pdvd, pow_succ, mul.right_comm, !mul_div_cancel ppos, ih],
+  rewrite [add.comm i, add.comm (succ i)]
+end
+
+theorem mult_pow {p : ℕ} (i : ℕ) (pgt1 : p > 1) : mult p (p^i) = i :=
+by rewrite [-(mul_one (p^i)), mult_pow_mul i pgt1 zero_lt_one, mult_one_right]
+
+theorem le_mult {p i n : ℕ} (pgt1 : p > 1) (npos : n > 0) (pidvd : p^i ∣ n) : i ≤ mult p n :=
+dvd.elim pidvd
+  (take m,
+    assume neq : n = p^i * m,
+    assert mpos : m > 0, from pos_of_mul_pos_left (neq ▸ npos),
+    by rewrite [neq, mult_pow_mul i pgt1 mpos]; apply le_add_right)
+
+theorem not_dvd_div_pow_mult {p n : ℕ} (pgt1 : p > 1) (npos : n > 0) : ¬ p ∣ n div p^(mult p n) :=
+assume pdvd : p ∣ n div p^(mult p n),
+obtain m (H : n div p^(mult p n) = p * m), from exists_eq_mul_right_of_dvd pdvd,
+assert neq : n = p^(succ (mult p n)) * m, from
+  calc
+    n     = p^mult p n * (n div p^mult p n) : by rewrite (mul_div_cancel' !pow_mult_dvd)
+      ... = p^(succ (mult p n)) * m         : by rewrite [H, pow_succ, mul.assoc],
+have H1 : p^(succ (mult p n)) ∣ n, by rewrite neq at {2}; apply dvd_mul_right,
+have H2 : succ (mult p n) ≤ mult p n, from le_mult pgt1 npos H1,
+show false, from !not_succ_le_self H2
+
+theorem mult_mul {p m n : ℕ} (primep : prime p) (mpos : m > 0) (npos : n > 0) :
+  mult p (m * n) = mult p m + mult p n :=
+let m' := m div p^mult p m, n' := n div p^mult p n in
+assert pgt1 : p > 1, from gt_one_of_prime primep,
+assert meq : m = p^mult p m * m', by rewrite (mul_div_cancel' !pow_mult_dvd),
+assert neq : n = p^mult p n * n', by rewrite (mul_div_cancel' !pow_mult_dvd),
+have m'pos : m' > 0, from pos_of_mul_pos_left (meq ▸ mpos),
+have n'pos : n' > 0, from pos_of_mul_pos_left (neq ▸ npos),
+have npdvdm' : ¬ p ∣ m', from !not_dvd_div_pow_mult pgt1 mpos,
+have npdvdn' : ¬ p ∣ n', from !not_dvd_div_pow_mult pgt1 npos,
+assert npdvdm'n' : ¬ p ∣ m' * n', from not_dvd_mul_of_prime primep npdvdm' npdvdn',
+assert m'n'pos : m' * n' > 0, from mul_pos m'pos n'pos,
+assert multm'n' : mult p (m' * n') = 0, from mult_eq_zero_of_not_dvd npdvdm'n',
+calc
+  mult p (m * n) = mult p (p^(mult p m + mult p n) * (m' * n')) :
+                     by rewrite [pow_add, mul.right_comm, -mul.assoc, -meq, mul.assoc,
+                                 mul.comm (n div _), -neq]
+             ... = mult p m + mult p n                          :
+                     by rewrite [!mult_pow_mul pgt1 m'n'pos, multm'n']
+
+theorem dvd_of_forall_prime_mult_le {m n : ℕ} (mpos : m > 0)
+    (H : ∀ {p}, prime p → mult p m ≤ mult p n) :
+  m ∣ n :=
+begin
+  revert H, revert n,
+  induction m using nat.strong_induction_on with [m, ih],
+  cases (decidable.em (m = 1)) with [meq, mneq],
+    {intros, rewrite meq, apply one_dvd},
+  have mgt1 : m > 1, from lt_of_le_of_ne (succ_le_of_lt mpos) (ne.symm mneq),
+  have mge2 : m ≥ 2, from succ_le_of_lt mgt1,
+  have hpd : ∃ p, prime p ∧ p ∣ m, from ex_prime_and_dvd mge2,
+  cases hpd with [p, H1],
+  cases H1 with [primep, pdvdm],
+  intro n,
+  cases (eq_zero_or_pos n) with [nz, npos],
+    {intros; rewrite nz; apply dvd_zero},
+  assume H : ∀ {p : ℕ}, prime p → mult p m ≤ mult p n,
+  obtain m' (meq : m = p * m'), from exists_eq_mul_right_of_dvd pdvdm,
+  assert pgt1 : p > 1, from gt_one_of_prime primep,
+  assert m'pos : m' > 0, from pos_of_ne_zero
+      (assume m'z, by revert mpos; rewrite [meq, m'z, mul_zero]; apply not_lt_zero),
+  have m'ltm : m' < m,
+    by rewrite [meq, -one_mul m' at {1}]; apply mul_lt_mul_of_lt_of_le m'pos pgt1 !le.refl,
+  have multpm : mult p m ≥ 1, from le_mult pgt1 mpos (by rewrite pow_one; apply pdvdm),
+  have multpn : mult p n ≥ 1, from le.trans multpm (H primep),
+  obtain n' (neq : n = p * n'),
+    from exists_eq_mul_right_of_dvd (dvd_of_mult_pos (lt_of_succ_le multpn)),
+  assert n'pos : n' > 0, from pos_of_ne_zero
+      (assume n'z, by revert npos; rewrite [neq, n'z, mul_zero]; apply not_lt_zero),
+  have H' : ∀q, prime q → mult q m' ≤ mult q n', from
+    (take q,
+      assume primeq : prime q,
+      have multqm : mult q m = mult q p + mult q m',
+        by rewrite [meq, mult_mul primeq (pos_of_prime primep) m'pos],
+      have multqn : mult q n = mult q p + mult q n',
+        by rewrite [neq, mult_mul primeq (pos_of_prime primep) n'pos],
+      show mult q m' ≤ mult q n', from le_of_add_le_add_left (multqm ▸ multqn ▸ H primeq)),
+  assert m'dvdn' : m' ∣ n', from ih m' m'ltm m'pos n' H',
+  show m ∣ n, by rewrite [meq, neq]; apply mul_dvd_mul !dvd.refl m'dvdn'
+end
+
+theorem eq_of_forall_prime_mult_eq {m n : ℕ} (mpos : m > 0) (npos : n > 0)
+    (H : ∀ {p}, prime p → mult p m = mult p n) : m = n :=
+dvd.antisymm
+  (dvd_of_forall_prime_mult_le mpos (take p, assume primep, H primep ▸ !le.refl))
+  (dvd_of_forall_prime_mult_le npos (take p, assume primep, H primep ▸ !le.refl))
+
+/- prime factors -/
+
+definition prime_factors (n : ℕ) : finset ℕ := { p ∈ upto (succ n) | prime p ∧ p ∣ n }
+
+theorem prime_of_mem_prime_factors {p n : ℕ} (H : p ∈ prime_factors n) : prime p :=
+and.left (of_mem_filter H)
+
+theorem dvd_of_mem_prime_factors {p n : ℕ} (H : p ∈ prime_factors n) : p ∣ n :=
+and.right (of_mem_filter H)
+
+theorem mem_prime_factors {p n : ℕ} (npos : n > 0) (primep : prime p) (pdvdn : p ∣ n) :
+  p ∈ prime_factors n :=
+have plen : p ≤ n, from le_of_dvd npos pdvdn,
+mem_filter_of_mem (mem_upto_of_lt (lt_succ_of_le plen)) (and.intro primep pdvdn)
+
+end nat


### PR DESCRIPTION
The main thing here is a definition of `mult p n`, the multiplicity of `p` in `n`, i.e. the largest power of `p` that divides `n` (assuming `n > 0` and `p > 1`). Here is one of the main theorems:

``` lean
theorem dvd_of_forall_prime_mult_le {m n : ℕ} (mpos : m > 0) 
    (H : ∀ {p}, prime p → mult p m ≤ mult p n) : m ∣ n
```

I still need to prove

``` lean
n > 0 → n = ∏ p : prime_factors n, p^(mult p n)
```

but I don't think it will be hard with the facts already there. We may need more properties of sums and products. I also started developing some properties of powers in algebra, but there is still a lot to do.

@htzh I renamed a few theorems in primes.lean in this commit. I am sorry if this breaks some of your proofs, but it should be easy to fix.

@leodemoura There might be a bug here:

https://github.com/avigad/lean/blob/master/library/theories/number_theory/prime_factorization.lean#L106

It is strange, the proof breaks when I put brackets around that line, but `begin ... end` works o.k. It might be hard to produce a small counterexample; I did this sort of thing many times, without problems. But let me know if you want me to try.

There are a lot of proofs by induction and cases in prime_factorization, like this one:

https://github.com/avigad/lean/blob/master/library/theories/number_theory/prime_factorization.lean#L68-L89

If we eventually have good syntax for induction and cases in proof terms, this would be a good place to try it out.
