### PR TITLE
feat(library): clean up "sorry"s in library

### DIFF
--- a/library/algebra/binary.lean
+++ b/library/algebra/binary.lean
@@ -58,6 +58,12 @@ namespace binary
       (a*b)*c = a*(b*c) : H_assoc
         ...   = a*(c*b) : H_comm
         ...   = (a*c)*b : H_assoc
+
+    theorem comm4 (a b c d : A) : a*b*(c*d) = a*c*(b*d) :=
+    calc
+      a*b*(c*d) = a*b*c*d   : H_assoc
+        ...     = a*c*b*d   : right_comm H_comm H_assoc
+        ...     = a*c*(b*d) : H_assoc
   end
 
   section

--- a/library/data/empty.lean
+++ b/library/data/empty.lean
@@ -6,8 +6,8 @@ Author: Jeremy Avigad, Floris van Doorn
 import logic.cast
 
 namespace empty
-  protected theorem elim (A : Type) (H : empty) : A :=
-  empty.rec (λe, A) H
+  protected theorem elim (A : Type) : empty → A :=
+  empty.rec (λe, A)
 
   protected theorem subsingleton [instance] : subsingleton empty :=
   subsingleton.intro (λ a b, !empty.elim a)

--- a/library/data/fin.lean
+++ b/library/data/fin.lean
@@ -26,8 +26,8 @@ lemma veq_of_eq : ∀ {i j : fin n}, i = j → (val i) = j
 | (mk iv ilt) (mk jv jlt) := assume Peq,
   show iv = jv, from fin.no_confusion Peq (λ Pe Pqe, Pe)
 
-lemma eq_iff_veq : ∀ {i j : fin n}, (val i) = j ↔ i = j :=
-take i j, iff.intro eq_of_veq veq_of_eq
+lemma eq_iff_veq {i j : fin n} : (val i) = j ↔ i = j :=
+iff.intro eq_of_veq veq_of_eq
 
 definition val_inj := @eq_of_veq n
 
@@ -37,10 +37,7 @@ section
 open decidable
 protected definition has_decidable_eq [instance] (n : nat) : ∀ (i j : fin n), decidable (i = j)
 | (mk ival ilt) (mk jval jlt) :=
-      match nat.has_decidable_eq ival jval with
-      | inl veq := inl (by substvars)
-      | inr vne := inr (by intro h; injection h; contradiction)
-      end
+  decidable_of_decidable_of_iff (nat.has_decidable_eq ival jval) eq_iff_veq
 end
 
 lemma dinj_lt (n : nat) : dinj (λ i, i < n) fin.mk :=

--- a/library/data/int/basic.lean
+++ b/library/data/int/basic.lean
@@ -45,49 +45,39 @@ namespace int
 
 attribute int.of_nat [coercion]
 
+notation `-[1+` n `]` := int.neg_succ_of_nat n    -- for pretty-printing output
+
 /- definitions of basic functions -/
 
-definition neg_of_nat (m : ℕ) : ℤ :=
-nat.cases_on m 0 (take m', neg_succ_of_nat m')
+definition neg_of_nat : ℕ → ℤ
+| 0 := 0
+| (succ m) := -[1+ m]
 
 definition sub_nat_nat (m n : ℕ) : ℤ :=
-nat.cases_on (n - m)
-  (of_nat (m - n))                                     -- m ≥ n
-  (take k, neg_succ_of_nat k)                          -- m < n, and n - m = succ k
+match n - m with
+  | 0        := m - n       -- m ≥ n
+  | (succ k) := -[1+ k]     -- m < n, and n - m = succ k
+end
 
 definition neg (a : ℤ) : ℤ :=
-  int.cases_on a
-    (take m,                                           -- a = of_nat m
-      nat.cases_on m 0 (take m', neg_succ_of_nat m'))
-    (take m, of_nat (succ m))                          -- a = neg_succ_of_nat m
+int.cases_on a neg_of_nat succ
 
-definition add (a b : ℤ) : ℤ :=
-  int.cases_on a
-    (take m,                                           -- a = of_nat m
-      int.cases_on b
-        (take n, of_nat (m + n))                         -- b = of_nat n
-        (take n, sub_nat_nat m (succ n)))                -- b = neg_succ_of_nat n
-    (take m,                                           -- a = neg_succ_of_nat m
-      int.cases_on b
-        (take n, sub_nat_nat n (succ m))                 -- b = of_nat n
-        (take n, neg_of_nat (succ m + succ n)))          -- b = neg_succ_of_nat n
+definition add : ℤ → ℤ → ℤ
+| (of_nat m) (of_nat n) := m + n
+| (of_nat m) -[1+ n]    := sub_nat_nat m (succ n)
+| -[1+ m]    (of_nat n) := sub_nat_nat n (succ m)
+| -[1+ m]    -[1+ n]    := neg_of_nat (succ m + succ n)
 
-definition mul (a b : ℤ) : ℤ :=
-  int.cases_on a
-    (take m,                                           -- a = of_nat m
-      int.cases_on b
-        (take n, of_nat (m * n))                         -- b = of_nat n
-        (take n, neg_of_nat (m * succ n)))               -- b = neg_succ_of_nat n
-    (take m,                                           -- a = neg_succ_of_nat m
-      int.cases_on b
-        (take n, neg_of_nat (succ m * n))                -- b = of_nat n
-        (take n, of_nat (succ m * succ n)))              -- b = neg_succ_of_nat n
+definition mul : ℤ → ℤ → ℤ
+| (of_nat m) (of_nat n) := m * n
+| (of_nat m) -[1+ n]    := neg_of_nat (m * succ n)
+| -[1+ m]    (of_nat n) := neg_of_nat (succ m * n)
+| -[1+ m]    -[1+ n]    := succ m * succ n
 
 /- notation -/
 
 protected definition prio : num := num.pred std.priority.default
 
-notation `-[1+` n `]` := int.neg_succ_of_nat n    -- for pretty-printing output
 prefix [priority int.prio] - := int.neg
 infix  [priority int.prio] +  := int.add
 infix  [priority int.prio] *  := int.mul
@@ -95,30 +85,25 @@ infix  [priority int.prio] *  := int.mul
 /- some basic functions and properties -/
 
 theorem of_nat.inj {m n : ℕ} (H : of_nat m = of_nat n) : m = n :=
-by injection H; assumption
+int.no_confusion H imp.id
 
 theorem of_nat_eq_of_nat (m n : ℕ) : of_nat m = of_nat n ↔ m = n :=
 iff.intro of_nat.inj !congr_arg
 
 theorem neg_succ_of_nat.inj {m n : ℕ} (H : neg_succ_of_nat m = neg_succ_of_nat n) : m = n :=
-by injection H; assumption
+int.no_confusion H imp.id
 
 theorem neg_succ_of_nat_eq (n : ℕ) : -[1+ n] = -(n + 1) := rfl
 
