### PR TITLE
Integer floor/ceiling and supremum property for reals

### DIFF
--- a/library/algebra/field.lean
+++ b/library/algebra/field.lean
@@ -297,8 +297,6 @@ section field
   theorem div_div_div_div (Hb : b ≠ 0) (Hc : c ≠ 0) (Hd : d ≠ 0) : (a / b) / (c / d) = (a * d) / (b * c) :=
     by rewrite [(div_div_eq_mul_div Hc Hd), (div_mul_eq_mul_div), (div_div_eq_div_mul Hb Hc)]
 
-  -- remaining to transfer from Isabelle fields: ordered fields
-
 end field
 
 structure discrete_field [class] (A : Type) extends field A :=

--- a/library/algebra/field.lean
+++ b/library/algebra/field.lean
@@ -150,11 +150,11 @@ section division_ring
             ... = -(b * (1 / a))  : neg_mul_eq_mul_neg
             ... = - (b * a⁻¹)     : inv_eq_one_div
 
-  theorem neg_div (Ha : a ≠ 0) : (-b) / a = - (b / a) :=
+  theorem neg_div : (-b) / a = - (b / a) :=
     by rewrite [neg_eq_neg_one_mul, mul_div_assoc, -neg_eq_neg_one_mul]
 
   theorem neg_div_neg_eq_div (Hb : b ≠ 0) : (-a) / (-b) = a / b :=
-    by rewrite [(div_neg_eq_neg_div Hb), (neg_div Hb), neg_neg]
+    by rewrite [(div_neg_eq_neg_div Hb), neg_div, neg_neg]
 
   theorem div_div (H : a ≠ 0) : 1 / (1 / a) = a :=
     symm (eq_one_div_of_mul_eq_one_left (mul_one_div_cancel H))
@@ -176,6 +176,9 @@ section division_ring
     by rewrite [↑divide, mul.assoc, (inv_mul_cancel Hb), mul_one]
 
   theorem div_add_div_same : a / c + b / c = (a + b) / c := !right_distrib⁻¹
+
+  theorem div_sub_div_same : (a / c) - (b / c) = (a - b) / c :=
+    by rewrite [sub_eq_add_neg, -neg_div, div_add_div_same]
 
   theorem inv_mul_add_mul_inv_eq_inv_add_inv (Ha : a ≠ 0) (Hb : b ≠ 0) :
           (1 / a) * (a + b) * (1 / b) = 1 / a + 1 / b :=
@@ -297,6 +300,10 @@ section field
   theorem div_div_div_div (Hb : b ≠ 0) (Hc : c ≠ 0) (Hd : d ≠ 0) : (a / b) / (c / d) = (a * d) / (b * c) :=
     by rewrite [(div_div_eq_mul_div Hc Hd), (div_mul_eq_mul_div), (div_div_eq_div_mul Hb Hc)]
 
+  theorem div_mul_eq_div_mul_one_div (Hb : b ≠ 0) (Hc : c ≠ 0) : a / (b * c) = (a / b) * (1 / c) :=
+    by rewrite [-div_div_eq_div_mul Hb Hc, -div_eq_mul_one_div]
+
+
 end field
 
 structure discrete_field [class] (A : Type) extends field A :=
@@ -359,11 +366,6 @@ section discrete_field
     decidable.by_cases
       (suppose a = 0, by rewrite [this, neg_zero, 2 div_zero, neg_zero])
       (suppose a ≠ 0, one_div_neg_eq_neg_one_div this)
-
-  theorem neg_div' : (-b) / a = - (b / a) :=
-    decidable.by_cases
-      (assume Ha : a = 0, by rewrite [Ha, 2 div_zero, neg_zero])
-      (assume Ha : a ≠ 0, neg_div Ha)
 
   theorem neg_div_neg_eq_div' : (-a) / (-b) = a / b :=
     decidable.by_cases
