### PR TITLE
set-based bigops

### DIFF
--- a/library/algebra/algebra.md
+++ b/library/algebra/algebra.md
@@ -11,7 +11,8 @@ Algebraic structures.
 * [lattice](lattice.lean)
 * [group](group.lean)
 * [group_power](group_power.lean) : nat and int powers
-* [group_bigops](group_bigops.lean) : finite products and sums
+* [group_bigops](group_bigops.lean) : products and sums over finsets
+* [group_set_bigops](group_set_bigops.lean) : products and sums over finite sets
 * [ring](ring.lean)
 * [ordered_group](ordered_group.lean)
 * [ordered_ring](ordered_ring.lean)

--- a/library/algebra/group_bigops.lean
+++ b/library/algebra/group_bigops.lean
@@ -7,6 +7,9 @@ Finite products on a monoid, and finite sums on an additive monoid.
 
 We have to be careful with dependencies. This theory imports files from finset and list, which
 import basic files from nat. Then nat imports this file to instantiate finite products and sums.
+
+Bigops based on finsets go in the namespace algebra.finset. There are also versions based on sets,
+defined in group_set_bigops.lean.
 -/
 import .group .group_power data.list.basic data.list.perm data.finset.basic
 open algebra function binary quot subtype list finset
@@ -99,7 +102,7 @@ end comm_monoid
 
 /- Prod: product indexed by a finset -/
 
-section comm_monoid
+namespace finset
   variable [cmB : comm_monoid B]
   include cmB
 
@@ -159,7 +162,7 @@ section comm_monoid
 
   theorem Prod_one (s : finset A) : Prod s (λ x, 1) = (1:B) :=
   quot.induction_on s (take u, !Prodl_one)
-end comm_monoid
+end finset
 
 section add_monoid
   variable [amB : add_monoid B]
@@ -201,7 +204,7 @@ end add_comm_monoid
 
 /- Sum -/
 
-section add_comm_monoid
+namespace finset
   variable [acmB : add_comm_monoid B]
   include acmB
   local attribute add_comm_monoid.to_comm_monoid [trans-instance]
@@ -228,6 +231,6 @@ section add_comm_monoid
   end deceqA
 
   theorem Sum_zero (s : finset A) : Sum s (λ x, 0) = (0:B) := Prod_one s
-end add_comm_monoid
+end finset
 
 end algebra