-definition has_decidable_eq [instance] : decidable_eq ℤ :=
-take a b,
-int.cases_on a
-  (take m,
-    int.cases_on b
-      (take n,
-        if H : m = n then inl (congr_arg of_nat H) else inr (take H1, H (of_nat.inj H1)))
-      (take n', inr (by contradiction)))
-  (take m',
-    int.cases_on b
-      (take n, inr (by contradiction))
-      (take n',
-        (if H : m' = n' then inl (congr_arg neg_succ_of_nat H) else
-            inr (take H1, H (neg_succ_of_nat.inj H1)))))
+private definition has_decidable_eq₂ : Π (a b : ℤ), decidable (a = b)
+| (of_nat m) (of_nat n) := decidable_of_decidable_of_iff
+    (nat.has_decidable_eq m n) (iff.symm (of_nat_eq_of_nat m n))
+| (of_nat m) -[1+ n]    := inr (by contradiction)
+| -[1+ m]    (of_nat n) := inr (by contradiction)
+| -[1+ m]    -[1+ n]    := if H : m = n then
+    inl (congr_arg neg_succ_of_nat H) else inr (not.mto neg_succ_of_nat.inj H)
+
+definition has_decidable_eq [instance] : decidable_eq ℤ := has_decidable_eq₂
 
 theorem of_nat_add (n m : nat) : of_nat (n + m) = of_nat n + of_nat m := rfl
 
@@ -127,30 +112,23 @@ theorem of_nat_succ (n : ℕ) : of_nat (succ n) = of_nat n + 1 := rfl
 theorem of_nat_mul (n m : ℕ) : of_nat (n * m) = of_nat n * of_nat m := rfl
 
 theorem sub_nat_nat_of_ge {m n : ℕ} (H : m ≥ n) : sub_nat_nat m n = of_nat (m - n) :=
-have H1 : n - m = 0, from sub_eq_zero_of_le H,
-calc
-  sub_nat_nat m n = nat.cases_on 0 (of_nat (m - n)) _ : H1 ▸ rfl
-    ... = of_nat (m - n) : rfl
+show sub_nat_nat m n = nat.cases_on 0 (m - n) _, from (sub_eq_zero_of_le H) ▸ rfl
 
 section
 local attribute sub_nat_nat [reducible]
 theorem sub_nat_nat_of_lt {m n : ℕ} (H : m < n) :
-  sub_nat_nat m n = neg_succ_of_nat (pred (n - m)) :=
+  sub_nat_nat m n = -[1+ pred (n - m)] :=
 have H1 : n - m = succ (pred (n - m)), from (succ_pred_of_pos (sub_pos_of_lt H))⁻¹,
-calc
-  sub_nat_nat m n = nat.cases_on (succ (pred (n - m))) (of_nat (m - n))
-        (take k, neg_succ_of_nat k) : H1 ▸ rfl
-    ... = neg_succ_of_nat (pred (n - m)) : rfl
+show sub_nat_nat m n = nat.cases_on (succ (pred (n - m))) (m - n) _, from H1 ▸ rfl
 end
 
-definition nat_abs (a : ℤ) : ℕ := int.cases_on a (take n, n) (take n', succ n')
+definition nat_abs (a : ℤ) : ℕ := int.cases_on a function.id succ
 
-theorem nat_abs_of_nat (n : ℕ) : nat_abs (of_nat n) = n := rfl
+theorem nat_abs_of_nat (n : ℕ) : nat_abs n = n := rfl
 
-theorem nat_abs_eq_zero {a : ℤ} : nat_abs a = 0 → a = 0 :=
-int.cases_on a
-  (take m,  suppose nat_abs (of_nat m) = 0, congr_arg of_nat this)
-  (take m', suppose nat_abs (neg_succ_of_nat m') = 0, absurd this (succ_ne_zero _))
+theorem nat_abs_eq_zero : Π {a : ℤ}, nat_abs a = 0 → a = 0
+| (of_nat m) H := congr_arg of_nat H
+| -[1+ m']   H := absurd H !succ_ne_zero
 
 /- int is a quotient of ordered pairs of natural numbers -/
 
@@ -162,24 +140,23 @@ protected theorem equiv.refl [refl] {p : ℕ × ℕ} : p ≡ p := !add.comm
 
 protected theorem equiv.symm [symm] {p q : ℕ × ℕ} (H : p ≡ q) : q ≡ p :=
 calc
-  pr1 q + pr2 p = pr2 p + pr1 q : !add.comm
+  pr1 q + pr2 p = pr2 p + pr1 q : add.comm
     ... = pr1 p + pr2 q         : H⁻¹
-    ... = pr2 q + pr1 p         : !add.comm
+    ... = pr2 q + pr1 p         : add.comm
 
 protected theorem equiv.trans [trans] {p q r : ℕ × ℕ} (H1 : p ≡ q) (H2 : q ≡ r) : p ≡ r :=
-have H3 : pr1 p + pr2 r + pr2 q = pr2 p + pr1 r + pr2 q, from
-  calc
-   pr1 p + pr2 r + pr2 q = pr1 p + pr2 q + pr2 r : by rewrite [*add.assoc, add.comm (pr₂ q)]
+add.cancel_right (calc
+   pr1 p + pr2 r + pr2 q = pr1 p + pr2 q + pr2 r : add.right_comm
     ... = pr2 p + pr1 q + pr2 r                  : {H1}
     ... = pr2 p + (pr1 q + pr2 r)                : add.assoc
     ... = pr2 p + (pr2 q + pr1 r)                : {H2}
-    ... = pr2 p + pr1 r + pr2 q                  : by rewrite [add.assoc, add.comm (pr₂ q)],
-show pr1 p + pr2 r = pr2 p + pr1 r, from add.cancel_right H3
+    ... = pr2 p + pr2 q + pr1 r                  : add.assoc
+    ... = pr2 p + pr1 r + pr2 q                  : add.right_comm)
 
 protected theorem equiv_equiv : is_equivalence int.equiv :=
 is_equivalence.mk @equiv.refl @equiv.symm @equiv.trans
 
-protected theorem equiv_cases {p q : ℕ × ℕ} (H : int.equiv p q) :
+protected theorem equiv_cases {p q : ℕ × ℕ} (H : p ≡ q) :
     (pr1 p ≥ pr2 p ∧ pr1 q ≥ pr2 q) ∨ (pr1 p < pr2 p ∧ pr1 q < pr2 q) :=
 or.elim (@le_or_gt (pr2 p) (pr1 p))
   (suppose pr1 p ≥ pr2 p,
@@ -199,108 +176,82 @@ theorem abstr_of_ge {p : ℕ × ℕ} (H : pr1 p ≥ pr2 p) : abstr p = of_nat (p
 sub_nat_nat_of_ge H
 
 theorem abstr_of_lt {p : ℕ × ℕ} (H : pr1 p < pr2 p) :
-  abstr p = neg_succ_of_nat (pred (pr2 p - pr1 p)) :=
+  abstr p = -[1+ pred (pr2 p - pr1 p)] :=
 sub_nat_nat_of_lt H
 
-definition repr (a : ℤ) : ℕ × ℕ := int.cases_on a (take m, (m, 0)) (take m, (0, succ m))
+definition repr : ℤ → ℕ × ℕ
+| (of_nat m) := (m, 0)
+| -[1+ m]    := (0, succ m)
 
-theorem abstr_repr (a : ℤ) : abstr (repr a) = a :=
-int.cases_on a (take m, (sub_nat_nat_of_ge (zero_le m))) (take m, rfl)
+theorem abstr_repr : Π (a : ℤ), abstr (repr a) = a
+| (of_nat m) := (sub_nat_nat_of_ge (zero_le m))
+| -[1+ m]    := rfl
 
 theorem repr_sub_nat_nat (m n : ℕ) : repr (sub_nat_nat m n) ≡ (m, n) :=
-or.elim (@le_or_gt n m)
-  (suppose m ≥ n,
-    have repr (sub_nat_nat m n) = (m - n, 0), from sub_nat_nat_of_ge this ▸ rfl,
-    this⁻¹ ▸
-      (calc
-        m - n + n = m : sub_add_cancel `m ≥ n`
-          ... = 0 + m : zero_add))
-  (suppose H : m < n,
-    have repr (sub_nat_nat m n) = (0, succ (pred (n - m))), from sub_nat_nat_of_lt H ▸ rfl,
-    this⁻¹ ▸
-      (calc
-        0 + n = n : zero_add
-          ... = n - m + m : sub_add_cancel (le_of_lt H)
-          ... = succ (pred (n - m)) + m : (succ_pred_of_pos (sub_pos_of_lt H))⁻¹))
+lt_ge_by_cases
+  (take H : m < n,
+    have H1 : repr (sub_nat_nat m n) = (0, n - m), by
+      rewrite [sub_nat_nat_of_lt H, -(succ_pred_of_pos (sub_pos_of_lt H))],
+    H1⁻¹ ▸ (!zero_add ⬝ (sub_add_cancel (le_of_lt H))⁻¹))
+  (take H : m ≥ n,
+    have H1 : repr (sub_nat_nat m n) = (m - n, 0), from sub_nat_nat_of_ge H ▸ rfl,
+    H1⁻¹ ▸ ((sub_add_cancel H) ⬝ !zero_add⁻¹))
 
 theorem repr_abstr (p : ℕ × ℕ) : repr (abstr p) ≡ p :=
 !prod.eta ▸ !repr_sub_nat_nat
 
 theorem abstr_eq {p q : ℕ × ℕ} (Hequiv : p ≡ q) : abstr p = abstr q :=
 or.elim (int.equiv_cases Hequiv)
-  (assume H2,
-    have H3 : pr1 p ≥ pr2 p, from and.elim_left H2,
-    have H4 : pr1 q ≥ pr2 q, from and.elim_right H2,
-    have H5 : pr1 p = pr1 q - pr2 q + pr2 p, from
-      calc
-        pr1 p = pr1 p + pr2 q - pr2 q : add_sub_cancel
-          ... = pr2 p + pr1 q - pr2 q : Hequiv
-          ... = pr2 p + (pr1 q - pr2 q) : add_sub_assoc H4
-          ... = pr1 q - pr2 q + pr2 p : add.comm,
-    have H6 : pr1 p - pr2 p = pr1 q - pr2 q, from
-      calc
-        pr1 p - pr2 p = pr1 q - pr2 q + pr2 p - pr2 p : H5
-                  ... = pr1 q - pr2 q                 : add_sub_cancel,
-    abstr_of_ge H3 ⬝ congr_arg of_nat H6 ⬝ (abstr_of_ge H4)⁻¹)
-  (assume H2,
-    have H3 : pr1 p < pr2 p, from and.elim_left H2,
-    have H4 : pr1 q < pr2 q, from and.elim_right H2,
-    have H5 : pr2 p = pr2 q - pr1 q + pr1 p, from
-      calc
-        pr2 p = pr2 p + pr1 q - pr1 q : add_sub_cancel
-          ... = pr1 p + pr2 q - pr1 q : Hequiv
-          ... = pr1 p + (pr2 q - pr1 q) : add_sub_assoc (le_of_lt H4)
-          ... = pr2 q - pr1 q + pr1 p : add.comm,
-    have H6 : pr2 p - pr1 p = pr2 q - pr1 q, from
-      calc
-        pr2 p - pr1 p = pr2 q - pr1 q + pr1 p - pr1 p : H5
-                  ... = pr2 q - pr1 q                 : add_sub_cancel,
-    abstr_of_lt H3 ⬝ congr_arg neg_succ_of_nat (congr_arg pred H6)⬝ (abstr_of_lt H4)⁻¹)
+  (and.rec (assume (Hp : pr1 p ≥ pr2 p) (Hq : pr1 q ≥ pr2 q),
+    have H : pr1 p - pr2 p = pr1 q - pr2 q, from
+      calc pr1 p - pr2 p
+           = pr1 p + pr2 q - pr2 q - pr2 p   : add_sub_cancel
+       ... = pr2 p + pr1 q - pr2 q - pr2 p   : Hequiv
+       ... = pr2 p + (pr1 q - pr2 q) - pr2 p : add_sub_assoc Hq
+       ... = pr1 q - pr2 q + pr2 p - pr2 p   : add.comm
+       ... = pr1 q - pr2 q                   : add_sub_cancel,
+    abstr_of_ge Hp ⬝ (H ▸ rfl) ⬝ (abstr_of_ge Hq)⁻¹))
+  (and.rec (assume (Hp : pr1 p < pr2 p) (Hq : pr1 q < pr2 q),
+    have H : pr2 p - pr1 p = pr2 q - pr1 q, from
+      calc pr2 p - pr1 p
+           = pr2 p + pr1 q - pr1 q - pr1 p   : add_sub_cancel
+       ... = pr1 p + pr2 q - pr1 q - pr1 p   : Hequiv
+       ... = pr1 p + (pr2 q - pr1 q) - pr1 p : add_sub_assoc (le_of_lt Hq)
+       ... = pr2 q - pr1 q + pr1 p - pr1 p   : add.comm
+       ... = pr2 q - pr1 q                   : add_sub_cancel,
+    abstr_of_lt Hp ⬝ (H ▸ rfl) ⬝ (abstr_of_lt Hq)⁻¹))
 
-theorem equiv_iff (p q : ℕ × ℕ) : (p ≡ q) ↔ ((p ≡ p) ∧ (q ≡ q) ∧ (abstr p = abstr q)) :=
-iff.intro
-  (assume H : int.equiv p q,
-    and.intro !equiv.refl (and.intro !equiv.refl (abstr_eq H)))
-  (assume H : int.equiv p p ∧ int.equiv q q ∧ abstr p = abstr q,
-    have H1 : abstr p = abstr q, from and.elim_right (and.elim_right H),
-    equiv.trans (H1 ▸ equiv.symm (repr_abstr p)) (repr_abstr q))
+theorem equiv_iff (p q : ℕ × ℕ) : (p ≡ q) ↔ (abstr p = abstr q) :=
+iff.intro abstr_eq (assume H, equiv.trans (H ▸ equiv.symm (repr_abstr p)) (repr_abstr q))
+
+theorem equiv_iff3 (p q : ℕ × ℕ) : (p ≡ q) ↔ ((p ≡ p) ∧ (q ≡ q) ∧ (abstr p = abstr q)) :=
+iff.trans !equiv_iff (iff.symm
+   (iff.trans (and_iff_right !equiv.refl) (and_iff_right !equiv.refl)))
 
 theorem eq_abstr_of_equiv_repr {a : ℤ} {p : ℕ × ℕ} (Hequiv : repr a ≡ p) : a = abstr p :=
-calc
-  a = abstr (repr a) : abstr_repr
-   ... = abstr p : abstr_eq Hequiv
+!abstr_repr⁻¹ ⬝ abstr_eq Hequiv
 
 theorem eq_of_repr_equiv_repr {a b : ℤ} (H : repr a ≡ repr b) : a = b :=
-calc
-  a = abstr (repr a) : abstr_repr
-    ... = abstr (repr b) : abstr_eq H
-    ... = b : abstr_repr
+eq_abstr_of_equiv_repr H ⬝ !abstr_repr
 
 section
 local attribute abstr [reducible]
 local attribute dist [reducible]
-theorem nat_abs_abstr (p : ℕ × ℕ) : nat_abs (abstr p) = dist (pr1 p) (pr2 p) :=
-let m := pr1 p, n := pr2 p in
-or.elim (@le_or_gt n m)
-  (assume H : m ≥ n,
-    calc
-      nat_abs (abstr (m, n)) = nat_abs (of_nat (m - n)) : int.abstr_of_ge H
-                         ... = dist m n                 : dist_eq_sub_of_ge H)
+theorem nat_abs_abstr : Π (p : ℕ × ℕ), nat_abs (abstr p) = dist (pr1 p) (pr2 p)
+| (m, n) := lt_ge_by_cases
   (assume H : m < n,
     calc
-      nat_abs (abstr (m, n)) = nat_abs (neg_succ_of_nat (pred (n - m))) : int.abstr_of_lt H
-        ... = succ (pred (n - m)) : rfl
+      nat_abs (abstr (m, n)) = nat_abs (-[1+ pred (n - m)]) : int.abstr_of_lt H
         ... = n - m               : succ_pred_of_pos (sub_pos_of_lt H)
         ... = dist m n            : dist_eq_sub_of_le (le_of_lt H))
+  (assume H : m ≥ n, (abstr_of_ge H)⁻¹ ▸ (dist_eq_sub_of_ge H)⁻¹)
 end
-
-theorem cases_of_nat (a : ℤ) : (∃n : ℕ, a = of_nat n) ∨ (∃n : ℕ, a = - of_nat n) :=
-int.cases_on a
-  (take n, or.inl (exists.intro n rfl))
-  (take n', or.inr (exists.intro (succ n') rfl))
 
 theorem cases_of_nat_succ (a : ℤ) : (∃n : ℕ, a = of_nat n) ∨ (∃n : ℕ, a = - (of_nat (succ n))) :=
 int.cases_on a (take m, or.inl (exists.intro _ rfl)) (take m, or.inr (exists.intro _ rfl))
+
+theorem cases_of_nat (a : ℤ) : (∃n : ℕ, a = of_nat n) ∨ (∃n : ℕ, a = - of_nat n) :=
+or.imp_right (Exists.rec (take n, (exists.intro _))) !cases_of_nat_succ
 
 theorem by_cases_of_nat {P : ℤ → Prop} (a : ℤ)
     (H1 : ∀n : ℕ, P (of_nat n)) (H2 : ∀n : ℕ, P (- of_nat n)) :
@@ -324,87 +275,55 @@ or.elim (cases_of_nat_succ a)
 
 definition padd (p q : ℕ × ℕ) : ℕ × ℕ := (pr1 p + pr1 q, pr2 p + pr2 q)
 
-theorem repr_add (a b : ℤ) :  repr (add a b) ≡ padd (repr a) (repr b) :=
-int.cases_on a
-  (take m,
-    int.cases_on b
-      (take n, !equiv.refl)
-      (take n',
-        have H1 : int.equiv (repr (add (of_nat m) (neg_succ_of_nat n'))) (m, succ n'),
-          from !repr_sub_nat_nat,
-        have H2 : padd (repr (of_nat m)) (repr (neg_succ_of_nat n')) = (m, 0 + succ n'),
-          from rfl,
-        (!zero_add ▸ H2)⁻¹ ▸ H1))
-  (take m',
-    int.cases_on b
-      (take n,
-        have H1 : int.equiv (repr (add (neg_succ_of_nat m') (of_nat n))) (n, succ m'),
-          from !repr_sub_nat_nat,
-        have H2 : padd (repr (neg_succ_of_nat m')) (repr (of_nat n)) = (0 + n, succ m'),
-          from rfl,
-        (!zero_add ▸ H2)⁻¹ ▸ H1)
-       (take n',!repr_sub_nat_nat))
+theorem repr_add : Π (a b : ℤ), repr (add a b) ≡ padd (repr a) (repr b)
+| (of_nat m) (of_nat n) := !equiv.refl
+| (of_nat m) -[1+ n]    := (!zero_add ▸ rfl)⁻¹ ▸ !repr_sub_nat_nat
+| -[1+ m]    (of_nat n) := (!zero_add ▸ rfl)⁻¹ ▸ !repr_sub_nat_nat
+| -[1+ m]    -[1+ n]    := !repr_sub_nat_nat
 
 theorem padd_congr {p p' q q' : ℕ × ℕ} (Ha : p ≡ p') (Hb : q ≡ q') : padd p q ≡ padd p' q' :=
-calc
-  pr1 (padd p q) + pr2 (padd p' q') = pr1 p + pr2 p' + (pr1 q + pr2 q') :
-                 by rewrite [↑padd, *add.assoc, add.left_comm (pr₁ q)]
+calc pr1 p + pr1 q + (pr2 p' + pr2 q')
+        = pr1 p + pr2 p' + (pr1 q + pr2 q') : add.comm4
     ... = pr2 p + pr1 p' + (pr1 q + pr2 q') : {Ha}
     ... = pr2 p + pr1 p' + (pr2 q + pr1 q') : {Hb}
-    ... = pr2 (padd p q) + pr1 (padd p' q') : by rewrite [↑padd, *add.assoc, add.left_comm (pr₁ p')]
+    ... = pr2 p + pr2 q + (pr1 p' + pr1 q') : add.comm4
 
 theorem padd_comm (p q : ℕ × ℕ) : padd p q = padd q p :=
-calc
-  padd p q = (pr1 p + pr1 q, pr2 p + pr2 q) : rfl
-    ... = (pr1 q + pr1 p, pr2 p + pr2 q) : add.comm
+calc (pr1 p + pr1 q, pr2 p + pr2 q)
+        = (pr1 q + pr1 p, pr2 p + pr2 q) : add.comm
     ... = (pr1 q + pr1 p, pr2 q + pr2 p) : add.comm
-    ... = padd q p : rfl
 
 theorem padd_assoc (p q r : ℕ × ℕ) : padd (padd p q) r = padd p (padd q r) :=
-calc
-  padd (padd p q) r = (pr1 p + pr1 q + pr1 r, pr2 p + pr2 q + pr2 r) : rfl
-    ... = (pr1 p + (pr1 q + pr1 r), pr2 p + pr2 q + pr2 r) : add.assoc
+calc (pr1 p + pr1 q + pr1 r, pr2 p + pr2 q + pr2 r)
+        = (pr1 p + (pr1 q + pr1 r), pr2 p + pr2 q + pr2 r) : add.assoc
     ... = (pr1 p + (pr1 q + pr1 r), pr2 p + (pr2 q + pr2 r)) : add.assoc
-    ... = padd p (padd q r) : rfl
 
 theorem add.comm (a b : ℤ) : a + b = b + a :=
-begin
-  apply eq_of_repr_equiv_repr,
-  apply equiv.trans,
-  apply repr_add,
-  apply equiv.symm,
-  apply eq.subst (padd_comm (repr b) (repr a)),
-  apply repr_add
-end
+eq_of_repr_equiv_repr (equiv.trans !repr_add
+   (equiv.symm (!padd_comm ▸ !repr_add)))
 
 theorem add.assoc (a b c : ℤ) : a + b + c = a + (b + c) :=
-assert H1 : repr (a + b + c) ≡ padd (padd (repr a) (repr b)) (repr c), from
-  equiv.trans (repr_add (a + b) c) (padd_congr !repr_add !equiv.refl),
-assert H2 : repr (a + (b + c)) ≡ padd (repr a) (padd (repr b) (repr c)), from
-  equiv.trans (repr_add a (b + c)) (padd_congr !equiv.refl !repr_add),
-begin
-  apply eq_of_repr_equiv_repr,
-  apply equiv.trans,
-  apply H1,
-  apply eq.subst (padd_assoc _ _ _)⁻¹,
-  apply equiv.symm,
-  apply H2
-end
+eq_of_repr_equiv_repr (calc
+         repr (a + b + c)
+       ≡ padd (repr (a + b)) (repr c)           : repr_add
+  ...  ≡ padd (padd (repr a) (repr b)) (repr c) : padd_congr !repr_add !equiv.refl
+  ...  = padd (repr a) (padd (repr b) (repr c)) : !padd_assoc
+  ...  ≡ padd (repr a) (repr (b + c))           : padd_congr !equiv.refl !repr_add
+  ...  ≡ repr (a + (b + c))                     : repr_add)
 
-theorem add_zero (a : ℤ) : a + 0 = a := int.cases_on a (take m, rfl) (take m', rfl)
+theorem add_zero : Π (a : ℤ), a + 0 = a := int.rec (λm, rfl) (λm, rfl)
 
-theorem zero_add (a : ℤ) : 0 + a = a := add.comm a 0 ▸ add_zero a
+theorem zero_add (a : ℤ) : 0 + a = a := !add.comm ▸ !add_zero
 
 /- negation -/
 
 definition pneg (p : ℕ × ℕ) : ℕ × ℕ := (pr2 p, pr1 p)
 
 -- note: this is =, not just ≡
-theorem repr_neg (a : ℤ) : repr (- a) = pneg (repr a) :=
-int.cases_on a
-  (take m,
-    nat.cases_on m rfl (take m', rfl))
-  (take m', rfl)
+theorem repr_neg : Π (a : ℤ), repr (- a) = pneg (repr a)
+| 0        := rfl
+| (succ m) := rfl
+| -[1+ m]  := rfl
 
 theorem pneg_congr {p p' : ℕ × ℕ} (H : p ≡ p') : pneg p ≡ pneg p' := eq.symm H
 
@@ -423,8 +342,13 @@ theorem padd_pneg (p : ℕ × ℕ) : padd p (pneg p) ≡ (0, 0) :=
 show pr1 p + pr2 p + 0 = pr2 p + pr1 p + 0, from !nat.add.comm ▸ rfl
 
 theorem padd_padd_pneg (p q : ℕ × ℕ) : padd (padd p q) (pneg q) ≡ p :=
-show pr1 p + pr1 q + pr2 q + pr2 p = pr2 p + pr2 q + pr1 q + pr1 p,
-from sorry -- by simp
+calc      pr1 p + pr1 q + pr2 q + pr2 p
+        = pr1 p + (pr1 q + pr2 q) + pr2 p : nat.add.assoc
+    ... = pr1 p + (pr1 q + pr2 q + pr2 p) : nat.add.assoc
+    ... = pr1 p + (pr2 q + pr1 q + pr2 p) : nat.add.comm
+    ... = pr1 p + (pr2 q + pr2 p + pr1 q) : add.right_comm
+    ... = pr1 p + (pr2 p + pr2 q + pr1 q) : nat.add.comm
+    ... = pr2 p + pr2 q + pr1 q + pr1 p   : nat.add.comm
 
 theorem add.left_inv (a : ℤ) : -a + a = 0 :=
 have H : repr (-a + a) ≡ repr 0, from
@@ -450,28 +374,20 @@ calc
     ... = pabs (repr a) : nat_abs_abstr
 
 theorem nat_abs_add_le (a b : ℤ) : nat_abs (a + b) ≤ nat_abs a + nat_abs b :=
-have H : nat_abs (a + b) = pabs (padd (repr a) (repr b)), from
-  calc
-    nat_abs (a + b) = pabs (repr (a + b)) : nat_abs_eq_pabs_repr
-      ... = pabs (padd (repr a) (repr b)) : pabs_congr !repr_add,
-have H1 : nat_abs a = pabs (repr a), from !nat_abs_eq_pabs_repr,
-have H2 : nat_abs b = pabs (repr b), from !nat_abs_eq_pabs_repr,
-have H3 : pabs (padd (repr a) (repr b)) ≤ pabs (repr a) + pabs (repr b),
-  from !dist_add_add_le_add_dist_dist,
-H⁻¹ ▸ H1⁻¹ ▸ H2⁻¹ ▸ H3
+calc
+  nat_abs (a + b) = pabs (repr (a + b)) : nat_abs_eq_pabs_repr 
+              ... = pabs (padd (repr a) (repr b)) : pabs_congr !repr_add
+              ... ≤ pabs (repr a) + pabs (repr b) : dist_add_add_le_add_dist_dist
+              ... = pabs (repr a) + nat_abs b     : nat_abs_eq_pabs_repr
+              ... = nat_abs a + nat_abs b         : nat_abs_eq_pabs_repr
 
 section
 local attribute nat_abs [reducible]
-theorem nat_abs_mul (a b : ℤ) : nat_abs (a * b) = #nat (nat_abs a) * (nat_abs b) :=
-int.cases_on a
-  (take m,
-    int.cases_on b
-      (take n, rfl)
-      (take n', !nat_abs_neg ▸ rfl))
-  (take m',
-    int.cases_on b
-      (take n, !nat_abs_neg ▸ rfl)
-      (take n', rfl))
+theorem nat_abs_mul : Π (a b : ℤ), nat_abs (a * b) = (nat_abs a) * (nat_abs b)
+| (of_nat m) (of_nat n) := rfl
+| (of_nat m) -[1+ n]    := !nat_abs_neg ▸ rfl
+| -[1+ m]    (of_nat n) := !nat_abs_neg ▸ rfl
+| -[1+ m]    -[1+ n]    := rfl
 end
 
 /- multiplication -/
@@ -483,65 +399,41 @@ theorem repr_neg_of_nat (m : ℕ) : repr (neg_of_nat m) = (0, m) :=
 nat.cases_on m rfl (take m', rfl)
 
 -- note: we have =, not just ≡
-theorem repr_mul (a b : ℤ) :  repr (mul a b) = pmul (repr a) (repr b) :=
-int.cases_on a
-  (take m,
-    int.cases_on b
-      (take n,
-        (calc
-          pmul (repr m) (repr n) = (m * n + 0 * 0, m * 0 + 0 * n) : rfl
-            ... = (m * n + 0 * 0, m * 0 + 0) : zero_mul)⁻¹)
-      (take n',
-        (calc
-          pmul (repr m) (repr (neg_succ_of_nat n')) =
-              (m * 0 + 0 * succ n', m * succ n' + 0 * 0) : rfl
-            ... = (m * 0 + 0, m * succ n' + 0 * 0) : zero_mul
-            ... = repr (mul m (neg_succ_of_nat n')) : repr_neg_of_nat)⁻¹))
-  (take m',
-    int.cases_on b
-      (take n,
-        (calc
-          pmul (repr (neg_succ_of_nat m')) (repr n) =
-              (0 * n + succ m' * 0, 0 * 0 + succ m' * n) : rfl
-            ... = (0 + succ m' * 0, 0 * 0 + succ m' * n) : zero_mul
-            ... = (0 + succ m' * 0, succ m' * n) : {!nat.zero_add}
-            ... = repr (mul (neg_succ_of_nat m') n) : repr_neg_of_nat)⁻¹)
-      (take n',
-        (calc
-          pmul (repr (neg_succ_of_nat m')) (repr (neg_succ_of_nat n')) =
-              (0 + succ m' * succ n', 0 * succ n') : rfl
-            ... = (succ m' * succ n', 0 * succ n') : nat.zero_add
-            ... = (succ m' * succ n', 0) : zero_mul
-            ... = repr (mul (neg_succ_of_nat m') (neg_succ_of_nat n')) : rfl)⁻¹))
+theorem repr_mul : Π (a b : ℤ), repr (a * b) = pmul (repr a) (repr b)
+| (of_nat m) (of_nat n) := calc
+          (m * n + 0 * 0, m * 0 + 0) = (m * n + 0 * 0, m * 0 + 0 * n) : zero_mul
+| (of_nat m) -[1+ n]    := calc
+          repr (m * -[1+ n]) = (m * 0 + 0, m * succ n + 0 * 0) : repr_neg_of_nat
+            ... = (m * 0 + 0 * succ n, m * succ n + 0 * 0) : zero_mul
+| -[1+ m]    (of_nat n) := calc
+          repr (-[1+ m] * n) = (0 + succ m * 0, succ m * n) : repr_neg_of_nat
+            ... = (0 + succ m * 0, 0 + succ m * n) : nat.zero_add
+            ... = (0 * n + succ m * 0, 0 + succ m * n) : zero_mul
+| -[1+ m]    -[1+ n]    := calc
+          (succ m * succ n, 0) = (succ m * succ n, 0 * succ n) : zero_mul
+            ... = (0 + succ m * succ n, 0 * succ n) : nat.zero_add
 
 theorem equiv_mul_prep {xa ya xb yb xn yn xm ym : ℕ}
   (H1 : xa + yb = ya + xb) (H2 : xn + ym = yn + xm)
-: xa * xn + ya * yn + (xb * ym + yb * xm) = xa * yn + ya * xn + (xb * xm + yb * ym) :=
-have H3 : xa * xn + ya * yn + (xb * ym + yb * xm) + (yb * xn + xb * yn + (xb * xn + yb * yn))
-    = xa * yn + ya * xn + (xb * xm + yb * ym) + (yb * xn + xb * yn + (xb * xn + yb * yn)), from
-  calc
-    xa * xn + ya * yn + (xb * ym + yb * xm) + (yb * xn + xb * yn + (xb * xn + yb * yn))
-          = xa * xn + yb * xn + (ya * yn + xb * yn) + (xb * xn + xb * ym + (yb * yn + yb * xm))
-            : sorry -- by simp
-      ... = (xa + yb) * xn + (ya + xb) * yn + (xb * (xn + ym) + yb * (yn + xm)) : sorry -- by simp
-      ... = (ya + xb) * xn + (xa + yb) * yn + (xb * (yn + xm) + yb * (xn + ym)) : sorry -- by simp
-      ... = ya * xn + xb * xn + (xa * yn + yb * yn) + (xb * yn + xb * xm + (yb*xn + yb*ym))
-            : sorry -- by simp
-      ... = xa * yn + ya * xn + (xb * xm + yb * ym) + (yb * xn + xb * yn + (xb * xn + yb * yn))
-            : sorry, -- by simp,
-nat.add.cancel_right H3
+: xa*xn+ya*yn+(xb*ym+yb*xm) = xa*yn+ya*xn+(xb*xm+yb*ym) :=
+nat.add.cancel_right (calc
+            xa*xn+ya*yn + (xb*ym+yb*xm) + (yb*xn+xb*yn + (xb*xn+yb*yn))
+          = xa*xn+ya*yn + (yb*xn+xb*yn) + (xb*ym+yb*xm + (xb*xn+yb*yn)) : add.comm4
+      ... = xa*xn+ya*yn + (yb*xn+xb*yn) + (xb*xn+yb*yn + (xb*ym+yb*xm)) : nat.add.comm
+      ... = xa*xn+yb*xn + (ya*yn+xb*yn) + (xb*xn+xb*ym + (yb*yn+yb*xm)) : !congr_arg2 add.comm4 add.comm4
+      ... = ya*xn+xb*xn + (xa*yn+yb*yn) + (xb*yn+xb*xm + (yb*xn+yb*ym))
+          : by rewrite[-+mul.left_distrib,-+mul.right_distrib]; exact H1 ▸ H2 ▸ rfl
+      ... = ya*xn+xa*yn + (xb*xn+yb*yn) + (xb*yn+yb*xn + (xb*xm+yb*ym)) : !congr_arg2 add.comm4 add.comm4
+      ... = xa*yn+ya*xn + (xb*xn+yb*yn) + (yb*xn+xb*yn + (xb*xm+yb*ym)) : !nat.add.comm ▸ !nat.add.comm ▸ rfl
+      ... = xa*yn+ya*xn + (yb*xn+xb*yn) + (xb*xn+yb*yn + (xb*xm+yb*ym)) : add.comm4
+      ... = xa*yn+ya*xn + (yb*xn+xb*yn) + (xb*xm+yb*ym + (xb*xn+yb*yn)) : nat.add.comm
+      ... = xa*yn+ya*xn + (xb*xm+yb*ym) + (yb*xn+xb*yn + (xb*xn+yb*yn)) : add.comm4)
 
-theorem pmul_congr {p p' q q' : ℕ × ℕ} (H1 : p ≡ p') (H2 : q ≡ q') : pmul p q ≡ pmul p' q' :=
-equiv_mul_prep H1 H2
+theorem pmul_congr {p p' q q' : ℕ × ℕ} : p ≡ p' → q ≡ q' → pmul p q ≡ pmul p' q' := equiv_mul_prep
 
 theorem pmul_comm (p q : ℕ × ℕ) : pmul p q = pmul q p :=
-calc
-  (pr1 p * pr1 q + pr2 p * pr2 q, pr1 p * pr2 q + pr2 p * pr1 q) =
-      (pr1 q * pr1 p + pr2 p * pr2 q, pr1 p * pr2 q + pr2 p * pr1 q) : mul.comm
-    ... = (pr1 q * pr1 p + pr2 q * pr2 p, pr1 p * pr2 q + pr2 p * pr1 q) : mul.comm
-    ... = (pr1 q * pr1 p + pr2 q * pr2 p, pr2 q * pr1 p + pr2 p * pr1 q) : mul.comm
-    ... = (pr1 q * pr1 p + pr2 q * pr2 p, pr2 q * pr1 p + pr1 q * pr2 p) : mul.comm
-    ... = (pr1 q * pr1 p + pr2 q * pr2 p, pr1 q * pr2 p + pr2 q * pr1 p) : nat.add.comm
+show (_,_) = (_,_), from !congr_arg2
+   (!congr_arg2 !mul.comm !mul.comm) (!nat.add.comm ⬝ (!congr_arg2 !mul.comm !mul.comm))
 
 theorem mul.comm (a b : ℤ) : a * b = b * a :=
 eq_of_repr_equiv_repr
@@ -550,10 +442,14 @@ eq_of_repr_equiv_repr
       ... = pmul (repr b) (repr a) : pmul_comm
       ... = repr (b * a) : repr_mul) ▸ !equiv.refl)
 
-theorem pmul_assoc (p q r: ℕ × ℕ) : pmul (pmul p q) r = pmul p (pmul q r) :=
-begin
-  unfold pmul, apply sorry -- simp
-end
+private theorem pmul_assoc_prep {p1 p2 q1 q2 r1 r2 : ℕ} :
+  ((p1*q1+p2*q2)*r1+(p1*q2+p2*q1)*r2, (p1*q1+p2*q2)*r2+(p1*q2+p2*q1)*r1) =
+   (p1*(q1*r1+q2*r2)+p2*(q1*r2+q2*r1), p1*(q1*r2+q2*r1)+p2*(q1*r1+q2*r2)) :=
+by rewrite[+mul.left_distrib,+mul.right_distrib,*mul.assoc];
+   exact (congr_arg2 pair (!add.comm4 ⬝ (!congr_arg !nat.add.comm))
+                          (!add.comm4 ⬝ (!congr_arg !nat.add.comm)))
+
+theorem pmul_assoc (p q r: ℕ × ℕ) : pmul (pmul p q) r = pmul p (pmul q r) := pmul_assoc_prep
 
 theorem mul.assoc (a b c : ℤ) : (a * b) * c = a * (b * c) :=
 eq_of_repr_equiv_repr
@@ -564,54 +460,41 @@ eq_of_repr_equiv_repr
       ... = pmul (repr a) (repr (b * c)) : repr_mul
       ... = repr (a * (b * c)) : repr_mul) ▸ !equiv.refl)
 
-set_option pp.coercions true
+theorem mul_one : Π (a : ℤ), a * 1 = a
+| (of_nat m) := !zero_add -- zero_add happens to be def. = to this thm
+| -[1+ m]    := !nat.zero_add ▸ rfl
 
-theorem mul_one (a : ℤ) : a * 1 = a :=
-eq_of_repr_equiv_repr (int.equiv_of_eq
-  ((calc
-    repr (a * 1) = pmul (repr a) (repr 1) : repr_mul
-      ... = (pr1 (repr a), pr2 (repr a)) :
-            begin
-              esimp [pmul, nat.of_num, num.to.int, repr],
-              rewrite [+mul_zero, +mul_one, nat.zero_add]
-            end
-      ... = repr a : prod.eta)))
 
 theorem one_mul (a : ℤ) : 1 * a = a :=
 mul.comm a 1 ▸ mul_one a
+
+private theorem mul_distrib_prep {a1 a2 b1 b2 c1 c2 : ℕ} :
+ ((a1+b1)*c1+(a2+b2)*c2, (a1+b1)*c2+(a2+b2)*c1) = 
+ (a1*c1+a2*c2+(b1*c1+b2*c2), a1*c2+a2*c1+(b1*c2+b2*c1)) :=
+by rewrite[+mul.right_distrib] ⬝ (!congr_arg2 !add.comm4 !add.comm4)
 
 theorem mul.right_distrib (a b c : ℤ) : (a + b) * c = a * c + b * c :=
 eq_of_repr_equiv_repr
   (calc
     repr ((a + b) * c) = pmul (repr (a + b)) (repr c) : repr_mul
       ... ≡ pmul (padd (repr a) (repr b)) (repr c) : pmul_congr !repr_add equiv.refl
-      ... = padd (pmul (repr a) (repr c)) (pmul (repr b) (repr c)) : sorry -- by simp
-      ... = padd (repr (a * c)) (pmul (repr b) (repr c)) : {(repr_mul a c)⁻¹}
+      ... = padd (pmul (repr a) (repr c)) (pmul (repr b) (repr c)) : mul_distrib_prep
+      ... = padd (repr (a * c)) (pmul (repr b) (repr c)) : repr_mul
       ... = padd (repr (a * c)) (repr (b * c)) : repr_mul
-      ... ≡ repr (a * c + b * c) : equiv.symm !repr_add)
+      ... ≡ repr (a * c + b * c) : repr_add)
 
 theorem mul.left_distrib (a b c : ℤ) : a * (b + c) = a * b + a * c :=
 calc
-  a * (b + c) = (b + c) * a : mul.comm a (b + c)
-    ... = b * a + c * a : mul.right_distrib b c a
-    ... = a * b + c * a : {mul.comm b a}
-    ... = a * b + a * c : {mul.comm c a}
+  a * (b + c) = (b + c) * a : mul.comm
+    ... = b * a + c * a : mul.right_distrib
+    ... = a * b + c * a : mul.comm
+    ... = a * b + a * c : mul.comm
 
 theorem zero_ne_one : (0 : int) ≠ 1 :=
-assume H : 0 = 1,
-show false, from succ_ne_zero 0 ((of_nat.inj H)⁻¹)
+assume H : 0 = 1, !succ_ne_zero (of_nat.inj H)⁻¹
 
 theorem eq_zero_or_eq_zero_of_mul_eq_zero {a b : ℤ} (H : a * b = 0) : a = 0 ∨ b = 0 :=
-have H2 : (nat_abs a) * (nat_abs b) = nat.zero, from
-  calc
-    (nat_abs a) * (nat_abs b) = (nat_abs (a * b)) : (nat_abs_mul a b)⁻¹
-      ... = (nat_abs 0) : {H}
-      ... = nat.zero : nat_abs_of_nat nat.zero,
-have H3 : (nat_abs a) = nat.zero ∨ (nat_abs b) = nat.zero,
-  from eq_zero_or_eq_zero_of_mul_eq_zero H2,
-or_of_or_of_imp_of_imp H3
-  (assume H : (nat_abs a) = nat.zero, nat_abs_eq_zero H)
-  (assume H : (nat_abs b) = nat.zero, nat_abs_eq_zero H)
+or.imp nat_abs_eq_zero nat_abs_eq_zero (eq_zero_or_eq_zero_of_mul_eq_zero (H ▸ (nat_abs_mul a b)⁻¹))
 
 section migrate_algebra
   open [classes] algebra
@@ -628,7 +511,7 @@ section migrate_algebra
     add_comm       := add.comm,
     mul            := mul,
     mul_assoc      := mul.assoc,
-    one            := (of_num 1),
+    one            := 1,
     one_mul        := one_mul,
     mul_one        := mul_one,
     left_distrib   := mul.left_distrib,
@@ -647,17 +530,14 @@ section migrate_algebra
 end migrate_algebra
 
 /- additional properties -/
-
-theorem of_nat_sub {m n : ℕ} (H : #nat m ≥ n) : of_nat (#nat m - n) = of_nat m - of_nat n :=
-have H1 : m = (#nat m - n + n), from (nat.sub_add_cancel H)⁻¹,
-have H2 : m = (#nat m - n) + n, from congr_arg of_nat H1,
-(sub_eq_of_eq_add H2)⁻¹
+theorem of_nat_sub {m n : ℕ} (H : m ≥ n) : m - n = sub m n :=
+(sub_eq_of_eq_add (!congr_arg (nat.sub_add_cancel H)⁻¹))⁻¹
 
 theorem neg_succ_of_nat_eq' (m : ℕ) : -[1+ m] = -m - 1 :=
 by rewrite [neg_succ_of_nat_eq, of_nat_add, neg_add]
 
-definition succ (a : ℤ) := a + (nat.succ zero)
-definition pred (a : ℤ) := a - (nat.succ zero)
+definition succ (a : ℤ) := a + (succ zero)
+definition pred (a : ℤ) := a - (succ zero)
 theorem pred_succ (a : ℤ) : pred (succ a) = a := !sub_add_cancel
 theorem succ_pred (a : ℤ) : succ (pred a) = a := !add_sub_cancel
 theorem neg_succ (a : ℤ) : -succ a = pred (-a) :=
@@ -675,18 +555,12 @@ theorem succ_neg_nat_succ (n : ℕ) : succ (-nat.succ n) = -n := !succ_neg_succ
 
 definition rec_nat_on [unfold 2] {P : ℤ → Type} (z : ℤ) (H0 : P 0)
   (Hsucc : Π⦃n : ℕ⦄, P n → P (succ n)) (Hpred : Π⦃n : ℕ⦄, P (-n) → P (-nat.succ n)) : P z :=
-begin
-  induction z with n n,
-   {exact nat.rec_on n H0 Hsucc},
-   {induction n with m ih,
-     exact Hpred H0,
-     exact Hpred ih}
-end
+int.rec (nat.rec H0 Hsucc) (λn, nat.rec H0 Hpred (nat.succ n)) z
 
 --the only computation rule of rec_nat_on which is not definitional
 theorem rec_nat_on_neg {P : ℤ → Type} (n : nat) (H0 : P zero)
   (Hsucc : Π⦃n : nat⦄, P n → P (succ n)) (Hpred : Π⦃n : nat⦄, P (-n) → P (-nat.succ n))
   : rec_nat_on (-nat.succ n) H0 Hsucc Hpred = Hpred (rec_nat_on (-n) H0 Hsucc Hpred) :=
-nat.rec_on n rfl (λn H, rfl)
+nat.rec rfl (λn H, rfl) n
 
 end int

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -461,7 +461,7 @@ lemma mem_of_dinj_of_mem_dmap (Pdi : dinj p f) :
 
 lemma not_mem_dmap_of_dinj_of_not_mem (Pdi : dinj p f) {l : list A} {a} (Pa : p a) :
   a ∉ l → (f a Pa) ∉ dmap p f l :=
-not_imp_not_of_imp (mem_of_dinj_of_mem_dmap Pdi Pa)
+not.mto (mem_of_dinj_of_mem_dmap Pdi Pa)
 
 end dmap
 

--- a/library/data/nat/basic.lean
+++ b/library/data/nat/basic.lean
@@ -65,7 +65,7 @@ theorem exists_eq_succ_of_ne_zero {n : ℕ} (H : n ≠ 0) : ∃k : ℕ, n = succ
 exists.intro _ (or_resolve_right !eq_zero_or_eq_succ_pred H)
 
 theorem succ.inj {n m : ℕ} (H : succ n = succ m) : n = m :=
-nat.no_confusion H (λe, e)
+nat.no_confusion H imp.id
 
 abbreviation eq_of_succ_eq_succ := @succ.inj
 
@@ -93,8 +93,7 @@ have stronger : P a ∧ P (succ a), from
 
 theorem sub_induction {P : ℕ → ℕ → Prop} (n m : ℕ) (H1 : ∀m, P 0 m)
    (H2 : ∀n, P (succ n) 0) (H3 : ∀n m, P n m → P (succ n) (succ m)) : P n m :=
-have general : ∀m, P n m, from nat.induction_on n
-  (take m : ℕ, H1 m)
+have general : ∀m, P n m, from nat.induction_on n H1
   (take k : ℕ,
     assume IH : ∀m, P k m,
     take m : ℕ,
@@ -146,11 +145,14 @@ nat.induction_on k
                      ... = n + succ (m + l)    : add_succ
                      ... = n + (m + succ l)    : add_succ)
 
-theorem add.left_comm [simp] (n m k : ℕ) : n + (m + k) = m + (n + k) :=
-left_comm add.comm add.assoc n m k
+theorem add.left_comm [simp] : Π (n m k : ℕ), n + (m + k) = m + (n + k) :=
+left_comm add.comm add.assoc
 
-theorem add.right_comm (n m k : ℕ) : n + m + k = n + k + m :=
-right_comm add.comm add.assoc n m k
+theorem add.right_comm : Π (n m k : ℕ), n + m + k = n + k + m :=
+right_comm add.comm add.assoc
+
+theorem add.comm4 : Π {n m k l : ℕ}, n + m + (k + l) = n + k + (m + l) :=
+comm4 add.comm add.assoc
 
 theorem add.cancel_left {n m k : ℕ} : n + m = n + k → m = k :=
 nat.induction_on n

--- a/library/data/nat/sub.lean
+++ b/library/data/nat/sub.lean
@@ -427,13 +427,8 @@ theorem dist_sub_eq_dist_add_right {k m : ℕ} (H : k ≥ m) (n : ℕ) :
 (dist_sub_eq_dist_add_left H n ▸ !dist.comm) ▸ !dist.comm
 
 theorem dist.triangle_inequality (n m k : ℕ) : dist n k ≤ dist n m + dist m k :=
-assert (m - k) + ((k - m) + (m - n)) = (m - n) + ((m - k) + (k - m)),
-  begin
-    generalize m - k, generalize k - m, generalize m - n, intro x y z,
-    rewrite [add.comm y x, add.left_comm]
-  end,
 have (n - m) + (m - k) + ((k - m) + (m - n)) = (n - m) + (m - n) + ((m - k) + (k - m)),
-  by rewrite [add.assoc, this, -add.assoc],
+from (!add.comm ▸ !add.left_comm ▸ !add.assoc) ⬝ !add.assoc⁻¹,
 this ▸ add_le_add !sub_lt_sub_add_sub !sub_lt_sub_add_sub
 
 theorem dist_add_add_le_add_dist_dist (n m k l : ℕ) : dist (n + m) (k + l) ≤ dist n k + dist m l :=
@@ -446,7 +441,7 @@ assert ∀ n m, dist n m = n - m + (m - n), from take n m, rfl,
 by rewrite [this, this n m, mul.right_distrib, *mul_sub_right_distrib]
 
 theorem dist_mul_left (k n m : ℕ) : dist (k * n) (k * m) = k * dist n m :=
-by rewrite [mul.comm k n, mul.comm k m, dist_mul_right, mul.comm]
+!mul.comm ▸ !mul.comm ▸ !dist_mul_right ⬝ !mul.comm
 
 theorem dist_mul_dist (n m k l : ℕ) : dist n m * dist k l = dist (n * k + m * l) (n * l + m * k) :=
 have aux : ∀k l, k ≥ l → dist n m * dist k l = dist (n * k + m * l) (n * l + m * k), from

--- a/library/data/quotient/util.lean
+++ b/library/data/quotient/util.lean
@@ -20,8 +20,8 @@ namespace quotient
   theorem flip_pair (a : A) (b : B) : flip (pair a b) = pair b a := rfl
   theorem flip_pr1 (a : A × B) : pr1 (flip a) = pr2 a := rfl
   theorem flip_pr2 (a : A × B) : pr2 (flip a) = pr1 a := rfl
-  theorem flip_flip (a : A × B) : flip (flip a) = a :=
-  destruct a (take x y, rfl)
+  theorem flip_flip : Π a : A × B, flip (flip a) = a
+  | (pair x y) := rfl
 
   theorem P_flip {P : A → B → Prop} (a : A × B) (H : P (pr1 a) (pr2 a))
     : P (pr2 (flip a)) (pr1 (flip a)) :=
@@ -59,14 +59,7 @@ namespace quotient
     map_pair2 f a b = pair (f (pr1 a) (pr1 b)) (f (pr2 a) (pr2 b)) := rfl
 
   theorem map_pair2_pair {A B C : Type} (f : A → B → C) (a a' : A) (b b' : B) :
-    map_pair2 f (pair a a') (pair b b') = pair (f a b) (f a' b') :=
-  calc
-    map_pair2 f (pair a a') (pair b b')
-          = pair (f (pr1 (pair a a')) b) (f (pr2 (pair a a')) (pr2 (pair b b')))
-              : {pr1.mk b b'}
-      ... = pair (f (pr1 (pair a a')) b) (f (pr2 (pair a a')) b') : {pr2.mk b b'}
-      ... = pair (f (pr1 (pair a a')) b) (f a' b') : {pr2.mk a a'}
-      ... = pair (f a b) (f a' b') : {pr1.mk a a'}
+    map_pair2 f (pair a a') (pair b b') = pair (f a b) (f a' b') := by esimp
 
   theorem map_pair2_pr1 {A B C : Type} (f : A → B → C) (a : A × A) (b : B × B) :
   pr1 (map_pair2 f a b) = f (pr1 a) (pr1 b) := by esimp
@@ -74,91 +67,34 @@ namespace quotient
   theorem map_pair2_pr2 {A B C : Type} (f : A → B → C) (a : A × A) (b : B × B) :
   pr2 (map_pair2 f a b) = f (pr2 a) (pr2 b) := by esimp
 
-  theorem map_pair2_flip {A B C : Type} (f : A → B → C) (a : A × A) (b : B × B) :
-    flip (map_pair2 f a b) = map_pair2 f (flip a) (flip b) :=
-  have Hx : pr1 (flip (map_pair2 f a b)) =  pr1 (map_pair2 f (flip a) (flip b)), from
-    calc
-      pr1 (flip (map_pair2 f a b)) = pr2 (map_pair2 f a b) : flip_pr1 _
-        ... = f (pr2 a) (pr2 b) : map_pair2_pr2 f a b
-        ... = f (pr1 (flip a)) (pr2 b) : {(flip_pr1 a)⁻¹}
-        ... = f (pr1 (flip a)) (pr1 (flip b)) : {(flip_pr1 b)⁻¹}
-        ... = pr1 (map_pair2 f (flip a) (flip b)) : (map_pair2_pr1 f _ _)⁻¹,
-  have Hy : pr2 (flip (map_pair2 f a b)) =  pr2 (map_pair2 f (flip a) (flip b)), from
-    calc
-      pr2 (flip (map_pair2 f a b)) = pr1 (map_pair2 f a b) : flip_pr2 _
-        ... = f (pr1 a) (pr1 b) : map_pair2_pr1 f a b
-        ... = f (pr2 (flip a)) (pr1 b) : {flip_pr2 a}
-        ... = f (pr2 (flip a)) (pr2 (flip b)) : {flip_pr2 b}
-        ... = pr2 (map_pair2 f (flip a) (flip b)) : (map_pair2_pr2 f _ _)⁻¹,
-  pair_eq Hx Hy
+  theorem map_pair2_flip {A B C : Type} (f : A → B → C) : Π (a : A × A) (b : B × B),
+    flip (map_pair2 f a b) = map_pair2 f (flip a) (flip b)
+  | (pair a₁ a₂) (pair b₁ b₂) := rfl
 
 -- add_rewrite flip_pr1 flip_pr2 flip_pair
 -- add_rewrite map_pair_pr1 map_pair_pr2 map_pair_pair
 -- add_rewrite map_pair2_pr1 map_pair2_pr2 map_pair2_pair
 
 theorem map_pair2_comm {A B : Type} {f : A → A → B} (Hcomm : ∀a b : A, f a b = f b a)
-  (v w : A × A) : map_pair2 f v w = map_pair2 f w v :=
-have Hx : pr1 (map_pair2 f v w) = pr1 (map_pair2 f w v), from
-  calc
-    pr1 (map_pair2 f v w) = f (pr1 v) (pr1 w) : map_pair2_pr1 f v w
-      ... = f (pr1 w) (pr1 v) : Hcomm _ _
-      ... = pr1 (map_pair2 f w v) : (map_pair2_pr1 f w v)⁻¹,
-have Hy : pr2 (map_pair2 f v w) = pr2 (map_pair2 f w v), from
-  calc
-    pr2 (map_pair2 f v w) = f (pr2 v) (pr2 w) : map_pair2_pr2 f v w
-      ... = f (pr2 w) (pr2 v) : Hcomm _ _
-      ... = pr2 (map_pair2 f w v) : (map_pair2_pr2 f w v)⁻¹,
-pair_eq Hx Hy
+  : Π (v w : A × A), map_pair2 f v w = map_pair2 f w v
+| (pair v₁ v₂) (pair w₁ w₂) :=
+  !map_pair2_pair ⬝ by rewrite [Hcomm v₁ w₁, Hcomm v₂ w₂] ⬝ !map_pair2_pair⁻¹
 
 theorem map_pair2_assoc {A : Type} {f : A → A → A}
     (Hassoc : ∀a b c : A, f (f a b) c = f a (f b c)) (u v w : A × A) :
   map_pair2 f (map_pair2 f u v) w = map_pair2 f u (map_pair2 f v w) :=
-have Hx : pr1 (map_pair2 f (map_pair2 f u v) w) =
-          pr1 (map_pair2 f u (map_pair2 f v w)), from
-  calc
-     pr1 (map_pair2 f (map_pair2 f u v) w)
-          = f (pr1 (map_pair2 f u v)) (pr1 w) : map_pair2_pr1 f _ _
-      ... = f (f (pr1 u) (pr1 v)) (pr1 w) : {map_pair2_pr1 f _ _}
-      ... = f (pr1 u) (f (pr1 v) (pr1 w)) : Hassoc (pr1 u) (pr1 v) (pr1 w)
-      ... = f (pr1 u) (pr1 (map_pair2 f v w)) : by rewrite [map_pair2_pr1 f]
-      ... = pr1 (map_pair2 f u (map_pair2 f v w)) : (map_pair2_pr1 f _ _)⁻¹,
-have Hy : pr2 (map_pair2 f (map_pair2 f u v) w) =
-          pr2 (map_pair2 f u (map_pair2 f v w)), from
-  calc
-     pr2 (map_pair2 f (map_pair2 f u v) w)
-          = f (pr2 (map_pair2 f u v)) (pr2 w) : map_pair2_pr2 f _ _
-      ... = f (f (pr2 u) (pr2 v)) (pr2 w) : {map_pair2_pr2 f _ _}
-      ... = f (pr2 u) (f (pr2 v) (pr2 w)) : Hassoc (pr2 u) (pr2 v) (pr2 w)
-      ... = f (pr2 u) (pr2 (map_pair2 f v w)) : {map_pair2_pr2 f _ _}
-      ... = pr2 (map_pair2 f u (map_pair2 f v w)) : (map_pair2_pr2 f _ _)⁻¹,
-pair_eq Hx Hy
+show pair (f (f (pr1 u) (pr1 v)) (pr1 w)) (f (f (pr2 u) (pr2 v)) (pr2 w)) =
+     pair (f (pr1 u) (f (pr1 v) (pr1 w))) (f (pr2 u) (f (pr2 v) (pr2 w))),
+by rewrite [Hassoc (pr1 u) (pr1 v) (pr1 w), Hassoc (pr2 u) (pr2 v) (pr2 w)]
 
 theorem map_pair2_id_right {A B : Type} {f : A → B → A} {e : B} (Hid : ∀a : A, f a e = a)
-  (v : A × A) : map_pair2 f v (pair e e) = v :=
-have Hx : pr1 (map_pair2 f v (pair e e)) = pr1 v, from
-  (calc
-    pr1 (map_pair2 f v (pair e e)) = f (pr1 v) (pr1 (pair e e)) : by esimp
-      ... = f (pr1 v) e : by esimp
-      ... = pr1 v : Hid (pr1 v)),
-have Hy : pr2 (map_pair2 f v (pair e e)) = pr2 v, from
-  (calc
-    pr2 (map_pair2 f v (pair e e)) = f (pr2 v) (pr2 (pair e e)) : by esimp
-      ... = f (pr2 v) e : by esimp
-      ... = pr2 v : Hid (pr2 v)),
-prod.eq Hx Hy
+  : Π (v : A × A), map_pair2 f v (pair e e) = v
+| (pair v₁ v₂) :=
+  !map_pair2_pair ⬝ by rewrite [Hid v₁, Hid v₂]
 
 theorem map_pair2_id_left {A B : Type} {f : B → A → A} {e : B} (Hid : ∀a : A, f e a = a)
-  (v : A × A) : map_pair2 f (pair e e) v = v :=
-have Hx : pr1 (map_pair2 f (pair e e) v) = pr1 v, from
-   calc
-    pr1 (map_pair2 f (pair e e) v) = f (pr1 (pair e e)) (pr1 v) : by esimp
-      ... = f e (pr1 v) : by esimp
-      ... = pr1 v : Hid (pr1 v),
-have Hy : pr2 (map_pair2 f (pair e e) v) = pr2 v, from
-   calc
-    pr2 (map_pair2 f (pair e e) v) = f (pr2 (pair e e)) (pr2 v) : by esimp
-      ... = f e (pr2 v) : by esimp
-      ... = pr2 v : Hid (pr2 v),
-prod.eq Hx Hy
+  : Π (v : A × A), map_pair2 f (pair e e) v = v
+| (pair v₁ v₂) :=
+  !map_pair2_pair ⬝ by rewrite [Hid v₁, Hid v₂]
 
 end quotient

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -27,13 +27,18 @@ theorem find_midpoint {a b : ℚ} (H : a > b) : ∃ c : ℚ, a > b + c ∧ c > 0
     (and.intro (have H2 [visible] : a + a > (b + b) + (a - b), from calc
       a + a > b + a : rat.add_lt_add_right H
       ... = b + a + b - b : rat.add_sub_cancel
-      ... = (b + b) + (a - b) : sorry, -- simp
+      ... = b + b + a - b : rat.add.right_comm
+      ... = (b + b) + (a - b) : add_sub,
      have H3 [visible] : (a + a) / (1 + 1) > ((b + b) + (a - b)) / (1 + 1),
        from div_lt_div_of_lt_of_pos H2 dec_trivial,
      by rewrite [div_two at H3, -div_add_div_same at H3, div_two at H3]; exact H3)
     (pos_div_of_pos_of_pos (iff.mpr !sub_pos_iff_lt H) dec_trivial))
 
-theorem add_sub_comm (a b c d : ℚ) : a + b - (c + d) = (a - c) + (b - d) := sorry
+theorem add_sub_comm (a b c d : ℚ) : a + b - (c + d) = (a - c) + (b - d) :=
+  calc
+     a + b - (c + d) = a + b - c - d   : sub_add_eq_sub_sub
+                 ... = a - c + b - d   : sub_add_eq_add_sub
+                 ... = a - c + (b - d) : add_sub
 
 theorem s_mul_assoc_lemma_4 {n : ℕ+} {ε q : ℚ} (Hε : ε > 0) (Hq : q > 0) (H : n ≥ pceil (q / ε)) :
         q * n⁻¹ ≤ ε :=
@@ -52,7 +57,19 @@ theorem s_mul_assoc_lemma_3 (a b n : ℕ+) (p : ℚ) :
         p * ((a * n)⁻¹ + (b * n)⁻¹) = p * (a⁻¹ + b⁻¹) * n⁻¹ :=
   by rewrite [rat.mul.assoc, rat.right_distrib, *inv_mul_eq_mul_inv]
 
-theorem find_thirds (a b : ℚ) : ∃ n : ℕ+, a + n⁻¹ + n⁻¹ + n⁻¹ < a + b := sorry
+theorem find_thirds (a b : ℚ) (H : b > 0) : ∃ n : ℕ+, a + n⁻¹ + n⁻¹ + n⁻¹ < a + b :=
+  let n := pceil (of_nat 4 / b) in
+  have of_nat 3 * n⁻¹ < b, from calc
+   of_nat 3 * n⁻¹ < of_nat 4 * n⁻¹
+                  : rat.mul_lt_mul_of_pos_right dec_trivial !inv_pos
+              ... ≤ of_nat 4 * (b / of_nat 4)
+                  : rat.mul_le_mul_of_nonneg_left (!inv_pceil_div dec_trivial H) !of_nat_nonneg
+              ... = b / of_nat 4 * of_nat 4 : rat.mul.comm
+              ... = b : rat.div_mul_cancel dec_trivial,
+  exists.intro n (calc
+    a + n⁻¹ + n⁻¹ + n⁻¹ = a + (1 + 1 + 1) * n⁻¹ : by rewrite[*rat.right_distrib,*rat.one_mul,-*rat.add.assoc]
+                    ... = a + of_nat 3 * n⁻¹    : {show 1+1+1=of_nat 3, from dec_trivial}
+                    ... < a + b                 : rat.add_lt_add_left this a)
 
 theorem squeeze {a b : ℚ} (H : ∀ j : ℕ+, a ≤ b + j⁻¹ + j⁻¹ + j⁻¹) : a ≤ b :=
   begin
@@ -60,7 +77,7 @@ theorem squeeze {a b : ℚ} (H : ∀ j : ℕ+, a ≤ b + j⁻¹ + j⁻¹ + j⁻�
     intro Hb,
     apply (exists.elim (find_midpoint Hb)),
     intro c Hc,
-    apply (exists.elim (find_thirds b c)),
+    apply (exists.elim (find_thirds b c (and.right Hc))),
     intro j Hbj,
     have Ha : a > b + j⁻¹ + j⁻¹ + j⁻¹, from lt.trans Hbj (and.left Hc),
     exact absurd !H (not_le_of_gt Ha)
@@ -77,26 +94,52 @@ theorem squeeze_2 {a b : ℚ} (H : ∀ ε : ℚ, ε > 0 → a ≥ b - ε) : a �
   end
 
 theorem rewrite_helper (a b c d : ℚ) : a * b  - c * d = a * (b - d) + (a - c) * d :=
-  sorry
+  by rewrite[rat.mul_sub_left_distrib, rat.mul_sub_right_distrib, add_sub, rat.sub_add_cancel]
 
 theorem rewrite_helper3 (a b c d e f g: ℚ) : a * (b + c) - (d * e + f * g) =
-        (a * b - d * e) + (a * c - f * g) := sorry
+        (a * b - d * e) + (a * c - f * g) :=
+  by rewrite[rat.mul.left_distrib, add_sub_comm]
 
-theorem rewrite_helper4 (a b c d : ℚ) : a * b - c * d = (a * b - a * d) + (a * d - c * d) := sorry
+theorem rewrite_helper4 (a b c d : ℚ) : a * b - c * d = (a * b - a * d) + (a * d - c * d) :=
+  by rewrite[add_sub, rat.sub_add_cancel]
 
-theorem rewrite_helper5 (a b x y : ℚ) : a - b = (a - x) + (x - y) + (y - b) := sorry
+theorem rewrite_helper5 (a b x y : ℚ) : a - b = (a - x) + (x - y) + (y - b) :=
+  by rewrite[*add_sub, *rat.sub_add_cancel]
 
 theorem rewrite_helper7 (a b c d x : ℚ) :
-        a * b * c - d = (b * c) * (a - x) + (x * b * c - d) := sorry
+        a * b * c - d = (b * c) * (a - x) + (x * b * c - d) :=
+  by rewrite[rat.mul_sub_left_distrib, add_sub]; exact (calc
+     a * b * c - d = a * b * c - x * b * c + x * b * c - d : rat.sub_add_cancel
+           ... = b * c * a - b * c * x + x * b * c - d :
+       have ∀ {a b c : ℚ}, a * b * c = b * c * a, from
+         λa b c, !rat.mul.comm ▸ !rat.mul.right_comm,
+       this ▸ this ▸ rfl)
 
 theorem ineq_helper (a b : ℚ) (k m n : ℕ+) (H : a ≤ (k * 2 * m)⁻¹ + (k * 2 * n)⁻¹)
                     (H2 : b ≤ (k * 2 * m)⁻¹ + (k * 2 * n)⁻¹) :
-        (rat_of_pnat k) * a + b * (rat_of_pnat k) ≤ m⁻¹ + n⁻¹ := sorry
+        (rat_of_pnat k) * a + b * (rat_of_pnat k) ≤ m⁻¹ + n⁻¹ :=
+  have (k * 2 * m)⁻¹ + (k * 2 * n)⁻¹ = (2 * k)⁻¹ * (m⁻¹ + n⁻¹),
+    by rewrite[rat.mul.left_distrib,*inv_mul_eq_mul_inv]; exact !rat.mul.comm ▸ rfl,
+  have a + b ≤ k⁻¹ * (m⁻¹ + n⁻¹), from calc
+   a + b ≤ (2 * k)⁻¹ * (m⁻¹ + n⁻¹) + (2 * k)⁻¹ * (m⁻¹ + n⁻¹) : rat.add_le_add (this ▸ H) (this ▸ H2)
+     ... = ((2 * k)⁻¹ + (2 * k)⁻¹) * (m⁻¹ + n⁻¹) : rat.mul.right_distrib
+     ... = k⁻¹ * (m⁻¹ + n⁻¹) : (pnat.add_halves k) ▸ rfl,
+  calc (rat_of_pnat k) * a + b * (rat_of_pnat k)
+         = (rat_of_pnat k) * a + (rat_of_pnat k) * b : rat.mul.comm
+     ... = (rat_of_pnat k) * (a + b) : rat.left_distrib
+     ... ≤ (rat_of_pnat k) * (k⁻¹ * (m⁻¹ + n⁻¹)) :
+             iff.mp (!rat.le_iff_mul_le_mul_left !rat_of_pnat_is_pos) this
+     ... = m⁻¹ + n⁻¹ : by rewrite[-rat.mul.assoc, inv_cancel_left, rat.one_mul]
 
 theorem factor_lemma (a b c d e : ℚ) : abs (a + b + c - (d + (b + e))) = abs ((a - d) + (c - e)) :=
-  sorry
+  !congr_arg (calc
+    a + b + c - (d + (b + e)) = a + b + c - (d + b + e)   : rat.add.assoc
+                         ...  = a + b - (d + b) + (c - e) : add_sub_comm
+                         ...  = a + b - b - d + (c - e)   : sub_add_eq_sub_sub_swap
+                         ...  = a - d + (c - e)           : rat.add_sub_cancel)
 
-theorem factor_lemma_2 (a b c d : ℚ) : (a + b) + (c + d) = (a + c) + (d + b) := sorry
+theorem factor_lemma_2 (a b c d : ℚ) : (a + b) + (c + d) = (a + c) + (d + b) :=
+  !rat.add.comm ▸ (binary.comm4 rat.add.comm rat.add.assoc a b c d)
 
 -------------------------------------
 -- The only sorry's after this point are for the simplifier.
@@ -164,8 +207,12 @@ theorem eq_of_bdd {s t : seq} (Hs : regular s) (Ht : regular t)
       apply rat.add_le_add,
       apply HNj (max j Nj) (max_right j Nj),
       apply Ht,
-      have hsimp : ∀ m : ℕ+, n⁻¹ + m⁻¹ + (j⁻¹ + (m⁻¹ + n⁻¹)) = (n⁻¹ + n⁻¹ + j⁻¹) + (m⁻¹ + m⁻¹),
-        from sorry, -- simplifier
+      have hsimp : ∀ m : ℕ+, n⁻¹ + m⁻¹ + (j⁻¹ + (m⁻¹ + n⁻¹)) = n⁻¹ + n⁻¹ + j⁻¹ + (m⁻¹ + m⁻¹),
+        from λm, calc
+           n⁻¹ + m⁻¹ + (j⁻¹ + (m⁻¹ + n⁻¹)) = n⁻¹ + (j⁻¹ + (m⁻¹ + n⁻¹)) + m⁻¹ : rat.add.right_comm
+                                       ... = n⁻¹ + (j⁻¹ + m⁻¹ + n⁻¹) + m⁻¹   : rat.add.assoc
+                                       ... = n⁻¹ + (n⁻¹ + (j⁻¹ + m⁻¹)) + m⁻¹ : rat.add.comm
+                                       ... = n⁻¹ + n⁻¹ + j⁻¹ + (m⁻¹ + m⁻¹)   : by rewrite[-*rat.add.assoc],
       rewrite hsimp,
       have Hms : (max j Nj)⁻¹ + (max j Nj)⁻¹ ≤ j⁻¹ + j⁻¹, begin
         apply rat.add_le_add,
@@ -247,8 +294,8 @@ theorem canon_bound {s : seq} (Hs : regular s) (n : ℕ+) : abs (s n) ≤ rat_of
     ... = abs (s pone) + (1 + 1) :
       by rewrite [add.comm 1 (abs (s pone)), rat.add.comm 1, rat.add.assoc]
     ... ≤ of_nat (ubound (abs (s pone))) + (1 + 1) : rat.add_le_add_right (!ubound_ge)
-    ... = of_nat (ubound (abs (s pone)) + (1 + 1)) : by rewrite of_nat_add
-    ... = of_nat (ubound (abs (s pone)) + 1 + 1) : by rewrite nat.add.assoc
+    ... = of_nat (ubound (abs (s pone)) + (1 + 1)) : of_nat_add
+    ... = of_nat (ubound (abs (s pone)) + 1 + 1) : nat.add.assoc
 
 definition K₂ (s t : seq) := max (K s) (K t)
 
@@ -546,13 +593,13 @@ theorem s_add_zero (s : seq) (H : regular s) : sadd s zero ≡ s :=
     apply rat.le.refl
   end
 
-  theorem s_neg_cancel (s : seq) (H : regular s) : sadd (sneg s) s ≡ zero :=
-    begin
-      rewrite [↑sadd, ↑sneg, ↑regular at H, ↑zero, ↑equiv],
-      intros,
-      rewrite [neg_add_eq_sub, rat.sub_self, rat.sub_zero, abs_zero],
-      apply add_invs_nonneg
-    end
+theorem s_neg_cancel (s : seq) (H : regular s) : sadd (sneg s) s ≡ zero :=
+  begin
+    rewrite [↑sadd, ↑sneg, ↑regular at H, ↑zero, ↑equiv],
+    intros,
+    rewrite [neg_add_eq_sub, rat.sub_self, rat.sub_zero, abs_zero],
+    apply add_invs_nonneg
+  end
 
 theorem neg_s_cancel (s : seq) (H : regular s) : sadd s (sneg s) ≡ zero :=
   begin
@@ -583,6 +630,7 @@ theorem add_well_defined {s t u v : seq} (Hs : regular s) (Ht : regular t) (Hu :
     apply Etv
   end
 
+set_option tactic.goal_names false
 theorem mul_bound_helper {s t : seq} (Hs : regular s) (Ht : regular t) (a b c : ℕ+) (j : ℕ+) :
         ∃ N : ℕ+, ∀ n : ℕ+, n ≥ N → abs (s (a * n) * t (b * n) - s (c * n) * t (c * n)) ≤ j⁻¹ :=
   begin
@@ -600,7 +648,8 @@ theorem mul_bound_helper {s t : seq} (Hs : regular s) (Ht : regular t) (a b c : 
         apply rat.le.trans,
         apply rat.mul_le_mul_of_nonneg_right,
         apply pceil_helper Hn,
-        repeat (apply rat.mul_pos | apply rat.add_pos | apply inv_pos | apply rat_of_pnat_is_pos),
+        repeat (apply rat.mul_pos | apply rat.add_pos | apply rat_of_pnat_is_pos | apply inv_pos),
+        --repeat (apply rat.mul_pos | apply rat.add_pos | apply inv_pos | apply rat_of_pnat_is_pos),
         apply rat.le_of_lt,
         apply rat.add_pos,
         apply rat.mul_pos,
@@ -609,15 +658,15 @@ theorem mul_bound_helper {s t : seq} (Hs : regular s) (Ht : regular t) (a b c : 
         repeat apply inv_pos,
         apply rat.mul_pos,
         apply rat.add_pos,
-        repeat apply inv_pos,
+        apply inv_pos,apply inv_pos, -- repeat apply inv_pos,
         apply rat_of_pnat_is_pos,
         have H : (rat_of_pnat (K s) * (b⁻¹ + c⁻¹) + (a⁻¹ + c⁻¹) * rat_of_pnat (K t)) ≠ 0, begin
           apply rat.ne_of_gt,
-          repeat (apply rat.mul_pos | apply rat.add_pos | apply inv_pos | apply rat_of_pnat_is_pos)
+          repeat (apply rat.mul_pos | apply rat.add_pos | apply rat_of_pnat_is_pos | apply inv_pos),
         end,
         rewrite (rat.div_helper H),
         apply rat.le.refl
-      end,
+    end,
     apply rat.add_le_add,
     rewrite [-rat.mul_sub_left_distrib, abs_mul],
     apply rat.le.trans,
@@ -648,7 +697,7 @@ theorem mul_bound_helper {s t : seq} (Hs : regular s) (Ht : regular t) (a b c : 
     apply rat.le_of_lt,
     apply rat.mul_pos,
     apply rat.add_pos,
-    repeat apply inv_pos,
+    apply inv_pos,apply inv_pos, -- repeat apply inv_pos,
     apply rat_of_pnat_is_pos,
     apply rat.le_of_lt,
     apply inv_pos
@@ -733,7 +782,11 @@ theorem mul_neg_equiv_neg_mul {s t : seq} : smul s (sneg t) ≡ sneg (smul s t) 
 theorem equiv_of_diff_equiv_zero {s t : seq} (Hs : regular s) (Ht : regular t)
         (H : sadd s (sneg t) ≡ zero) : s ≡ t :=
   begin
-    have hsimp : ∀ a b c d e : ℚ, a + b + c + (d + e) = (b + d) + a + e + c, from sorry,
+    have hsimp : ∀ a b c d e : ℚ, a + b + c + (d + e) = b + d + a + e + c, from
+     λ a b c d e, calc
+         a + b + c + (d + e) = a + b + (d + e) + c : rat.add.right_comm
+                         ... = a + (b + d) + e + c : by rewrite[-*rat.add.assoc]
+                         ... = b + d + a + e + c   : rat.add.comm,
     apply eq_of_bdd Hs Ht,
     intros,
     let He := bdd_of_eq H,

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -22,8 +22,8 @@ open eq.ops
 open pnat
 
 
-local notation 2 := pnat.pos (nat.of_num 2) dec_trivial
-local notation 3 := pnat.pos (nat.of_num 3) dec_trivial
+local notation 2 := subtype.tag (nat.of_num 2) dec_trivial
+local notation 3 := subtype.tag (nat.of_num 3) dec_trivial
 
 namespace s
 
@@ -206,11 +206,15 @@ theorem sub_consts (a b : ℚ) : const a + -const b = const (a - b) := !add_cons
 theorem add_half_const (n : ℕ+) : const (2 * n)⁻¹ + const (2 * n)⁻¹ = const (n⁻¹) :=
   by rewrite [add_consts, pnat.add_halves]-/
 
-theorem p_add_fractions (n : ℕ+) : (2 * n)⁻¹ + (2 * 3 * n)⁻¹ + (3 * n)⁻¹ = n⁻¹ := sorry
+theorem p_add_fractions (n : ℕ+) : (2 * n)⁻¹ + (2 * 3 * n)⁻¹ + (3 * n)⁻¹ = n⁻¹ :=
+  assert T : 2⁻¹ + 2⁻¹ * 3⁻¹ + 3⁻¹ = 1, from dec_trivial,
+  by rewrite[*inv_mul_eq_mul_inv,-*rat.right_distrib,T,rat.one_mul]
 
-theorem rewrite_helper9 (a b c : ℝ) : b - c = (b - a) - (c - a) := sorry
+theorem rewrite_helper9 (a b c : ℝ) : b - c = (b - a) - (c - a) :=
+  by rewrite[-sub_add_eq_sub_sub_swap,sub_add_cancel]
 
-theorem rewrite_helper10 (a b c d : ℝ) : c - d = (c - a) + (a - b) + (b - d) := sorry
+theorem rewrite_helper10 (a b c d : ℝ) : c - d = (c - a) + (a - b) + (b - d) :=
+  by rewrite[*add_sub,*sub_add_cancel]
 
 definition rep (x : ℝ) : s.reg_seq := some (quot.exists_rep x)
 

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -16,14 +16,15 @@ open eq.ops pnat
 
 local notation 0 := rat.of_num 0
 local notation 1 := rat.of_num 1
-local notation 2 := pnat.pos (nat.of_num 2) dec_trivial
+local notation 2 := subtype.tag (nat.of_num 2) dec_trivial
 
 namespace s
 
 -----------------------------
 -- helper lemmas
 
-theorem neg_add_rewrite {a b : ℚ} : a + -b = -(b + -a) := sorry
+theorem neg_add_rewrite {a b : ℚ} : a + -b = -(b + -a) :=
+  by rewrite[neg_add_rev,neg_neg]
 
 theorem abs_abs_sub_abs_le_abs_sub (a b : ℚ) : abs (abs a - abs b) ≤ abs (a - b) :=
   begin
@@ -37,10 +38,6 @@ theorem abs_abs_sub_abs_le_abs_sub (a b : ℚ) : abs (abs a - abs b) ≤ abs (a 
     apply le_abs_self,
     apply trivial
   end
-
--- does this not exist already??
-theorem forall_of_not_exists {A : Type} {P : A → Prop} (H : ¬ ∃ a : A, P a) : ∀ a : A, ¬ P a :=
-  take a, assume Ha, H (exists.intro a Ha)
 
 theorem and_of_not_or {a b : Prop} (H : ¬ (a ∨ b)) : ¬ a ∧ ¬ b :=
   and.intro (assume H', H (or.inl H')) (assume H', H (or.inr H'))
@@ -517,7 +514,7 @@ theorem s_le_total {s t : seq} (Hs : regular s) (Ht : regular t) : s_le s t ∨ 
 theorem s_le_of_not_lt {s t : seq} (Hle : ¬ s_lt s t) : s_le t s :=
   begin
     rewrite [↑s_le, ↑nonneg, ↑s_lt at Hle, ↑pos at Hle],
-    let Hle' := forall_of_not_exists Hle,
+    let Hle' := iff.mp forall_iff_not_exists Hle,
     intro n,
     let Hn := neg_le_neg (rat.le_of_not_gt (Hle' n)),
     rewrite [↑sadd, ↑sneg, neg_add_rewrite],

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -17,7 +17,7 @@ open -[coercions] nat
 open eq eq.ops pnat
 local notation 0 := rat.of_num 0
 local notation 1 := rat.of_num 1
-notation 2 := pnat.pos (of_num 2) dec_trivial
+notation 2 := subtype.tag (of_num 2) dec_trivial
 
 ----------------------------------------------------------------------------------------------------
 
@@ -43,11 +43,21 @@ theorem sep_by_inv {a b : ℚ} (H : a > b) : ∃ N : ℕ+, a > (b + N⁻¹ + N�
     apply and.right Hc)
   end
 
-theorem helper_1 {a : ℚ} (H : a > 0) : -a + -a ≤ -a := sorry
+theorem helper_1 {a : ℚ} (H : a > 0) : -a + -a ≤ -a :=
+  !neg_add ▸ neg_le_neg (le_add_of_nonneg_left (le_of_lt H))
 
-theorem rewrite_helper8 (a b c : ℚ) : a - b = c - b + (a - c) := sorry -- simp
+theorem rewrite_helper8 (a b c : ℚ) : a - b = c - b + (a - c) :=
+  by rewrite[add_sub,rat.sub_add_cancel] ⬝ !rat.add.comm
 
-theorem nonneg_of_ge_neg_invs (a : ℚ) (H : ∀ n : ℕ+, -n⁻¹ ≤ a) : 0 ≤ a := sorry
+theorem nonneg_of_ge_neg_invs (a : ℚ) (H : ∀ n : ℕ+, -n⁻¹ ≤ a) : 0 ≤ a :=
+  rat.le_of_not_gt (suppose a < 0,
+    have H2 : 0 < -a, from neg_pos_of_neg this,
+   (rat.not_lt_of_ge !H) (iff.mp !lt_neg_iff_lt_neg (calc
+       (pceil (of_num 2 / -a))⁻¹ ≤ -a / of_num 2
+          : !inv_pceil_div dec_trivial H2
+                             ... < -a / 1
+          : div_lt_div_of_pos_of_lt_of_pos dec_trivial dec_trivial H2
+                             ... = -a : div_one)))
 
 ---------
 namespace s

--- a/library/data/subtype.lean
+++ b/library/data/subtype.lean
@@ -22,18 +22,16 @@ namespace subtype
   rfl
 
   theorem tag_eq {a1 a2 : A} {H1 : P a1} {H2 : P a2} (H3 : a1 = a2) : tag a1 H1 = tag a2 H2 :=
-  eq.subst H3 (take H2, tag_irrelevant H1 H2) H2
+  eq.subst H3 (tag_irrelevant H1) H2
 
-  protected theorem eq {a1 a2 : {x | P x}} : ∀(H : elt_of a1 = elt_of a2), a1 = a2 :=
-  destruct a1 (take x1 H1, destruct a2 (take x2 H2 H, tag_eq H))
+  protected theorem eq : ∀ {a1 a2 : {x | P x}} (H : elt_of a1 = elt_of a2), a1 = a2
+  | (tag x1 H1) (tag x2 H2) := tag_eq
 
   protected definition is_inhabited [instance] {a : A} (H : P a) : inhabited {x | P x} :=
   inhabited.mk (tag a H)
 
   protected definition has_decidable_eq [instance] [H : decidable_eq A] : ∀ s₁ s₂ : {x | P x}, decidable (s₁ = s₂)
   | (tag v₁ p₁) (tag v₂ p₂) :=
-    match H v₁ v₂ with
-    | inl veq := begin left, substvars end
-    | inr vne := begin right, intro h, injection h, contradiction end
-    end
+  decidable_of_decidable_of_iff (H v₁ v₂)
+    (iff.intro tag_eq (λh, subtype.no_confusion h (λa b, a)))
 end subtype

--- a/library/init/measurable.lean
+++ b/library/init/measurable.lean
@@ -12,14 +12,14 @@ open nat
 inductive measurable [class] (A : Type) :=
 mk : (A → nat) → measurable A
 
-definition size_of {A : Type} [s : measurable A] (a : A) : nat :=
-measurable.rec_on s (λ f, f) a
+definition size_of {A : Type} [s : measurable A] : A → nat :=
+measurable.rec_on s (λ f, f)
 
 definition nat.measurable [instance] : measurable nat :=
 measurable.mk (λ a, a)
 
 definition option.measurable [instance] (A : Type) [s : measurable A] : measurable (option A) :=
-measurable.mk (λ a, option.cases_on a zero (λ a, size_of a))
+measurable.mk (λ a, option.cases_on a zero size_of)
 
 definition prod.measurable [instance] (A B : Type) [sa : measurable A] [sb : measurable B] : measurable (prod A B) :=
 measurable.mk (λ p, prod.cases_on p (λ a b, size_of a + size_of b))

--- a/library/init/nat.lean
+++ b/library/init/nat.lean
@@ -31,7 +31,7 @@ namespace nat
   -- add is defined in init.num
 
   definition sub (a b : nat) : nat :=
-  nat.rec_on b a (λ b₁ r, pred r)
+  nat.rec_on b a (λ b₁, pred)
 
   definition mul (a b : nat) : nat :=
   nat.rec_on b zero (λ b₁ r, r + a)
@@ -56,11 +56,11 @@ namespace nat
 
   /- properties of inequality -/
 
-  theorem le_of_eq {n m : ℕ} (p : n = m) : n ≤ m := p ▸ le.refl n
+  theorem le_of_eq {n m : ℕ} (p : n = m) : n ≤ m := p ▸ !le.refl
 
-  theorem le_succ (n : ℕ) : n ≤ succ n := by repeat constructor
+  theorem le_succ (n : ℕ) : n ≤ succ n := le.step !le.refl
 
-  theorem pred_le (n : ℕ) : pred n ≤ n := by cases n;all_goals (repeat constructor)
+  theorem pred_le (n : ℕ) : pred n ≤ n := by cases n;repeat constructor
 
   theorem le_succ_iff_true [simp] (n : ℕ) : n ≤ succ n ↔ true :=
   iff_true_intro (le_succ n)
@@ -68,8 +68,8 @@ namespace nat
   theorem pred_le_iff_true [simp] (n : ℕ) : pred n ≤ n ↔ true :=
   iff_true_intro (pred_le n)
 
-  theorem le.trans [trans] {n m k : ℕ} (H1 : n ≤ m) (H2 : m ≤ k) : n ≤ k :=
-  by induction H2 with n H2 IH;exact H1;exact le.step IH
+  theorem le.trans [trans] {n m k : ℕ} (H1 : n ≤ m) : m ≤ k → n ≤ k :=
+  le.rec H1 (λp H2, le.step)
 
   theorem le_succ_of_le {n m : ℕ} (H : n ≤ m) : n ≤ succ m := le.trans H !le_succ
 
@@ -77,62 +77,51 @@ namespace nat
 
   theorem le_of_lt {n m : ℕ} (H : n < m) : n ≤ m := le_of_succ_le H
 
-  theorem succ_le_succ {n m : ℕ} (H : n ≤ m) : succ n ≤ succ m :=
-  by induction H;reflexivity;exact le.step v_0
+  theorem succ_le_succ {n m : ℕ} : n ≤ m → succ n ≤ succ m :=
+  le.rec !le.refl (λa b, le.step)
 
-  theorem pred_le_pred {n m : ℕ} (H : n ≤ m) : pred n ≤ pred m :=
-  by induction H;reflexivity;cases b;exact v_0;exact le.step v_0
+  theorem pred_le_pred {n m : ℕ} : n ≤ m → pred n ≤ pred m :=
+  le.rec !le.refl (nat.rec (λa b, b) (λa b c, le.step))
 
-  theorem le_of_succ_le_succ {n m : ℕ} (H : succ n ≤ succ m) : n ≤ m :=
-  pred_le_pred H
+  theorem le_of_succ_le_succ {n m : ℕ} : succ n ≤ succ m → n ≤ m :=
+  pred_le_pred
 
-  theorem le_succ_of_pred_le {n m : ℕ} (H : pred n ≤ m) : n ≤ succ m :=
-  by cases n;exact le.step H;exact succ_le_succ H
-
-  theorem not_succ_le_self {n : ℕ} : ¬succ n ≤ n :=
-  by induction n with n IH;all_goals intros;cases a;apply IH;exact le_of_succ_le_succ a
-
-  theorem succ_le_self_iff_false [simp] (n : ℕ) : succ n ≤ n ↔ false :=
-  iff_false_intro not_succ_le_self
-
-  theorem zero_le (n : ℕ) : 0 ≤ n :=
-  by induction n with n IH;apply le.refl;exact le.step IH
-
-  theorem zero_le_iff_true [simp] (n : ℕ) : 0 ≤ n ↔ true :=
-  iff_true_intro (zero_le n)
-
-  theorem lt.step {n m : ℕ} (H : n < m) : n < succ m :=
-  le.step H
-
-  theorem zero_lt_succ (n : ℕ) : 0 < succ n :=
-  by induction n with n IH;apply le.refl;exact le.step IH
-
-  theorem zero_lt_succ_iff_true [simp] (n : ℕ) : 0 < succ n ↔ true :=
-  iff_true_intro (zero_lt_succ n)
-
-  theorem lt.trans [trans] {n m k : ℕ} (H1 : n < m) (H2 : m < k) : n < k :=
-  le.trans (le.step H1) H2
-
-  theorem lt_of_le_of_lt [trans] {n m k : ℕ} (H1 : n ≤ m) (H2 : m < k) : n < k :=
-  le.trans (succ_le_succ H1) H2
-
-  theorem lt_of_lt_of_le [trans] {n m k : ℕ} (H1 : n < m) (H2 : m ≤ k) : n < k :=
-  le.trans H1 H2
-
-  theorem le.antisymm {n m : ℕ} (H1 : n ≤ m) (H2 : m ≤ n) : n = m :=
-  begin
-    cases H1 with m' H1',
-    { reflexivity},
-    { cases H2 with n' H2',
-      { reflexivity},
-      { exfalso, apply not_succ_le_self, exact lt.trans H1' H2'}},
-  end
+  theorem le_succ_of_pred_le {n m : ℕ} : pred n ≤ m → n ≤ succ m :=
+  nat.cases_on n le.step (λa, succ_le_succ)
 
   theorem not_succ_le_zero (n : ℕ) : ¬succ n ≤ zero :=
   by intro H; cases H
 
   theorem succ_le_zero_iff_false (n : ℕ) : succ n ≤ zero ↔ false :=
-  iff_false_intro (not_succ_le_zero n)
+  iff_false_intro !not_succ_le_zero
+
+  theorem not_succ_le_self : Π {n : ℕ}, ¬succ n ≤ n :=
+  nat.rec !not_succ_le_zero (λa b c, b (le_of_succ_le_succ c))
+
+  theorem succ_le_self_iff_false [simp] (n : ℕ) : succ n ≤ n ↔ false :=
+  iff_false_intro not_succ_le_self
+
+  theorem zero_le : ∀ (n : ℕ), 0 ≤ n :=
+  nat.rec !le.refl (λa, le.step)
+
+  theorem zero_le_iff_true [simp] (n : ℕ) : 0 ≤ n ↔ true :=
+  iff_true_intro !zero_le
+
+  theorem lt.step {n m : ℕ} : n < m → n < succ m := le.step
+
+  theorem zero_lt_succ (n : ℕ) : 0 < succ n :=
+  succ_le_succ !zero_le
+
+  theorem zero_lt_succ_iff_true [simp] (n : ℕ) : 0 < succ n ↔ true :=
+  iff_true_intro (zero_lt_succ n)
+
+  theorem lt.trans [trans] {n m k : ℕ} (H1 : n < m) : m < k → n < k :=
+  le.trans (le.step H1)
+
+  theorem lt_of_le_of_lt [trans] {n m k : ℕ} (H1 : n ≤ m) : m < k → n < k :=
+  le.trans (succ_le_succ H1)
+
+  theorem lt_of_lt_of_le [trans] {n m k : ℕ} : n < m → m ≤ k → n < k := le.trans
 
   theorem lt.irrefl (n : ℕ) : ¬n < n := not_succ_le_self
 
@@ -149,143 +138,112 @@ namespace nat
   theorem le_lt_antisymm {n m : ℕ} (H1 : n ≤ m) (H2 : m < n) : false :=
   !lt.irrefl (lt_of_le_of_lt H1 H2)
 
+  theorem le.antisymm {n m : ℕ} (H1 : n ≤ m) : m ≤ n → n = m :=
+  le.cases_on H1 (λa, rfl) (λa b c, absurd (lt_of_le_of_lt b c) !lt.irrefl)
+
   theorem lt_le_antisymm {n m : ℕ} (H1 : n < m) (H2 : m ≤ n) : false :=
   le_lt_antisymm H2 H1
 
-  theorem lt.asymm {n m : ℕ} (H1 : n < m) (H2 : m < n) : false :=
-  le_lt_antisymm (le_of_lt H1) H2
+  theorem lt.asymm {n m : ℕ} (H1 : n < m) : ¬ m < n :=
+  le_lt_antisymm (le_of_lt H1)
 
-  definition lt.by_cases {a b : ℕ} {P : Type} (H1 : a < b → P) (H2 : a = b → P) (H3 : b < a → P) : P :=
-  begin
-    revert b H1 H2 H3, induction a with a IH,
-    { intros, cases b,
-        exact H2 rfl,
-        exact H1 !zero_lt_succ},
-    { intros, cases b with b,
-        exact H3 !zero_lt_succ,
-      { apply IH,
-          intro H, exact H1 (succ_le_succ H),
-          intro H, exact H2 (congr rfl H),
-          intro H, exact H3 (succ_le_succ H)}}
-  end
-
-  theorem lt.trichotomy (a b : ℕ) : a < b ∨ a = b ∨ b < a :=
-  lt.by_cases (λH, inl H) (λH, inr (inl H)) (λH, inr (inr H))
-
-  theorem lt_ge_by_cases {a b : ℕ} {P : Type} (H1 : a < b → P) (H2 : a ≥ b → P) : P :=
-  lt.by_cases H1 (λH, H2 (le_of_eq H⁻¹)) (λH, H2 (le_of_lt H))
-
-  theorem lt_or_ge (a b : ℕ) : (a < b) ∨ (a ≥ b) :=
-  lt_ge_by_cases inl inr
-
-  theorem not_lt_zero (a : ℕ) : ¬ a < zero :=
-  by intro H; cases H
+  theorem not_lt_zero (a : ℕ) : ¬ a < zero := !not_succ_le_zero
 
   theorem lt_zero_iff_false [simp] (a : ℕ) : a < zero ↔ false :=
   iff_false_intro (not_lt_zero a)
 
+  theorem eq_or_lt_of_le {a b : ℕ} (H : a ≤ b) : a = b ∨ a < b :=
+  le.cases_on H (inl rfl) (λn h, inr (succ_le_succ h))
+
+  theorem le_of_eq_or_lt {a b : ℕ} (H : a = b ∨ a < b) : a ≤ b :=
+  or.elim H !le_of_eq !le_of_lt
+
   -- less-than is well-founded
   definition lt.wf [instance] : well_founded lt :=
-  begin
-    constructor, intro n, induction n with n IH,
-    { constructor, intros n H, exfalso, exact !not_lt_zero H},
-    { constructor, intros m H,
-      assert aux : ∀ {n₁} (hlt : m < n₁), succ n = n₁ → acc lt m,
-        { intros n₁ hlt, induction hlt,
-          { intro p, injection p with q, exact q ▸ IH},
-          { intro p, injection p with q, exact (acc.inv (q ▸ IH) a)}},
-      apply aux H rfl},
-  end
+  well_founded.intro (nat.rec
+    (!acc.intro (λn H, absurd H (not_lt_zero n)))
+    (λn IH, !acc.intro (λm H,
+      elim (eq_or_lt_of_le (le_of_succ_le_succ H))
+        (λe, eq.substr e IH) (acc.inv IH))))
 
-  definition measure {A : Type} (f : A → ℕ) : A → A → Prop :=
-  inv_image lt f
+  definition measure {A : Type} : (A → ℕ) → A → A → Prop :=
+  inv_image lt
 
   definition measure.wf {A : Type} (f : A → ℕ) : well_founded (measure f) :=
   inv_image.wf f lt.wf
 
-  theorem succ_lt_succ {a b : ℕ} (H : a < b) : succ a < succ b :=
-  succ_le_succ H
+  theorem succ_lt_succ {a b : ℕ} : a < b → succ a < succ b :=
+  succ_le_succ
 
-  theorem lt_of_succ_lt {a b : ℕ} (H : succ a < b) : a < b :=
-  le_of_succ_le H
+  theorem lt_of_succ_lt {a b : ℕ} : succ a < b → a < b :=
+  le_of_succ_le
 
-  theorem lt_of_succ_lt_succ {a b : ℕ} (H : succ a < succ b) : a < b :=
-  le_of_succ_le_succ H
+  theorem lt_of_succ_lt_succ {a b : ℕ} : succ a < succ b → a < b :=
+  le_of_succ_le_succ
 
   definition decidable_le [instance] : decidable_rel le :=
-  begin
-    intros n, induction n with n IH,
-    { intro m, left, apply zero_le},
-    { intro m, cases m with m,
-      { right, apply not_succ_le_zero},
-      { let H := IH m, clear IH,
-        cases H with H H,
-          left, exact succ_le_succ H,
-          right, intro H2, exact H (le_of_succ_le_succ H2)}}
-  end
+  nat.rec (λm, (decidable.inl !zero_le))
+     (λn IH m, !nat.cases_on (decidable.inr (not_succ_le_zero n))
+       (λm, decidable.rec (λH, inl (succ_le_succ H))
+          (λH, inr (λa, H (le_of_succ_le_succ a))) (IH m)))
 
   definition decidable_lt [instance] : decidable_rel lt := _
   definition decidable_gt [instance] : decidable_rel gt := _
   definition decidable_ge [instance] : decidable_rel ge := _
 
-  theorem eq_or_lt_of_le {a b : ℕ} (H : a ≤ b) : a = b ∨ a < b :=
-  by cases H with b' H; exact inl rfl; exact inr (succ_le_succ H)
+  theorem lt_or_ge (a b : ℕ) : a < b ∨ a ≥ b :=
+  nat.rec (inr !zero_le) (λn, or.rec
+    (λh, inl (le_succ_of_le h))
+    (λh, elim (eq_or_lt_of_le h) (λe, inl (eq.subst e !le.refl)) inr)) b
 
-  theorem le_of_eq_or_lt {a b : ℕ} (H : a = b ∨ a < b) : a ≤ b :=
-  by cases H with H H; exact le_of_eq H; exact le_of_lt H
+  theorem lt_ge_by_cases {a b : ℕ} {P : Type} (H1 : a < b → P) (H2 : a ≥ b → P) : P :=
+  by_cases H1 (λh, H2 (elim !lt_or_ge (λa, absurd a h) (λa, a)))
+
+  definition lt.by_cases {a b : ℕ} {P : Type} (H1 : a < b → P) (H2 : a = b → P) (H3 : b < a → P) : P :=
+  lt_ge_by_cases H1 (λh₁,
+    lt_ge_by_cases H3 (λh₂, H2 (le.antisymm h₂ h₁)))
+
+  theorem lt.trichotomy (a b : ℕ) : a < b ∨ a = b ∨ b < a :=
+  lt.by_cases (λH, inl H) (λH, inr (inl H)) (λH, inr (inr H))
 
   theorem eq_or_lt_of_not_lt {a b : ℕ} (hnlt : ¬ a < b) : a = b ∨ b < a :=
   or.rec_on (lt.trichotomy a b)
     (λ hlt, absurd hlt hnlt)
     (λ h, h)
 
-  theorem lt_succ_of_le {a b : ℕ} (h : a ≤ b) : a < succ b :=
-  succ_le_succ h
+  theorem lt_succ_of_le {a b : ℕ} : a ≤ b → a < succ b :=
+  succ_le_succ
 
   theorem lt_of_succ_le {a b : ℕ} (h : succ a ≤ b) : a < b := h
 
   theorem succ_le_of_lt {a b : ℕ} (h : a < b) : succ a ≤ b := h
 
   theorem succ_sub_succ_eq_sub [simp] (a b : ℕ) : succ a - succ b = a - b :=
-  by induction b with b IH;reflexivity; apply congr (eq.refl pred) IH
+  nat.rec rfl (λ b, congr_arg pred) b
 
   theorem sub_eq_succ_sub_succ (a b : ℕ) : a - b = succ a - succ b :=
-  eq.rec_on (succ_sub_succ_eq_sub a b) rfl
+  eq.symm !succ_sub_succ_eq_sub
 
   theorem zero_sub_eq_zero [simp] (a : ℕ) : zero - a = zero :=
-  nat.rec_on a
-    rfl
-    (λ a₁ (ih : zero - a₁ = zero), congr (eq.refl pred) ih)
+  nat.rec rfl (λ a, congr_arg pred) a
 
   theorem zero_eq_zero_sub (a : ℕ) : zero = zero - a :=
-  eq.rec_on (zero_sub_eq_zero a) rfl
-
-  theorem sub_lt {a b : ℕ} : zero < a → zero < b → a - b < a :=
-  have aux : Π {a}, zero < a → Π {b}, zero < b → a - b < a, from
-    λa h₁, le.rec_on h₁
-      (λb h₂, le.cases_on h₂
-        (lt.base zero)
-        (λ b₁ bpos,
-          eq.rec_on (sub_eq_succ_sub_succ zero b₁)
-           (eq.rec_on (zero_eq_zero_sub b₁) (lt.base zero))))
-      (λa₁ apos ih b h₂, le.cases_on h₂
-        (lt.base a₁)
-        (λ b₁ bpos,
-          eq.rec_on (sub_eq_succ_sub_succ a₁ b₁)
-            (lt.trans (@ih b₁ bpos) (lt.base a₁)))),
-  λ h₁ h₂, aux h₁ h₂
+  eq.symm !zero_sub_eq_zero
 
   theorem sub_le (a b : ℕ) : a - b ≤ a :=
-  nat.rec_on b
-    (le.refl a)
-    (λ b₁ ih, le.trans !pred_le ih)
+  nat.rec_on b !le.refl (λ b₁, le.trans !pred_le)
 
   theorem sub_le_iff_true [simp] (a b : ℕ) : a - b ≤ a ↔ true :=
   iff_true_intro (sub_le a b)
 
+  theorem sub_lt {a b : ℕ} (H1 : zero < a) (H2 : zero < b) : a - b < a :=
+  !nat.cases_on (λh, absurd h !lt.irrefl)
+    (λa h, succ_le_succ (!nat.cases_on (λh, absurd h !lt.irrefl)
+      (λb c, eq.substr !succ_sub_succ_eq_sub !sub_le) H2)) H1
+
   theorem sub_lt_succ (a b : ℕ) : a - b < succ a :=
-  lt_succ_of_le (sub_le a b)
+  lt_succ_of_le !sub_le
 
   theorem sub_lt_succ_iff_true [simp] (a b : ℕ) : a - b < succ a ↔ true :=
-  iff_true_intro (sub_lt_succ a b)
+  iff_true_intro !sub_lt_succ
 end nat

--- a/library/logic/eq.lean
+++ b/library/logic/eq.lean
@@ -110,9 +110,8 @@ section
   assume (Hp : p) (Heq : p = false), Heq ▸ Hp
 
   theorem p_ne_true : ¬p → p ≠ true :=
-  assume (Hnp : ¬p) (Heq : p = true), absurd trivial (Heq ▸ Hnp)
+  assume (Hnp : ¬p) (Heq : p = true), (Heq ▸ Hnp) trivial
 end
 
 theorem true_ne_false : ¬true = false :=
-assume H : true = false,
-  H ▸ trivial
+p_ne_false trivial

--- a/library/logic/identities.lean
+++ b/library/logic/identities.lean
@@ -34,55 +34,26 @@ calc
      ... ↔ b ∧ (a ∧ c)      : and.assoc
 
 theorem not_not_iff {a : Prop} [D : decidable a] : (¬¬a) ↔ a :=
-iff.intro
-  (assume H : ¬¬a,
-    by_cases (assume H' : a, H') (assume H' : ¬a, absurd H' H))
-  (assume H : a, assume H', H' H)
+iff.intro by_contradiction not_not_intro
 
-theorem not_not_elim {a : Prop} [D : decidable a] (H : ¬¬a) : a :=
-iff.mp not_not_iff H
+theorem not_not_elim {a : Prop} [D : decidable a] : ¬¬a → a :=
+by_contradiction
 
-theorem not_true_iff_false [simp] : ¬true ↔ false :=
-iff.intro (assume H, H trivial) false.elim
+theorem not_or_iff_not_and_not {a b : Prop} : ¬(a ∨ b) ↔ ¬a ∧ ¬b :=
+or.imp_distrib
 
-theorem not_false_iff_true [simp] : ¬false ↔ true :=
-iff.intro (assume H, trivial) (assume H H', H')
-
-theorem not_or_iff_not_and_not {a b : Prop} [Da : decidable a] [Db : decidable b] :
-  ¬(a ∨ b) ↔ ¬a ∧ ¬b :=
-iff.intro
-  (assume H, or.elim (em a)
-    (assume Ha, absurd (or.inl Ha) H)
-    (assume Hna, or.elim (em b)
-      (assume Hb, absurd (or.inr Hb) H)
-      (assume Hnb, and.intro Hna Hnb)))
-  (assume (H : ¬a ∧ ¬b) (N : a ∨ b),
-    or.elim N
-      (assume Ha, absurd Ha (and.elim_left H))
-      (assume Hb, absurd Hb (and.elim_right H)))
-
-theorem not_and_iff_not_or_not {a b : Prop} [Da : decidable a] [Db : decidable b] :
+theorem not_and_iff_not_or_not {a b : Prop} [Da : decidable a] :
   ¬(a ∧ b) ↔ ¬a ∨ ¬b :=
 iff.intro
-  (assume H, or.elim (em a)
-    (assume Ha, or.elim (em b)
-      (assume Hb, absurd (and.intro Ha Hb) H)
-      (assume Hnb, or.inr Hnb))
-    (assume Hna, or.inl Hna))
-  (assume (H : ¬a ∨ ¬b) (N : a ∧ b),
-    or.elim H
-      (assume Hna, absurd (and.elim_left N) Hna)
-      (assume Hnb, absurd (and.elim_right N) Hnb))
+  (λH, by_cases (λa, or.inr (not.mto (and.intro a) H)) or.inl)
+  (or.rec (not.mto and.left) (not.mto and.right))
 
 theorem imp_iff_not_or {a b : Prop} [Da : decidable a] : (a → b) ↔ ¬a ∨ b :=
 iff.intro
-  (assume H : a → b, (or.elim (em a)
-    (assume Ha  : a,   or.inr (H Ha))
-    (assume Hna : ¬a, or.inl Hna)))
-  (assume (H : ¬a ∨ b) (Ha : a),
-    or_resolve_right H (not_not_iff⁻¹ ▸ Ha))
+  (by_cases (λHa H, or.inr (H Ha)) (λHa H, or.inl Ha))
+  (or.rec not.elim imp.intro)
 
-theorem not_implies_iff_and_not {a b : Prop} [Da : decidable a] [Db : decidable b] :
+theorem not_implies_iff_and_not {a b : Prop} [Da : decidable a] :
   ¬(a → b) ↔ a ∧ ¬b :=
 calc
   ¬(a → b) ↔ ¬(¬a ∨ b) : {imp_iff_not_or}
@@ -90,39 +61,30 @@ calc
        ... ↔ a ∧ ¬b    : {not_not_iff}
 
 theorem peirce {a b : Prop} [D : decidable a] : ((a → b) → a) → a :=
-assume H, by_contradiction (assume Hna : ¬a,
-  have Hnna : ¬¬a, from not_not_of_not_implies (mt H Hna),
-  absurd (not_not_elim Hnna) Hna)
+by_cases imp.intro (imp.syl imp.mp not.elim)
 
 theorem forall_not_of_not_exists {A : Type} {p : A → Prop} [D : ∀x, decidable (p x)]
   (H : ¬∃x, p x) : ∀x, ¬p x :=
-take x, or.elim (em (p x))
-  (assume Hp : p x,   absurd (exists.intro x Hp) H)
-  (assume Hnp : ¬p x, Hnp)
+take x, by_cases
+  (assume Hp : p x, absurd (exists.intro x Hp) H)
+  imp.id
 
 theorem forall_of_not_exists_not {A : Type} {p : A → Prop} [D : decidable_pred p] :
   ¬(∃ x, ¬p x) → ∀ x, p x :=
-assume Hne, take x, by_contradiction (assume Hnp : ¬ p x, Hne (exists.intro x Hnp))
+imp.syl (forall_imp_forall (λa, not_not_elim)) forall_not_of_not_exists
 
 theorem exists_not_of_not_forall {A : Type} {p : A → Prop} [D : ∀x, decidable (p x)]
     [D' : decidable (∃x, ¬p x)] (H : ¬∀x, p x) :
   ∃x, ¬p x :=
-by_contradiction
-  (assume H1 : ¬∃x, ¬p x,
-    have H2 : ∀x, ¬¬p x, from forall_not_of_not_exists H1,
-    have H3 : ∀x, p x, from take x, not_not_elim (H2 x),
-    absurd H3 H)
+by_contradiction (λH1, absurd (λx, not_not_elim (forall_not_of_not_exists H1 x)) H)
 
 theorem exists_of_not_forall_not {A : Type} {p : A → Prop} [D : ∀x, decidable (p x)]
-    [D' : decidable (∃x, ¬¬p x)] (H : ¬∀x, ¬ p x) :
+    [D' : decidable (∃x, p x)] (H : ¬∀x, ¬ p x) :
   ∃x, p x :=
-obtain x (H : ¬¬ p x), from exists_not_of_not_forall H,
-exists.intro x (not_not_elim H)
+by_contradiction (imp.syl H forall_not_of_not_exists)
 
 theorem ne_self_iff_false {A : Type} (a : A) : (a ≠ a) ↔ false :=
-iff.intro
-  (assume H, false.of_ne H)
-  (assume H, false.elim H)
+iff.intro false.of_ne false.elim
 
 theorem eq_self_iff_true [simp] {A : Type} (a : A) : (a = a) ↔ true :=
 iff_true_intro rfl
@@ -131,20 +93,12 @@ theorem heq_self_iff_true [simp] {A : Type} (a : A) : (a == a) ↔ true :=
 iff_true_intro (heq.refl a)
 
 theorem iff_not_self [simp] (a : Prop) : (a ↔ ¬a) ↔ false :=
-iff.intro
-  (assume H,
-    have H' : ¬a, from assume Ha, (H ▸ Ha) Ha,
-    H' (H⁻¹ ▸ H'))
-  (assume H, false.elim H)
+iff_false_intro (λH,
+   have H' : ¬a, from (λHa, (mp H Ha) Ha),
+   H' (iff.mpr H H'))
 
 theorem true_iff_false [simp] : (true ↔ false) ↔ false :=
-not_true_iff_false ▸ (iff_not_self true)
+not_true ▸ (iff_not_self true)
 
 theorem false_iff_true [simp] : (false ↔ true) ↔ false :=
-not_false_iff_true ▸ (iff_not_self false)
-
-theorem iff_true_iff [simp] (a : Prop) : (a ↔ true) ↔ a :=
-iff.intro (assume H, of_iff_true H) (assume H, iff_true_intro H)
-
-theorem iff_false_iff_not [simp] (a : Prop) : (a ↔ false) ↔ ¬a :=
-iff.intro (assume H, not_of_iff_false H) (assume H, iff_false_intro H)
+not_false_iff ▸ (iff_not_self false)

--- a/library/logic/instances.lean
+++ b/library/logic/instances.lean
@@ -21,43 +21,19 @@ relation.is_equivalence.mk @iff.refl @iff.symm @iff.trans
 /- congruences for logic operations -/
 
 theorem is_congruence_not : is_congruence iff iff not :=
-is_congruence.mk
-  (take a b,
-    assume H : a ↔ b, iff.intro
-      (assume H1 : ¬a, assume H2 : b, H1 (iff.elim_right H H2))
-      (assume H1 : ¬b, assume H2 : a, H1 (iff.elim_left H H2)))
+is_congruence.mk @congr_not
 
 theorem is_congruence_and : is_congruence2 iff iff iff and :=
-is_congruence2.mk
-  (take a1 b1 a2 b2,
-    assume H1 : a1 ↔ b1, assume H2 : a2 ↔ b2,
-    iff.intro
-      (assume H3 : a1 ∧ a2, and_of_and_of_imp_of_imp H3 (iff.elim_left H1) (iff.elim_left H2))
-      (assume H3 : b1 ∧ b2, and_of_and_of_imp_of_imp H3 (iff.elim_right H1) (iff.elim_right H2)))
+is_congruence2.mk @congr_and
 
 theorem is_congruence_or : is_congruence2 iff iff iff or :=
-is_congruence2.mk
-  (take a1 b1 a2 b2,
-    assume H1 : a1 ↔ b1, assume H2 : a2 ↔ b2,
-    iff.intro
-      (assume H3 : a1 ∨ a2, or_of_or_of_imp_of_imp H3 (iff.elim_left H1) (iff.elim_left H2))
-      (assume H3 : b1 ∨ b2, or_of_or_of_imp_of_imp H3 (iff.elim_right H1) (iff.elim_right H2)))
+is_congruence2.mk @congr_or
 
 theorem is_congruence_imp : is_congruence2 iff iff iff imp :=
-is_congruence2.mk
-  (take a1 b1 a2 b2,
-    assume H1 : a1 ↔ b1, assume H2 : a2 ↔ b2,
-    iff.intro
-      (assume H3 : a1 → a2, assume Hb1 : b1, iff.elim_left H2 (H3 ((iff.elim_right H1) Hb1)))
-      (assume H3 : b1 → b2, assume Ha1 : a1, iff.elim_right H2 (H3 ((iff.elim_left H1) Ha1))))
+is_congruence2.mk @congr_imp
 
 theorem is_congruence_iff : is_congruence2 iff iff iff iff :=
-is_congruence2.mk
-  (take a1 b1 a2 b2,
-    assume H1 : a1 ↔ b1, assume H2 : a2 ↔ b2,
-    iff.intro
-      (assume H3 : a1 ↔ a2, iff.trans (iff.symm H1) (iff.trans H3 H2))
-      (assume H3 : b1 ↔ b2, iff.trans H1 (iff.trans H3 (iff.symm H2))))
+is_congruence2.mk @congr_iff
 
 definition is_congruence_not_compose [instance] := is_congruence.compose is_congruence_not
 definition is_congruence_and_compose [instance] := is_congruence.compose21 is_congruence_and
@@ -75,7 +51,7 @@ end general_subst
 /- iff can be coerced to implication -/
 
 definition mp_like_iff [instance] : relation.mp_like iff :=
-relation.mp_like.mk (λa b (H : a ↔ b), iff.elim_left H)
+relation.mp_like.mk @iff.mp
 
 /- support for calculations with iff -/
 

--- a/library/logic/quantifiers.lean
+++ b/library/logic/quantifiers.lean
@@ -8,6 +8,12 @@ Universal and existential quantifiers. See also init.logic.
 import .connectives
 open inhabited nonempty
 
+theorem exists_imp_distrib {A : Type} {B : Prop} {P : A → Prop} : ((∃ a : A, P a) → B) ↔ (∀ a : A, P a → B) :=
+iff.intro (λ e x H, e (exists.intro x H)) Exists.rec
+
+theorem forall_iff_not_exists {A : Type} {P : A → Prop} : (¬ ∃ a : A, P a) ↔ ∀ a : A, ¬ P a :=
+exists_imp_distrib
+
 theorem not_forall_not_of_exists {A : Type} {p : A → Prop} (H : ∃x, p x) : ¬∀x, ¬p x :=
 assume H1 : ∀x, ¬p x,
   obtain (w : A) (Hw : p w), from H,
@@ -18,50 +24,36 @@ assume H1 : ∃x, ¬p x,
   obtain (w : A) (Hw : ¬p w), from H1,
   absurd (H2 w) Hw
 
-theorem forall_congr {A : Type} {φ ψ : A → Prop} (H : ∀x, φ x ↔ ψ x) : (∀x, φ x) ↔ (∀x, ψ x) :=
-iff.intro
-  (assume Hl, take x, iff.elim_left (H x) (Hl x))
-  (assume Hr, take x, iff.elim_right (H x) (Hr x))
+theorem forall_congr {A : Type} {φ ψ : A → Prop} : (∀x, φ x ↔ ψ x) → ((∀x, φ x) ↔ (∀x, ψ x)) :=
+forall_iff_forall
 
-theorem exists_congr {A : Type} {φ ψ : A → Prop} (H : ∀x, φ x ↔ ψ x) : (∃x, φ x) ↔ (∃x, ψ x) :=
-iff.intro
-  (assume Hex, obtain w Pw, from Hex,
-    exists.intro w (iff.elim_left (H w) Pw))
-  (assume Hex, obtain w Qw, from Hex,
-    exists.intro w (iff.elim_right (H w) Qw))
+theorem exists_congr {A : Type} {φ ψ : A → Prop} : (∀x, φ x ↔ ψ x) → ((∃x, φ x) ↔ (∃x, ψ x)) :=
+exists_iff_exists
 
 theorem forall_true_iff_true (A : Type) : (∀x : A, true) ↔ true :=
-iff.intro (assume H, trivial) (assume H, take x, trivial)
+iff_true_intro (λH, trivial)
 
 theorem forall_p_iff_p (A : Type) [H : inhabited A] (p : Prop) : (∀x : A, p) ↔ p :=
-iff.intro (assume Hl, inhabited.destruct H (take x, Hl x)) (assume Hr, take x, Hr)
+iff.intro (inhabited.destruct H) (λHr x, Hr)
 
 theorem exists_p_iff_p (A : Type) [H : inhabited A] (p : Prop) : (∃x : A, p) ↔ p :=
-iff.intro
-  (assume Hl, obtain a Hp, from Hl, Hp)
-  (assume Hr, inhabited.destruct H (take a, exists.intro a Hr))
+iff.intro (Exists.rec (λx Hp, Hp)) (inhabited.destruct H exists.intro)
 
 theorem forall_and_distribute {A : Type} (φ ψ : A → Prop) :
   (∀x, φ x ∧ ψ x) ↔ (∀x, φ x) ∧ (∀x, ψ x) :=
 iff.intro
-  (assume H, and.intro (take x, and.elim_left (H x)) (take x, and.elim_right (H x)))
-  (assume H, take x, and.intro (and.elim_left H x) (and.elim_right H x))
+  (assume H, and.intro (take x, and.left (H x)) (take x, and.right (H x)))
+  (assume H x, and.intro (and.left H x) (and.right H x))
 
 theorem exists_or_distribute {A : Type} (φ ψ : A → Prop) :
   (∃x, φ x ∨ ψ x) ↔ (∃x, φ x) ∨ (∃x, ψ x) :=
 iff.intro
-  (assume H, obtain (w : A) (Hw : φ w ∨ ψ w), from H,
-    or.elim Hw
-      (assume Hw1 : φ w, or.inl (exists.intro w Hw1))
-      (assume Hw2 : ψ w, or.inr (exists.intro w Hw2)))
-  (assume H, or.elim H
-    (assume H1, obtain (w : A) (Hw : φ w), from H1,
-      exists.intro w (or.inl Hw))
-    (assume H2, obtain (w : A) (Hw : ψ w), from H2,
-      exists.intro w (or.inr Hw)))
+  (Exists.rec (λx, or.imp !exists.intro !exists.intro))
+  (or.rec (exists_imp_exists (λx, or.inl))
+          (exists_imp_exists (λx, or.inr)))
 
-theorem nonempty_of_exists {A : Type} {P : A → Prop} (H : ∃x, P x) : nonempty A :=
-obtain w Hw, from H, nonempty.intro w
+theorem nonempty_of_exists {A : Type} {P : A → Prop} : (∃x, P x) → nonempty A :=
+Exists.rec (λw H, intro w)
 
 section
   open decidable eq.ops
@@ -70,16 +62,12 @@ section
   include H
 
   definition decidable_forall_eq [instance] : decidable (∀ x, x = a → P x) :=
-  decidable.rec_on H
-     (λ pa,  inl (λ x heq, eq.rec_on (eq.rec_on heq rfl) pa))
-     (λ npa, inr (λ h, absurd (h a rfl) npa))
+  if pa : P a then inl (λ x heq, eq.substr heq pa)
+  else inr (not.mto (λH, H a rfl) pa)
 
   definition decidable_exists_eq [instance] : decidable (∃ x, x = a ∧ P x) :=
-  decidable.rec_on H
-     (λ pa, inl (exists.intro a (and.intro rfl pa)))
-     (λ npa, inr (λ h,
-       obtain (w : A) (Hw : w = a ∧ P w), from h,
-       absurd (and.rec_on Hw (λ h₁ h₂, h₁ ▸ h₂)) npa))
+  if pa : P a then inl (exists.intro a (and.intro rfl pa))
+  else inr (Exists.rec (λh, and.rec (λheq, eq.substr heq pa)))
 end
 
 /- exists_unique -/
@@ -96,7 +84,7 @@ exists.intro w (and.intro H1 H2)
 theorem exists_unique.elim {A : Type} {p : A → Prop} {b : Prop}
     (H2 : ∃!x, p x) (H1 : ∀x, p x → (∀y, p y → y = x) → b) : b :=
 obtain w Hw, from H2,
-H1 w (and.elim_left Hw) (and.elim_right Hw)
+H1 w (and.left Hw) (and.right Hw)
 
 /- congruences -/
 
@@ -104,23 +92,13 @@ section
   variables {A : Type} {p₁ p₂ : A → Prop} (H : ∀x, p₁ x ↔ p₂ x)
 
   theorem congr_forall : (∀x, p₁ x) ↔ (∀x, p₂ x) :=
-  iff.intro
-    (assume H', take x, iff.mp (H x) (H' x))
-    (assume H', take x, iff.mpr (H x) (H' x))
+  forall_congr H
 
   theorem congr_exists : (∃x, p₁ x) ↔ (∃x, p₂ x) :=
-  iff.intro
-    (assume H', exists.elim H' (λ x H₁, exists.intro x (iff.mp (H x) H₁)))
-    (assume H', exists.elim H' (λ x H₁, exists.intro x (iff.mpr (H x) H₁)))
+  exists_congr H
 
   include H
   theorem congr_exists_unique : (∃!x, p₁ x) ↔ (∃!x, p₂ x) :=
-  begin
-    apply congr_exists,
-    intro x,
-    apply congr_and (H x),
-    apply congr_forall,
-    intro y,
-    apply congr_imp (H y) !iff.rfl
-  end
+   congr_exists (λx, congr_and (H x) (congr_forall
+     (λy, congr_imp (H y) iff.rfl)))
 end


### PR DESCRIPTION
Breaking changes: pnat was redefined to use subtype instead of a custom inductive type, which affects the notation for pnat 2 and 3