@@ -445,6 +447,9 @@ section discrete_field
 
   theorem div_helper (H : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
     by rewrite [div_mul_eq_mul_div, one_mul, (div_mul_right' H)]
+
+  theorem div_mul_eq_div_mul_one_div' : a / (b * c) = (a / b) * (1 / c) :=
+    by rewrite [-div_div_eq_div_mul', -div_eq_mul_one_div]
 
 end discrete_field
 

--- a/library/algebra/group.lean
+++ b/library/algebra/group.lean
@@ -558,6 +558,10 @@ section add_comm_group
 
   theorem add_eq_of_eq_sub' {a b c : A} (H : b = c - a) : a + b = c :=
   !add.comm ▸ add_eq_of_eq_sub H
+
+  theorem sub_sub_self (a b : A) : a - (a - b) = b :=
+  by rewrite [sub_eq_add_neg, neg_sub, add.comm, sub_add_cancel]
+ 
 end add_comm_group
 
 definition group_of_add_group (A : Type) [G : add_group A] : group A :=

--- a/library/algebra/group_power.lean
+++ b/library/algebra/group_power.lean
@@ -133,4 +133,38 @@ theorem ipow_comm (a : A) (i j : ℤ) : ipow a i * ipow a j = ipow a j * ipow a 
 by rewrite [-*ipow_add, int.add.comm]
 end group
 
+section ordered_ring
+open nat
+variable [s : linear_ordered_ring A]
+include s
+
+theorem pow_pos {a : A} (H : a > 0) (n : ℕ) : pow a n > 0 :=
+  begin
+    induction n,
+    rewrite pow_zero,
+    apply zero_lt_one,
+    rewrite pow_succ,
+    apply mul_pos,
+    apply v_0, apply H
+  end
+
+theorem pow_ge_one_of_ge_one {a : A} (H : a ≥ 1) (n : ℕ) : pow a n ≥ 1 :=
+  begin
+    induction n,
+    rewrite pow_zero,
+    apply le.refl,
+    rewrite [pow_succ, -{1}mul_one],
+    apply mul_le_mul v_0 H zero_le_one,
+    apply le_of_lt,
+    apply pow_pos,
+    apply gt_of_ge_of_gt H zero_lt_one
+  end
+
+local notation 2 := (1 : A) + 1
+
+theorem pow_two_add (n : ℕ) : pow 2 n + pow 2 n = pow 2 (succ n) :=
+  by rewrite [pow_succ, left_distrib, *mul_one]
+
+end ordered_ring
+
 end algebra

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -297,6 +297,12 @@ section linear_ordered_field
       ... = (a * 2) / 2           : by rewrite left_distrib
       ... = a                     : by rewrite [@mul_div_cancel A _ _ _ two_ne_zero]
 
+  theorem sub_self_div_two : a - a / 2 = a / 2 :=
+    by rewrite [-{a}add_halves at {1}, add_sub_cancel]
+
+  theorem div_two_sub_self : a / 2 - a = - (a / 2) :=
+    by rewrite [-{a}add_halves at {2}, sub_add_eq_sub_sub, sub_self, zero_sub]
+
 theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a ≤ b * b) : a ≤ b :=
   begin
     apply le_of_not_gt,

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -318,6 +318,8 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
     symm (iff.mpr (eq_div_iff_mul_eq (ne_of_gt (add_pos zero_lt_one zero_lt_one)))
            (by rewrite [left_distrib, *mul_one]))
 
+  theorem two_ge_one : (2 : A) ≥ 1 :=
+    by rewrite -(add_zero 1) at {3}; apply add_le_add_left; apply zero_le_one
 
   theorem mul_le_mul_of_mul_div_le (H : a * (b / c) ≤ d) (Hc : c > 0) : b * a ≤ d * c :=
     begin
@@ -331,6 +333,15 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
       a / (1 + 1) < a / (1 + 1) + a / (1 + 1) : lt_add_of_pos_left Ha
               ... = a : add_halves
 
+
+  theorem div_mul_le_div_mul_of_div_le_div_pos {e : A} (Hb : b ≠ 0) (Hd : d ≠ 0) (H : a / b ≤ c / d)
+          (He : e > 0) : a / (b * e) ≤ c / (d * e) :=
+    begin
+      rewrite [div_mul_eq_div_mul_one_div Hb (ne_of_gt He), div_mul_eq_div_mul_one_div Hd (ne_of_gt He)],
+      apply mul_le_mul_of_nonneg_right H,
+      apply le_of_lt,
+      apply div_pos_of_pos He
+    end
 
 end linear_ordered_field
 
@@ -462,6 +473,15 @@ section discrete_linear_ordered_field
       apply iff.mpr (sub_neg_iff_lt _ _),
       apply div_lt_div_of_lt,
       exact Hb, exact H
+    end
+
+  theorem div_mul_le_div_mul_of_div_le_div_pos' {d e : A} (H : a / b ≤ c / d)
+          (He : e > 0) : a / (b * e) ≤ c / (d * e) :=
+    begin
+      rewrite [2 div_mul_eq_div_mul_one_div'],
+      apply mul_le_mul_of_nonneg_right H,
+      apply le_of_lt,
+      apply div_pos_of_pos He
     end
 
   theorem abs_one_div : abs (1 / a) = 1 / abs a :=

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -306,6 +306,12 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
       apply le_mul_of_div_le Hc H
     end
 
+  theorem div_two_lt_of_pos (H : a > 0) : a / (1 + 1) < a :=
+    have Ha : a / (1 + 1) > 0, from pos_div_of_pos_of_pos H (add_pos zero_lt_one zero_lt_one),
+    calc
+      a / (1 + 1) < a / (1 + 1) + a / (1 + 1) : lt_add_of_pos_left Ha
+              ... = a : add_halves
+
 end linear_ordered_field
 
 structure discrete_linear_ordered_field [class] (A : Type) extends linear_ordered_field A,

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -266,10 +266,23 @@ section linear_ordered_field
     exact mul_lt_mul_of_pos_right H (div_pos_of_pos Hc)
   end
 
+
+  theorem div_le_div_of_le_of_pos (H : a ≤ b) (Hc : 0 < c) : a / c ≤ b / c :=
+    begin
+      rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
+      exact mul_le_mul_of_nonneg_right H (le_of_lt (div_pos_of_pos Hc))
+    end
+
   theorem div_lt_div_of_lt_of_neg (H : b < a) (Hc : c < 0) : a / c < b / c :=
   begin
     rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
     exact mul_lt_mul_of_neg_right H (div_neg_of_neg Hc)
+  end
+
+  theorem div_le_div_of_le_of_neg (H : b ≤ a) (Hc : c < 0) : a / c ≤ b / c :=
+  begin
+    rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
+    exact mul_le_mul_of_nonpos_right H (le_of_lt (div_neg_of_neg Hc))
   end
 
   theorem two_ne_zero : (1 : A) + 1 ≠ 0 :=
@@ -311,6 +324,7 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
     calc
       a / (1 + 1) < a / (1 + 1) + a / (1 + 1) : lt_add_of_pos_left Ha
               ... = a : add_halves
+
 
 end linear_ordered_field
 

--- a/library/algebra/ordered_group.lean
+++ b/library/algebra/ordered_group.lean
@@ -654,6 +654,21 @@ section
       apply abs_add_le_abs_add_abs,
       apply le.refl
     end
+
+theorem dist_bdd_within_interval {a b lb ub : A} (H : lb < ub) (Hal : lb ≤ a) (Hau : a ≤ ub)
+        (Hbl : lb ≤ b) (Hbu : b ≤ ub) : abs (a - b) ≤ ub - lb :=
+  begin
+    cases (decidable.em (b ≤ a)) with [Hba, Hba],
+    rewrite (abs_of_nonneg (iff.mpr !sub_nonneg_iff_le Hba)),
+    apply sub_le_sub,
+    apply Hau,
+    apply Hbl,
+    rewrite [abs_of_neg (iff.mpr !sub_neg_iff_lt (lt_of_not_ge Hba)), neg_sub],
+    apply sub_le_sub,
+    apply Hbu,
+    apply Hal
+  end
+
   end
 end
 

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -292,6 +292,26 @@ theorem canon_bound {s : seq} (Hs : regular s) (n : ℕ+) : abs (s n) ≤ rat_of
     ... = of_nat (ubound (abs (s pone)) + (1 + 1)) : of_nat_add
     ... = of_nat (ubound (abs (s pone)) + 1 + 1) : nat.add.assoc
 
+theorem bdd_of_regular {s : seq} (H : regular s) : ∃ b : ℚ, ∀ n : ℕ+, s n ≤ b :=
+  begin
+    existsi rat_of_pnat (K s),
+    intros,
+    apply rat.le.trans,
+    apply le_abs_self,
+    apply canon_bound H
+  end
+
+theorem bdd_of_regular_strict {s : seq} (H : regular s) : ∃ b : ℚ, ∀ n : ℕ+, s n < b :=
+  begin
+    cases bdd_of_regular H with [b, Hb],
+    existsi b + 1,
+    intro n,
+    apply rat.lt_of_le_of_lt,
+    apply Hb,
+    apply rat.lt_add_of_pos_right,
+    apply rat.zero_lt_one
+  end
+
 definition K₂ (s t : seq) := max (K s) (K t)
 
 theorem K₂_symm (s t : seq) : K₂ s t = K₂ t s :=

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -6,7 +6,6 @@ The real numbers, constructed as equivalence classes of Cauchy sequences of rati
 This construction follows Bishop and Bridges (1985).
 
 To do:
- o Break positive naturals into their own file
  o Rename things and possibly make theorems private
 -/
 
@@ -687,8 +686,7 @@ theorem mul_bound_helper {s t : seq} (Hs : regular s) (Ht : regular t) (a b c : 
     apply add_invs_nonneg,
     rewrite [*inv_mul_eq_mul_inv, -rat.right_distrib, mul.comm _ n⁻¹, rat.mul.assoc],
     apply rat.mul_le_mul,
-    apply rat.le.refl,
-    apply rat.le.refl,
+    repeat apply rat.le.refl,
     apply rat.le_of_lt,
     apply rat.mul_pos,
     apply rat.add_pos,

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -946,10 +946,10 @@ theorem const_reg (a : ℚ) : regular (const a) :=
   end
 
 theorem add_consts (a b : ℚ) : sadd (const a) (const b) ≡ const (a + b) :=
-  begin
-    rewrite [↑sadd, ↑const],
-    apply equiv.refl
-  end
+  by apply equiv.refl
+
+theorem mul_consts (a b : ℚ) : smul (const a) (const b) ≡ const (a * b) :=
+  by apply equiv.refl
 
 ---------------------------------------------
 -- create the type of regular sequences and lift theorems
@@ -1037,6 +1037,8 @@ theorem r_zero_nequiv_one : ¬ requiv r_zero r_one :=
 definition r_const (a : ℚ) : reg_seq := reg_seq.mk (const a) (const_reg a)
 
 theorem r_add_consts (a b : ℚ) : requiv (r_const a + r_const b) (r_const (a + b)) := add_consts a b
+
+theorem r_mul_consts (a b : ℚ) : requiv (r_const a * r_const b) (r_const (a * b)) := mul_consts a b
 
 end s
 ----------------------------------------------
@@ -1128,14 +1130,17 @@ protected definition comm_ring [reducible] : algebra.comm_ring ℝ :=
     apply mul_comm
   end
 
-definition const (a : ℚ) : ℝ := quot.mk (s.r_const a)
+definition of_rat [coercion] (a : ℚ) : ℝ := quot.mk (s.r_const a)
 
-theorem add_consts (a b : ℚ) : const a + const b = const (a + b) :=
-  quot.sound (s.r_add_consts a b)
+theorem of_rat_add (a b : ℚ) : of_rat a + of_rat b = of_rat (a + b) :=
+   quot.sound (s.r_add_consts a b)
 
-theorem sub_consts (a b : ℚ) : const a + -const b = const (a - b) := !add_consts
+theorem of_rat_sub (a b : ℚ) : of_rat a + - of_rat b = of_rat (a - b) := !of_rat_add
 
-theorem add_half_const (n : ℕ+) : const (2 * n)⁻¹ + const (2 * n)⁻¹ = const (n⁻¹) :=
-  by rewrite [add_consts, pnat.add_halves]
+theorem of_rat_mul (a b : ℚ) : of_rat a * of_rat b = of_rat (a * b) :=
+  quot.sound (s.r_mul_consts a b)
+
+theorem add_half_of_rat (n : ℕ+) : of_rat (2 * n)⁻¹ + of_rat (2 * n)⁻¹ = of_rat (n⁻¹) :=
+  by rewrite [of_rat_add, pnat.add_halves]
 
 end real

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -949,6 +949,9 @@ theorem add_consts (a b : ℚ) : sadd (const a) (const b) ≡ const (a + b) :=
 theorem mul_consts (a b : ℚ) : smul (const a) (const b) ≡ const (a * b) :=
   by apply equiv.refl
 
+theorem neg_const (a : ℚ) : sneg (const a) ≡ const (-a) :=
+  by apply equiv.refl
+
 ---------------------------------------------
 -- create the type of regular sequences and lift theorems
 
@@ -1037,6 +1040,8 @@ definition r_const (a : ℚ) : reg_seq := reg_seq.mk (const a) (const_reg a)
 theorem r_add_consts (a b : ℚ) : requiv (r_const a + r_const b) (r_const (a + b)) := add_consts a b
 
 theorem r_mul_consts (a b : ℚ) : requiv (r_const a * r_const b) (r_const (a * b)) := mul_consts a b
+
+theorem r_neg_const (a : ℚ) : requiv (-r_const a) (r_const (-a)) := neg_const a
 
 end s
 ----------------------------------------------
@@ -1133,7 +1138,9 @@ definition of_rat [coercion] (a : ℚ) : ℝ := quot.mk (s.r_const a)
 theorem of_rat_add (a b : ℚ) : of_rat a + of_rat b = of_rat (a + b) :=
    quot.sound (s.r_add_consts a b)
 
-theorem of_rat_sub (a b : ℚ) : of_rat a + - of_rat b = of_rat (a - b) := !of_rat_add
+theorem of_rat_neg (a : ℚ) : -of_rat a = of_rat (-a) := quot.sound (s.r_neg_const a)
+
+--theorem of_rat_sub (a b : ℚ) : of_rat a + - of_rat b = of_rat (a - b) := !of_rat_add
 
 theorem of_rat_mul (a b : ℚ) : of_rat a * of_rat b = of_rat (a * b) :=
   quot.sound (s.r_mul_consts a b)

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -406,7 +406,11 @@ theorem converges_of_cauchy {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) :
     rewrite [-*pnat.mul.assoc, p_add_fractions],
     apply rat.le.refl
   end
--- archimedean property
+
+-------------------------------------------
+-- int embedding theorems
+-- archimedean properties, integer floor and ceiling
+
 section ints
 
 open int
@@ -428,7 +432,6 @@ theorem archimedean (x : ℝ) : ∃ z : ℤ, x ≤ of_rat (of_int z) :=
     apply H
   end
 
-set_option pp.coercions true
 theorem archimedean_strict (x : ℝ) : ∃ z : ℤ, x < of_rat (of_int z) :=
   begin
     cases archimedean x with [z, Hz],
@@ -552,10 +555,10 @@ definition ex_floor (x : ℝ) :=
       apply some_spec (archimedean' x)
     end))
 
-noncomputable definition floor (x : ℝ) :=
+noncomputable definition floor (x : ℝ) : ℤ :=
   some (ex_floor x)
 
-noncomputable definition ceil (x : ℝ) := - floor (-x)
+noncomputable definition ceil (x : ℝ) : ℤ := - floor (-x)
 
 theorem floor_spec (x : ℝ) : of_rat (of_int (floor x)) ≤ x :=
   and.left (some_spec (ex_floor x))
@@ -615,6 +618,8 @@ end ints
 --------------------------------------------------
 -- supremum property
 -- this development roughly follows the proof of completeness done in Isabelle.
+-- It does not depend on the previous proof of Cauchy completeness. Much of the same
+-- machinery can be used to show that Cauchy completeness implies the supremum property.
 
 section supremum
 open prod nat
@@ -658,8 +663,6 @@ noncomputable definition bisect (ab : ℚ × ℚ) :=
     (pr1 ab, (avg (pr1 ab) (pr2 ab)))
   else
     (avg (pr1 ab) (pr2 ab), pr2 ab)
-
-set_option pp.coercions true
 
 noncomputable definition under : ℚ := of_int (floor (elt - 1))
 
@@ -1039,7 +1042,7 @@ theorem under_over_equiv : p_under_seq ≡ p_over_seq :=
 
 theorem under_over_eq : sup_under = sup_over := quot.sound under_over_equiv
 
-theorem supremum_property : ∃ x : ℝ, sup x :=
+theorem ex_sup_of_inh_of_bdd : ∃ x : ℝ, sup x :=
   exists.intro sup_over (and.intro over_bound (under_over_eq ▸ under_lowest_bound))
 
 end supremum

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -407,13 +407,10 @@ theorem converges_of_cauchy {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) :
     apply rat.le.refl
   end
 
---------------------------------------------------
--- archimedean property
-
-theorem archimedean (x y : ℝ) (Hx : x > 0) (Hy : y > 0) : ∃ n : ℕ, (of_rat (of_nat n)) * x ≥ y := sorry
 
 --------------------------------------------------
 -- supremum property
+-- this development roughly follows the proof of completeness done in Isabelle.
 
 section supremum
 open prod nat
@@ -424,7 +421,7 @@ parameter X : ℝ → Prop
 
 definition rpt {A : Type} (op : A → A) : ℕ → A → A
  | rpt 0 := λ a, a
- | rpt (succ k) := λ a, ((rpt k) (op a))
+ | rpt (succ k) := λ a, op (rpt k a)
 
 
 definition ub (x : ℝ) := ∀ y : ℝ, X y → y ≤ x
@@ -521,14 +518,42 @@ definition over_seq := λ n : ℕ, pr2 (rpt bisect n (under, over)) -- B
 
 definition avg_seq := λ n : ℕ, avg (over_seq n) (under_seq n) -- C
 
+theorem avg_symm (n : ℕ) : avg_seq n = avg (under_seq n) (over_seq n) :=
+  by rewrite [↑avg_seq, ↑avg, rat.add.comm]
+
 theorem over_0 : over_seq 0 = over := rfl
 theorem under_0 : under_seq 0 = under := rfl
 
+theorem succ_helper (n : ℕ) : avg (pr1 (rpt bisect n (under, over))) (pr2 (rpt bisect n (under, over))) = avg_seq n :=
+   by rewrite avg_symm
+
 theorem under_succ (n : ℕ) : under_seq (succ n) =
-        (if ub (avg_seq n) then under_seq n else avg_seq n) := sorry
+        (if ub (avg_seq n) then under_seq n else avg_seq n) :=
+  begin
+    cases (decidable.em (ub (avg_seq n))) with [Hub, Hub],
+    rewrite [if_pos Hub],
+    have H :  pr1 (bisect (rpt bisect n (under, over))) = under_seq n, by
+      rewrite [↑under_seq, ↑bisect at {2}, -succ_helper at Hub, if_pos Hub],
+    apply H,
+    rewrite [if_neg Hub],
+    have H : pr1 (bisect (rpt bisect n (under, over))) = avg_seq n, by
+      rewrite [↑bisect at {2}, -succ_helper at Hub, if_neg Hub, avg_symm],
+    apply H
+  end
 
 theorem over_succ (n : ℕ) : over_seq (succ n) =
-        (if ub (avg_seq n) then avg_seq n else over_seq n) := sorry
+        (if ub (avg_seq n) then avg_seq n else over_seq n) :=
+  begin
+    cases (decidable.em (ub (avg_seq n))) with [Hub, Hub],
+    rewrite [if_pos Hub],
+    have H : pr2 (bisect (rpt bisect n (under, over))) = avg_seq n, by
+      rewrite [↑bisect at {2}, -succ_helper at Hub, if_pos Hub, avg_symm],
+    apply H,
+    rewrite [if_neg Hub],
+    have H : pr2 (bisect (rpt bisect n (under, over))) = over_seq n, by
+      rewrite [↑over_seq, ↑bisect at {2}, -succ_helper at Hub, if_neg Hub],
+    apply H
+  end
 
 -- rat.pow_zero refers to algebra.pow?
 theorem rat.pow_zero (a : ℚ) : rat.pow a 0 = 1 := sorry
@@ -539,17 +564,12 @@ theorem rat.pow_one (a : ℚ) : rat.pow a 1 = a := sorry
 
 theorem rat.pow_add (a : ℚ) (m : ℕ) : ∀ n, rat.pow a (m + n) = rat.pow a m * rat.pow a n := sorry
 
---theorem rat.pow_div (a : ℚ) (n : ℕ) : rat.pow a n * a = rat.pow a (n+1) := sorry
-
---rat.pow
-
 theorem div_two_sub_self (a : ℚ) : a / 2 - a = - (a / 2) := sorry
 
 theorem sub_self_div_two (a : ℚ) : a - a / 2 = a / 2 := sorry
 
 theorem rat.div_sub_div_same (a b c : ℚ) : (a / c) - (b / c) = (a - b) / c := sorry
 
-omit inh bdd floor_spec ceil_spec floor_succ ceil_succ
 theorem width (n : ℕ) : over_seq n - under_seq n = (over - under) / (rat.pow 2 n) :=
   nat.induction_on n
     (by rewrite [over_0, under_0, rat.pow_zero, rat.div_one])
@@ -561,17 +581,31 @@ theorem width (n : ℕ) : over_seq n - under_seq n = (over - under) / (rat.pow 2
         ... = (over - under) / (rat.pow 2 a * 2) : rat.div_div_eq_div_mul (rat.ne_of_gt (rat.pow_pos dec_trivial _)) dec_trivial
         ... = (over - under) / rat.pow 2 (a + 1) : by rewrite  rat.pow_add,
       cases (decidable.em (ub (avg_seq a))),
-      rewrite [*if_pos a_1],
-      rewrite [↑succ, -Hou, -rat.sub_eq_add_neg, -div_two_sub_self, rat.add.assoc],
-      rewrite [*if_neg a_1],
-      apply (calc
-        over_seq a - avg_seq a = over_seq a - (over_seq a) / 2 - (under_seq a) / 2 : rat.sub_add_eq_sub_sub
-        ... = (over_seq a) / 2 - (under_seq a) / 2 : sub_self_div_two
-        ... = (over - under) / rat.pow 2 (a + 1) : Hou
-      )
+      rewrite [*if_pos a_1, -add_one, -Hou, ↑avg_seq, ↑avg, rat.add.assoc, div_two_sub_self],
+      rewrite [*if_neg a_1, -add_one, -Hou, ↑avg_seq, ↑avg, rat.sub_add_eq_sub_sub, sub_self_div_two]
     end)
 
-theorem binary_bound (a : ℚ) : ∃ n : ℕ, a ≤ rat.pow 2 n := sorry
+
+
+theorem binary_nat_bound (a : ℕ) : of_nat a ≤ (rat.pow 2 a) :=
+  nat.induction_on a (rat.zero_le_one) (begin apply sorry end)
+
+theorem binary_bound (a : ℚ) : ∃ n : ℕ, a ≤ rat.pow 2 n :=
+  exists.intro (ubound a) (calc
+      a ≤ of_nat (ubound a) : ubound_ge
+    ... ≤ rat.pow 2 (ubound a) : binary_nat_bound)
+
+theorem rat_of_pnat_add {k : ℕ} (H : succ k > 0) : rat_of_pnat (subtype.tag (succ k) H) = (rat.of_nat k) + 1 := sorry
+
+theorem rat_power_two_le (k : ℕ+) : rat_of_pnat k ≤ rat.pow 2 k~ :=
+  begin
+  apply subtype.rec_on k,
+  intros n Hn,
+  induction n,
+  apply absurd Hn !nat.not_lt_self,
+  rewrite (rat_of_pnat_add Hn),
+  apply sorry
+  end
 
 theorem width_narrows : ∃ n : ℕ, over_seq n - under_seq n ≤ 1 :=
   begin
@@ -711,17 +745,7 @@ theorem over_seq_mono (i j : ℕ) (H : i ≤ j) : over_seq j ≤ over_seq i :=
     apply over_seq_mono_helper
   end
 
-theorem rat_of_pnat_add {k : ℕ} (H : succ k > 0) : rat_of_pnat (subtype.tag (succ k) H) = (rat.of_nat k) + 1 := sorry
 
-theorem rat_power_two_le (k : ℕ+) : rat_of_pnat k ≤ rat.pow 2 k~ :=
-  begin
-  apply subtype.rec_on k,
-  intros n Hn,
-  induction n,
-  apply absurd Hn !nat.not_lt_self,
-  rewrite (rat_of_pnat_add Hn),
-  apply sorry
-  end
 
 theorem rat_power_two_inv_ge (k : ℕ+) : 1 / rat.pow 2 k~ ≤ k⁻¹ :=
   rat.div_le_div_of_le !rat_of_pnat_is_pos !rat_power_two_le

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -623,10 +623,6 @@ theorem under_seq'_lt_over_seq' : ∀ m n : ℕ, under_seq' m < over_seq' n :=
 theorem under_seq'_lt_over_seq'_single : ∀ n : ℕ, under_seq' n < over_seq' n :=
   by intros; apply under_seq_lt_over_seq
 
-theorem dist_bdd_within_interval {a b lb ub : ℚ} (H : lb < ub) (Hal : lb ≤ a) (Hau : a ≤ ub)
-        (Hbl : lb ≤ b) (Hbu : b ≤ ub) : rat.abs (a - b) ≤ ub - lb := sorry
-
-
 --theorem over_dist (n : ℕ) : abs (over - over_seq n) ≤ (over - under) / rat.pow 2 n := sorry
 
 theorem under_seq_mono_helper (i k : ℕ) : under_seq i ≤ under_seq (i + k) :=
@@ -708,7 +704,7 @@ theorem regular_lemma_helper {s : seq} {m n : ℕ+} (Hm : m ≤ n)
     cases (H m n Hm) with [T1under, T1over],
     cases (H m m (!pnat.le.refl)) with [T2under, T2over],
     apply rat.le.trans,
-    apply dist_bdd_within_interval,
+    apply rat.dist_bdd_within_interval,
     apply under_seq'_lt_over_seq'_single,
     rotate 1,
     repeat assumption,

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -509,7 +509,7 @@ definition under_seq' := λ n, under_seq (n + some width_narrows)
 
 theorem width' (n : ℕ) : over_seq' n - under_seq' n ≤ 1 / rat.pow 2 n := sorry
 
-theorem twos (y r : ℚ) (H : 0 < r) : ∃ n : ℕ, y / (rat.pow 2 n) < r := sorry
+--theorem twos (y r : ℚ) (H : 0 < r) : ∃ n : ℕ, y / (rat.pow 2 n) < r := sorry
 
 theorem PA (n : ℕ) : ¬ ub (under_seq n) :=
   nat.induction_on n
@@ -575,9 +575,63 @@ theorem dist_bdd_within_interval {a b lb ub : ℚ} (H : lb < ub) (Hal : lb ≤ a
 
 --theorem over_dist (n : ℕ) : abs (over - over_seq n) ≤ (over - under) / rat.pow 2 n := sorry
 
-theorem under_seq_mono : ∀ i j : ℕ, i ≤ j → under_seq i ≤ under_seq j := sorry
+theorem rat.div_le_div_of_le_of_pos {a b c : ℚ} (H : a ≤ b) (Hc : c > 0) : a / c ≤ b / c := sorry
 
-theorem over_seq_mono : ∀ i j : ℕ, i ≤ j → over_seq j ≤ over_seq i := sorry
+theorem under_seq_mono_helper (i k : ℕ) : under_seq i ≤ under_seq (i + k) :=
+  (nat.induction_on k
+    (by rewrite nat.add_zero; apply rat.le.refl)
+    (begin
+      intros a Ha,
+      rewrite [add_succ, under_succ],
+      cases (decidable.em (ub (avg_seq (i + a)))) with [Havg, Havg],
+      rewrite (if_pos Havg),
+      apply Ha,
+      rewrite [if_neg Havg, ↑avg_seq, ↑avg],
+      apply rat.le.trans,
+      apply Ha,
+      rewrite -rat.add_halves at {1},
+      apply rat.add_le_add_right,
+      apply rat.div_le_div_of_le_of_pos,
+      apply rat.le_of_lt,
+      apply under_seq_lt_over_seq,
+      apply dec_trivial
+    end))
+
+theorem under_seq_mono (i j : ℕ) (H : i ≤ j) : under_seq i ≤ under_seq j :=
+  begin
+    cases le.elim H with [k, Hk'],
+    rewrite -Hk',
+    apply under_seq_mono_helper
+  end
+
+theorem over_seq_mono_helper (i k : ℕ) : over_seq (i + k) ≤ over_seq i :=
+  nat.induction_on k
+    (by rewrite nat.add_zero; apply rat.le.refl)
+    (begin
+      intros a Ha,
+      rewrite [add_succ, over_succ],
+      cases (decidable.em (ub (avg_seq (i + a)))) with [Havg, Havg],
+      rewrite [if_pos Havg, ↑avg_seq, ↑avg],
+      apply rat.le.trans,
+      rotate 1,
+      apply Ha,
+      rotate 1,
+      rewrite -{over_seq (i + a)}rat.add_halves at {2},
+      apply rat.add_le_add_left,
+      apply rat.div_le_div_of_le_of_pos,
+      apply rat.le_of_lt,
+      apply under_seq_lt_over_seq,
+      apply dec_trivial,
+      rewrite [if_neg Havg],
+      apply Ha
+    end)
+
+theorem over_seq_mono (i j : ℕ) (H : i ≤ j) : over_seq j ≤ over_seq i :=
+  begin
+    cases le.elim H with [k, Hk'],
+    rewrite -Hk',
+    apply over_seq_mono_helper
+  end
 
 theorem rat_power_two_le (k : ℕ+) : rat_of_pnat k ≤ rat.pow 2 k~ := sorry
 

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -227,7 +227,7 @@ theorem r_abs_nonneg {x : ℝ} : zero ≤ x → re_abs x = x :=
 theorem r_abs_nonpos {x : ℝ} : x ≤ zero → re_abs x = -x :=
   quot.induction_on x (λ a Ha, quot.sound (s.r_equiv_neg_abs_of_le_zero Ha))
 
-theorem abs_const' (a : ℚ) : const (rat.abs a) = re_abs (const a) := quot.sound (s.r_abs_const a)
+theorem abs_const' (a : ℚ) : of_rat (rat.abs a) = re_abs (of_rat a) := quot.sound (s.r_abs_const a)
 
 theorem re_abs_is_abs : re_abs = real.abs := funext
   (begin
@@ -242,30 +242,30 @@ theorem re_abs_is_abs : re_abs = real.abs := funext
     rewrite [abs_of_neg (lt_of_not_ge Hor2), r_abs_nonpos Hor2']
   end)
 
-theorem abs_const (a : ℚ) : const (rat.abs a) = abs (const a) :=
+theorem abs_const (a : ℚ) : of_rat (rat.abs a) = abs (of_rat a) :=
   by rewrite -re_abs_is_abs -- ????
 
-theorem rat_approx' (x : ℝ) : ∀ n : ℕ+, ∃ q : ℚ, re_abs (x - const q) ≤ const n⁻¹ :=
+theorem rat_approx' (x : ℝ) : ∀ n : ℕ+, ∃ q : ℚ, re_abs (x - of_rat q) ≤ of_rat n⁻¹ :=
   quot.induction_on x (λ s n, s.r_rat_approx s n)
 
-theorem rat_approx (x : ℝ) : ∀ n : ℕ+, ∃ q : ℚ, abs (x - const q) ≤ const n⁻¹ :=
+theorem rat_approx (x : ℝ) : ∀ n : ℕ+, ∃ q : ℚ, abs (x - of_rat q) ≤ of_rat n⁻¹ :=
   by rewrite -re_abs_is_abs; apply rat_approx'
 
 noncomputable definition approx (x : ℝ) (n : ℕ+) := some (rat_approx x n)
 
-theorem approx_spec (x : ℝ) (n : ℕ+) : abs (x - (const (approx x n))) ≤ const n⁻¹ :=
+theorem approx_spec (x : ℝ) (n : ℕ+) : abs (x - (of_rat (approx x n))) ≤ of_rat n⁻¹ :=
   some_spec (rat_approx x n)
 
-theorem approx_spec' (x : ℝ) (n : ℕ+) : abs ((const (approx x n)) - x) ≤ const n⁻¹ :=
+theorem approx_spec' (x : ℝ) (n : ℕ+) : abs ((of_rat (approx x n)) - x) ≤ of_rat n⁻¹ :=
   by rewrite abs_sub; apply approx_spec
 
 notation `r_seq` := ℕ+ → ℝ
 
 noncomputable definition converges_to (X : r_seq) (a : ℝ) (N : ℕ+ → ℕ+) :=
-  ∀ k : ℕ+, ∀ n : ℕ+, n ≥ N k → abs (X n - a) ≤ const k⁻¹
+  ∀ k : ℕ+, ∀ n : ℕ+, n ≥ N k → abs (X n - a) ≤ of_rat k⁻¹
 
 noncomputable definition cauchy (X : r_seq) (M : ℕ+ → ℕ+) :=
-  ∀ k : ℕ+, ∀ m n : ℕ+, m ≥ M k → n ≥ M k → abs (X m - X n) ≤ const k⁻¹
+  ∀ k : ℕ+, ∀ m n : ℕ+, m ≥ M k → n ≥ M k → abs (X m - X n) ≤ of_rat k⁻¹
 --set_option pp.implicit true
 --set_option pp.coercions true
 
@@ -276,18 +276,18 @@ noncomputable definition cauchy (X : r_seq) (M : ℕ+ → ℕ+) :=
 -- Need to finish the migration to real to fix this.
 
 --set_option pp.all true
-theorem add_consts2 (a b : ℚ) : const a + const b = const (a + b) :=
-  !add_consts --quot.sound (s.r_add_consts a b)
+--theorem add_consts2 (a b : ℚ) : const a + const b = const (a + b) :=
+--  !add_consts --quot.sound (s.r_add_consts a b)
 --check add_consts
 --check add_consts2
 
-theorem sub_consts2 (a b : ℚ) : const a - const b = const (a - b) := !sub_consts
+/-theorem sub_consts2 (a b : ℚ) : const a - const b = const (a - b) := !sub_consts
 
 theorem add_half_const2 (n : ℕ+) : const (2 * n)⁻¹ + const (2 * n)⁻¹ = const (n⁻¹) :=
-  by xrewrite [add_consts2, pnat.add_halves]
+  by xrewrite [add_consts2, pnat.add_halves]-/
 
-set_option pp.all true
-
+--set_option pp.all true
+set_option pp.coercions true
 theorem cauchy_of_converges_to {X : r_seq} {a : ℝ} {N : ℕ+ → ℕ+} (Hc : converges_to X a N) :
         cauchy X (λ k, N (2 * k)) :=
   begin
@@ -302,8 +302,10 @@ theorem cauchy_of_converges_to {X : r_seq} {a : ℝ} {N : ℕ+ → ℕ+} (Hc : c
     krewrite abs_neg,
     apply Hc,
     apply Hn,
-    xrewrite add_half_const2,
-    eapply real.le.refl
+    xrewrite of_rat_add,
+    apply of_rat_le_of_rat_of_le,
+    rewrite pnat.add_halves,
+    apply rat.le.refl
   end
 
 definition Nb (M : ℕ+ → ℕ+) := λ k, pnat.max (3 * k) (M (2 * k))
@@ -317,8 +319,8 @@ noncomputable definition lim_seq {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X 
 
 theorem lim_seq_reg_helper {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) {m n : ℕ+}
         (Hmn : M (2 * n) ≤M (2 * m)) :
-           abs (const (lim_seq Hc m) - X (Nb M m)) + abs (X (Nb M m) - X (Nb M n)) + abs
-            (X (Nb M n) - const (lim_seq Hc n)) ≤ const (m⁻¹ + n⁻¹) :=
+           abs (of_rat (lim_seq Hc m) - X (Nb M m)) + abs (X (Nb M m) - X (Nb M n)) + abs
+            (X (Nb M n) - of_rat (lim_seq Hc n)) ≤ of_rat (m⁻¹ + n⁻¹) :=
   begin
     apply le.trans,
     apply add_le_add_three,
@@ -333,8 +335,8 @@ theorem lim_seq_reg_helper {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) {m 
     apply pnat.le.trans,
     apply Hmn,
     apply Nb_spec_right,
-    rewrite [*add_consts2, rat.add.assoc, pnat.add_halves],
-    apply const_le_const_of_le,
+    rewrite [*of_rat_add, rat.add.assoc, pnat.add_halves],
+    apply of_rat_le_of_rat_of_le,
     apply rat.add_le_add_right,
     apply inv_ge_of_le,
     apply pnat.mul_le_mul_left
@@ -346,8 +348,8 @@ theorem lim_seq_reg {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) : s.regula
   begin
     rewrite ↑s.regular,
     intro m n,
-    apply le_of_const_le_const,
-    rewrite [abs_const, -sub_consts, -sub_eq_add_neg, (rewrite_helper10 (X (Nb M m)) (X (Nb M n)))],--, -sub_consts2, (rewrite_helper10 (X (Nb M m)) (X (Nb M n)))],
+    apply le_of_rat_le_of_rat,
+    rewrite [abs_const, -of_rat_sub, -sub_eq_add_neg, (rewrite_helper10 (X (Nb M m)) (X (Nb M n)))],
     apply real.le.trans,
     apply abs_add_three,
     let Hor := decidable.em (M (2 * m) ≥ M (2 * n)),
@@ -379,22 +381,22 @@ noncomputable definition lim {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) :
   quot.mk (r_lim_seq Hc)
 
 theorem re_lim_spec {x : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy x M) (k : ℕ+) :
-        re_abs ((lim Hc) - (const ((lim_seq Hc) k))) ≤ const k⁻¹ :=
+        re_abs ((lim Hc) - (of_rat ((lim_seq Hc) k))) ≤ of_rat k⁻¹ :=
   r_lim_seq_spec Hc k
 
 theorem lim_spec' {x : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy x M) (k : ℕ+) :
-        abs ((lim Hc) - (const ((lim_seq Hc) k))) ≤ const k⁻¹ :=
+        abs ((lim Hc) - (of_rat ((lim_seq Hc) k))) ≤ of_rat k⁻¹ :=
   by rewrite -re_abs_is_abs; apply re_lim_spec
 
 theorem lim_spec {x : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy x M) (k : ℕ+) :
-        abs ((const ((lim_seq Hc) k)) - (lim Hc)) ≤ const (k)⁻¹ :=
+        abs ((of_rat ((lim_seq Hc) k)) - (lim Hc)) ≤ of_rat (k)⁻¹ :=
   by rewrite abs_sub; apply lim_spec'
 
 theorem converges_of_cauchy {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) :
         converges_to X (lim Hc) (Nb M) :=
   begin
     intro k n Hn,
-    rewrite (rewrite_helper10 (X (Nb M n)) (const (lim_seq Hc n))),
+    rewrite (rewrite_helper10 (X (Nb M n)) (of_rat (lim_seq Hc n))),
     apply le.trans,
     apply abs_add_three,
     apply le.trans,
@@ -418,8 +420,8 @@ theorem converges_of_cauchy {X : r_seq} {M : ℕ+ → ℕ+} (Hc : cauchy X M) :
     rewrite ↑lim_seq,
     apply approx_spec,
     apply lim_spec,
-    rewrite 2 add_consts2,
-    apply const_le_const_of_le,
+    rewrite 2 of_rat_add,
+    apply of_rat_le_of_rat_of_le,
     apply rat.le.trans,
     apply rat.add_le_add_three,
     apply rat.le.refl,

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -990,6 +990,19 @@ theorem lt_of_const_lt_const {a b : ℚ} (H : s_lt (const a) (const b)) : a < b 
     apply pnat.inv_pos
   end
 
+theorem s_le_of_le_pointwise {s t : seq} (Hs : regular s) (Ht : s.regular t)
+        (H : ∀ n : ℕ+, s n ≤ t n) : s_le s t :=
+  begin
+    rewrite [↑s_le, ↑nonneg, ↑sadd, ↑sneg],
+    intros,
+    apply rat.le.trans,
+    apply iff.mpr !neg_nonpos_iff_nonneg,
+    apply le_of_lt,
+    apply inv_pos,
+    apply iff.mpr !sub_nonneg_iff_le,
+    apply H
+  end
+
 -------- lift to reg_seqs
 definition r_lt (s t : reg_seq) := s_lt (reg_seq.sq s) (reg_seq.sq t)
 definition r_le (s t : reg_seq) := s_le (reg_seq.sq s) (reg_seq.sq t)

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -918,6 +918,22 @@ theorem s_lt_of_le_of_lt {s t u : seq} (Hs : regular s) (Ht : regular t) (Hu : r
     apply max_left
   end
 
+theorem le_of_le_reprs {s t : seq} (Hs : regular s) (Ht : regular t)
+        (Hle : ∀ n : ℕ+, s_le s (const (t n))) : s_le s t :=
+  begin
+    rewrite [↑s_le, ↑nonneg],
+    intro m,
+    apply Hle (2 * m) m
+  end
+
+theorem le_of_reprs_le {s t : seq} (Hs : regular s) (Ht : regular t)
+        (Hle : ∀ n : ℕ+, s_le (const (t n)) s) : s_le t s :=
+  begin
+    rewrite [↑s_le, ↑nonneg],
+    intro m,
+    apply Hle (2 * m) m
+  end
+
 -----------------------------
 -- of_rat theorems
 
@@ -1061,6 +1077,12 @@ theorem r_const_lt_const_of_lt {a b : ℚ} (H : a < b) : r_lt (r_const a) (r_con
 theorem r_lt_of_const_lt_const {a b : ℚ} (H : r_lt (r_const a) (r_const b)) : a < b :=
   lt_of_const_lt_const H
 
+theorem r_le_of_le_reprs (s t : reg_seq) (Hle : ∀ n : ℕ+, r_le s (r_const (reg_seq.sq t n))) : r_le s t :=
+  le_of_le_reprs (reg_seq.is_reg s) (reg_seq.is_reg t) Hle
+
+theorem r_le_of_reprs_le (s t : reg_seq) (Hle : ∀ n : ℕ+, r_le (r_const (reg_seq.sq t n)) s) : r_le t s :=
+  le_of_reprs_le (reg_seq.is_reg s) (reg_seq.is_reg t) Hle
+
 end s
 
 open real
@@ -1186,5 +1208,24 @@ theorem of_rat_lt_of_rat_of_lt (a b : ℚ) : a < b → of_rat a < of_rat b :=
 
 theorem lt_of_rat_lt_of_rat (a b : ℚ) : of_rat a < of_rat b → a < b :=
   s.r_lt_of_const_lt_const
+
+theorem of_rat_sub (a b : ℚ) : of_rat a - of_rat b = of_rat (a - b) := rfl
+
+open s
+set_option pp.coercions true
+theorem le_of_le_reprs (x : ℝ) (t : seq) (Ht : regular t) : (∀ n : ℕ+, x ≤ t n) →
+        x ≤ quot.mk (reg_seq.mk t Ht) :=
+  quot.induction_on x (take s Hs,
+    show s.r_le s (reg_seq.mk t Ht), from
+      have H' : ∀ n : ℕ+, r_le s (r_const (t n)), from Hs,
+      by apply r_le_of_le_reprs; apply Hs)
+
+
+theorem le_of_reprs_le (x : ℝ) (t : seq) (Ht : regular t) : (∀ n : ℕ+, t n ≤ x) →
+        quot.mk (reg_seq.mk t Ht) ≤ x :=
+  quot.induction_on x (take s Hs,
+    show s.r_le (reg_seq.mk t Ht) s, from
+      have H' : ∀ n : ℕ+, r_le (r_const (t n)) s, from Hs,
+      by apply r_le_of_reprs_le; apply Hs)
 
 end real

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -919,7 +919,7 @@ theorem s_lt_of_le_of_lt {s t u : seq} (Hs : regular s) (Ht : regular t) (Hu : r
   end
 
 -----------------------------
--- const theorems
+-- of_rat theorems
 
 theorem const_le_const_of_le {a b : ℚ} (H : a ≤ b) : s_le (const a) (const b) :=
   begin
@@ -1136,10 +1136,10 @@ section migrate_algebra
                    gt_of_ge_of_gt [trans]
 end migrate_algebra
 
-theorem const_le_const_of_le (a b : ℚ) : a ≤ b → const a ≤ const b :=
+theorem of_rat_le_of_rat_of_le (a b : ℚ) : a ≤ b → of_rat a ≤ of_rat b :=
   s.r_const_le_const_of_le
 
-theorem le_of_const_le_const (a b : ℚ) : const a ≤ const b → a ≤ b :=
+theorem le_of_rat_le_of_rat (a b : ℚ) : of_rat a ≤ of_rat b → a ≤ b :=
   s.r_le_of_const_le_const
 
 end real

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -941,6 +941,39 @@ theorem le_of_const_le_const {a b : ℚ} (H : s_le (const a) (const b)) : a ≤ 
     apply nonneg_of_ge_neg_invs _ H
   end
 
+theorem nat_inv_lt_rat {a : ℚ} (H : a > 0) : ∃ n : ℕ+, n⁻¹ < a :=
+  begin
+    existsi (pceil (1 / (a / (1 + 1)))),
+    apply lt_of_le_of_lt,
+    rotate 1,
+    apply div_two_lt_of_pos H,
+    rewrite -(@div_div' (a / (1 + 1))),
+    apply pceil_helper,
+    rewrite div_div',
+    apply pnat.le.refl,
+    apply div_pos_of_pos,
+    apply pos_div_of_pos_of_pos H dec_trivial
+  end
+
+
+theorem const_lt_const_of_lt {a b : ℚ} (H : a < b) : s_lt (const a) (const b) :=
+  begin
+    rewrite [↑s_lt, ↑pos, ↑sadd, ↑sneg, ↑const],
+    apply nat_inv_lt_rat,
+    apply (iff.mpr !sub_pos_iff_lt H)
+  end
+
+theorem lt_of_const_lt_const {a b : ℚ} (H : s_lt (const a) (const b)) : a < b :=
+  begin
+    rewrite [↑s_lt at H, ↑pos at H, ↑const at H, ↑sadd at H, ↑sneg at H],
+    cases H with [n, Hn],
+    apply (iff.mp !sub_pos_iff_lt),
+    apply lt.trans,
+    rotate 1,
+    assumption,
+    apply pnat.inv_pos
+  end
+
 -------- lift to reg_seqs
 definition r_lt (s t : reg_seq) := s_lt (reg_seq.sq s) (reg_seq.sq t)
 definition r_le (s t : reg_seq) := s_le (reg_seq.sq s) (reg_seq.sq t)
@@ -1021,6 +1054,12 @@ theorem r_const_le_const_of_le {a b : ℚ} (H : a ≤ b) : r_le (r_const a) (r_c
 
 theorem r_le_of_const_le_const {a b : ℚ} (H : r_le (r_const a) (r_const b)) : a ≤ b :=
   le_of_const_le_const H
+
+theorem r_const_lt_const_of_lt {a b : ℚ} (H : a < b) : r_lt (r_const a) (r_const b) :=
+  const_lt_const_of_lt H
+
+theorem r_lt_of_const_lt_const {a b : ℚ} (H : r_lt (r_const a) (r_const b)) : a < b :=
+  lt_of_const_lt_const H
 
 end s
 
@@ -1141,5 +1180,11 @@ theorem of_rat_le_of_rat_of_le (a b : ℚ) : a ≤ b → of_rat a ≤ of_rat b :
 
 theorem le_of_rat_le_of_rat (a b : ℚ) : of_rat a ≤ of_rat b → a ≤ b :=
   s.r_le_of_const_le_const
+
+theorem of_rat_lt_of_rat_of_lt (a b : ℚ) : a < b → of_rat a < of_rat b :=
+  s.r_const_lt_const_of_lt
+
+theorem lt_of_rat_lt_of_rat (a b : ℚ) : of_rat a < of_rat b → a < b :=
+  s.r_lt_of_const_lt_const
 
 end real

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -1212,7 +1212,6 @@ theorem lt_of_rat_lt_of_rat (a b : ℚ) : of_rat a < of_rat b → a < b :=
 theorem of_rat_sub (a b : ℚ) : of_rat a - of_rat b = of_rat (a - b) := rfl
 
 open s
-set_option pp.coercions true
 theorem le_of_le_reprs (x : ℝ) (t : seq) (Ht : regular t) : (∀ n : ℕ+, x ≤ t n) →
         x ≤ quot.mk (reg_seq.mk t Ht) :=
   quot.induction_on x (take s Hs,


### PR DESCRIPTION
This proves that every bounded, inhabited set of reals has a supremum. The proof does not use Cauchy completeness, so in effect this is a second completeness proof. (The proof from Cauchy completeness uses most of the same machinery as the direct proof.)

To prove this we use various embedding integers in the reals: we need integer floor and ceiling, and an Archimedean property.