--- a/library/algebra/group_set_bigops.lean
+++ b/library/algebra/group_set_bigops.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Set-based version of group_bigops.
+-/
+import .group_bigops data.set.finite
+open set
+
+namespace algebra
+namespace set
+
+variables {A B : Type}
+
+/- Prod: product indexed by a set -/
+
+section Prod
+  variable [cmB : comm_monoid B]
+  include cmB
+
+  noncomputable definition Prod (s : set A) (f : A → B) : B := algebra.finset.Prod (to_finset s) f
+
+  -- ∏ x ∈ s, f x
+  notation `∏` binders `∈` s, r:(scoped f, prod s f) := r
+
+  theorem Prod_empty (f : A → B) : Prod ∅ f = 1 :=
+  by rewrite [↑Prod, to_finset_empty]
+
+  theorem Prod_of_not_finite {s : set A} (nfins : ¬ finite s) (f : A → B) : Prod s f = 1 :=
+  by rewrite [↑Prod, to_finset_of_not_finite nfins]
+
+  theorem Prod_mul (s : set A) (f g : A → B) : Prod s (λx, f x * g x) = Prod s f * Prod s g :=
+  by rewrite [↑Prod, finset.Prod_mul]
+
+  theorem Prod_insert_of_mem (f : A → B) {a : A} {s : set A} (H : a ∈ s) :
+    Prod (insert a s) f = Prod s f :=
+  by_cases
+    (suppose finite s,
+      assert (#finset a ∈ set.to_finset s), by rewrite mem_to_finset_eq; apply H,
+      by rewrite [↑Prod, to_finset_insert, finset.Prod_insert_of_mem f this])
+    (assume nfs : ¬ finite s,
+      assert ¬ finite (insert a s), from assume H, nfs (finite_of_finite_insert H),
+      by rewrite [Prod_of_not_finite nfs, Prod_of_not_finite this])
+
+  theorem Prod_insert_of_not_mem (f : A → B) {a : A} {s : set A} [fins : finite s] (H : a ∉ s) :
+    Prod (insert a s) f = f a * Prod s f :=
+  assert (#finset a ∉ set.to_finset s), by rewrite mem_to_finset_eq; apply H,
+  by rewrite [↑Prod, to_finset_insert, finset.Prod_insert_of_not_mem f this]
+
+  theorem Prod_union (f : A → B) {s₁ s₂ : set A} [fins₁ : finite s₁] [fins₂ : finite s₂]
+      (disj : s₁ ∩ s₂ = ∅) :
+    Prod (s₁ ∪ s₂) f = Prod s₁ f * Prod s₂ f :=
+  begin
+    rewrite [↑Prod, to_finset_union],
+    apply finset.Prod_union,
+    apply finset.eq_of_to_set_eq_to_set,
+    rewrite [finset.to_set_inter, *to_set_to_finset, finset.to_set_empty, disj]
+  end
+
+  theorem Prod_ext {s : set A} {f g : A → B} (H : ∀{x}, x ∈ s → f x = g x) : Prod s f = Prod s g :=
+  by_cases
+    (suppose finite s,
+      by esimp [Prod]; apply finset.Prod_ext; intro x; rewrite [mem_to_finset_eq]; apply H)
+    (assume nfs : ¬ finite s,
+      by rewrite [*Prod_of_not_finite nfs])
+
+  theorem Prod_one (s : set A) : Prod s (λ x, 1) = (1:B) :=
+  by rewrite [↑Prod, finset.Prod_one]
+end Prod
+
+/- Sum -/
+
+section Sum
+  variable [acmB : add_comm_monoid B]
+  include acmB
+  local attribute add_comm_monoid.to_comm_monoid [trans-instance]
+
+  noncomputable definition Sum (s : set A) (f : A → B) : B := Prod s f
+
+  -- ∑ x ∈ s, f x
+  notation `∑` binders `∈` s, r:(scoped f, Sum s f) := r
+
+  theorem Sum_empty (f : A → B) : Sum ∅ f = 0 := Prod_empty f
+  theorem Sum_add (s : set A) (f g : A → B) :
+    Sum s (λx, f x + g x) = Sum s f + Sum s g := Prod_mul s f g
+
+  theorem Sum_insert_of_mem (f : A → B) {a : A} {s : set A} (H : a ∈ s) :
+    Sum (insert a s) f = Sum s f := Prod_insert_of_mem f H
+  theorem Sum_insert_of_not_mem (f : A → B) {a : A} {s : set A} [fins : finite s] (H : a ∉ s) :
+    Sum (insert a s) f = f a + Sum s f := Prod_insert_of_not_mem f H
+  theorem Sum_union (f : A → B) {s₁ s₂ : set A} [fins₁ : finite s₁] [fins₂ : finite s₂]
+      (disj : s₁ ∩ s₂ = ∅) :
+    Sum (s₁ ∪ s₂) f = Sum s₁ f + Sum s₂ f := Prod_union f disj
+  theorem Sum_ext {s : set A} {f g : A → B} (H : ∀x, x ∈ s → f x = g x) :
+    Sum s f = Sum s g := Prod_ext H
+
+  theorem Sum_zero (s : set A) : Sum s (λ x, 0) = (0:B) := Prod_one s
+end Sum
+
+end set
+
+
+end algebra

--- a/library/data/finset/bigops.lean
+++ b/library/data/finset/bigops.lean
@@ -36,7 +36,7 @@ include deceqB
 
 definition Unionl (l : list A) (f : A → finset B) : finset B := algebra.Prodl l f
 notation `⋃` binders `←` l, r:(scoped f, Unionl l f) := r
-definition Union (s : finset A) (f : A → finset B) : finset B := algebra.Prod s f
+definition Union (s : finset A) (f : A → finset B) : finset B := algebra.finset.Prod s f
 notation `⋃` binders `∈` s, r:(scoped f, finset.Union s f) := r
 
 theorem Unionl_nil (f : A → finset B) : Unionl [] f = ∅ := algebra.Prodl_nil f
@@ -57,20 +57,20 @@ section deceqA
   theorem Unionl_empty (l : list A) : Unionl l (λ x, ∅) = (∅ : finset B) := algebra.Prodl_one l
 end deceqA
 
-theorem Union_empty (f : A → finset B) : Union ∅ f = ∅ := algebra.Prod_empty f
+theorem Union_empty (f : A → finset B) : Union ∅ f = ∅ := algebra.finset.Prod_empty f
 theorem Union_mul (s : finset A) (f g : A → finset B) :
-  Union s (λx, f x ∪ g x) = Union s f ∪ Union s g := algebra.Prod_mul s f g
+  Union s (λx, f x ∪ g x) = Union s f ∪ Union s g := algebra.finset.Prod_mul s f g
 section deceqA
   include deceqA
   theorem Union_insert_of_mem (f : A → finset B) {a : A} {s : finset A} (H : a ∈ s) :
-    Union (insert a s) f = Union s f := algebra.Prod_insert_of_mem f H
+    Union (insert a s) f = Union s f := algebra.finset.Prod_insert_of_mem f H
   private theorem Union_insert_of_not_mem (f : A → finset B) {a : A} {s : finset A} (H : a ∉ s) :
-    Union (insert a s) f = f a ∪ Union s f := algebra.Prod_insert_of_not_mem f H
+    Union (insert a s) f = f a ∪ Union s f := algebra.finset.Prod_insert_of_not_mem f H
   theorem Union_union (f : A → finset B) {s₁ s₂ : finset A} (disj : s₁ ∩ s₂ = ∅) :
-    Union (s₁ ∪ s₂) f = Union s₁ f ∪ Union s₂ f := algebra.Prod_union f disj
+    Union (s₁ ∪ s₂) f = Union s₁ f ∪ Union s₂ f := algebra.finset.Prod_union f disj
   theorem Union_ext {s : finset A} {f g : A → finset B} (H : ∀x, x ∈ s → f x = g x) :
-    Union s f = Union s g := algebra.Prod_ext H
-  theorem Union_empty' (s : finset A) : Union s (λ x, ∅) = (∅ : finset B) := algebra.Prod_one s
+    Union s f = Union s g := algebra.finset.Prod_ext H
+  theorem Union_empty' (s : finset A) : Union s (λ x, ∅) = (∅ : finset B) := algebra.finset.Prod_one s
 
   -- this will eventually be an instance of something more general
   theorem inter_Union (s : finset B) (t : finset A) (f : A → finset B) :

--- a/library/data/finset/card.lean
+++ b/library/data/finset/card.lean
@@ -170,6 +170,21 @@ have H : card s₁ + 0 = card s₁ + card (s₂ \ s₁),
 assert H1 : s₂ \ s₁ = ∅, from eq_empty_of_card_eq_zero (add.left_cancel H)⁻¹,
 by rewrite [-union_diff_cancel Hsub, H1, union_empty]
 
+lemma exists_two_of_card_gt_one {s : finset A} : 1 < card s → ∃ a b, a ∈ s ∧ b ∈ s ∧ a ≠ b :=
+begin
+  intro h,
+  induction s with a s nain ih₁,
+   {exact absurd h dec_trivial},
+   {induction s with b s nbin ih₂,
+    {exact absurd h dec_trivial},
+     clear ih₁ ih₂,
+     existsi a, existsi b, split,
+      {apply mem_insert},
+      split,
+      {apply mem_insert_of_mem _ !mem_insert},
+      {intro aeqb, subst a, exact absurd !mem_insert nain}}
+end
+
 theorem Sum_const_eq_card_mul (s : finset A) (n : nat) : (∑ x ∈ s, n) = card s * n :=
 begin
   induction s with a s' H IH,
@@ -208,21 +223,6 @@ finset.induction_on s
     by rewrite [Union_insert, Sum_insert_of_not_mem _ H,
                 card_union_of_disjoint H8, H6])
 end deceqB
-
-lemma exists_two_of_card_gt_one {s : finset A} : 1 < card s → ∃ a b, a ∈ s ∧ b ∈ s ∧ a ≠ b :=
-begin
-  intro h,
-  induction s with a s nain ih₁,
-   {exact absurd h dec_trivial},
-   {induction s with b s nbin ih₂,
-    {exact absurd h dec_trivial},
-     clear ih₁ ih₂,
-     existsi a, existsi b, split,
-      {apply mem_insert},
-      split,
-      {apply mem_insert_of_mem _ !mem_insert},
-      {intro aeqb, subst a, exact absurd !mem_insert nain}}
-end
 
 lemma dvd_Sum_of_dvd (f : A → nat) (n : nat) (s : finset A) : (∀ a, a ∈ s → n ∣ f a) → n ∣ Sum s f :=
 begin

--- a/library/data/finset/card.lean
+++ b/library/data/finset/card.lean
@@ -6,7 +6,7 @@ Author: Jeremy Avigad
 Cardinality calculations for finite sets.
 -/
 import .to_set .bigops data.set.function data.nat.power data.nat.bigops
-open nat eq.ops
+open nat nat.finset eq.ops
 
 namespace finset
 

--- a/library/data/finset/partition.lean
+++ b/library/data/finset/partition.lean
@@ -45,13 +45,13 @@ begin
 end
 
 theorem class_equation (f : @partition A _) :
-  card (partition.set f) = nat.Sum (equiv_classes f) card :=
+  card (partition.set f) = nat.finset.Sum (equiv_classes f) card :=
 let s := (partition.set f), p := (partition.part f), img := image p s in
   calc
     card s = card (Union s p) : partition.complete f
        ... = card (Union img id) : image_eq_Union_index_image s p
        ... = card (Union (equiv_classes f) id) : rfl
-       ... = nat.Sum (equiv_classes f) card : card_Union_of_disjoint _ id (equiv_class_disjoint f)
+       ... = nat.finset.Sum (equiv_classes f) card : card_Union_of_disjoint _ id (equiv_class_disjoint f)
 
 lemma equiv_class_refl {f : A → finset A} (Pequiv : is_partition f) : ∀ a, a ∈ f a :=
 take a, by rewrite [Pequiv a a]
@@ -113,9 +113,9 @@ begin rewrite [binary_union P at {1}], apply Union_union, exact binary_inter_emp
 
 end
 
-open nat
+open nat nat.finset
 section
-open algebra
+open algebra algebra.finset
 
 variables {B : Type} [acmB : add_comm_monoid B]
 include acmB

--- a/library/data/finset/to_set.lean
+++ b/library/data/finset/to_set.lean
@@ -94,4 +94,10 @@ definition decidable_bounded_exists (s : finset A) (p : A → Prop) [h : decidab
   decidable (∃₀ x ∈ ts s, p x) :=
 decidable_of_decidable_of_iff _ !any_iff_exists
 
+/- properties -/
+
+theorem inj_on_to_set {B : Type} [h : decidable_eq B] (f : A → B) (s : finset A) :
+  inj_on f s = inj_on f (ts s) :=
+rfl
+
 end finset

--- a/library/data/nat/bigops.lean
+++ b/library/data/nat/bigops.lean
@@ -38,24 +38,28 @@ end deceqA
 
 /- Prod -/
 
-definition Prod (s : finset A) (f : A → nat) : nat := algebra.Prod s f
+namespace finset
+
+definition Prod (s : finset A) (f : A → nat) : nat := algebra.finset.Prod s f
 notation `∏` binders `∈` s, r:(scoped f, Prod s f) := r
 
-theorem Prod_empty (f : A → nat) : Prod ∅ f = 1 := algebra.Prod_empty f
+theorem Prod_empty (f : A → nat) : Prod ∅ f = 1 := algebra.finset.Prod_empty f
 theorem Prod_mul (s : finset A) (f g : A → nat) : Prod s (λx, f x * g x) = Prod s f * Prod s g :=
-  algebra.Prod_mul s f g
+  algebra.finset.Prod_mul s f g
 section deceqA
   include deceqA
   theorem Prod_insert_of_mem (f : A → nat) {a : A} {s : finset A} (H : a ∈ s) :
-    Prod (insert a s) f = Prod s f := algebra.Prod_insert_of_mem f H
+    Prod (insert a s) f = Prod s f := algebra.finset.Prod_insert_of_mem f H
   theorem Prod_insert_of_not_mem (f : A → nat) {a : A} {s : finset A} (H : a ∉ s) :
-    Prod (insert a s) f = f a * Prod s f := algebra.Prod_insert_of_not_mem f H
+    Prod (insert a s) f = f a * Prod s f := algebra.finset.Prod_insert_of_not_mem f H
   theorem Prod_union (f : A → nat) {s₁ s₂ : finset A} (disj : s₁ ∩ s₂ = ∅) :
-    Prod (s₁ ∪ s₂) f = Prod s₁ f * Prod s₂ f := algebra.Prod_union f disj
+    Prod (s₁ ∪ s₂) f = Prod s₁ f * Prod s₂ f := algebra.finset.Prod_union f disj
   theorem Prod_ext {s : finset A} {f g : A → nat} (H : ∀x, x ∈ s → f x = g x) :
-    Prod s f = Prod s g := algebra.Prod_ext H
-  theorem Prod_one (s : finset A) : Prod s (λ x, nat.succ 0) = 1 := algebra.Prod_one s
+    Prod s f = Prod s g := algebra.finset.Prod_ext H
+  theorem Prod_one (s : finset A) : Prod s (λ x, nat.succ 0) = 1 := algebra.finset.Prod_one s
 end deceqA
+
+end finset
 
 /- Suml -/
 
@@ -82,23 +86,27 @@ end deceqA
 
 /- Sum -/
 
-definition Sum (s : finset A) (f : A → nat) : nat := algebra.Sum s f
+namespace finset
+
+definition Sum (s : finset A) (f : A → nat) : nat := algebra.finset.Sum s f
 notation `∑` binders `∈` s, r:(scoped f, Sum s f) := r
 
-theorem Sum_empty (f : A → nat) : Sum ∅ f = 0 := algebra.Sum_empty f
+theorem Sum_empty (f : A → nat) : Sum ∅ f = 0 := algebra.finset.Sum_empty f
 theorem Sum_add (s : finset A) (f g : A → nat) : Sum s (λx, f x + g x) = Sum s f + Sum s g :=
-  algebra.Sum_add s f g
+  algebra.finset.Sum_add s f g
 section deceqA
   include deceqA
   theorem Sum_insert_of_mem (f : A → nat) {a : A} {s : finset A} (H : a ∈ s) :
-    Sum (insert a s) f = Sum s f := algebra.Sum_insert_of_mem f H
+    Sum (insert a s) f = Sum s f := algebra.finset.Sum_insert_of_mem f H
   theorem Sum_insert_of_not_mem (f : A → nat) {a : A} {s : finset A} (H : a ∉ s) :
-    Sum (insert a s) f = f a + Sum s f := algebra.Sum_insert_of_not_mem f H
+    Sum (insert a s) f = f a + Sum s f := algebra.finset.Sum_insert_of_not_mem f H
   theorem Sum_union (f : A → nat) {s₁ s₂ : finset A} (disj : s₁ ∩ s₂ = ∅) :
-    Sum (s₁ ∪ s₂) f = Sum s₁ f + Sum s₂ f := algebra.Sum_union f disj
+    Sum (s₁ ∪ s₂) f = Sum s₁ f + Sum s₂ f := algebra.finset.Sum_union f disj
   theorem Sum_ext {s : finset A} {f g : A → nat} (H : ∀x, x ∈ s → f x = g x) :
-    Sum s f = Sum s g := algebra.Sum_ext H
-  theorem Sum_zero (s : finset A) : Sum s (λ x, zero) = 0 := algebra.Sum_zero s
+    Sum s f = Sum s g := algebra.finset.Sum_ext H
+  theorem Sum_zero (s : finset A) : Sum s (λ x, zero) = 0 := algebra.finset.Sum_zero s
 end deceqA
+
+end finset
 
 end nat

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -3,7 +3,7 @@ Copyright (c) 2014 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jeremy Avigad, Leonardo de Moura
 -/
-import logic algebra.binary
+import logic.connectives algebra.binary
 open eq.ops binary
 
 definition set [reducible] (X : Type) := X → Prop
@@ -219,7 +219,7 @@ theorem union_diff_cancel {s t : set X} [dec : Π x, decidable (x ∈ s)] (H : s
 setext (take x, iff.intro
   (assume H1 : x ∈ s ∪ (t \ s), or.elim H1 (assume H2, !H H2) (assume H2, and.left H2))
   (assume H1 : x ∈ t,
-    decidable.by_cases 
+    decidable.by_cases
       (suppose x ∈ s, or.inl this)
       (suppose x ∉ s, or.inr (and.intro H1 this))))
 

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -215,6 +215,14 @@ theorem mem_diff_iff (s t : set X) (x : X) : x ∈ s \ t ↔ x ∈ s ∧ x ∉ t
 
 theorem mem_diff_eq (s t : set X) (x : X) : x ∈ s \ t = (x ∈ s ∧ x ∉ t) := rfl
 
+theorem union_diff_cancel {s t : set X} [dec : Π x, decidable (x ∈ s)] (H : s ⊆ t) : s ∪ (t \ s) = t :=
+setext (take x, iff.intro
+  (assume H1 : x ∈ s ∪ (t \ s), or.elim H1 (assume H2, !H H2) (assume H2, and.left H2))
+  (assume H1 : x ∈ t,
+    decidable.by_cases 
+      (suppose x ∈ s, or.inl this)
+      (suppose x ∉ s, or.inr (and.intro H1 this))))
+
 /- powerset -/
 
 definition powerset (s : set X) : set (set X) := {x : set X | x ⊆ s}

--- a/library/data/set/finite.lean
+++ b/library/data/set/finite.lean
@@ -7,7 +7,7 @@ The notion of "finiteness" for sets. This approach is not computational: for exa
 an element  s : set A  satsifies  finite s  doesn't mean that we can compute the cardinality. For
 a computational representation, use the finset type.
 -/
-import data.set.function data.finset logic.choice
+import data.set.function data.finset.card logic.choice
 open nat
 
 variable {A : Type}

--- a/library/data/set/finite.lean
+++ b/library/data/set/finite.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2014 Jeremy Avigad. All rights reserved.
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: Jeremy Avigad
 
@@ -211,12 +211,12 @@ by rewrite [card_insert_of_not_mem !not_mem_empty, card_empty]
 /- Note: the induction tactic does not work well with the set induction principle with the
    extra predicate "finite". -/
 theorem eq_empty_of_card_eq_zero {s : set A} [fins : finite s] : card s = 0 → s = ∅ :=
-induction_on_finite s 
+induction_on_finite s
   (by intro H; exact rfl)
   (begin
     intro a s' fins' anins IH H,
     rewrite (card_insert_of_not_mem anins) at H,
-    apply nat.no_confusion H 
+    apply nat.no_confusion H
   end)
 
 theorem card_upto (n : ℕ) : card {i | i < n} = n :=
@@ -230,7 +230,7 @@ begin
   apply finset.card_add_card
 end
 
-theorem card_union (s₁ s₂ : set A) [fins₁ : finite s₁] [fins₂ : finite s₂] : 
+theorem card_union (s₁ s₂ : set A) [fins₁ : finite s₁] [fins₂ : finite s₂] :
   card (s₁ ∪ s₂) = card s₁ + card s₂ - card (s₁ ∩ s₂) :=
 calc
   card (s₁ ∪ s₂) = card (s₁ ∪ s₂) + card (s₁ ∩ s₂) - card (s₁ ∩ s₂) : add_sub_cancel
@@ -249,10 +249,68 @@ calc
   card s₂ = card (s₁ ∪ (s₂ \ s₁))    : {this}
       ... = card s₁ + card (s₂ \ s₁) : card_union_of_disjoint H1
 
-theorem card_le_card_of_subset {s₁ s₂ : set A} [fins₁ : finite s₁] [fins₂ : finite s₂] (H : s₁ ⊆ s₂) : 
+theorem card_le_card_of_subset {s₁ s₂ : set A} [fins₁ : finite s₁] [fins₂ : finite s₂] (H : s₁ ⊆ s₂) :
   card s₁ ≤ card s₂ :=
 calc
   card s₂ = card s₁ + card (s₂ \ s₁) : card_eq_card_add_card_diff H
       ... ≥ card s₁                  : le_add_right
+
+variable {B : Type}
+
+theorem card_image_eq_of_inj_on {f : A → B} {s : set A} [fins : finite s] (injfs : inj_on f s) :
+  card (image f s) = card s :=
+begin
+  rewrite [↑card, to_finset_image];
+  apply finset.card_image_eq_of_inj_on,
+  rewrite to_set_to_finset,
+  apply injfs
+end
+
+theorem card_le_of_inj_on (a : set A) (b : set B) [finb : finite b]
+    (Pex : ∃ f : A → B, inj_on f a ∧ (image f a ⊆ b)) :
+  card a ≤ card b :=
+by_cases
+  (assume fina : finite a,
+    obtain f H, from Pex,
+    finset.card_le_of_inj_on (to_finset a) (to_finset b)
+      (exists.intro f
+        begin
+          rewrite [finset.subset_eq_to_set_subset, finset.to_set_image, *to_set_to_finset],
+          exact H
+        end))
+  (assume nfina : ¬ finite a,
+    by rewrite [card_of_not_finite nfina]; exact !zero_le)
+
+theorem card_image_le (f : A → B) (s : set A) [fins : finite s] : card (image f s) ≤ card s :=
+by rewrite [↑card, to_finset_image]; apply finset.card_image_le
+
+theorem inj_on_of_card_image_eq {f : A → B} {s : set A} [fins : finite s]
+  (H : card (image f s) = card s) : inj_on f s :=
+begin
+  rewrite -to_set_to_finset,
+  apply finset.inj_on_of_card_image_eq,
+  rewrite [-to_finset_to_set (finset.image _ _), finset.to_set_image, to_set_to_finset],
+  exact H
+end
+
+theorem card_pos_of_mem {a : A} {s : set A} [fins : finite s] (H : a ∈ s) : card s > 0 :=
+have (#finset a ∈ to_finset s), by rewrite [finset.mem_eq_mem_to_set, to_set_to_finset]; apply H,
+finset.card_pos_of_mem this
+
+theorem eq_of_card_eq_of_subset {s₁ s₂ : set A} [fins₁ : finite s₁] [fins₂ : finite s₂]
+    (Hcard : card s₁ = card s₂) (Hsub : s₁ ⊆ s₂) :
+  s₁ = s₂ :=
+begin
+  rewrite [-to_set_to_finset s₁, -to_set_to_finset s₂, -finset.eq_eq_to_set_eq],
+  apply finset.eq_of_card_eq_of_subset Hcard,
+  rewrite [to_finset_subset_to_finset_eq],
+  exact Hsub
+end
+
+theorem exists_two_of_card_gt_one {s : set A} (H : 1 < card s) : ∃ a b, a ∈ s ∧ b ∈ s ∧ a ≠ b :=
+assert fins : finite s, from
+  by_contradiction
+    (assume nfins, by rewrite [card_of_not_finite nfins at H]; apply !not_succ_le_zero H),
+by rewrite [-to_set_to_finset s]; apply finset.exists_two_of_card_gt_one H
 
 end set

--- a/library/data/set/function.lean
+++ b/library/data/set/function.lean
@@ -75,6 +75,12 @@ setext (take y, iff.intro
         obtain x [(xt : x ∈ t) (fxy : f x = y)], from yift,
         mem_image (or.inr xt) fxy)))
 
+theorem image_empty (f : X → Y) : image f ∅ = ∅ :=
+eq_empty_of_forall_not_mem
+  (take y, suppose y ∈ image f ∅,
+    obtain x [(H : x ∈ empty) H'], from this,
+    H)
+
 /- maps to -/
 
 definition maps_to [reducible] (f : X → Y) (a : set X) (b : set Y) : Prop := ∀⦃x⦄, x ∈ a → f x ∈ b

--- a/library/theories/group_theory/action.lean
+++ b/library/theories/group_theory/action.lean
@@ -249,7 +249,7 @@ lemma subg_moversets_of_orbit_eq_stab_lcosets :
       existsi b, subst Ph₂, assumption
       end))
 
-open nat
+open nat nat.finset
 
 theorem orbit_stabilizer_theorem : card H = card (orbit hom H a) * card (stab hom H a) :=
         calc card H = card (fin_lcosets (stab hom H a) H) * card (stab hom H a) : lagrange_theorem stab_subset
@@ -297,7 +297,7 @@ take a b, propext (iff.intro
   (assume Peq, Peq ▸ in_orbit_refl))
 
 variables (hom) (H)
-open nat finset.partition fintype
+open nat nat.finset finset.partition fintype
 
 definition orbit_partition : @partition S _ :=
 mk univ (orbit hom H) orbit_is_partition

--- a/library/theories/group_theory/finsubg.lean
+++ b/library/theories/group_theory/finsubg.lean
@@ -173,8 +173,8 @@ definition fin_lcoset_partition_subg (Psub : H ⊆ G) :=
 open nat
 
 theorem lagrange_theorem (Psub : H ⊆ G) : card G = card (fin_lcosets H G) * card H := calc
-        card G = nat.Sum (fin_lcosets H G) card : class_equation (fin_lcoset_partition_subg Psub)
-        ... = nat.Sum (fin_lcosets H G) (λ x, card H) : nat.Sum_ext (take g P, fin_lcosets_card_eq g P)
+        card G = nat.finset.Sum (fin_lcosets H G) card : class_equation (fin_lcoset_partition_subg Psub)
+        ... = nat.finset.Sum (fin_lcosets H G) (λ x, card H) : nat.finset.Sum_ext (take g P, fin_lcosets_card_eq g P)
         ... = card (fin_lcosets H G) * card H : Sum_const_eq_card_mul
 
 end fin_lcoset
@@ -304,7 +304,7 @@ fintype.mk (all_lcosets G H)
 lemma card_lcoset_type : card (lcoset_type G H) = card (fin_lcosets H G) :=
 length_all_lcosets
 
-open nat
+open nat nat.finset
 variable [finsubgH : is_finsubg H]
 include finsubgH
 

--- a/library/theories/number_theory/prime_factorization.lean
+++ b/library/theories/number_theory/prime_factorization.lean
@@ -10,7 +10,7 @@ Multiplicity and prime factors. We have:
 
 -/
 import data.nat data.finset .primes
-open eq.ops finset well_founded decidable
+open eq.ops finset well_founded decidable nat.finset
 
 namespace nat
 


### PR DESCRIPTION
I am still in the process of creating a library based on finite sets. The finset-based bigops will be in algebra.finset, nat.finset, ... and the set-based versions will be algebra.set, nat.set, ...
