### PR TITLE
powerset, and other additions to set and finset

### DIFF
--- a/library/data/list/perm.lean
+++ b/library/data/list/perm.lean
@@ -119,7 +119,7 @@ assume p, perm.induction_on p
   (λ x y l, by rewrite *length_cons)
   (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, eq.trans r₁ r₂)
 
-theorem eq_singlenton_of_perm_inv (a : A) {l : list A} : [a] ~ l → l = [a] :=
+theorem eq_singleton_of_perm_inv (a : A) {l : list A} : [a] ~ l → l = [a] :=
 have gen : ∀ l₂, perm l₂ l → l₂ = [a] → l = [a], from
   take l₂, assume p, perm.induction_on p
     (λ e, e)
@@ -134,10 +134,10 @@ have gen : ∀ l₂, perm l₂ l → l₂ = [a] → l = [a], from
     (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂ e, r₂ (r₁ e)),
 assume p, gen [a] p rfl
 
-theorem eq_singlenton_of_perm (a b : A) : [a] ~ [b] → a = b :=
+theorem eq_singleton_of_perm (a b : A) : [a] ~ [b] → a = b :=
 assume p,
 begin
-  injection eq_singlenton_of_perm_inv a p with e₁,
+  injection eq_singleton_of_perm_inv a p with e₁,
   rewrite e₁
 end
 

--- a/library/data/nat/find.lean
+++ b/library/data/nat/find.lean
@@ -97,9 +97,9 @@ private definition find_x : {x : nat | p x} :=
 @fix _ _ _ wf_gtb find.F 0 lbp_zero
 end find_x
 
-protected definition choose {p : nat → Prop} [d : decidable_pred p] : (∃ x, p x) → nat :=
+protected definition find {p : nat → Prop} [d : decidable_pred p] : (∃ x, p x) → nat :=
 assume h, elt_of (find_x h)
 
-protected theorem choose_spec {p : nat → Prop} [d : decidable_pred p] (ex : ∃ x, p x) : p (nat.choose ex) :=
+protected theorem find_spec {p : nat → Prop} [d : decidable_pred p] (ex : ∃ x, p x) : p (nat.find ex) :=
 has_property (find_x ex)
 end nat

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -3,8 +3,8 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jeremy Avigad, Leonardo de Moura
 -/
-import logic
-open eq.ops
+import logic algebra.binary
+open eq.ops binary
 
 definition set [reducible] (X : Type) := X → Prop
 
@@ -29,8 +29,12 @@ theorem subset.refl (a : set X) : a ⊆ a := take x, assume H, H
 theorem subset.trans (a b c : set X) (subab : a ⊆ b) (subbc : b ⊆ c) : a ⊆ c :=
 take x, assume ax, subbc (subab ax)
 
