### PR TITLE
choose, and varia

### DIFF
--- a/library/data/finset/basic.lean
+++ b/library/data/finset/basic.lean
@@ -213,7 +213,7 @@ decidable.by_cases
   (assume H : a ∈ s, by rewrite [card_insert_of_mem H]; apply le_succ)
   (assume H : a ∉ s, by rewrite [card_insert_of_not_mem H])
 
-lemma non_empty_of_card_succ {s : finset A} {n : nat} : card s = succ n → s ≠ ∅ :=
+lemma ne_empty_of_card_eq_succ {s : finset A} {n : nat} : card s = succ n → s ≠ ∅ :=
 by intros; substvars; contradiction
 
 protected theorem induction [recursor 6] {P : finset A → Prop}

--- a/library/data/finset/basic.lean
+++ b/library/data/finset/basic.lean
@@ -160,7 +160,7 @@ quot.lift_on s
   (λ (l₁ l₂ : nodup_list A) (p : l₁ ~ l₂), quot.sound (perm_insert a p))
 
 -- set builder notation
-notation `{[`:max a:(foldr `,` (x b, insert x b) ∅) `]}`:0 := a
+notation `'{`:max a:(foldr `,` (x b, insert x b) ∅) `}`:0 := a
 -- notation `⦃` a:(foldr `,` (x b, insert x b) ∅) `⦄` := a
 
 theorem mem_insert (a : A) (s : finset A) : a ∈ insert a s :=
@@ -184,7 +184,7 @@ propext (iff.intro
     (assume H' : x = a, eq.subst (eq.symm H') !mem_insert)
     (assume H' : x ∈ s, !mem_insert_of_mem H')))
 
-theorem insert_empty_eq (a : A) : {[ a ]} = singleton a := rfl
+theorem insert_empty_eq (a : A) : '{a} = singleton a := rfl
 
 theorem insert_eq_of_mem {a : A} {s : finset A} (H : a ∈ s) : insert a s = s :=
 ext
