### PR TITLE
fix(api): fix typos in function name and comment.

### DIFF
--- a/src/api/decl.cpp
+++ b/src/api/decl.cpp
@@ -58,7 +58,7 @@ lean_bool lean_decl_mk_thm(lean_name n, lean_list_name p, lean_expr t, lean_expr
     LEAN_CATCH;
 }
 
-lean_bool lean_decl_mk_thm(lean_env e, lean_name n, lean_list_name p, lean_expr t, lean_expr v, lean_decl * r, lean_exception * ex) {
+lean_bool lean_decl_mk_thm_with(lean_env e, lean_name n, lean_list_name p, lean_expr t, lean_expr v, lean_decl * r, lean_exception * ex) {
     LEAN_TRY;
     check_nonnull(e);
     check_nonnull(n);

--- a/src/api/ios.cpp
+++ b/src/api/ios.cpp
@@ -37,7 +37,7 @@ void lean_ios_del(lean_ios ios) {
 lean_bool lean_ios_is_std(lean_ios ios) {
     if (!ios)
         return lean_false;
-    return dynamic_cast<string_output_channel*>(&to_io_state_ref(ios).get_regular_channel()) != nullptr;
+    return dynamic_cast<string_output_channel*>(&to_io_state_ref(ios).get_regular_channel()) == nullptr;
 }
 
 lean_bool lean_ios_set_options(lean_ios ios, lean_options o, lean_exception * ex) {

--- a/src/api/lean_env.h
+++ b/src/api/lean_env.h
@@ -68,7 +68,7 @@ lean_bool lean_env_forget(lean_env e, lean_env * r, lean_exception * ex);
     \remark Every declaration passed to \c f must be disposed using \c lean_decl_del. */
 lean_bool lean_env_for_each_decl(lean_env e, void (*f)(lean_decl), lean_exception * ex);
 /** \brief Execute \c f for each global universe in \c env.
-    \remark Every name passed to \c f must be disposed using \c lean_nam_del. */
+    \remark Every name passed to \c f must be disposed using \c lean_name_del. */
 lean_bool lean_env_for_each_univ(lean_env e, void (*f)(lean_name), lean_exception * ex);
 /*@}*/
 /*@}*/


### PR DESCRIPTION
This fixes a few errors/typos found in the C API.