-theorem subset.antisymm (a b : set X) (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
+theorem subset.antisymm {a b : set X} (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
 setext (λ x, iff.intro (λ ina, h₁ ina) (λ inb, h₂ inb))
+
+-- an alterantive name
+theorem eq_of_subset_of_subset {a b : set X} (h₁ : a ⊆ b) (h₂ : b ⊆ a) : a = b :=
+subset.antisymm h₁ h₂
 
 definition strict_subset (a b : set X) := a ⊆ b ∧ a ≠ b
 infix `⊂`:50 := strict_subset
@@ -57,6 +61,20 @@ theorem not_mem_empty (x : X) : ¬ (x ∈ ∅) :=
 assume H : x ∈ ∅, H
 
 theorem mem_empty_eq (x : X) : x ∈ ∅ = false := rfl
+
+theorem eq_empty_of_forall_not_mem {s : set X} (H : ∀ x, x ∉ s) : s = ∅ :=
+setext (take x, iff.intro
+  (assume xs, absurd xs (H x))
+  (assume xe, absurd xe !not_mem_empty))
+
+theorem empty_subset (s : set X) : ∅ ⊆ s :=
+take x, assume H, false.elim H
+
+theorem eq_empty_of_subset_empty {s : set X} (H : s ⊆ ∅) : s = ∅ :=
+subset.antisymm H (empty_subset s)
+
+theorem subset_empty_iff (s : set X) : s ⊆ ∅ ↔ s = ∅ :=
+iff.intro eq_empty_of_subset_empty (take xeq, by rewrite xeq; apply subset.refl ∅)
 
 /- universal set -/
 
@@ -94,6 +112,12 @@ setext (take x, or.comm)
 theorem union.assoc (a b c : set X) : (a ∪ b) ∪ c = a ∪ (b ∪ c) :=
 setext (take x, or.assoc)
 
+theorem union.left_comm (s₁ s₂ s₃ : set X) : s₁ ∪ (s₂ ∪ s₃) = s₂ ∪ (s₁ ∪ s₃) :=
+!left_comm union.comm union.assoc s₁ s₂ s₃
+
+theorem union.right_comm (s₁ s₂ s₃ : set X) : (s₁ ∪ s₂) ∪ s₃ = (s₁ ∪ s₃) ∪ s₂ :=
+!right_comm union.comm union.assoc s₁ s₂ s₃
+
 /- intersection -/
 
 definition inter [reducible] (a b : set X) : set X := λx, x ∈ a ∧ x ∈ b
@@ -117,6 +141,12 @@ setext (take x, !and.comm)
 
 theorem inter.assoc (a b c : set X) : (a ∩ b) ∩ c = a ∩ (b ∩ c) :=
 setext (take x, !and.assoc)
+
+theorem inter.left_comm (s₁ s₂ s₃ : set X) : s₁ ∩ (s₂ ∩ s₃) = s₂ ∩ (s₁ ∩ s₃) :=
+!left_comm inter.comm inter.assoc s₁ s₂ s₃
+
+theorem inter.right_comm (s₁ s₂ s₃ : set X) : (s₁ ∩ s₂) ∩ s₃ = (s₁ ∩ s₃) ∩ s₂ :=
+!right_comm inter.comm inter.assoc s₁ s₂ s₃
 
 theorem inter_univ (a : set X) : a ∩ univ = a :=
 setext (take x, !and_true)

--- a/library/data/set/function.lean
+++ b/library/data/set/function.lean
@@ -58,6 +58,23 @@ take y, assume Hy : y ∈ f '[a],
 obtain x (Hx₁ : x ∈ a) (Hx₂ : f x = y), from Hy,
 mem_image (H Hx₁) Hx₂
 
+theorem image_union (f : X → Y) (s t : set X) :
+  image f (s ∪ t) = image f s ∪ image f t :=
+setext (take y, iff.intro
+  (assume H : y ∈ image f (s ∪ t),
+    obtain x [(xst : x ∈ s ∪ t) (fxy : f x = y)], from H,
+    or.elim xst
+      (assume xs, or.inl (mem_image xs fxy))
+      (assume xt, or.inr (mem_image xt fxy)))
+  (assume H : y ∈ image f s ∪ image f t,
+    or.elim H
+      (assume yifs : y ∈ image f s,
+        obtain x [(xs : x ∈ s) (fxy : f x = y)], from yifs,
+        mem_image (or.inl xs) fxy)
+      (assume yift : y ∈ image f t,
+        obtain x [(xt : x ∈ t) (fxy : f x = y)], from yift,
+        mem_image (or.inr xt) fxy)))
+
 /- maps to -/
 
 definition maps_to [reducible] (f : X → Y) (a : set X) (b : set Y) : Prop := ∀⦃x⦄, x ∈ a → f x ∈ b

--- a/library/theories/group_theory/action.lean
+++ b/library/theories/group_theory/action.lean
@@ -66,7 +66,7 @@ lemma exists_of_orbit {b : S} : b ∈ orbit hom H a → ∃ h, h ∈ H ∧ hom h
 
 lemma orbit_of_exists {b : S} : (∃ h, h ∈ H ∧ hom h a = b) → b ∈ orbit hom H a :=
 assume Pex, obtain h PinH Phab, from Pex,
-mem_image_of_mem_of_eq (mem_image_of_mem hom PinH) Phab
+mem_image (mem_image_of_mem hom PinH) Phab
 
 lemma is_fixed_point_of_mem_fixed_points :
   a ∈ fixed_points hom H → is_fixed_point hom H a :=
@@ -266,7 +266,7 @@ variables {hom : G → perm S} [Hom : is_hom_class hom] {H : finset G} [subgH : 
 include Hom subgH
 
 lemma in_orbit_refl {a : S} : a ∈ orbit hom H a :=
-mem_image_of_mem_of_eq (mem_image_of_mem_of_eq (finsubg_has_one H) (hom_map_one hom)) rfl
+mem_image (mem_image (finsubg_has_one H) (hom_map_one hom)) rfl
 
 lemma in_orbit_trans {a b c : S} :
   a ∈ orbit hom H b → b ∈ orbit hom H c → a ∈ orbit hom H c :=
@@ -339,7 +339,7 @@ ext take s, iff.intro
   (assume Pin,
    obtain Psin Ps, from iff.elim_left !mem_filter_iff Pin,
    obtain a Pa, from exists_of_mem_orbits Psin,
-   mem_image_of_mem_of_eq
+   mem_image
      (mem_filter_of_mem !mem_univ (eq.symm
        (eq_of_card_eq_of_subset (by rewrite [card_singleton, Pa, Ps])
          (subset_of_forall
@@ -543,7 +543,7 @@ ext (take (pp : perm (fin (succ n))), iff.intro
   mem_filter_of_mem !mem_univ Ppp)
   (assume Pstab,
   assert Ppp : pp maxi = maxi, from of_mem_filter Pstab,
-  mem_image_of_mem_of_eq !mem_univ (lift_lower_eq Ppp)))
+  mem_image !mem_univ (lift_lower_eq Ppp)))
 
 definition move_from_max_to (i : fin (succ n)) : perm (fin (succ n)) :=
 perm.mk (madd (i - maxi)) madd_inj
@@ -552,8 +552,8 @@ lemma orbit_max : orbit (@id (perm (fin (succ n)))) univ maxi = univ :=
 ext (take i, iff.intro
   (assume P, !mem_univ)
   (assume P, begin
-    apply mem_image_of_mem_of_eq,
-      apply mem_image_of_mem_of_eq,
+    apply mem_image,
+      apply mem_image,
         apply mem_univ (move_from_max_to i), apply rfl,
       apply sub_add_cancel
     end))

--- a/library/theories/group_theory/cyclic.lean
+++ b/library/theories/group_theory/cyclic.lean
@@ -182,7 +182,7 @@ assume Pe, let s := image (pow a) (upto (succ n)) in
 assert Psub: cyc a ⊆ s, from subset_of_forall
   (take g, assume Pgin, obtain i Pilt Pig, from of_mem_filter Pgin, begin
   rewrite [-Pig, pow_mod Pe],
-  apply mem_image_of_mem_of_eq,
+  apply mem_image,
     apply mem_upto_of_lt (mod_lt i !zero_lt_succ),
     exact rfl end),
 #nat calc order a ≤ card s : card_le_card_of_subset Psub

--- a/library/theories/group_theory/finsubg.lean
+++ b/library/theories/group_theory/finsubg.lean
@@ -96,7 +96,7 @@ lemma fin_lrcoset_comm {a b : A} :
 by esimp [fin_lcoset, fin_rcoset]; rewrite [-*image_compose, lmul_rmul]
 
 lemma inv_mem_fin_inv {a : A} : a ∈ H → a⁻¹ ∈ fin_inv H :=
-assume Pin, mem_image_of_mem_of_eq Pin rfl
+assume Pin, mem_image Pin rfl
 
 lemma fin_lcoset_eq (a : A) : ts (fin_lcoset H a) = a ∘> (ts H) := calc
       ts (fin_lcoset H a) = coset.l a (ts H) : to_set_image
@@ -401,11 +401,11 @@ lemma lrcoset_same_of_mem_normalizer {g : G} :
   g ∈ normalizer H → fin_lcoset H g = fin_rcoset H g :=
 assume Pg, ext take h, iff.intro
   (assume Pl, obtain j Pjin Pj, from exists_of_mem_image Pl,
-  mem_image_of_mem_of_eq (of_mem_filter Pg j Pjin)
+  mem_image (of_mem_filter Pg j Pjin)
     (calc g*j*g⁻¹*g = g*j : inv_mul_cancel_right
                 ... = h   : Pj))
   (assume Pr, obtain j Pjin Pj, from exists_of_mem_image Pr,
-  mem_image_of_mem_of_eq (of_mem_filter (finsubg_has_inv (normalizer H) Pg) j Pjin)
+  mem_image (of_mem_filter (finsubg_has_inv (normalizer H) Pg) j Pjin)
     (calc g*(g⁻¹*j*g⁻¹⁻¹) = g*(g⁻¹*j*g)   : inv_inv
                       ... = g*(g⁻¹*(j*g)) : mul.assoc
                       ... = j*g           : mul_inv_cancel_left


### PR DESCRIPTION
I still need to define notation for the powerset, in both finset and set. I'll do that soon.

I renamed `mem_image_of_mem_of_eq` in `finset` to `mem_image` to match the name in `set`. The shorter name seems sufficient to identify the theorem. It is used often in Haitao's group theory files.

Also, we now have synonyms `subset.antisymm` and `eq_of_subset_of_subset` in `finset` and `set`. (Before, it had one name in one and the other name in the other.)