@@ -384,7 +384,7 @@ ext (take x,
     x ∈ insert a s ↔ x ∈ insert a s            : iff.refl
                ... = (x = a ∨ x ∈ s)           : mem_insert_eq
                ... = (x ∈ singleton a ∨ x ∈ s) : mem_singleton_eq
-               ... = (x ∈ {[ a ]} ∪ s)         : mem_union_eq)
+               ... = (x ∈ '{a} ∪ s)         : mem_union_eq)
 
 theorem insert_union (a : A) (s t : finset A) : insert a (s ∪ t) = insert a s ∪ t :=
 by rewrite [*insert_eq, union.assoc]

--- a/library/data/finset/bigops.lean
+++ b/library/data/finset/bigops.lean
@@ -126,7 +126,7 @@ section deceqA
     intros [H1, H2],
     rewrite [Union_insert, H2 _ !mem_insert],
     cases (decidable.em (s' = ∅)) with [seq, sne],
-      {rewrite [seq, Union_empty, union_empty] },
+      {rewrite [seq, Union_empty, union_empty]},
     have H3 : ∀ x, x ∈ s' → f x = t, from (λ x H', H2 x (mem_insert_of_mem _ H')),
     rewrite [IH sne H3, union_self]
   end

--- a/library/data/finset/bigops.lean
+++ b/library/data/finset/bigops.lean
@@ -117,6 +117,19 @@ section deceqA
       finset.induction_on s
         (by rewrite Union_empty)
         (take s1 a Pa IH, by rewrite [image_insert, *Union_insert, IH])
+
+  lemma Union_const [deceqB : decidable_eq B] {f : A → finset B} {s : finset A} {t : finset B}
+    (a : A) : s ≠ ∅ → (∀ x, x ∈ s → f x = t) → Union s f = t :=
+  begin
+    induction s with a' s' H IH,
+      {intros [H1, H2], exfalso, apply H1 !rfl},
+    intros [H1, H2],
+    rewrite [Union_insert, H2 _ !mem_insert],
+    cases (decidable.em (s' = ∅)) with [seq, sne],
+      {rewrite [seq, Union_empty, union_empty] },
+    have H3 : ∀ x, x ∈ s' → f x = t, from (λ x H', H2 x (mem_insert_of_mem _ H')),
+    rewrite [IH sne H3, union_self]
+  end
 end deceqA
 
 end union

--- a/library/data/finset/bigops.lean
+++ b/library/data/finset/bigops.lean
@@ -118,8 +118,8 @@ section deceqA
         (by rewrite Union_empty)
         (take s1 a Pa IH, by rewrite [image_insert, *Union_insert, IH])
 
-  lemma Union_const [deceqB : decidable_eq B] {f : A → finset B} {s : finset A} {t : finset B}
-    (a : A) : s ≠ ∅ → (∀ x, x ∈ s → f x = t) → Union s f = t :=
+  lemma Union_const [deceqB : decidable_eq B] {f : A → finset B} {s : finset A} {t : finset B} :
+    s ≠ ∅ → (∀ x, x ∈ s → f x = t) → Union s f = t :=
   begin
     induction s with a' s' H IH,
       {intros [H1, H2], exfalso, apply H1 !rfl},

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -74,6 +74,18 @@ ext (take y, iff.intro
         show y ∈ image f (insert a s), from eq.subst (eq.symm H2) H3)
       (assume H2 : y ∈ image f s,
         show y ∈ image f (insert a s), from mem_image_of_mem_image_of_subset H2 !subset_insert)))
+
+lemma image_compose {C : Type} [deceqC : decidable_eq C] {f : B → C} {g : A → B} {s : finset A} :
+  image (f∘g) s = image f (image g s) :=
+ext (take z, iff.intro
+  (assume Hz : z ∈ image (f∘g) s,
+    obtain x (Hx : x ∈ s) (Hgfx : f (g x) = z), from exists_of_mem_image Hz,
+    by rewrite -Hgfx; apply mem_image_of_mem _ (mem_image_of_mem _ Hx))
+  (assume Hz : z ∈ image f (image g s),
+    obtain y (Hy : y ∈ image g s) (Hfy : f y = z), from exists_of_mem_image Hz,
+    obtain x (Hx : x ∈ s) (Hgx : g x = y), from exists_of_mem_image Hy,
+    mem_image_of_mem_of_eq Hx (by esimp; rewrite [Hgx, Hfy])))
+
 end image
 
 /- filter and set-builder notation -/

--- a/library/data/nat/fact.lean
+++ b/library/data/nat/fact.lean
@@ -21,19 +21,11 @@ rfl
 lemma fact_succ (n) : fact (succ n) = succ n * fact n :=
 rfl
 
-lemma fact_ne_zero : ∀ n, fact n ≠ 0
-| 0        := by contradiction
-| (succ n) :=
-  begin
-    intro h,
-    rewrite [fact_succ at h],
-    cases (eq_zero_or_eq_zero_of_mul_eq_zero h) with h₁ h₂,
-      contradiction,
-      exact fact_ne_zero n h₂
-  end
+lemma fact_pos : ∀ n, fact n > 0
+| 0        := zero_lt_one
+| (succ n) := mul_pos !succ_pos (fact_pos n)
 
-lemma fact_gt_0 (n) : fact n > 0 :=
-pos_of_ne_zero (fact_ne_zero n)
+lemma fact_ne_zero (n : ℕ) : fact n ≠ 0 := ne_of_gt !fact_pos
 
 lemma dvd_fact : ∀ {m n}, m > 0 → m ≤ n → m ∣ fact n
 | m 0        h₁ h₂ := absurd h₁ (not_lt_of_ge h₂)

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -148,9 +148,9 @@ notation `{` binders `|` r:(scoped:1 P, set_of P) `}` := r
 definition filter (P : X → Prop) (s : set X) : set X := λx, x ∈ s ∧ P x
 notation `{` binders ∈ s `|` r:(scoped:1 p, filter p s) `}` := r
 
--- {[x, y, z]}
+-- '{x, y, z}
 definition insert (x : X) (a : set X) : set X := {y : X | y = x ∨ y ∈ a}
-notation `{[`:max a:(foldr `,` (x b, insert x b) ∅) `]}`:0 := a
+notation `'{`:max a:(foldr `,` (x b, insert x b) ∅) `}`:0 := a
 
 /- set difference -/
 

--- a/library/theories/combinatorics/choose.lean
+++ b/library/theories/combinatorics/choose.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Binomial coefficients, "n choose k".
+-/
+import data.nat.div data.nat.fact
+open decidable
+
+namespace nat
+
+/- choose -/
+
+definition choose : ℕ → ℕ → ℕ
+| 0 0               := 1
+| 0 (succ k)        := 0
+| (succ n) 0        := 1
+| (succ n) (succ k) := choose n (succ k) + choose n k
+
+theorem choose_zero_right (n : ℕ) : choose n 0 = 1 :=
+nat.cases_on n rfl (take m, rfl)
+
+theorem choose_zero_succ (k : ℕ) : choose 0 (succ k) = 0 := rfl
+
+theorem choose_succ_succ (n k : ℕ) : choose (succ n) (succ k) = choose n (succ k) + choose n k := rfl
+
+theorem choose_eq_zero_of_lt {n : ℕ} : ∀{k : ℕ}, n < k → choose n k = 0 :=
+nat.induction_on n
+  (take k, assume H : 0 < k,
+    obtain k' (H : k = succ k'), from exists_eq_succ_of_pos H,
+    by rewrite H)
+  (take n',
+    assume IH: ∀ k, n' < k → choose n' k = 0,
+    take k,
+    assume H : succ n' < k,
+    obtain k' (keq : k = succ k'), from exists_eq_succ_of_lt H,
+    assert H' : n' < k', by rewrite keq at H; apply lt_of_succ_lt_succ H,
+    by rewrite [keq, choose_succ_succ, IH _ H', IH _ (lt.trans H' !lt_succ_self)])
+
+theorem choose_self (n : ℕ) : choose n n = 1 :=
+begin
+  induction n with [n, ih],
+    {apply rfl},
+  rewrite [choose_succ_succ, ih, choose_eq_zero_of_lt !lt_succ_self]
+end
+
+theorem choose_succ_self (n : ℕ) : choose (succ n) n = succ n :=
+begin
+  induction n with [n, ih],
+    {apply rfl},
+  rewrite [choose_succ_succ, ih, choose_self, add.comm]
+end
+
+theorem choose_one_right (n : ℕ) : choose n 1 = n :=
+begin
+  induction n with [n, ih],
+    {apply rfl},
+  rewrite [choose_succ_succ, ih, choose_zero_right]
+end
+
+theorem choose_pos {n : ℕ} : ∀ {k : ℕ}, k ≤ n → choose n k > 0 :=
+begin
+  induction n with [n, ih],
+    {intros [k, H],
+      have kz : k = 0, from eq_of_le_of_ge H !zero_le,
+      rewrite [kz, choose_zero_right]; apply zero_lt_one},
+  intro k,
+  cases k with k,
+    {intro H, rewrite [choose_zero_right], apply zero_lt_one},
+  assume H : succ k ≤ succ n,
+  assert H' : k ≤ n, from le_of_succ_le_succ H,
+  by rewrite [choose_succ_succ]; apply add_pos_right (ih H')
+end
+
+-- A key identity. The proof is subtle.
+theorem succ_mul_choose_eq (n : ℕ) : ∀ k, succ n * (choose n k) = choose (succ n) (succ k) * succ k :=
+begin
+  induction n with [n, ih],
+    {intro k,
+      cases k with k',
+        {rewrite [*choose_self, one_mul, mul_one]},
+        {have H : 1 < succ (succ k'), from succ_lt_succ !zero_lt_succ,
+          rewrite [one_mul, choose_zero_succ, choose_eq_zero_of_lt H, zero_mul]}},
+  intro k,
+  cases k with k',
+    {rewrite [choose_zero_right, choose_one_right]},
+  rewrite [choose_succ_succ (succ n), mul.right_distrib, -ih (succ k')],
+  rewrite [choose_succ_succ at {1}, mul.left_distrib, *succ_mul (succ n), mul_succ, -ih k'],
+  rewrite [*add.assoc, add.left_comm (choose n _)]
+end
+
+theorem choose_mul_fact_mul_fact {n : ℕ} :
+  ∀ {k : ℕ}, k ≤ n → choose n k * fact k * fact (n - k) = fact n :=
+begin
+  induction n using nat.strong_induction_on with [n, ih],
+  cases n with n,
+    {intro k H, have kz : k = 0, from eq_zero_of_le_zero H, rewrite [kz]},
+  intro k,
+  intro H,  -- k ≤ n,
+  cases k with k,
+    {rewrite [choose_zero_right, fact_zero, *one_mul]},
+  have kle : k ≤ n, from le_of_succ_le_succ H,
+  show choose (succ n) (succ k) * fact (succ k) * fact (succ n - succ k) = fact (succ n), from
+  begin
+    rewrite [succ_sub_succ, fact_succ, -mul.assoc, -succ_mul_choose_eq],
+    rewrite [fact_succ n, -ih n !lt_succ_self kle, *mul.assoc]
+  end
+end
+
+theorem choose_def_alt {n k : ℕ} (H : k ≤ n) : choose n k = fact n div (fact k * fact (n -k)) :=
+eq.symm (div_eq_of_eq_mul_left (mul_pos !fact_pos !fact_pos)
+    (by rewrite [-mul.assoc, choose_mul_fact_mul_fact H]))
+
+theorem fact_mul_fact_dvd_fact {n k : ℕ} (H : k ≤ n) : fact k * fact (n - k) ∣ fact n :=
+by rewrite [-choose_mul_fact_mul_fact H, mul.assoc]; apply dvd_mul_left
+
+end nat

--- a/library/theories/combinatorics/combinatorics.md
+++ b/library/theories/combinatorics/combinatorics.md
@@ -1,0 +1,4 @@
+theories.combinatorics
+======================
+
+* [choose](choose.lean)

--- a/library/theories/number_theory/primes.lean
+++ b/library/theories/number_theory/primes.lean
@@ -113,7 +113,7 @@ open eq.ops
 theorem infinite_primes (n : nat) : ∃ p, p ≥ n ∧ prime p :=
 let m := fact (n + 1) in
 have Hn1 : n + 1 ≥ 1, from succ_le_succ (zero_le _),
-have m_ge_1 : m ≥ 1,  from le_of_lt_succ (succ_lt_succ (fact_gt_0 _)),
+have m_ge_1 : m ≥ 1,  from le_of_lt_succ (succ_lt_succ (fact_pos _)),
 have m1_ge_2 : m + 1 ≥ 2, from succ_le_succ m_ge_1,
 obtain p (prime_p : prime p) (p_dvd_m1 : p ∣ m + 1), from ex_prime_and_dvd m1_ge_2,
 have p_ge_2 : p ≥ 2, from ge_two_of_prime prime_p,

--- a/library/theories/theories.md
+++ b/library/theories/theories.md
@@ -2,3 +2,4 @@ theories
 ========
 
 * [number_theory](number_theory.md)
+* [combinatorics](combinatorics.md)


### PR DESCRIPTION
The file `choose.lean` gives a recursive description of `choose n k` and proves it is equivalent to the usual definition with factorials. (There is a lot more to do in that file.) The name currently conflicts with `nat.choose` in `/library/data/nat/choose.lean`, so we cannot load both at once.

Questions:
- Should we change the other `choose` to `find`?
- Should we introduce infix notation for `choose`?

@htzh: this pull request includes the two theorems you asked for, with two small changes:
- I reoriented the equation in `image_compose` (nso it agrees with the corresponding theorem for sets)
- The theorem `Union_const` was false as you stated it (this is why we have formal proof!). I added the hypothesis `s ≠ ∅`.
  By the way, I also changed the theorem `non_empty_of_card_succ` to `ne_empty_of_card_eq_succ`. I think you use that theorem?

I changed the notation `{[a, b, c]}` to `'{a, b, c}`, to avoid notational conflicts. Anyhow I like the new notation better.

By the way, `choose.lean` contains some more examples of proofs with induction and cases. It would be interesting to know if they can be made more readable with better support for induction and cases in proof term mode.
