### PR TITLE
various housecleaning

### DIFF
--- a/library/algebra/field.lean
+++ b/library/algebra/field.lean
@@ -6,7 +6,6 @@ Authors: Robert Lewis
 Structures with multiplicative and additive components, including division rings and fields.
 The development is modeled after Isabelle's library.
 -/
-----------------------------------------------------------------------------------------------------
 import logic.eq logic.connectives data.unit data.sigma data.prod
 import algebra.binary algebra.group algebra.ring
 open eq eq.ops
@@ -37,22 +36,10 @@ section division_ring
   theorem inv_mul_cancel (H : a ≠ 0) : a⁻¹ * a = 1 :=
   division_ring.inv_mul_cancel H
 
-  theorem inv_eq_one_div : a⁻¹ = 1 / a := !one_mul⁻¹
+  theorem inv_eq_one_div (a : A) : a⁻¹ = 1 / a := !one_mul⁻¹
 
--- the following are only theorems if we assume inv_zero here
-/-  theorem inv_zero : 0⁻¹ = 0 := !division_ring.inv_zero
-
-  theorem one_div_zero : 1 / 0 = 0 :=
-    calc
-      1 / 0 = 1 * 0⁻¹ : refl
-        ... = 1 * 0 : division_ring.inv_zero A
-        ... = 0 : mul_zero
--/
-
-  theorem div_eq_mul_one_div : a / b = a * (1 / b) :=
+  theorem div_eq_mul_one_div (a b : A) : a / b = a * (1 / b) :=
     by rewrite [↑divide, one_mul]
-
---  theorem div_zero : a / 0 = 0 := by rewrite [div_eq_mul_one_div, one_div_zero, mul_zero]
 
   theorem mul_one_div_cancel (H : a ≠ 0) : a * (1 / a) = 1 :=
     by rewrite [-inv_eq_one_div, (mul_inv_cancel H)]
@@ -64,36 +51,32 @@ section division_ring
 
   theorem one_div_one : 1 / 1 = (1:A) := div_self (ne.symm zero_ne_one)
 
-  theorem mul_div_assoc : (a * b) / c = a * (b / c) := !mul.assoc
+  theorem mul_div_assoc (a b : A) : (a * b) / c = a * (b / c) := !mul.assoc
 
   theorem one_div_ne_zero (H : a ≠ 0) : 1 / a ≠ 0 :=
     assume H2 : 1 / a = 0,
     have C1 : 0 = (1:A), from symm (by rewrite [-(mul_one_div_cancel H), H2, mul_zero]),
     absurd C1 zero_ne_one
 
---  theorem ne_zero_of_one_div_ne_zero (H : 1 / a ≠ 0) : a ≠ 0 :=
---    assume Ha : a = 0, absurd (Ha⁻¹ ▸ one_div_zero) H
-
   theorem one_inv_eq : 1⁻¹ = (1:A) :=
   by rewrite [-mul_one, inv_mul_cancel (ne.symm (@zero_ne_one A _))]
 
-  theorem div_one : a / 1 = a :=
+  theorem div_one (a : A) : a / 1 = a :=
     by rewrite [↑divide, one_inv_eq, mul_one]
 
-  theorem zero_div : 0 / a = 0 := !zero_mul
+  theorem zero_div (a : A) : 0 / a = 0 := !zero_mul
 
-  -- note: integral domain has a "mul_ne_zero". Discrete fields are int domains.
-  theorem mul_ne_zero' (Ha : a ≠ 0) (Hb : b ≠ 0) : a * b ≠ 0 :=
+  -- note: integral domain has a "mul_ne_zero". A commutative division ring is an integral
+  -- domain, but let's not define that class for now.
+  theorem division_ring.mul_ne_zero (Ha : a ≠ 0) (Hb : b ≠ 0) : a * b ≠ 0 :=
     assume H : a * b = 0,
     have C1 : a = 0, by rewrite [-mul_one, -(mul_one_div_cancel Hb), -mul.assoc, H, zero_mul],
       absurd C1 Ha
 
   theorem mul_ne_zero_comm (H : a * b ≠ 0) : b * a ≠ 0 :=
     have H2 : a ≠ 0 ∧ b ≠ 0, from ne_zero_and_ne_zero_of_mul_ne_zero H,
-    mul_ne_zero' (and.right H2) (and.left H2)
+    division_ring.mul_ne_zero (and.right H2) (and.left H2)
 
-
-  -- make "left" and "right" versions?
   theorem eq_one_div_of_mul_eq_one (H : a * b = 1) : b = 1 / a :=
     have a ≠ 0, from
       (suppose a = 0,
@@ -106,7 +89,6 @@ section division_ring
         ... = 1 * b             : one_div_mul_cancel this
         ... = b                 : one_mul)
 
-  -- which one is left and which is right?
   theorem eq_one_div_of_mul_eq_one_left (H : b * a = 1) : b = 1 / a :=
     have a ≠ 0, from
       (suppose a = 0,
@@ -122,16 +104,18 @@ section division_ring
         ... = b * 1             : mul_one_div_cancel this
         ... = b                 : mul_one)
 
-  theorem one_div_mul_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) : (1 / a) * (1 / b) = 1 / (b * a) :=
+  theorem division_ring.one_div_mul_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) :
+      (1 / a) * (1 / b) = 1 / (b * a) :=
     have (b * a) * ((1 / a) * (1 / b)) = 1, by
-      rewrite [mul.assoc, -(mul.assoc a), (mul_one_div_cancel Ha), one_mul, (mul_one_div_cancel Hb)],
+      rewrite [mul.assoc, -(mul.assoc a), (mul_one_div_cancel Ha), one_mul,
+               (mul_one_div_cancel Hb)],
     eq_one_div_of_mul_eq_one this
 
   theorem one_div_neg_one_eq_neg_one : (1:A) / (-1) = -1 :=
     have (-1) * (-1) = (1:A), by rewrite [-neg_eq_neg_one_mul, neg_neg],
     symm (eq_one_div_of_mul_eq_one this)
 
-  theorem one_div_neg_eq_neg_one_div (H : a ≠ 0) : 1 / (- a) = - (1 / a) :=
+  theorem division_ring.one_div_neg_eq_neg_one_div (H : a ≠ 0) : 1 / (- a) = - (1 / a) :=
     have -1 ≠ 0, from
       (suppose -1 = 0, absurd (symm (calc
           1 = -(-1) : neg_neg
@@ -139,86 +123,87 @@ section division_ring
         ... = (0:A) : neg_zero)) zero_ne_one),
     calc
       1 / (- a) = 1 / ((-1) * a)        : neg_eq_neg_one_mul
-            ... = (1 / a) * (1 / (- 1)) : one_div_mul_one_div H this
+            ... = (1 / a) * (1 / (- 1)) : division_ring.one_div_mul_one_div H this
             ... = (1 / a) * (-1)        : one_div_neg_one_eq_neg_one
             ... = - (1 / a)             : mul_neg_one_eq_neg
 
-  theorem div_neg_eq_neg_div (Ha : a ≠ 0) : b / (- a) = - (b / a) :=
+  theorem div_neg_eq_neg_div (b : A) (Ha : a ≠ 0) : b / (- a) = - (b / a) :=
     calc
       b / (- a) = b * (1 / (- a)) : inv_eq_one_div
-            ... = b * -(1 / a)    : one_div_neg_eq_neg_one_div Ha
+            ... = b * -(1 / a)    : division_ring.one_div_neg_eq_neg_one_div Ha
             ... = -(b * (1 / a))  : neg_mul_eq_mul_neg
             ... = - (b * a⁻¹)     : inv_eq_one_div
 
-  theorem neg_div : (-b) / a = - (b / a) :=
+  theorem neg_div (a b : A) : (-b) / a = - (b / a) :=
     by rewrite [neg_eq_neg_one_mul, mul_div_assoc, -neg_eq_neg_one_mul]
 
-  theorem neg_div_neg_eq_div (Hb : b ≠ 0) : (-a) / (-b) = a / b :=
-    by rewrite [(div_neg_eq_neg_div Hb), neg_div, neg_neg]
+  theorem division_ring.neg_div_neg_eq (a : A) {b : A} (Hb : b ≠ 0) : (-a) / (-b) = a / b :=
+    by rewrite [(div_neg_eq_neg_div _ Hb), neg_div, neg_neg]
 
-  theorem div_div (H : a ≠ 0) : 1 / (1 / a) = a :=
+  theorem division_ring.one_div_one_div (H : a ≠ 0) : 1 / (1 / a) = a :=
     symm (eq_one_div_of_mul_eq_one_left (mul_one_div_cancel H))
 
-  theorem eq_of_invs_eq (Ha : a ≠ 0) (Hb : b ≠ 0) (H : 1 / a = 1 / b) : a = b :=
-    by rewrite [-(div_div Ha), H, (div_div Hb)]
+  theorem division_ring.eq_of_one_div_eq_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) (H : 1 / a = 1 / b) :
+      a = b :=
+    by rewrite [-(division_ring.one_div_one_div Ha), H, (division_ring.one_div_one_div Hb)]
 
   theorem mul_inv_eq (Ha : a ≠ 0) (Hb : b ≠ 0) : (b * a)⁻¹ = a⁻¹ * b⁻¹ :=
     eq.symm (calc
       a⁻¹ * b⁻¹ = (1 / a) * b⁻¹ : inv_eq_one_div
       ... = (1 / a) * (1 / b)   : inv_eq_one_div
-      ... = (1 / (b * a))       : one_div_mul_one_div Ha Hb
+      ... = (1 / (b * a))       : division_ring.one_div_mul_one_div Ha Hb
       ... = (b * a)⁻¹           : inv_eq_one_div)
 
-  theorem mul_div_cancel (Hb : b ≠ 0) : a * b / b = a :=
+  theorem mul_div_cancel (a : A) {b : A} (Hb : b ≠ 0) : a * b / b = a :=
     by rewrite [↑divide, mul.assoc, (mul_inv_cancel Hb), mul_one]
 
-  theorem div_mul_cancel (Hb : b ≠ 0) : a / b * b = a :=
+  theorem div_mul_cancel (a : A) {b : A} (Hb : b ≠ 0) : a / b * b = a :=
     by rewrite [↑divide, mul.assoc, (inv_mul_cancel Hb), mul_one]
 
-  theorem div_add_div_same : a / c + b / c = (a + b) / c := !right_distrib⁻¹
+  theorem div_add_div_same (a b c : A) : a / c + b / c = (a + b) / c := !right_distrib⁻¹
 
-  theorem div_sub_div_same : (a / c) - (b / c) = (a - b) / c :=
+  theorem div_sub_div_same (a b c : A) : (a / c) - (b / c) = (a - b) / c :=
     by rewrite [sub_eq_add_neg, -neg_div, div_add_div_same]
 
-  theorem inv_mul_add_mul_inv_eq_inv_add_inv (Ha : a ≠ 0) (Hb : b ≠ 0) :
+  theorem one_div_mul_add_mul_one_div_eq_one_div_add_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) :
           (1 / a) * (a + b) * (1 / b) = 1 / a + 1 / b :=
     by rewrite [(left_distrib (1 / a)), (one_div_mul_cancel Ha), right_distrib, one_mul,
       mul.assoc, (mul_one_div_cancel Hb), mul_one, add.comm]
 
-  theorem inv_mul_sub_mul_inv_eq_inv_add_inv (Ha : a ≠ 0) (Hb : b ≠ 0) :
+  theorem one_div_mul_sub_mul_one_div_eq_one_div_add_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) :
           (1 / a) * (b - a) * (1 / b) = 1 / a - 1 / b :=
     by rewrite [(mul_sub_left_distrib (1 / a)), (one_div_mul_cancel Ha), mul_sub_right_distrib,
       one_mul, mul.assoc, (mul_one_div_cancel Hb), mul_one, one_mul]
 
-  theorem div_eq_one_iff_eq (Hb : b ≠ 0) : a / b = 1 ↔ a = b :=
+  theorem div_eq_one_iff_eq (a : A) {b : A} (Hb : b ≠ 0) : a / b = 1 ↔ a = b :=
     iff.intro
     (suppose a / b = 1, symm (calc
       b   = 1 * b     : one_mul
       ... = a / b * b : this
-      ... = a         : div_mul_cancel Hb))
+      ... = a         : div_mul_cancel _ Hb))
     (suppose a = b, calc
       a / b = b / b : this
         ... = 1     : div_self Hb)
 
-  theorem eq_of_div_eq_one (Hb : b ≠ 0) : a / b = 1 → a = b :=
-    iff.mp (div_eq_one_iff_eq Hb)
+  theorem eq_of_div_eq_one (a : A) {b : A} (Hb : b ≠ 0) : a / b = 1 → a = b :=
+    iff.mp (!div_eq_one_iff_eq Hb)
 
-  theorem eq_div_iff_mul_eq (Hc : c ≠ 0) : a = b / c ↔ a * c = b :=
+  theorem eq_div_iff_mul_eq (a : A) {b : A} (Hc : c ≠ 0) : a = b / c ↔ a * c = b :=
     iff.intro
-      (suppose a = b / c, by rewrite [this, (div_mul_cancel Hc)])
-      (suppose a * c = b, by rewrite [-(mul_div_cancel Hc), this])
+      (suppose a = b / c, by rewrite [this, (!div_mul_cancel Hc)])
+      (suppose a * c = b, by rewrite [-(!mul_div_cancel Hc), this])
 
-  theorem eq_div_of_mul_eq (Hc : c ≠ 0) : a * c = b → a = b / c :=
-    iff.mpr (eq_div_iff_mul_eq Hc)
+  theorem eq_div_of_mul_eq (a b : A) {c : A} (Hc : c ≠ 0) : a * c = b → a = b / c :=
+    iff.mpr (!eq_div_iff_mul_eq Hc)
 
-  theorem mul_eq_of_eq_div (Hc : c ≠ 0) : a = b / c → a * c = b :=
-    iff.mp (eq_div_iff_mul_eq Hc)
+  theorem mul_eq_of_eq_div (a b: A) {c : A} (Hc : c ≠ 0) : a = b / c → a * c = b :=
+    iff.mp (!eq_div_iff_mul_eq Hc)
 
-  theorem add_div_eq_mul_add_div (Hc : c ≠ 0) : a + b / c = (a * c + b) / c :=
-    have (a + b / c) * c = a * c + b, by rewrite [right_distrib, (div_mul_cancel Hc)],
-    (iff.elim_right (eq_div_iff_mul_eq Hc)) this
+  theorem add_div_eq_mul_add_div (a b : A) {c : A} (Hc : c ≠ 0) : a + b / c = (a * c + b) / c :=
+    have (a + b / c) * c = a * c + b, by rewrite [right_distrib, (!div_mul_cancel Hc)],
+    (iff.elim_right (!eq_div_iff_mul_eq Hc)) this
 
-  theorem mul_mul_div (Hc : c ≠ 0) : a = a * c * (1 / c) :=
+  theorem mul_mul_div (a : A) {c : A} (Hc : c ≠ 0) : a = a * c * (1 / c) :=
     calc
       a   = a * 1             : mul_one
       ... = a * (c * (1 / c)) : mul_one_div_cancel Hc
@@ -226,7 +211,6 @@ section division_ring
 
   -- There are many similar rules to these last two in the Isabelle library
   -- that haven't been ported yet. Do as necessary.
-
 end division_ring
 
 structure field [class] (A : Type) extends division_ring A, comm_ring A
@@ -236,83 +220,92 @@ section field
   include s
   local attribute divide [reducible]
 
-  theorem one_div_mul_one_div' (Ha : a ≠ 0) (Hb : b ≠ 0) : (1 / a) * (1 / b) =  1 / (a * b) :=
-     by rewrite [(one_div_mul_one_div Ha Hb), mul.comm b]
+  theorem field.one_div_mul_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) : (1 / a) * (1 / b) =  1 / (a * b) :=
+     by rewrite [(division_ring.one_div_mul_one_div Ha Hb), mul.comm b]
 
-  theorem div_mul_right (Hb : b ≠ 0) (H : a * b ≠ 0) : a / (a * b) = 1 / b :=
+  theorem field.div_mul_right (Hb : b ≠ 0) (H : a * b ≠ 0) : a / (a * b) = 1 / b :=
     have a ≠ 0, from and.left (ne_zero_and_ne_zero_of_mul_ne_zero H),
     symm (calc
       1 / b = 1 * (1 / b)             : one_mul
         ... = (a * a⁻¹) * (1 / b)     : mul_inv_cancel this
         ... = a * (a⁻¹ * (1 / b))     : mul.assoc
-        ... = a * ((1 / a) * (1 / b)) :inv_eq_one_div
-        ... = a * (1 / (b * a))       : one_div_mul_one_div this Hb
+        ... = a * ((1 / a) * (1 / b)) : inv_eq_one_div
+        ... = a * (1 / (b * a))       : division_ring.one_div_mul_one_div this Hb
         ... = a * (1 / (a * b))       : mul.comm
         ... = a * (a * b)⁻¹           : inv_eq_one_div)
 
-  theorem div_mul_left (Ha : a ≠ 0) (H : a * b ≠ 0) : b / (a * b) = 1 / a :=
+  theorem field.div_mul_left (Ha : a ≠ 0) (H : a * b ≠ 0) : b / (a * b) = 1 / a :=
     let H1 : b * a ≠ 0 := mul_ne_zero_comm H in
-    by rewrite [mul.comm a, (div_mul_right Ha H1)]
+    by rewrite [mul.comm a, (field.div_mul_right Ha H1)]
 
   theorem mul_div_cancel_left (Ha : a ≠ 0) : a * b / a = b :=
-    by rewrite [mul.comm a, (mul_div_cancel Ha)]
+    by rewrite [mul.comm a, (!mul_div_cancel Ha)]
 
   theorem mul_div_cancel' (Hb : b ≠ 0) : b * (a / b) = a :=
-    by rewrite [mul.comm, (div_mul_cancel Hb)]
+    by rewrite [mul.comm, (!div_mul_cancel Hb)]
 
   theorem one_div_add_one_div (Ha : a ≠ 0) (Hb : b ≠ 0) : 1 / a + 1 / b = (a + b) / (a * b) :=
-    assert a * b ≠ 0, from (mul_ne_zero' Ha Hb),
-    by rewrite [add.comm, -(div_mul_left Ha this), -(div_mul_right Hb this), ↑divide, -right_distrib]
+    assert a * b ≠ 0, from (division_ring.mul_ne_zero Ha Hb),
+    by rewrite [add.comm, -(field.div_mul_left Ha this), -(field.div_mul_right Hb this), ↑divide,
+                -right_distrib]
 
-  theorem div_mul_div (Hb : b ≠ 0) (Hd : d ≠ 0) : (a / b) * (c / d) = (a * c) / (b * d) :=
+  theorem field.div_mul_div (a : A) {b : A} (c : A) {d : A} (Hb : b ≠ 0) (Hd : d ≠ 0) :
+      (a / b) * (c / d) = (a * c) / (b * d) :=
      by rewrite [↑divide, 2 mul.assoc, (mul.comm b⁻¹), mul.assoc, (mul_inv_eq Hd Hb)]
 
-  theorem mul_div_mul_left (Hb : b ≠ 0) (Hc : c ≠ 0) : (c * a) / (c * b) = a / b :=
-    by rewrite [-(div_mul_div Hc Hb), (div_self Hc), one_mul]
+  theorem mul_div_mul_left (a : A) {b c : A} (Hb : b ≠ 0) (Hc : c ≠ 0) :
+      (c * a) / (c * b) = a / b :=
+    by rewrite [-(!field.div_mul_div Hc Hb), (div_self Hc), one_mul]
 
-  theorem mul_div_mul_right (Hb : b ≠ 0) (Hc : c ≠ 0) : (a * c) / (b * c) = a / b :=
-    by rewrite [(mul.comm a), (mul.comm b), (mul_div_mul_left Hb Hc)]
+  theorem mul_div_mul_right (a : A) {b c : A} (Hb : b ≠ 0) (Hc : c ≠ 0) :
+      (a * c) / (b * c) = a / b :=
+    by rewrite [(mul.comm a), (mul.comm b), (!mul_div_mul_left Hb Hc)]
 
-  theorem div_mul_eq_mul_div : (b / c) * a = (b * a) / c :=
+  theorem div_mul_eq_mul_div (a b c : A) : (b / c) * a = (b * a) / c :=
     by rewrite [↑divide, mul.assoc, (mul.comm c⁻¹), -mul.assoc]
 
-  -- this one is odd -- I am not sure what to call it, but again, the prefix is right
-  theorem div_mul_eq_mul_div_comm (Hc : c ≠ 0) : (b / c) * a = b * (a / c) :=
-    by rewrite [(div_mul_eq_mul_div), -(one_mul c), -(div_mul_div (ne.symm zero_ne_one) Hc), div_one, one_mul]
+  theorem field.div_mul_eq_mul_div_comm (a b : A) {c : A} (Hc : c ≠ 0) :
+      (b / c) * a = b * (a / c) :=
+    by rewrite [(div_mul_eq_mul_div), -(one_mul c), -(!field.div_mul_div (ne.symm zero_ne_one) Hc),
+                div_one, one_mul]
 
-  theorem div_add_div (Hb : b ≠ 0) (Hd : d ≠ 0) :
+  theorem div_add_div (a : A) {b : A} (c : A) {d : A} (Hb : b ≠ 0) (Hd : d ≠ 0) :
       (a / b) + (c / d) = ((a * d) + (b * c)) / (b * d) :=
-    by rewrite [-(mul_div_mul_right Hb Hd), -(mul_div_mul_left Hd Hb), div_add_div_same]
+    by rewrite [-(!mul_div_mul_right Hb Hd), -(!mul_div_mul_left Hd Hb), div_add_div_same]
 
-  theorem div_sub_div (Hb : b ≠ 0) (Hd : d ≠ 0) :
+  theorem div_sub_div (a : A) {b : A} (c : A) {d : A} (Hb : b ≠ 0) (Hd : d ≠ 0) :
       (a / b) - (c / d) = ((a * d) - (b * c)) / (b * d) :=
-      by rewrite [↑sub, neg_eq_neg_one_mul, -mul_div_assoc, (div_add_div Hb Hd),
+      by rewrite [↑sub, neg_eq_neg_one_mul, -mul_div_assoc, (!div_add_div Hb Hd),
          -mul.assoc, (mul.comm b), mul.assoc, -neg_eq_neg_one_mul]
 
-  theorem mul_eq_mul_of_div_eq_div (Hb : b ≠ 0) (Hd : d ≠ 0) (H : a / b = c / d) : a * d = c * b :=
+  theorem mul_eq_mul_of_div_eq_div (a : A) {b : A} (c : A) {d : A} (Hb : b ≠ 0)
+      (Hd : d ≠ 0) (H : a / b = c / d) : a * d = c * b :=
     by rewrite [-mul_one, mul.assoc, (mul.comm d), -mul.assoc, -(div_self Hb),
-         -(div_mul_eq_mul_div_comm Hb), H, (div_mul_eq_mul_div), (div_mul_cancel Hd)]
+         -(!field.div_mul_eq_mul_div_comm Hb), H, (div_mul_eq_mul_div), (!div_mul_cancel Hd)]
 
-  theorem one_div_div (Ha : a ≠ 0) (Hb : b ≠ 0) : 1 / (a / b) = b / a :=
+  theorem field.one_div_div (Ha : a ≠ 0) (Hb : b ≠ 0) : 1 / (a / b) = b / a :=
     have (a / b) * (b / a) = 1, from calc
-      (a / b) * (b / a) = (a * b) / (b * a) : div_mul_div Hb Ha
+      (a / b) * (b / a) = (a * b) / (b * a) : !field.div_mul_div Hb Ha
       ... = (a * b) / (a * b) : mul.comm
-      ... = 1 : div_self (mul_ne_zero' Ha Hb),
+      ... = 1 : div_self (division_ring.mul_ne_zero Ha Hb),
     symm (eq_one_div_of_mul_eq_one this)
 
-  theorem div_div_eq_mul_div (Hb : b ≠ 0) (Hc : c ≠ 0) : a / (b / c) = (a * c) / b :=
-    by rewrite [div_eq_mul_one_div, (one_div_div Hb Hc), -mul_div_assoc]
+  theorem field.div_div_eq_mul_div (a : A) {b c : A} (Hb : b ≠ 0) (Hc : c ≠ 0) :
+      a / (b / c) = (a * c) / b :=
+    by rewrite [div_eq_mul_one_div, (field.one_div_div Hb Hc), -mul_div_assoc]
 
-  theorem div_div_eq_div_mul (Hb : b ≠ 0) (Hc : c ≠ 0) : (a / b) / c = a / (b * c) :=
-    by rewrite [div_eq_mul_one_div, (div_mul_div Hb Hc), mul_one]
+  theorem field.div_div_eq_div_mul (a : A) {b c : A} (Hb : b ≠ 0) (Hc : c ≠ 0) :
+      (a / b) / c = a / (b * c) :=
+    by rewrite [div_eq_mul_one_div, (!field.div_mul_div Hb Hc), mul_one]
 
-  theorem div_div_div_div (Hb : b ≠ 0) (Hc : c ≠ 0) (Hd : d ≠ 0) : (a / b) / (c / d) = (a * d) / (b * c) :=
-    by rewrite [(div_div_eq_mul_div Hc Hd), (div_mul_eq_mul_div), (div_div_eq_div_mul Hb Hc)]
+  theorem field.div_div_div_div_eq (a : A) {b c d : A} (Hb : b ≠ 0) (Hc : c ≠ 0) (Hd : d ≠ 0) :
+       (a / b) / (c / d) = (a * d) / (b * c) :=
+    by rewrite [(!field.div_div_eq_mul_div Hc Hd), (div_mul_eq_mul_div),
+                (!field.div_div_eq_div_mul Hb Hc)]
 
-  theorem div_mul_eq_div_mul_one_div (Hb : b ≠ 0) (Hc : c ≠ 0) : a / (b * c) = (a / b) * (1 / c) :=
-    by rewrite [-div_div_eq_div_mul Hb Hc, -div_eq_mul_one_div]
-
-
+  theorem field.div_mul_eq_div_mul_one_div (a : A) {b c : A} (Hb : b ≠ 0) (Hc : c ≠ 0) :
+      a / (b * c) = (a / b) * (1 / c) :=
+    by rewrite [-!field.div_div_eq_div_mul Hb Hc, -div_eq_mul_one_div]
 end field
 
 structure discrete_field [class] (A : Type) extends field A :=
@@ -328,7 +321,6 @@ section discrete_field
 
   -- many of the theorems in discrete_field are the same as theorems in field or division ring,
   -- but with fewer hypotheses since 0⁻¹ = 0 and equality is decidable.
-  -- they are named with '. Is there a better convention?
 
   theorem discrete_field.eq_zero_or_eq_zero_of_mul_eq_zero
     (x y : A) (H : x * y = 0) : x = 0 ∨ y = 0 :=
@@ -350,18 +342,18 @@ section discrete_field
         ... = 1 * 0 : discrete_field.inv_zero A
         ... = 0 : mul_zero
 
-  theorem div_zero : a / 0 = 0 := by rewrite [div_eq_mul_one_div, one_div_zero, mul_zero]
+  theorem div_zero (a : A) : a / 0 = 0 := by rewrite [div_eq_mul_one_div, one_div_zero, mul_zero]
 
   theorem ne_zero_of_one_div_ne_zero (H : 1 / a ≠ 0) : a ≠ 0 :=
     assume Ha : a = 0, absurd (Ha⁻¹ ▸ one_div_zero) H
 
-  theorem inv_zero_imp_zero (H : 1 / a = 0) : a = 0 :=
+  theorem eq_zero_of_one_div_eq_zero (H : 1 / a = 0) : a = 0 :=
     decidable.by_cases
       (assume Ha, Ha)
       (assume Ha, false.elim ((one_div_ne_zero Ha) H))
 
--- the following could all go in "discrete_division_ring"
-  theorem one_div_mul_one_div'' : (1 / a) * (1 / b) = 1 / (b * a) :=
+  variables (a b)
+  theorem one_div_mul_one_div' : (1 / a) * (1 / b) = 1 / (b * a) :=
     decidable.by_cases
       (suppose a = 0,
         by rewrite [this, div_zero, zero_mul, -(@div_zero A s 1), mul_zero b])
@@ -369,32 +361,34 @@ section discrete_field
         decidable.by_cases
           (suppose b = 0,
             by rewrite [this, div_zero, mul_zero, -(@div_zero A s 1), zero_mul a])
-          (suppose b ≠ 0, one_div_mul_one_div Ha this))
+          (suppose b ≠ 0, division_ring.one_div_mul_one_div Ha this))
 
-  theorem one_div_neg_eq_neg_one_div' : 1 / (- a) = - (1 / a) :=
+  theorem one_div_neg_eq_neg_one_div : 1 / (- a) = - (1 / a) :=
     decidable.by_cases
       (suppose a = 0, by rewrite [this, neg_zero, 2 div_zero, neg_zero])
-      (suppose a ≠ 0, one_div_neg_eq_neg_one_div this)
+      (suppose a ≠ 0, division_ring.one_div_neg_eq_neg_one_div this)
 
-  theorem neg_div_neg_eq_div' : (-a) / (-b) = a / b :=
+  theorem neg_div_neg_eq : (-a) / (-b) = a / b :=
     decidable.by_cases
       (assume Hb : b = 0, by rewrite [Hb, neg_zero, 2 div_zero])
-      (assume Hb : b ≠ 0, neg_div_neg_eq_div Hb)
+      (assume Hb : b ≠ 0, !division_ring.neg_div_neg_eq Hb)
 
-  theorem div_div' : 1 / (1 / a) = a :=
+  theorem one_div_one_div : 1 / (1 / a) = a :=
     decidable.by_cases
       (assume Ha : a = 0, by rewrite [Ha, 2 div_zero])
-      (assume Ha : a ≠ 0, div_div Ha)
+      (assume Ha : a ≠ 0, division_ring.one_div_one_div Ha)
 
-  theorem eq_of_invs_eq' (H : 1 / a = 1 / b) : a = b :=
+  variables {a b}
+  theorem eq_of_one_div_eq_one_div (H : 1 / a = 1 / b) : a = b :=
     decidable.by_cases
       (assume Ha : a = 0,
-      have Hb : b = 0, from inv_zero_imp_zero (by rewrite [-H, Ha, div_zero]),
+      have Hb : b = 0, from eq_zero_of_one_div_eq_zero (by rewrite [-H, Ha, div_zero]),
       Hb⁻¹ ▸ Ha)
       (assume Ha : a ≠ 0,
       have Hb : b ≠ 0, from ne_zero_of_one_div_ne_zero (H ▸ (one_div_ne_zero Ha)),
-      eq_of_invs_eq Ha Hb H)
+      division_ring.eq_of_one_div_eq_one_div Ha Hb H)
 
+  variables (a b)
   theorem mul_inv' : (b * a)⁻¹ = a⁻¹ * b⁻¹ :=
     decidable.by_cases
       (assume Ha : a = 0, by rewrite [Ha, mul_zero, 2 inv_zero, zero_mul])
@@ -404,62 +398,68 @@ section discrete_field
           (assume Hb : b ≠ 0, mul_inv_eq Ha Hb))
 
 -- the following are specifically for fields
-  theorem one_div_mul_one_div''' : (1 / a) * (1 / b) =  1 / (a * b) :=
-     by rewrite [(one_div_mul_one_div''), mul.comm b]
+  theorem one_div_mul_one_div : (1 / a) * (1 / b) =  1 / (a * b) :=
+     by rewrite [one_div_mul_one_div', mul.comm b]
 
-  theorem div_mul_right' (Ha : a ≠ 0) : a / (a * b) = 1 / b :=
+  variable {a}
+  theorem div_mul_right (Ha : a ≠ 0) : a / (a * b) = 1 / b :=
     decidable.by_cases
       (assume Hb : b = 0, by rewrite [Hb, mul_zero, 2 div_zero])
-      (assume Hb : b ≠ 0, div_mul_right Hb (mul_ne_zero Ha Hb))
+      (assume Hb : b ≠ 0, field.div_mul_right Hb (mul_ne_zero Ha Hb))
 
-  theorem div_mul_left' (Hb : b ≠ 0) : b / (a * b) = 1 / a :=
-    by rewrite [mul.comm a, div_mul_right' Hb]
+  variables (a) {b}
+  theorem div_mul_left (Hb : b ≠ 0) : b / (a * b) = 1 / a :=
+    by rewrite [mul.comm a, div_mul_right _ Hb]
 
-  theorem div_mul_div' : (a / b) * (c / d) = (a * c) / (b * d) :=
+  variables (a b c)
+  theorem div_mul_div : (a / b) * (c / d) = (a * c) / (b * d) :=
     decidable.by_cases
       (assume Hb : b = 0, by rewrite [Hb, div_zero, zero_mul, -(@div_zero A s (a * c)), zero_mul])
       (assume Hb : b ≠ 0,
         decidable.by_cases
-          (assume Hd : d = 0, by rewrite [Hd, div_zero, mul_zero, -(@div_zero A s (a * c)), mul_zero])
-          (assume Hd : d ≠ 0, div_mul_div Hb Hd))
+          (assume Hd : d = 0, by rewrite [Hd, div_zero, mul_zero, -(@div_zero A s (a * c)),
+                                          mul_zero])
+          (assume Hd : d ≠ 0, !field.div_mul_div Hb Hd))
 
+  variable {c}
   theorem mul_div_mul_left' (Hc : c ≠ 0) : (c * a) / (c * b) = a / b :=
     decidable.by_cases
       (assume Hb : b = 0, by rewrite [Hb, mul_zero, 2 div_zero])
-      (assume Hb : b ≠ 0, mul_div_mul_left Hb Hc)
+      (assume Hb : b ≠ 0, !mul_div_mul_left Hb Hc)
 
   theorem mul_div_mul_right' (Hc : c ≠ 0) : (a * c) / (b * c) = a / b :=
-    by rewrite [(mul.comm a), (mul.comm b), (mul_div_mul_left' Hc)]
+    by rewrite [(mul.comm a), (mul.comm b), (!mul_div_mul_left' Hc)]
 
-  -- this one is odd -- I am not sure what to call it, but again, the prefix is right
-  theorem div_mul_eq_mul_div_comm' : (b / c) * a = b * (a / c) :=
+  variables (a b c d)
+  theorem div_mul_eq_mul_div_comm : (b / c) * a = b * (a / c) :=
     decidable.by_cases
       (assume Hc : c = 0, by rewrite [Hc, div_zero, zero_mul, -(mul_zero b), -(@div_zero A s a)])
-      (assume Hc : c ≠ 0, div_mul_eq_mul_div_comm Hc)
+      (assume Hc : c ≠ 0, !field.div_mul_eq_mul_div_comm Hc)
 
- theorem one_div_div' : 1 / (a / b) = b / a :=
+  theorem one_div_div : 1 / (a / b) = b / a :=
     decidable.by_cases
       (assume Ha : a = 0, by rewrite [Ha, zero_div, 2 div_zero])
       (assume Ha : a ≠ 0,
       decidable.by_cases
         (assume Hb : b = 0, by rewrite [Hb, 2 div_zero, zero_div])
-        (assume Hb : b ≠ 0, one_div_div Ha Hb))
+        (assume Hb : b ≠ 0, field.one_div_div Ha Hb))
 
-  theorem div_div_eq_mul_div' : a / (b / c) = (a * c) / b :=
-    by rewrite [div_eq_mul_one_div, one_div_div', -mul_div_assoc]
+  theorem div_div_eq_mul_div : a / (b / c) = (a * c) / b :=
+    by rewrite [div_eq_mul_one_div, one_div_div, -mul_div_assoc]
 
-  theorem div_div_eq_div_mul' : (a / b) / c = a / (b * c) :=
-    by rewrite [div_eq_mul_one_div, div_mul_div', mul_one]
+  theorem div_div_eq_div_mul : (a / b) / c = a / (b * c) :=
+    by rewrite [div_eq_mul_one_div, div_mul_div, mul_one]
 
-  theorem div_div_div_div' : (a / b) / (c / d) = (a * d) / (b * c) :=
-    by rewrite [div_div_eq_mul_div', div_mul_eq_mul_div, div_div_eq_div_mul']
+  theorem div_div_div_div_eq : (a / b) / (c / d) = (a * d) / (b * c) :=
+    by rewrite [div_div_eq_mul_div, div_mul_eq_mul_div, div_div_eq_div_mul]
 
+  variable {a}
   theorem div_helper (H : a ≠ 0) : (1 / (a * b)) * a = 1 / b :=
-    by rewrite [div_mul_eq_mul_div, one_mul, (div_mul_right' H)]
+    by rewrite [div_mul_eq_mul_div, one_mul, !div_mul_right H]
 
-  theorem div_mul_eq_div_mul_one_div' : a / (b * c) = (a / b) * (1 / c) :=
-    by rewrite [-div_div_eq_div_mul', -div_eq_mul_one_div]
-
+  variable (a)
+  theorem div_mul_eq_div_mul_one_div : a / (b * c) = (a / b) * (1 / c) :=
+    by rewrite [-div_div_eq_div_mul, -div_eq_mul_one_div]
 end discrete_field
 
 end algebra

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -2,9 +2,7 @@
 Copyright (c) 2014 Robert Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Lewis
-
 -/
-
 import algebra.ordered_ring algebra.field
 open eq eq.ops
 
@@ -46,7 +44,7 @@ section linear_ordered_field
   theorem lt_mul_of_gt_one_right (Hb : b > 0) (H : a > 1) : b < b * a :=
       mul_one _ ▸ (mul_lt_mul_of_pos_left H Hb)
 
-  theorem one_le_div_iff_le (Hb : b > 0) : 1 ≤ a / b ↔ b ≤ a :=
+  theorem one_le_div_iff_le (a : A) {b : A} (Hb : b > 0) : 1 ≤ a / b ↔ b ≤ a :=
     have Hb' : b ≠ 0, from ne.symm (ne_of_lt Hb),
     iff.intro
     (assume H : 1 ≤ a / b,
@@ -61,12 +59,12 @@ section linear_ordered_field
        ... = a / b       : div_eq_mul_one_div)
 
   theorem le_of_one_le_div (Hb : b > 0) (H : 1 ≤ a / b) : b ≤ a :=
-    (iff.mp (one_le_div_iff_le Hb)) H
+    (iff.mp (!one_le_div_iff_le Hb)) H
 
   theorem one_le_div_of_le (Hb : b > 0) (H : b ≤ a) : 1 ≤ a / b :=
-    (iff.mpr (one_le_div_iff_le Hb)) H
+    (iff.mpr (!one_le_div_iff_le Hb)) H
 
-  theorem one_lt_div_iff_lt (Hb : b > 0) : 1 < a / b ↔ b < a :=
+  theorem one_lt_div_iff_lt (a : A) {b : A} (Hb : b > 0) : 1 < a / b ↔ b < a :=
     have Hb' : b ≠ 0, from ne.symm (ne_of_lt Hb),
     iff.intro
     (assume H : 1 < a / b,
@@ -80,59 +78,56 @@ section linear_ordered_field
       ... = a / b       : div_eq_mul_one_div)
 
   theorem lt_of_one_lt_div (Hb : b > 0) (H : 1 < a / b) : b < a :=
-    (iff.mp (one_lt_div_iff_lt Hb)) H
+    (iff.mp (!one_lt_div_iff_lt Hb)) H
 
   theorem one_lt_div_of_lt (Hb : b > 0) (H : b < a) : 1 < a / b :=
-    (iff.mpr (one_lt_div_iff_lt Hb)) H
+    (iff.mpr (!one_lt_div_iff_lt Hb)) H
 
-  theorem exists_lt : ∃ x, x < a :=
+  theorem exists_lt (a : A) : ∃ x, x < a :=
     have H : a - 1 < a, from add_lt_of_le_of_neg (le.refl _) zero_gt_neg_one,
     exists.intro _ H
 
-  theorem exists_gt : ∃ x, x > a :=
+  theorem exists_gt (a : A) : ∃ x, x > a :=
     have H : a + 1 > a, from lt_add_of_le_of_pos (le.refl _) zero_lt_one,
     exists.intro _ H
 
   -- the following theorems amount to four iffs, for <, ≤, ≥, >.
 
   theorem mul_le_of_le_div (Hc : 0 < c) (H : a ≤ b / c) : a * c ≤ b :=
-    div_mul_cancel (ne.symm (ne_of_lt Hc)) ▸ mul_le_mul_of_nonneg_right H (le_of_lt Hc)
+    !div_mul_cancel (ne.symm (ne_of_lt Hc)) ▸ mul_le_mul_of_nonneg_right H (le_of_lt Hc)
 
   theorem le_div_of_mul_le (Hc : 0 < c) (H : a * c ≤ b) : a ≤ b / c :=
     calc
-      a   = a * c * (1 / c) : mul_mul_div (ne.symm (ne_of_lt Hc))
+      a   = a * c * (1 / c) : !mul_mul_div (ne.symm (ne_of_lt Hc))
       ... ≤ b * (1 / c)     : mul_le_mul_of_nonneg_right H (le_of_lt (one_div_pos_of_pos Hc))
       ... = b / c           : div_eq_mul_one_div
 
   theorem mul_lt_of_lt_div (Hc : 0 < c) (H : a < b / c) : a * c < b :=
-    div_mul_cancel (ne.symm (ne_of_lt Hc)) ▸ mul_lt_mul_of_pos_right H Hc
+    !div_mul_cancel (ne.symm (ne_of_lt Hc)) ▸ mul_lt_mul_of_pos_right H Hc
 
   theorem lt_div_of_mul_lt (Hc : 0 < c) (H : a * c < b) : a < b / c :=
     calc
-      a   = a * c * (1 / c) : mul_mul_div (ne.symm (ne_of_lt Hc))
+      a   = a * c * (1 / c) : !mul_mul_div (ne.symm (ne_of_lt Hc))
       ... < b * (1 / c)     : mul_lt_mul_of_pos_right H (one_div_pos_of_pos Hc)
       ... = b / c           : div_eq_mul_one_div
 
   theorem mul_le_of_div_le_of_neg (Hc : c < 0) (H : b / c ≤ a) : a * c ≤ b :=
-    div_mul_cancel (ne_of_lt Hc) ▸ mul_le_mul_of_nonpos_right H (le_of_lt Hc)
+    !div_mul_cancel (ne_of_lt Hc) ▸ mul_le_mul_of_nonpos_right H (le_of_lt Hc)
 
   theorem div_le_of_mul_le_of_neg (Hc : c < 0) (H : a * c ≤ b) : b / c ≤ a :=
     calc
-      a   = a * c * (1 / c) : mul_mul_div (ne_of_lt Hc)
+      a   = a * c * (1 / c) : !mul_mul_div (ne_of_lt Hc)
       ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right H (le_of_lt (one_div_neg_of_neg Hc))
       ... = b / c           : div_eq_mul_one_div
 
   theorem mul_lt_of_gt_div_of_neg (Hc : c < 0) (H : a > b / c) : a * c < b :=
-    div_mul_cancel (ne_of_lt Hc) ▸ mul_lt_mul_of_neg_right H Hc
+    !div_mul_cancel (ne_of_lt Hc) ▸ mul_lt_mul_of_neg_right H Hc
 
-  theorem gt_div_of_mul_gt_of_neg (Hc : c < 0) (H : a * c < b) : a > b / c :=
+  theorem div_lt_of_mul_gt_of_neg (Hc : c < 0) (H : a * c < b) : b / c < a :=
     calc
-      a   = a * c * (1 / c) : mul_mul_div (ne_of_lt Hc)
+      a   = a * c * (1 / c) : !mul_mul_div (ne_of_lt Hc)
       ... > b * (1 / c)     : mul_lt_mul_of_neg_right H (one_div_neg_of_neg Hc)
       ... = b / c           : div_eq_mul_one_div
-
-
-  -----
 
   theorem div_le_of_le_mul (Hb : b > 0) (H : a ≤ b * c) : a / b ≤ c :=
     calc
@@ -143,7 +138,7 @@ section linear_ordered_field
 
   theorem le_mul_of_div_le (Hc : c > 0) (H : a / c ≤ b) : a ≤ b * c :=
     calc
-      a = a / c * c : div_mul_cancel (ne.symm (ne_of_lt Hc))
+      a = a / c * c : !div_mul_cancel (ne.symm (ne_of_lt Hc))
     ... ≤ b * c     : mul_le_mul_of_nonneg_right H (le_of_lt Hc)
 
   -- following these in the isabelle file, there are 8 biconditionals for the above with - signs
@@ -156,7 +151,7 @@ section linear_ordered_field
       ... = 0 : sub_self,
     calc
       0 > a / c - b / d : H1
-      ... = (a * d - c * b) / (c * d) : div_sub_div Hc Hd
+      ... = (a * d - c * b) / (c * d) : !div_sub_div Hc Hd
       ... = (a * d - b * c) / (c * d) : mul.comm
 
   theorem mul_sub_mul_div_mul_nonpos (Hc : c ≠ 0) (Hd : d ≠ 0) (H : a / c ≤ b / d) :
@@ -166,20 +161,20 @@ section linear_ordered_field
       ... = 0 : sub_self,
     calc
       0 ≥ a / c - b / d : H1
-      ... = (a * d - c * b) / (c * d) : div_sub_div Hc Hd
+      ... = (a * d - c * b) / (c * d) : !div_sub_div Hc Hd
       ... = (a * d - b * c) / (c * d) : mul.comm
 
   theorem div_lt_div_of_mul_sub_mul_div_neg (Hc : c ≠ 0) (Hd : d ≠ 0)
       (H : (a * d - b * c) / (c * d) < 0) : a / c < b / d :=
     assert H1 : (a * d - c * b) / (c * d) < 0,     by rewrite [mul.comm c b]; exact H,
-    assert H2 : a / c - b / d < 0,                 by rewrite [div_sub_div Hc Hd]; exact H1,
+    assert H2 : a / c - b / d < 0,                 by rewrite [!div_sub_div Hc Hd]; exact H1,
     assert H3 : a / c - b / d + b / d < 0 + b / d, from add_lt_add_right H2 _,
     begin rewrite [zero_add at H3, neg_add_cancel_right at H3], exact H3 end
 
   theorem div_le_div_of_mul_sub_mul_div_nonpos (Hc : c ≠ 0) (Hd : d ≠ 0)
       (H : (a * d - b * c) / (c * d) ≤ 0) : a / c ≤ b / d :=
     assert H1 : (a * d - c * b) / (c * d) ≤ 0,     by rewrite [mul.comm c b]; exact H,
-    assert H2 : a / c - b / d ≤ 0,                 by rewrite [div_sub_div Hc Hd]; exact H1,
+    assert H2 : a / c - b / d ≤ 0,                 by rewrite [!div_sub_div Hc Hd]; exact H1,
     assert H3 : a / c - b / d + b / d ≤ 0 + b / d, from add_le_add_right H2 _,
     begin rewrite [zero_add at H3, neg_add_cancel_right at H3], exact H3 end
 
@@ -249,7 +244,6 @@ section linear_ordered_field
       exact Hb
     end
 
-
   theorem div_nonneg_of_nonpos_of_neg (Ha : a ≤ 0) (Hb : b < 0) : 0 ≤ a / b :=
     begin
       rewrite div_eq_mul_one_div,
@@ -265,7 +259,6 @@ section linear_ordered_field
     rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
     exact mul_lt_mul_of_pos_right H (one_div_pos_of_pos Hc)
   end
-
 
   theorem div_le_div_of_le_of_pos (H : a ≤ b) (Hc : 0 < c) : a / c ≤ b / c :=
     begin
@@ -293,17 +286,17 @@ section linear_ordered_field
 
   notation 2 := 1 + 1
 
-  theorem add_halves : a / 2 + a / 2 = a :=
+  theorem add_halves (a : A) : a / 2 + a / 2 = a :=
     calc
       a / 2 + a / 2 = (a + a) / 2 : by rewrite div_add_div_same
       ... = (a * 1 + a * 1) / 2   : by rewrite mul_one
       ... = (a * 2) / 2           : by rewrite left_distrib
       ... = a                     : by rewrite [@mul_div_cancel A _ _ _ two_ne_zero]
 
-  theorem sub_self_div_two : a - a / 2 = a / 2 :=
+  theorem sub_self_div_two (a : A) : a - a / 2 = a / 2 :=
     by rewrite [-{a}add_halves at {1}, add_sub_cancel]
 
-  theorem div_two_sub_self : a / 2 - a = - (a / 2) :=
+  theorem div_two_sub_self (a : A) : a / 2 - a = - (a / 2) :=
     by rewrite [-{a}add_halves at {2}, sub_add_eq_sub_sub, sub_self, zero_sub]
 
 theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a ≤ b * b) : a ≤ b :=
@@ -317,8 +310,8 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
     apply (not_le_of_gt H') H
   end
 
-  theorem add_self_div_two : (a + a) / 2 = a :=
-    symm (iff.mpr (eq_div_iff_mul_eq (ne_of_gt (add_pos zero_lt_one zero_lt_one)))
+  theorem add_self_div_two (a : A) : (a + a) / 2 = a :=
+    symm (iff.mpr (!eq_div_iff_mul_eq (ne_of_gt (add_pos zero_lt_one zero_lt_one)))
            (by rewrite [left_distrib, *mul_one]))
 
   theorem two_ge_one : (2 : A) ≥ 1 :=
@@ -340,7 +333,8 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
   theorem div_mul_le_div_mul_of_div_le_div_pos {e : A} (Hb : b ≠ 0) (Hd : d ≠ 0) (H : a / b ≤ c / d)
           (He : e > 0) : a / (b * e) ≤ c / (d * e) :=
     begin
-      rewrite [div_mul_eq_div_mul_one_div Hb (ne_of_gt He), div_mul_eq_div_mul_one_div Hd (ne_of_gt He)],
+      rewrite [!field.div_mul_eq_div_mul_one_div Hb (ne_of_gt He),
+               !field.div_mul_eq_div_mul_one_div Hd (ne_of_gt He)],
       apply mul_le_mul_of_nonneg_right H,
       apply le_of_lt,
       apply one_div_pos_of_pos He
@@ -355,7 +349,8 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
         ... = (b + b) + (a - b) : add_sub,
       assert H3 : (a + a) / (1 + 1) > ((b + b) + (a - b)) / (1 + 1),
         from div_lt_div_of_lt_of_pos H2 two_pos,
-      by rewrite [add_self_div_two at H3, -div_add_div_same at H3, add_self_div_two at H3]; exact H3)
+      by rewrite [add_self_div_two at H3, -div_add_div_same at H3, add_self_div_two at H3];
+           exact H3)
       (div_pos_of_pos_of_pos (iff.mpr !sub_pos_iff_lt H) two_pos))
 
 end linear_ordered_field
@@ -388,14 +383,14 @@ section discrete_linear_ordered_field
     have H1 : 0 < 1 / (1 / a), from one_div_pos_of_pos H,
     have H2 : 1 / a ≠ 0, from
       (assume H3 : 1 / a = 0,
-      have H4 : 1 / (1 / a) = 0, from H3⁻¹ ▸ div_zero,
+      have H4 : 1 / (1 / a) = 0, from H3⁻¹ ▸ !div_zero,
       absurd H4 (ne.symm (ne_of_lt H1))),
-    (div_div (ne_zero_of_one_div_ne_zero H2)) ▸ H1
+    (division_ring.one_div_one_div (ne_zero_of_one_div_ne_zero H2)) ▸ H1
 
   theorem neg_of_one_div_neg (H : 1 / a < 0) : a < 0 :=
     have H1 : 0 < - (1 / a), from neg_pos_of_neg H,
     have Ha : a ≠ 0, from ne_zero_of_one_div_ne_zero (ne_of_lt H),
-    have H2 : 0 < 1 / (-a), from (one_div_neg_eq_neg_one_div Ha)⁻¹ ▸ H1,
+    have H2 : 0 < 1 / (-a), from (division_ring.one_div_neg_eq_neg_one_div Ha)⁻¹ ▸ H1,
     have H3 : 0 < -a, from pos_of_one_div_pos H2,
     neg_of_neg_pos H3
 
@@ -417,9 +412,9 @@ section discrete_linear_ordered_field
     have H'   : -b > 0,                from neg_pos_of_neg H,
     have Hl'  : - (1 / b) ≤ - (1 / a), from neg_le_neg Hl,
     have Hl'' : 1 / - b ≤ 1 / - a,     from calc
-      1 / -b = - (1 / b) : by rewrite [one_div_neg_eq_neg_one_div (ne_of_lt H)]
+      1 / -b = - (1 / b) : by rewrite [division_ring.one_div_neg_eq_neg_one_div (ne_of_lt H)]
          ... ≤ - (1 / a) : Hl'
-         ... = 1 / -a    : by rewrite [one_div_neg_eq_neg_one_div Ha],
+         ... = 1 / -a    : by rewrite [division_ring.one_div_neg_eq_neg_one_div Ha],
     le_of_neg_le_neg (le_of_one_div_le_one_div H' Hl'')
 
   theorem lt_of_one_div_lt_one_div (H : 0 < a) (Hl : 1 / a < 1 / b) : b < a :=
@@ -487,19 +482,19 @@ section discrete_linear_ordered_field
   theorem div_mul_le_div_mul_of_div_le_div_pos' {d e : A} (H : a / b ≤ c / d)
           (He : e > 0) : a / (b * e) ≤ c / (d * e) :=
     begin
-      rewrite [2 div_mul_eq_div_mul_one_div'],
+      rewrite [2 div_mul_eq_div_mul_one_div],
       apply mul_le_mul_of_nonneg_right H,
       apply le_of_lt,
       apply one_div_pos_of_pos He
     end
 
-  theorem abs_one_div : abs (1 / a) = 1 / abs a :=
+  theorem abs_one_div (a : A) : abs (1 / a) = 1 / abs a :=
     if H : a > 0 then
       by rewrite [abs_of_pos H, abs_of_pos (one_div_pos_of_pos H)]
     else
       (if H' : a < 0 then
           by rewrite [abs_of_neg H', abs_of_neg (one_div_neg_of_neg H'),
-                         -(one_div_neg_eq_neg_one_div (ne_of_lt H'))]
+                         -(division_ring.one_div_neg_eq_neg_one_div (ne_of_lt H'))]
        else
          assert Heq : a = 0, from eq_of_le_of_ge (le_of_not_gt H) (le_of_not_gt H'),
          by rewrite [Heq, div_zero, *abs_zero, div_zero])
@@ -517,7 +512,7 @@ section discrete_linear_ordered_field
   theorem sub_le_of_abs_sub_le_right (H : abs (a - b) ≤ c) : a - c ≤ b :=
     sub_le_of_abs_sub_le_left (!abs_sub ▸ H)
 
-  theorem abs_sub_square : abs (a - b) * abs (a - b) = a * a + b * b - 2 * a * b :=
+  theorem abs_sub_square (a b : A) : abs (a - b) * abs (a - b) = a * a + b * b - 2 * a * b :=
     by rewrite [abs_mul_abs_self, *mul_sub_left_distrib, *mul_sub_right_distrib,
              sub_add_eq_sub_sub, sub_neg_eq_add, *right_distrib, sub_add_eq_sub_sub, *one_mul,
              *add.assoc, {_ + b * b}add.comm, {_ + (b * b + _)}add.comm, mul.comm b a, *add.assoc]
@@ -541,7 +536,7 @@ section discrete_linear_ordered_field
     (suppose a = 0, by subst a; rewrite [zero_div, sign_zero])
     (suppose a ≠ 0,
       have abs a ≠ 0, from assume H, this (eq_zero_of_abs_eq_zero H),
-      eq_div_of_mul_eq this !eq_sign_mul_abs⁻¹)
+      !eq_div_of_mul_eq this !eq_sign_mul_abs⁻¹)
 
 end discrete_linear_ordered_field
 end algebra

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -299,17 +299,6 @@ section linear_ordered_field
   theorem div_two_sub_self (a : A) : a / 2 - a = - (a / 2) :=
     by rewrite [-{a}add_halves at {2}, sub_add_eq_sub_sub, sub_self, zero_sub]
 
-theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a ≤ b * b) : a ≤ b :=
-  begin
-    apply le_of_not_gt,
-    intro Hab,
-    let Hposa := lt_of_le_of_lt Hb Hab,
-    let H' := calc
-      b * b ≤ a * b : mul_le_mul_of_nonneg_right (le_of_lt Hab) Hb
-      ... < a * a : mul_lt_mul_of_pos_left Hab Hposa,
-    apply (not_le_of_gt H') H
-  end
-
   theorem add_self_div_two (a : A) : (a + a) / 2 = a :=
     symm (iff.mpr (!eq_div_iff_mul_eq (ne_of_gt (add_pos zero_lt_one zero_lt_one)))
            (by rewrite [left_distrib, *mul_one]))
@@ -498,38 +487,6 @@ section discrete_linear_ordered_field
        else
          assert Heq : a = 0, from eq_of_le_of_ge (le_of_not_gt H) (le_of_not_gt H'),
          by rewrite [Heq, div_zero, *abs_zero, div_zero])
-
-  theorem sub_le_of_abs_sub_le_left (H : abs (a - b) ≤ c) : b - c ≤ a :=
-    if Hz : 0 ≤ a - b then
-      (calc
-        a ≥ b : (iff.mp !sub_nonneg_iff_le) Hz
-      ... ≥ b - c : sub_le_of_nonneg _ _ (le.trans !abs_nonneg H))
-    else
-      (have Habs : b - a ≤ c, by rewrite [abs_of_neg (lt_of_not_ge Hz) at H, neg_sub at H]; apply H,
-       have Habs' : b ≤ c + a, from (iff.mpr !le_add_iff_sub_right_le) Habs,
-       (iff.mp !le_add_iff_sub_left_le) Habs')
-
-  theorem sub_le_of_abs_sub_le_right (H : abs (a - b) ≤ c) : a - c ≤ b :=
-    sub_le_of_abs_sub_le_left (!abs_sub ▸ H)
-
-  theorem abs_sub_square (a b : A) : abs (a - b) * abs (a - b) = a * a + b * b - 2 * a * b :=
-    by rewrite [abs_mul_abs_self, *mul_sub_left_distrib, *mul_sub_right_distrib,
-             sub_add_eq_sub_sub, sub_neg_eq_add, *right_distrib, sub_add_eq_sub_sub, *one_mul,
-             *add.assoc, {_ + b * b}add.comm, {_ + (b * b + _)}add.comm, mul.comm b a, *add.assoc]
-
-  theorem abs_abs_sub_abs_le_abs_sub (a b : A) : abs (abs a - abs b) ≤ abs (a - b) :=
-  begin
-    apply nonneg_le_nonneg_of_squares_le,
-    repeat apply abs_nonneg,
-    rewrite [*abs_sub_square, *abs_abs, *abs_mul_abs_self],
-    apply sub_le_sub_left,
-    rewrite *mul.assoc,
-    apply mul_le_mul_of_nonneg_left,
-    rewrite -abs_mul,
-    apply le_abs_self,
-    apply le_of_lt,
-    apply two_pos
-  end
 
   theorem sign_eq_div_abs (a : A) : sign a = a / (abs a) :=
   decidable.by_cases

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -33,10 +33,10 @@ section linear_ordered_field
         ... = a * a⁻¹     : mul_inv_cancel (ne_of_lt H)
         ... = a * (1 / a) : inv_eq_one_div
 
-  theorem div_pos_of_pos (H : 0 < a) : 0 < 1 / a :=
+  theorem one_div_pos_of_pos (H : 0 < a) : 0 < 1 / a :=
     lt_of_mul_lt_mul_left (mul_zero_lt_mul_inv_of_pos H) (le_of_lt H)
 
-  theorem div_neg_of_neg (H : a < 0) : 1 / a < 0 :=
+  theorem one_div_neg_of_neg (H : a < 0) : 1 / a < 0 :=
     gt_of_mul_lt_mul_neg_left (mul_zero_lt_mul_inv_of_neg H) (le_of_lt H)
 
 
@@ -55,7 +55,7 @@ section linear_ordered_field
         ... ≤ b * (a / b) : le_mul_of_ge_one_right (le_of_lt Hb) H
         ... = a           : mul_div_cancel' Hb')
     (assume H : b ≤ a,
-      have Hbinv : 1 / b > 0, from  div_pos_of_pos Hb, calc
+      have Hbinv : 1 / b > 0, from  one_div_pos_of_pos Hb, calc
         1  = b * (1 / b) : mul_one_div_cancel Hb'
        ... ≤ a * (1 / b) : mul_le_mul_of_nonneg_right H (le_of_lt Hbinv)
        ... = a / b       : div_eq_mul_one_div)
@@ -74,7 +74,7 @@ section linear_ordered_field
         b   < b * (a / b) : lt_mul_of_gt_one_right Hb H
         ... = a           : mul_div_cancel' Hb')
     (assume H : b < a,
-      have Hbinv : 1 / b > 0, from  div_pos_of_pos Hb, calc
+      have Hbinv : 1 / b > 0, from  one_div_pos_of_pos Hb, calc
         1 = b * (1 / b) : mul_one_div_cancel Hb'
       ... < a * (1 / b) : mul_lt_mul_of_pos_right H Hbinv
       ... = a / b       : div_eq_mul_one_div)
@@ -101,7 +101,7 @@ section linear_ordered_field
   theorem le_div_of_mul_le (Hc : 0 < c) (H : a * c ≤ b) : a ≤ b / c :=
     calc
       a   = a * c * (1 / c) : mul_mul_div (ne.symm (ne_of_lt Hc))
-      ... ≤ b * (1 / c)     : mul_le_mul_of_nonneg_right H (le_of_lt (div_pos_of_pos Hc))
+      ... ≤ b * (1 / c)     : mul_le_mul_of_nonneg_right H (le_of_lt (one_div_pos_of_pos Hc))
       ... = b / c           : div_eq_mul_one_div
 
   theorem mul_lt_of_lt_div (Hc : 0 < c) (H : a < b / c) : a * c < b :=
@@ -110,25 +110,25 @@ section linear_ordered_field
   theorem lt_div_of_mul_lt (Hc : 0 < c) (H : a * c < b) : a < b / c :=
     calc
       a   = a * c * (1 / c) : mul_mul_div (ne.symm (ne_of_lt Hc))
-      ... < b * (1 / c)     : mul_lt_mul_of_pos_right H (div_pos_of_pos Hc)
+      ... < b * (1 / c)     : mul_lt_mul_of_pos_right H (one_div_pos_of_pos Hc)
       ... = b / c           : div_eq_mul_one_div
 
-  theorem mul_le_of_ge_div_neg (Hc : c < 0) (H : a ≥ b / c) : a * c ≤ b :=
+  theorem mul_le_of_div_le_of_neg (Hc : c < 0) (H : b / c ≤ a) : a * c ≤ b :=
     div_mul_cancel (ne_of_lt Hc) ▸ mul_le_mul_of_nonpos_right H (le_of_lt Hc)
 
-  theorem ge_div_of_mul_le_neg (Hc : c < 0) (H : a * c ≤ b) : a ≥ b / c :=
+  theorem div_le_of_mul_le_of_neg (Hc : c < 0) (H : a * c ≤ b) : b / c ≤ a :=
     calc
       a   = a * c * (1 / c) : mul_mul_div (ne_of_lt Hc)
-      ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right H (le_of_lt (div_neg_of_neg Hc))
+      ... ≥ b * (1 / c)     : mul_le_mul_of_nonpos_right H (le_of_lt (one_div_neg_of_neg Hc))
       ... = b / c           : div_eq_mul_one_div
 
-  theorem mul_lt_of_gt_div_neg (Hc : c < 0) (H : a > b / c) : a * c < b :=
+  theorem mul_lt_of_gt_div_of_neg (Hc : c < 0) (H : a > b / c) : a * c < b :=
     div_mul_cancel (ne_of_lt Hc) ▸ mul_lt_mul_of_neg_right H Hc
 
-  theorem gt_div_of_mul_gt_neg (Hc : c < 0) (H : a * c < b) : a > b / c :=
+  theorem gt_div_of_mul_gt_of_neg (Hc : c < 0) (H : a * c < b) : a > b / c :=
     calc
       a   = a * c * (1 / c) : mul_mul_div (ne_of_lt Hc)
-      ... > b * (1 / c)     : mul_lt_mul_of_neg_right H (div_neg_of_neg Hc)
+      ... > b * (1 / c)     : mul_lt_mul_of_neg_right H (one_div_neg_of_neg Hc)
       ... = b / c           : div_eq_mul_one_div
 
 
@@ -137,7 +137,7 @@ section linear_ordered_field
   theorem div_le_of_le_mul (Hb : b > 0) (H : a ≤ b * c) : a / b ≤ c :=
     calc
       a / b = a * (1 / b)       : div_eq_mul_one_div
-        ... ≤ (b * c) * (1 / b) : mul_le_mul_of_nonneg_right H (le_of_lt (div_pos_of_pos Hb))
+        ... ≤ (b * c) * (1 / b) : mul_le_mul_of_nonneg_right H (le_of_lt (one_div_pos_of_pos Hb))
         ... = (b * c) / b       : div_eq_mul_one_div
         ... = c                 : mul_div_cancel_left (ne.symm (ne_of_lt Hb))
 
@@ -183,106 +183,106 @@ section linear_ordered_field
     assert H3 : a / c - b / d + b / d ≤ 0 + b / d, from add_le_add_right H2 _,
     begin rewrite [zero_add at H3, neg_add_cancel_right at H3], exact H3 end
 
-  theorem pos_div_of_pos_of_pos (Ha : 0 < a) (Hb : 0 < b) : 0 < a / b :=
+  theorem div_pos_of_pos_of_pos (Ha : 0 < a) (Hb : 0 < b) : 0 < a / b :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_pos,
       exact Ha,
-      apply div_pos_of_pos,
+      apply one_div_pos_of_pos,
       exact Hb
     end
 
-  theorem nonneg_div_of_nonneg_of_pos (Ha : 0 ≤ a) (Hb : 0 < b) : 0 ≤ a / b :=
+  theorem div_nonneg_of_nonneg_of_pos (Ha : 0 ≤ a) (Hb : 0 < b) : 0 ≤ a / b :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_nonneg,
       exact Ha,
       apply le_of_lt,
-      apply div_pos_of_pos,
+      apply one_div_pos_of_pos,
       exact Hb
     end
 
-  theorem neg_div_of_neg_of_pos (Ha : a < 0) (Hb : 0 < b) : a / b < 0:=
+  theorem div_neg_of_neg_of_pos (Ha : a < 0) (Hb : 0 < b) : a / b < 0:=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_neg_of_neg_of_pos,
       exact Ha,
-      apply div_pos_of_pos,
+      apply one_div_pos_of_pos,
       exact Hb
     end
 
-  theorem nonpos_div_of_nonpos_of_pos (Ha : a ≤ 0) (Hb : 0 < b) : a / b ≤ 0 :=
+  theorem div_nonpos_of_nonpos_of_pos (Ha : a ≤ 0) (Hb : 0 < b) : a / b ≤ 0 :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_nonpos_of_nonpos_of_nonneg,
       exact Ha,
       apply le_of_lt,
-      apply div_pos_of_pos,
+      apply one_div_pos_of_pos,
       exact Hb
     end
 
-  theorem neg_div_of_pos_of_neg (Ha : 0 < a) (Hb : b < 0) : a / b < 0 :=
+  theorem div_neg_of_pos_of_neg (Ha : 0 < a) (Hb : b < 0) : a / b < 0 :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_neg_of_pos_of_neg,
       exact Ha,
-      apply div_neg_of_neg,
+      apply one_div_neg_of_neg,
       exact Hb
     end
 
-  theorem nonpos_div_of_nonneg_of_neg (Ha : 0 ≤ a) (Hb : b < 0) :  a / b ≤ 0 :=
+  theorem div_nonpos_of_nonneg_of_neg (Ha : 0 ≤ a) (Hb : b < 0) :  a / b ≤ 0 :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_nonpos_of_nonneg_of_nonpos,
       exact Ha,
       apply le_of_lt,
-      apply div_neg_of_neg,
+      apply one_div_neg_of_neg,
       exact Hb
     end
 
-  theorem pos_div_of_neg_of_neg (Ha : a < 0) (Hb : b < 0) : 0 < a / b :=
+  theorem div_pos_of_neg_of_neg (Ha : a < 0) (Hb : b < 0) : 0 < a / b :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_pos_of_neg_of_neg,
       exact Ha,
-      apply div_neg_of_neg,
+      apply one_div_neg_of_neg,
       exact Hb
     end
 
 
-  theorem nonneg_div_of_nonpos_of_neg (Ha : a ≤ 0) (Hb : b < 0) : 0 ≤ a / b :=
+  theorem div_nonneg_of_nonpos_of_neg (Ha : a ≤ 0) (Hb : b < 0) : 0 ≤ a / b :=
     begin
       rewrite div_eq_mul_one_div,
       apply mul_nonneg_of_nonpos_of_nonpos,
       exact Ha,
       apply le_of_lt,
-      apply div_neg_of_neg,
+      apply one_div_neg_of_neg,
       exact Hb
     end
 
   theorem div_lt_div_of_lt_of_pos (H : a < b) (Hc : 0 < c) : a / c < b / c :=
   begin
     rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
-    exact mul_lt_mul_of_pos_right H (div_pos_of_pos Hc)
+    exact mul_lt_mul_of_pos_right H (one_div_pos_of_pos Hc)
   end
 
 
   theorem div_le_div_of_le_of_pos (H : a ≤ b) (Hc : 0 < c) : a / c ≤ b / c :=
     begin
       rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
-      exact mul_le_mul_of_nonneg_right H (le_of_lt (div_pos_of_pos Hc))
+      exact mul_le_mul_of_nonneg_right H (le_of_lt (one_div_pos_of_pos Hc))
     end
 
   theorem div_lt_div_of_lt_of_neg (H : b < a) (Hc : c < 0) : a / c < b / c :=
   begin
     rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
-    exact mul_lt_mul_of_neg_right H (div_neg_of_neg Hc)
+    exact mul_lt_mul_of_neg_right H (one_div_neg_of_neg Hc)
   end
 
   theorem div_le_div_of_le_of_neg (H : b ≤ a) (Hc : c < 0) : a / c ≤ b / c :=
   begin
     rewrite [{a/c}div_eq_mul_one_div, {b/c}div_eq_mul_one_div],
-    exact mul_le_mul_of_nonpos_right H (le_of_lt (div_neg_of_neg Hc))
+    exact mul_le_mul_of_nonpos_right H (le_of_lt (one_div_neg_of_neg Hc))
   end
 
   theorem two_pos : (1 : A) + 1 > 0 :=
@@ -317,7 +317,7 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
     apply (not_le_of_gt H') H
   end
 
-  theorem div_two : (a + a) / 2 = a :=
+  theorem add_self_div_two : (a + a) / 2 = a :=
     symm (iff.mpr (eq_div_iff_mul_eq (ne_of_gt (add_pos zero_lt_one zero_lt_one)))
            (by rewrite [left_distrib, *mul_one]))
 
@@ -331,7 +331,7 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
     end
 
   theorem div_two_lt_of_pos (H : a > 0) : a / (1 + 1) < a :=
-    have Ha : a / (1 + 1) > 0, from pos_div_of_pos_of_pos H (add_pos zero_lt_one zero_lt_one),
+    have Ha : a / (1 + 1) > 0, from div_pos_of_pos_of_pos H (add_pos zero_lt_one zero_lt_one),
     calc
       a / (1 + 1) < a / (1 + 1) + a / (1 + 1) : lt_add_of_pos_left Ha
               ... = a : add_halves
@@ -343,10 +343,10 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
       rewrite [div_mul_eq_div_mul_one_div Hb (ne_of_gt He), div_mul_eq_div_mul_one_div Hd (ne_of_gt He)],
       apply mul_le_mul_of_nonneg_right H,
       apply le_of_lt,
-      apply div_pos_of_pos He
+      apply one_div_pos_of_pos He
     end
 
-  theorem find_midpoint (H : a > b) : ∃ c : A, a > b + c ∧ c > 0 :=
+  theorem exists_add_lt_and_pos_of_lt (H : b < a) : ∃ c : A, b + c < a ∧ c > 0 :=
     exists.intro ((a - b) / (1 + 1))
       (and.intro (assert H2 : a + a > (b + b) + (a - b), from calc
         a + a > b + a : add_lt_add_right H
@@ -355,8 +355,8 @@ theorem nonneg_le_nonneg_of_squares_le  (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a
         ... = (b + b) + (a - b) : add_sub,
       assert H3 : (a + a) / (1 + 1) > ((b + b) + (a - b)) / (1 + 1),
         from div_lt_div_of_lt_of_pos H2 two_pos,
-      by rewrite [div_two at H3, -div_add_div_same at H3, div_two at H3]; exact H3)
-      (pos_div_of_pos_of_pos (iff.mpr !sub_pos_iff_lt H) two_pos))
+      by rewrite [add_self_div_two at H3, -div_add_div_same at H3, add_self_div_two at H3]; exact H3)
+      (div_pos_of_pos_of_pos (iff.mpr !sub_pos_iff_lt H) two_pos))
 
 end linear_ordered_field
 
@@ -384,24 +384,24 @@ section discrete_linear_ordered_field
      :  discrete_field A :=
      ⦃ discrete_field, s, has_decidable_eq := dec_eq_of_dec_lt⦄
 
-    theorem pos_of_div_pos (H : 0 < 1 / a) : 0 < a :=
-    have H1 : 0 < 1 / (1 / a), from div_pos_of_pos H,
+    theorem pos_of_one_div_pos (H : 0 < 1 / a) : 0 < a :=
+    have H1 : 0 < 1 / (1 / a), from one_div_pos_of_pos H,
     have H2 : 1 / a ≠ 0, from
       (assume H3 : 1 / a = 0,
       have H4 : 1 / (1 / a) = 0, from H3⁻¹ ▸ div_zero,
       absurd H4 (ne.symm (ne_of_lt H1))),
     (div_div (ne_zero_of_one_div_ne_zero H2)) ▸ H1
 
-  theorem neg_of_div_neg (H : 1 / a < 0) : a < 0 :=
+  theorem neg_of_one_div_neg (H : 1 / a < 0) : a < 0 :=
     have H1 : 0 < - (1 / a), from neg_pos_of_neg H,
     have Ha : a ≠ 0, from ne_zero_of_one_div_ne_zero (ne_of_lt H),
     have H2 : 0 < 1 / (-a), from (one_div_neg_eq_neg_one_div Ha)⁻¹ ▸ H1,
-    have H3 : 0 < -a, from pos_of_div_pos H2,
+    have H3 : 0 < -a, from pos_of_one_div_pos H2,
     neg_of_neg_pos H3
 
-  theorem le_of_div_le (H : 0 < a) (Hl : 1 / a ≤ 1 / b) : b ≤ a :=
-    have Hb : 0 < b, from pos_of_div_pos (calc
-      0   < 1 / a : div_pos_of_pos H
+  theorem le_of_one_div_le_one_div (H : 0 < a) (Hl : 1 / a ≤ 1 / b) : b ≤ a :=
+    have Hb : 0 < b, from pos_of_one_div_pos (calc
+      0   < 1 / a : one_div_pos_of_pos H
       ... ≤ 1 / b : Hl),
     have H' : 1 ≤ a / b, from (calc
       1   = a / a       : div_self (ne.symm (ne_of_lt H))
@@ -410,21 +410,21 @@ section discrete_linear_ordered_field
       ... = a / b       : div_eq_mul_one_div
       ), le_of_one_le_div Hb H'
 
-  theorem le_of_div_le_neg (H : b < 0) (Hl : 1 / a ≤ 1 / b) : b ≤ a :=
-    assert Ha : a ≠ 0, from ne_of_lt (neg_of_div_neg (calc
+  theorem le_of_one_div_le_one_div_of_neg (H : b < 0) (Hl : 1 / a ≤ 1 / b) : b ≤ a :=
+    assert Ha : a ≠ 0, from ne_of_lt (neg_of_one_div_neg (calc
       1 / a ≤ 1 / b : Hl
-        ... < 0     : div_neg_of_neg H)),
+        ... < 0     : one_div_neg_of_neg H)),
     have H'   : -b > 0,                from neg_pos_of_neg H,
     have Hl'  : - (1 / b) ≤ - (1 / a), from neg_le_neg Hl,
     have Hl'' : 1 / - b ≤ 1 / - a,     from calc
       1 / -b = - (1 / b) : by rewrite [one_div_neg_eq_neg_one_div (ne_of_lt H)]
          ... ≤ - (1 / a) : Hl'
          ... = 1 / -a    : by rewrite [one_div_neg_eq_neg_one_div Ha],
-    le_of_neg_le_neg (le_of_div_le H' Hl'')
+    le_of_neg_le_neg (le_of_one_div_le_one_div H' Hl'')
 
-  theorem lt_of_div_lt (H : 0 < a) (Hl : 1 / a < 1 / b) : b < a :=
-    have Hb : 0 < b, from pos_of_div_pos (calc
-      0   < 1 / a : div_pos_of_pos H
+  theorem lt_of_one_div_lt_one_div (H : 0 < a) (Hl : 1 / a < 1 / b) : b < a :=
+    have Hb : 0 < b, from pos_of_one_div_pos (calc
+      0   < 1 / a : one_div_pos_of_pos H
       ... < 1 / b : Hl),
     have H : 1 < a / b, from (calc
       1   = a / a       : div_self (ne.symm (ne_of_lt H))
@@ -433,47 +433,44 @@ section discrete_linear_ordered_field
       ... = a / b       : div_eq_mul_one_div),
       lt_of_one_lt_div Hb H
 
-
-  theorem lt_of_div_lt_neg (H : b < 0) (Hl : 1 / a < 1 / b) : b < a :=
-    have H1 : b ≤ a, from le_of_div_le_neg H (le_of_lt Hl),
+  theorem lt_of_one_div_lt_one_div_of_neg (H : b < 0) (Hl : 1 / a < 1 / b) : b < a :=
+    have H1 : b ≤ a, from le_of_one_div_le_one_div_of_neg H (le_of_lt Hl),
     have Hn : b ≠ a, from
       (assume Hn' : b = a,
       have Hl' : 1 / a = 1 / b, from Hn' ▸ refl _,
       absurd Hl' (ne_of_lt Hl)),
     lt_of_le_of_ne H1 Hn
 
-
   theorem div_lt_div_of_lt (Ha : 0 < a) (H : a < b) : 1 / b < 1 / a :=
     lt_of_not_ge
       (assume H',
-      absurd H (not_lt_of_ge (le_of_div_le Ha H')))
+      absurd H (not_lt_of_ge (le_of_one_div_le_one_div Ha H')))
 
   theorem div_le_div_of_le (Ha : 0 < a) (H : a ≤ b) : 1 / b ≤ 1 / a :=
     le_of_not_gt
       (assume H',
-      absurd H (not_le_of_gt (lt_of_div_lt Ha H')))
+      absurd H (not_le_of_gt (lt_of_one_div_lt_one_div Ha H')))
 
   theorem div_lt_div_of_lt_neg (Hb : b < 0) (H : a < b) : 1 / b < 1 / a :=
     lt_of_not_ge
       (assume H',
-      absurd H (not_lt_of_ge (le_of_div_le_neg Hb H')))
+      absurd H (not_lt_of_ge (le_of_one_div_le_one_div_of_neg Hb H')))
 
   theorem div_le_div_of_le_neg (Hb : b < 0) (H : a ≤ b) : 1 / b ≤ 1 / a :=
     le_of_not_gt
       (assume H',
-      absurd H (not_le_of_gt (lt_of_div_lt_neg Hb H')))
+      absurd H (not_le_of_gt (lt_of_one_div_lt_one_div_of_neg Hb H')))
 
-
-  theorem one_lt_div (H1 : 0 < a) (H2 : a < 1) : 1 < 1 / a :=
+  theorem one_lt_one_div (H1 : 0 < a) (H2 : a < 1) : 1 < 1 / a :=
     one_div_one ▸ div_lt_div_of_lt H1 H2
 
-  theorem one_le_div (H1 : 0 < a) (H2 : a ≤ 1) : 1 ≤ 1 / a :=
+  theorem one_le_one_div (H1 : 0 < a) (H2 : a ≤ 1) : 1 ≤ 1 / a :=
     one_div_one ▸ div_le_div_of_le H1 H2
 
-  theorem neg_one_lt_div_neg (H1 : a < 0) (H2 : -1 < a) : 1 / a < -1 :=
+  theorem one_div_lt_neg_one (H1 : a < 0) (H2 : -1 < a) : 1 / a < -1 :=
     one_div_neg_one_eq_neg_one ▸ div_lt_div_of_lt_neg H1 H2
 
-  theorem neg_one_le_div_neg (H1 : a < 0) (H2 : -1 ≤ a) : 1 / a ≤ -1 :=
+  theorem one_div_le_neg_one (H1 : a < 0) (H2 : -1 ≤ a) : 1 / a ≤ -1 :=
     one_div_neg_one_eq_neg_one ▸ div_le_div_of_le_neg H1 H2
 
   theorem div_lt_div_of_pos_of_lt_of_pos (Hb : 0 < b) (H : b < a) (Hc : 0 < c) : c / a < c / b :=
@@ -493,21 +490,21 @@ section discrete_linear_ordered_field
       rewrite [2 div_mul_eq_div_mul_one_div'],
       apply mul_le_mul_of_nonneg_right H,
       apply le_of_lt,
-      apply div_pos_of_pos He
+      apply one_div_pos_of_pos He
     end
 
   theorem abs_one_div : abs (1 / a) = 1 / abs a :=
     if H : a > 0 then
-      by rewrite [abs_of_pos H, abs_of_pos (div_pos_of_pos H)]
+      by rewrite [abs_of_pos H, abs_of_pos (one_div_pos_of_pos H)]
     else
       (if H' : a < 0 then
-          by rewrite [abs_of_neg H', abs_of_neg (div_neg_of_neg H'),
+          by rewrite [abs_of_neg H', abs_of_neg (one_div_neg_of_neg H'),
                          -(one_div_neg_eq_neg_one_div (ne_of_lt H'))]
        else
          assert Heq : a = 0, from eq_of_le_of_ge (le_of_not_gt H) (le_of_not_gt H'),
          by rewrite [Heq, div_zero, *abs_zero, div_zero])
 
-  theorem ge_sub_of_abs_sub_le_left (H : abs (a - b) ≤ c) : a ≥ b - c :=
+  theorem sub_le_of_abs_sub_le_left (H : abs (a - b) ≤ c) : b - c ≤ a :=
     if Hz : 0 ≤ a - b then
       (calc
         a ≥ b : (iff.mp !sub_nonneg_iff_le) Hz
@@ -517,8 +514,8 @@ section discrete_linear_ordered_field
        have Habs' : b ≤ c + a, from (iff.mpr !le_add_iff_sub_right_le) Habs,
        (iff.mp !le_add_iff_sub_left_le) Habs')
 
-  theorem ge_sub_of_abs_sub_le_right (H : abs (a - b) ≤ c) : b ≥ a - c :=
-    ge_sub_of_abs_sub_le_left (!abs_sub ▸ H)
+  theorem sub_le_of_abs_sub_le_right (H : abs (a - b) ≤ c) : a - c ≤ b :=
+    sub_le_of_abs_sub_le_left (!abs_sub ▸ H)
 
   theorem abs_sub_square : abs (a - b) * abs (a - b) = a * a + b * b - 2 * a * b :=
     by rewrite [abs_mul_abs_self, *mul_sub_left_distrib, *mul_sub_right_distrib,

--- a/library/algebra/ordered_ring.lean
+++ b/library/algebra/ordered_ring.lean
@@ -437,6 +437,17 @@ section
         ... ≤ b * c : mul_le_mul_of_nonneg_left Hc Hb,
     le_of_mul_le_mul_right H' (lt_of_lt_of_le zero_lt_one Hc)
 
+  theorem nonneg_le_nonneg_of_squares_le {a b : A} (Ha : a ≥ 0) (Hb : b ≥ 0) (H : a * a ≤ b * b) :
+      a ≤ b :=
+    begin
+      apply le_of_not_gt,
+      intro Hab,
+      let Hposa := lt_of_le_of_lt Hb Hab,
+      let H' := calc
+        b * b ≤ a * b : mul_le_mul_of_nonneg_right (le_of_lt Hab) Hb
+        ... < a * a : mul_lt_mul_of_pos_left Hab Hposa,
+      apply (not_le_of_gt H') H
+    end
 end
 
 /- TODO: Isabelle's library has all kinds of cancelation rules for the simplifier.
@@ -647,6 +658,41 @@ section
 
   theorem abs_mul_self (a : A) : abs (a * a) = a * a :=
   by rewrite [abs_mul, abs_mul_abs_self]
+
+  theorem sub_le_of_abs_sub_le_left (H : abs (a - b) ≤ c) : b - c ≤ a :=
+    if Hz : 0 ≤ a - b then
+      (calc
+        a ≥ b : (iff.mp !sub_nonneg_iff_le) Hz
+      ... ≥ b - c : sub_le_of_nonneg _ _ (le.trans !abs_nonneg H))
+    else
+      (have Habs : b - a ≤ c, by rewrite [abs_of_neg (lt_of_not_ge Hz) at H, neg_sub at H]; apply H,
+       have Habs' : b ≤ c + a, from (iff.mpr !le_add_iff_sub_right_le) Habs,
+       (iff.mp !le_add_iff_sub_left_le) Habs')
+
+  theorem sub_le_of_abs_sub_le_right (H : abs (a - b) ≤ c) : a - c ≤ b :=
+    sub_le_of_abs_sub_le_left (!abs_sub ▸ H)
+
+  theorem abs_sub_square (a b : A) : abs (a - b) * abs (a - b) = a * a + b * b - (1 + 1) * a * b :=
+    by rewrite [abs_mul_abs_self, *mul_sub_left_distrib, *mul_sub_right_distrib,
+             sub_add_eq_sub_sub, sub_neg_eq_add, *right_distrib, sub_add_eq_sub_sub, *one_mul,
+             *add.assoc, {_ + b * b}add.comm, {_ + (b * b + _)}add.comm, mul.comm b a, *add.assoc]
+
+  theorem abs_abs_sub_abs_le_abs_sub (a b : A) : abs (abs a - abs b) ≤ abs (a - b) :=
+  begin
+    apply nonneg_le_nonneg_of_squares_le,
+    repeat apply abs_nonneg,
+    rewrite [*abs_sub_square, *abs_abs, *abs_mul_abs_self],
+    apply sub_le_sub_left,
+    rewrite *mul.assoc,
+    apply mul_le_mul_of_nonneg_left,
+    rewrite -abs_mul,
+    apply le_abs_self,
+    apply le_of_lt,
+    apply add_pos,
+    apply zero_lt_one,
+    apply zero_lt_one
+  end
+
 end
 
 /- TODO: Multiplication and one, starting with mult_right_le_one_le. -/

--- a/library/algebra/ring_power.lean
+++ b/library/algebra/ring_power.lean
@@ -52,7 +52,32 @@ or.elim (eq_zero_or_pos m)
     obtain m' (h₂ : m = succ m'), from exists_eq_succ_of_pos `m > 0`,
     show a = 0, by rewrite h₂ at H; apply h₁ m' H)
 
+theorem pow_ne_zero_of_ne_zero {a : A} {m : ℕ} (H : a ≠ 0) : a^m ≠ 0 :=
+assume H', H (eq_zero_of_pow_eq_zero H')
+
 end integral_domain
+
+section division_ring
+variable [s : division_ring A]
+include s
+
+theorem division_ring.pow_ne_zero_of_ne_zero {a : A} {m : ℕ} (H : a ≠ 0) : a^m ≠ 0 :=
+or.elim (eq_zero_or_pos m)
+  (suppose m = 0,
+    by rewrite [`m = 0`, pow_zero]; exact (ne.symm zero_ne_one))
+  (suppose m > 0,
+    have h₁ : ∀ m, a^succ m ≠ 0,
+      begin
+        intro m,
+        induction m with m ih,
+          {rewrite pow_one; assumption},
+        rewrite pow_succ,
+        apply division_ring.mul_ne_zero H ih
+      end,
+    obtain m' (h₂ : m = succ m'), from exists_eq_succ_of_pos `m > 0`,
+    show a^m ≠ 0, by rewrite h₂; apply h₁ m')
+
+end division_ring
 
 section linear_ordered_semiring
 variable [s : linear_ordered_semiring A]
@@ -111,16 +136,29 @@ end
 
 end decidable_linear_ordered_comm_ring
 
+section field
+variable [s : field A]
+include s
+
+theorem field.div_pow (a : A) {b : A} {n : ℕ} (bnz : b ≠ 0) : (a / b)^n = a^n / b^n :=
+begin
+  induction n with n ih,
+    rewrite [*pow_zero, div_one],
+  have bnnz : b^n ≠ 0, from division_ring.pow_ne_zero_of_ne_zero bnz,
+  rewrite [*pow_succ, ih, !field.div_mul_div bnz bnnz]
+end
+
+end field
+
 section discrete_field
 variable [s : discrete_field A]
 include s
 
-theorem div_pow (a : A) {b : A} {n : ℕ} (bnz : b ≠ 0) : (a / b)^n = a^n / b^n :=
+theorem div_pow (a : A) {b : A} {n : ℕ} : (a / b)^n = a^n / b^n :=
 begin
   induction n with n ih,
     rewrite [*pow_zero, div_one],
-  have bnnz : b^n ≠ 0, from suppose b^n = 0, bnz (eq_zero_of_pow_eq_zero this),
-  rewrite [*pow_succ, ih, div_mul_div bnz bnnz]
+  rewrite [*pow_succ, ih, div_mul_div]
 end
 
 end discrete_field

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -212,6 +212,38 @@ theorem diff_union_cancel {s t : finset A} (H : s ⊆ t) : (t \ s) ∪ s = t :=
 eq.subst !union.comm (!union_diff_cancel H)
 end diff
 
+/- set complement -/
+section complement
+
+variables {A : Type} [deceqA : decidable_eq A] [h : fintype A]
+include deceqA h
+
+definition complement (s : finset A) : finset A := univ \ s
+prefix [priority finset.prio] - := complement
+
+theorem mem_complement {s : finset A} {x : A} (H : x ∉ s) : x ∈ -s :=
+mem_diff !mem_univ H
+
+theorem not_mem_of_mem_complement {s : finset A} {x : A} (H : x ∈ -s) : x ∉ s :=
+not_mem_of_mem_diff H
+
+theorem mem_complement_iff (s : finset A) (x : A) : x ∈ -s ↔ x ∉ s :=
+iff.intro not_mem_of_mem_complement mem_complement
+
+section
+  open classical
+
+  theorem union_eq_comp_comp_inter_comp (s t : finset A) : s ∪ t = -(-s ∩ -t) :=
+  ext (take x, by rewrite [mem_union_iff, mem_complement_iff, mem_inter_iff, *mem_complement_iff,
+                           or_iff_not_and_not])
+
+  theorem inter_eq_comp_comp_union_comp (s t : finset A) : s ∩ t = -(-s ∪ -t) :=
+  ext (take x, by rewrite [mem_inter_iff, mem_complement_iff, mem_union_iff, *mem_complement_iff,
+                           and_iff_not_or_not])
+end
+
+end complement
+
 /- all -/
 section all
 variables {A : Type}

--- a/library/data/int/div.lean
+++ b/library/data/int/div.lean
@@ -11,7 +11,6 @@ import data.int.order data.nat.div
 open [coercions] [reduce-hints] nat
 open [declarations] nat (succ)
 open eq.ops
-notation `ℕ` := nat
 
 namespace int
 

--- a/library/data/pnat.lean
+++ b/library/data/pnat.lean
@@ -185,7 +185,7 @@ theorem two_mul (p : ℕ+) : rat_of_pnat (2 * p) = (1 + 1) * rat_of_pnat p :=
 
 theorem add_halves (p : ℕ+) : (2 * p)⁻¹ + (2 * p)⁻¹ = p⁻¹ :=
   begin
-    rewrite [↑inv, -(@add_halves (1 / (rat_of_pnat p))), *div_div_eq_div_mul'],
+    rewrite [↑inv, -(@add_halves (1 / (rat_of_pnat p))), rat.div_div_eq_div_mul],
     have H : rat_of_pnat (2 * p) = rat_of_pnat p * (1 + 1), by rewrite [rat.mul.comm, two_mul],
     rewrite *H
   end
@@ -197,7 +197,7 @@ theorem add_halves_double (m n : ℕ+) :
   by rewrite [-add_halves m, -add_halves n, hsimp]
 
 theorem inv_mul_eq_mul_inv {p q : ℕ+} : (p * q)⁻¹ = p⁻¹ * q⁻¹ :=
-  by rewrite [↑inv, pnat_to_rat_mul, one_div_mul_one_div''']
+  by rewrite [↑inv, pnat_to_rat_mul, one_div_mul_one_div]
 
 theorem inv_mul_le_inv (p q : ℕ+) : (p * q)⁻¹ ≤ q⁻¹ :=
   begin
@@ -277,10 +277,9 @@ theorem pceil_helper {a : ℚ} {n : ℕ+} (H : pceil a ≤ n) (Ha : a > 0) : n�
   rat.le.trans (inv_ge_of_le H) (div_le_div_of_le Ha (ubound_ge a))
 
 theorem inv_pceil_div (a b : ℚ) (Ha : a > 0) (Hb : b > 0) : (pceil (a / b))⁻¹ ≤ b / a :=
-  div_div' ▸ div_le_div_of_le
+  !one_div_one_div ▸ div_le_div_of_le
     (one_div_pos_of_pos (div_pos_of_pos_of_pos Hb Ha))
-    ((div_div_eq_mul_div (ne_of_gt Hb) (ne_of_gt Ha))⁻¹ ▸
-      !rat.one_mul⁻¹ ▸ !ubound_ge)
+    (!div_div_eq_mul_div⁻¹ ▸ !rat.one_mul⁻¹ ▸ !ubound_ge)
 
 theorem sep_by_inv {a b : ℚ} (H : a > b) : ∃ N : ℕ+, a > (b + N⁻¹ + N⁻¹) :=
   begin
@@ -311,6 +310,6 @@ theorem nonneg_of_ge_neg_invs (a : ℚ) (H : ∀ n : ℕ+, -n⁻¹ ≤ a) : 0 �
           : !inv_pceil_div dec_trivial H2
                              ... < -a / 1
           : div_lt_div_of_pos_of_lt_of_pos dec_trivial dec_trivial H2
-                             ... = -a : div_one)))
+                             ... = -a : !div_one)))
 
 end pnat

--- a/library/data/pnat.lean
+++ b/library/data/pnat.lean
@@ -7,9 +7,7 @@ Basic facts about the positive natural numbers.
 
 Developed primarily for use in the construction of ℝ. For the most part, the only theorems here
 are those needed for that construction.
-
 -/
-
 import data.rat.order data.nat
 open nat rat subtype eq.ops
 
@@ -113,7 +111,7 @@ theorem pnat_le_of_rat_of_pnat_le {m n : ℕ+} (H : rat_of_pnat m ≤ rat_of_pna
 definition inv (n : ℕ+) : ℚ := (1 : ℚ) / rat_of_pnat n
 postfix `⁻¹` := inv
 
-theorem inv_pos (n : ℕ+) : n⁻¹ > 0 := div_pos_of_pos !rat_of_pnat_is_pos
+theorem inv_pos (n : ℕ+) : n⁻¹ > 0 := one_div_pos_of_pos !rat_of_pnat_is_pos
 
 theorem inv_le_one (n : ℕ+) : n⁻¹ ≤ (1 : ℚ) :=
   begin
@@ -180,7 +178,7 @@ theorem inv_gt_of_lt {p q : ℕ+} (H : p < q) : q⁻¹ < p⁻¹ :=
   div_lt_div_of_lt !rat_of_pnat_is_pos (rat_of_pnat_lt_of_pnat_lt H)
 
 theorem ge_of_inv_le {p q : ℕ+} (H : p⁻¹ ≤ q⁻¹) : q ≤ p :=
-  pnat_le_of_rat_of_pnat_le (le_of_div_le !rat_of_pnat_is_pos H)
+  pnat_le_of_rat_of_pnat_le (le_of_one_div_le_one_div !rat_of_pnat_is_pos H)
 
 theorem two_mul (p : ℕ+) : rat_of_pnat (2 * p) = (1 + 1) * rat_of_pnat p :=
   by rewrite pnat_to_rat_mul
@@ -280,13 +278,13 @@ theorem pceil_helper {a : ℚ} {n : ℕ+} (H : pceil a ≤ n) (Ha : a > 0) : n�
 
 theorem inv_pceil_div (a b : ℚ) (Ha : a > 0) (Hb : b > 0) : (pceil (a / b))⁻¹ ≤ b / a :=
   div_div' ▸ div_le_div_of_le
-    (div_pos_of_pos (pos_div_of_pos_of_pos Hb Ha))
+    (one_div_pos_of_pos (div_pos_of_pos_of_pos Hb Ha))
     ((div_div_eq_mul_div (ne_of_gt Hb) (ne_of_gt Ha))⁻¹ ▸
       !rat.one_mul⁻¹ ▸ !ubound_ge)
 
 theorem sep_by_inv {a b : ℚ} (H : a > b) : ∃ N : ℕ+, a > (b + N⁻¹ + N⁻¹) :=
   begin
-    apply exists.elim (find_midpoint H),
+    apply exists.elim (exists_add_lt_and_pos_of_lt H),
     intro c Hc,
     existsi (pceil ((1 + 1 + 1) / c)),
     apply rat.lt.trans,

--- a/library/data/rat/basic.lean
+++ b/library/data/rat/basic.lean
@@ -544,7 +544,7 @@ end migrate_algebra
 
 theorem eq_num_div_denom (a : ℚ) : a = num a / denom a :=
 have H : of_int (denom a) ≠ 0, from assume H', ne_of_gt (denom_pos a) (of_int.inj H'),
-iff.mpr (eq_div_iff_mul_eq H) (mul_denom a)
+iff.mpr (!eq_div_iff_mul_eq H) (mul_denom a)
 
 theorem of_int_div {a b : ℤ} (H : b ∣ a) : of_int (a div b) = of_int a / of_int b :=
 decidable.by_cases
@@ -556,7 +556,7 @@ decidable.by_cases
       int.dvd.elim H
         (take c, assume Hc : a = b * c,
           by rewrite [Hc, !int.mul_div_cancel_left bnz, mul.comm]),
-    iff.mpr (eq_div_iff_mul_eq bnz') H')
+    iff.mpr (!eq_div_iff_mul_eq bnz') H')
 
 theorem of_int_pow (a : ℤ) (n : ℕ) : of_int (a^n) = (of_int a)^n :=
 begin

--- a/library/data/rat/basic.lean
+++ b/library/data/rat/basic.lean
@@ -512,7 +512,7 @@ section migrate_algebra
     add_comm         := add.comm,
     mul              := mul,
     mul_assoc        := mul.assoc,
-    one              := (of_num 1),
+    one              := 1,
     one_mul          := one_mul,
     mul_one          := mul_one,
     left_distrib     := mul.left_distrib,

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -24,8 +24,8 @@ theorem s_mul_assoc_lemma_3 (a b n : ℕ+) (p : ℚ) :
 theorem s_mul_assoc_lemma_4 {n : ℕ+} {ε q : ℚ} (Hε : ε > 0) (Hq : q > 0) (H : n ≥ pceil (q / ε)) :
         q * n⁻¹ ≤ ε :=
   begin
-    let H2 := pceil_helper H (pos_div_of_pos_of_pos Hq Hε),
-    let H3 := mul_le_of_le_div (pos_div_of_pos_of_pos Hq Hε) H2,
+    let H2 := pceil_helper H (div_pos_of_pos_of_pos Hq Hε),
+    let H3 := mul_le_of_le_div (div_pos_of_pos_of_pos Hq Hε) H2,
     rewrite -(one_mul ε),
     apply mul_le_mul_of_mul_div_le,
     repeat assumption
@@ -49,7 +49,7 @@ theorem squeeze {a b : ℚ} (H : ∀ j : ℕ+, a ≤ b + j⁻¹ + j⁻¹ + j⁻�
   begin
     apply rat.le_of_not_gt,
     intro Hb,
-    cases find_midpoint Hb with [c, Hc],
+    cases exists_add_lt_and_pos_of_lt Hb with [c, Hc],
     cases find_thirds b c (and.right Hc) with [j, Hbj],
     have Ha : a > b + j⁻¹ + j⁻¹ + j⁻¹, from lt.trans Hbj (and.left Hc),
     apply (not_le_of_gt Ha) !H
@@ -59,7 +59,7 @@ theorem squeeze_2 {a b : ℚ} (H : ∀ ε : ℚ, ε > 0 → a ≥ b - ε) : a �
   begin
     apply rat.le_of_not_gt,
     intro Hb,
-    cases find_midpoint Hb with [c, Hc],
+    cases exists_add_lt_and_pos_of_lt Hb with [c, Hc],
     let Hc' := H c (and.right Hc),
     apply (rat.not_le_of_gt (and.left Hc)) (iff.mpr !le_add_iff_sub_right_le Hc')
   end
@@ -206,7 +206,7 @@ theorem pnat_bound {ε : ℚ} (Hε : ε > 0) : ∃ p : ℕ+, p⁻¹ ≤ ε :=
     rewrite -(rat.div_div (rat.ne_of_gt Hε)) at {2},
     apply pceil_helper,
     apply le.refl,
-    apply div_pos_of_pos Hε
+    apply one_div_pos_of_pos Hε
   end
 
 theorem bdd_of_eq_var {s t : seq} (Hs : regular s) (Ht : regular t) (Heq : s ≡ t) :
@@ -699,7 +699,7 @@ theorem mul_zero_equiv_zero {s t : seq} (Hs : regular s) (Ht : regular t) (Htz :
     apply zero_is_reg,
     intro ε Hε,
     let Bd := bdd_of_eq_var Ht zero_is_reg Htz (ε / (Kq s))
-                            (pos_div_of_pos_of_pos Hε (Kq_bound_pos Hs)),
+                            (div_pos_of_pos_of_pos Hε (Kq_bound_pos Hs)),
     cases Bd with [N, HN],
     existsi N,
     intro n Hn,

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -1028,10 +1028,17 @@ definition neg (x : ℝ) : ℝ :=
                                    quot.sound (rneg_well_defined Hab)))
 prefix [priority real.prio] `-` := neg
 
-definition zero : ℝ := quot.mk r_zero
+open rat -- no coercions before
+
+definition of_rat [coercion] (a : ℚ) : ℝ := quot.mk (s.r_const a)
+definition of_num [coercion] [reducible] (n : num) : ℝ := of_rat (rat.of_num n)
+
+--definition zero : ℝ := 0
+--definition one : ℝ := 1
+--definition zero : ℝ := quot.mk r_zero
 --notation 0 := zero
 
-definition one : ℝ := quot.mk r_one
+--definition one : ℝ := quot.mk r_one
 
 theorem add_comm (x y : ℝ) : x + y = y + x :=
   quot.induction_on₂ x y (λ s t, quot.sound (r_add_comm s t))
@@ -1039,13 +1046,13 @@ theorem add_comm (x y : ℝ) : x + y = y + x :=
 theorem add_assoc (x y z : ℝ) : x + y + z = x + (y + z) :=
   quot.induction_on₃ x y z (λ s t u, quot.sound (r_add_assoc s t u))
 
-theorem zero_add (x : ℝ) : zero + x = x :=
+theorem zero_add (x : ℝ) : 0 + x = x :=
   quot.induction_on x (λ s, quot.sound (r_zero_add s))
 
-theorem add_zero (x : ℝ) : x + zero = x :=
+theorem add_zero (x : ℝ) : x + 0 = x :=
   quot.induction_on x (λ s, quot.sound (r_add_zero s))
 
-theorem neg_cancel (x : ℝ) : -x + x = zero :=
+theorem neg_cancel (x : ℝ) : -x + x = 0 :=
   quot.induction_on x (λ s, quot.sound (r_neg_cancel s))
 
 theorem mul_assoc (x y z : ℝ) : x * y * z = x * (y * z) :=
@@ -1054,10 +1061,10 @@ theorem mul_assoc (x y z : ℝ) : x * y * z = x * (y * z) :=
 theorem mul_comm (x y : ℝ) : x * y = y * x :=
   quot.induction_on₂ x y (λ s t, quot.sound (r_mul_comm s t))
 
-theorem one_mul (x : ℝ) : one * x = x :=
+theorem one_mul (x : ℝ) : 1 * x = x :=
   quot.induction_on x (λ s, quot.sound (r_one_mul s))
 
-theorem mul_one (x : ℝ) : x * one = x :=
+theorem mul_one (x : ℝ) : x * 1 = x :=
   quot.induction_on x (λ s, quot.sound (r_mul_one s))
 
 theorem distrib (x y z : ℝ) : x * (y + z) = x * y + x * z :=
@@ -1066,8 +1073,8 @@ theorem distrib (x y z : ℝ) : x * (y + z) = x * y + x * z :=
 theorem distrib_l (x y z : ℝ) : (x + y) * z = x * z + y * z :=
   by rewrite [mul_comm, distrib, {x * _}mul_comm, {y * _}mul_comm] -- this shouldn't be necessary
 
-theorem zero_ne_one : ¬ zero = one :=
-  take H : zero = one,
+theorem zero_ne_one : ¬ (0 : ℝ) = 1 :=
+  take H : 0 = 1,
   absurd (quot.exact H) (r_zero_nequiv_one)
 
 protected definition comm_ring [reducible] : algebra.comm_ring ℝ :=
@@ -1075,7 +1082,7 @@ protected definition comm_ring [reducible] : algebra.comm_ring ℝ :=
     fapply algebra.comm_ring.mk,
     exact add,
     exact add_assoc,
-    exact zero,
+    exact of_num 0,
     exact zero_add,
     exact add_zero,
     exact neg,
@@ -1083,17 +1090,13 @@ protected definition comm_ring [reducible] : algebra.comm_ring ℝ :=
     exact add_comm,
     exact mul,
     exact mul_assoc,
-    apply one,
+    apply of_num 1,
     apply one_mul,
     apply mul_one,
     apply distrib,
     apply distrib_l,
     apply mul_comm
   end
-
-open rat -- no coercions before
-
-definition of_rat [coercion] (a : ℚ) : ℝ := quot.mk (s.r_const a)
 
 theorem of_rat_add (a b : ℚ) : of_rat a + of_rat b = of_rat (a + b) :=
    quot.sound (s.r_add_consts a b)

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -8,13 +8,12 @@ This construction follows Bishop and Bridges (1985).
 To do:
  o Rename things and possibly make theorems private
 -/
-
 import data.nat data.rat.order data.pnat
 open nat eq eq.ops pnat
 open -[coercions] rat
 local notation 0 := rat.of_num 0
 local notation 1 := rat.of_num 1
-----------------------------------------------------------------------------------------------------
+
 -- small helper lemmas
 
 theorem s_mul_assoc_lemma_3 (a b n : ℕ+) (p : ℚ) :
@@ -39,7 +38,7 @@ theorem find_thirds (a b : ℚ) (H : b > 0) : ∃ n : ℕ+, a + n⁻¹ + n⁻¹ 
               ... ≤ of_nat 4 * (b / of_nat 4)
                   : rat.mul_le_mul_of_nonneg_left (!inv_pceil_div dec_trivial H) !of_nat_nonneg
               ... = b / of_nat 4 * of_nat 4 : rat.mul.comm
-              ... = b : rat.div_mul_cancel dec_trivial,
+              ... = b : !rat.div_mul_cancel dec_trivial,
   exists.intro n (calc
     a + n⁻¹ + n⁻¹ + n⁻¹ = a + (1 + 1 + 1) * n⁻¹ : by rewrite[*rat.right_distrib,*rat.one_mul,-*rat.add.assoc]
                     ... = a + of_nat 3 * n⁻¹    : {show 1+1+1=of_nat 3, from dec_trivial}
@@ -203,7 +202,7 @@ theorem eq_of_bdd_var {s t : seq} (Hs : regular s) (Ht : regular t)
 theorem pnat_bound {ε : ℚ} (Hε : ε > 0) : ∃ p : ℕ+, p⁻¹ ≤ ε :=
   begin
     existsi (pceil (1 / ε)),
-    rewrite -(rat.div_div (rat.ne_of_gt Hε)) at {2},
+    rewrite -(rat.one_div_one_div ε) at {2},
     apply pceil_helper,
     apply le.refl,
     apply one_div_pos_of_pos Hε
@@ -621,7 +620,7 @@ theorem mul_bound_helper {s t : seq} (Hs : regular s) (Ht : regular t) (a b c : 
           apply rat.ne_of_gt,
           repeat (apply rat.mul_pos | apply rat.add_pos | apply rat_of_pnat_is_pos | apply inv_pos),
         end,
-        rewrite (rat.div_helper H),
+        rewrite (!rat.div_helper H),
         apply rat.le.refl
     end,
     apply rat.add_le_add,

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -738,8 +738,7 @@ theorem width (n : ℕ) : over_seq n - under_seq n = (over - under) / (rat.pow 2
       let Hou := calc
         (over_seq a) / 2 - (under_seq a) / 2 = ((over - under) / rat.pow 2 a) / 2 :
                                                by rewrite [rat.div_sub_div_same, Ha]
-        ... = (over - under) / (rat.pow 2 a * 2) :
-               rat.div_div_eq_div_mul (rat.ne_of_gt (rat.pow_pos dec_trivial _)) dec_trivial
+        ... = (over - under) / (rat.pow 2 a * 2) : rat.div_div_eq_div_mul
         ... = (over - under) / rat.pow 2 (a + 1) : by rewrite rat.pow_add,
       cases em (ub (avg_seq a)),
       rewrite [*if_pos a_1, -add_one, -Hou, ↑avg_seq, ↑avg, rat.add.assoc, rat.div_two_sub_self],

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -8,7 +8,6 @@ This construction follows Bishop and Bridges (1985).
 At this point, we no longer proceed constructively: this file makes heavy use of decidability
 and excluded middle.
 -/
-
 import data.real.basic data.real.order data.rat data.nat
 open -[coercions] rat
 open -[coercions] nat
@@ -196,11 +195,11 @@ theorem reg_inv_reg {s : seq} (Hs : regular s) (Hsep : sep s zero) : regular (s_
         apply add_invs_nonneg,
        rewrite [(s_inv_of_sep_lt_p Hs Hsep Hmlt),
                 (s_inv_of_sep_gt_p Hs Hsep (le_of_not_gt Hnlt))],
-       rewrite [(div_sub_div Hsp Hspn), div_eq_mul_one_div, *abs_mul, *mul_one, *one_mul],
+       rewrite [(!div_sub_div Hsp Hspn), div_eq_mul_one_div, *abs_mul, *mul_one, *one_mul],
        apply rat.le.trans,
        apply rat.mul_le_mul,
        apply Hs,
-       rewrite [-(mul_one 1), -(div_mul_div Hsp Hspn), abs_mul],
+       rewrite [-(mul_one 1), -(!field.div_mul_div Hsp Hspn), abs_mul],
        apply rat.mul_le_mul,
        rewrite -(s_inv_of_sep_lt_p Hs Hsep Hmlt),
        apply le_ps Hs Hsep,
@@ -218,11 +217,11 @@ theorem reg_inv_reg {s : seq} (Hs : regular s) (Hsep : sep s zero) : regular (s_
       cases em (n < ps Hs Hsep) with [Hnlt, Hnlt],
         rewrite [(s_inv_of_sep_lt_p Hs Hsep Hnlt),
                  (s_inv_of_sep_gt_p Hs Hsep (le_of_not_gt Hmlt))],
-        rewrite [(div_sub_div Hspm Hsp), div_eq_mul_one_div, *abs_mul, *mul_one, *one_mul],
+        rewrite [(!div_sub_div Hspm Hsp), div_eq_mul_one_div, *abs_mul, *mul_one, *one_mul],
         apply rat.le.trans,
         apply rat.mul_le_mul,
         apply Hs,
-        rewrite [-(mul_one 1), -(div_mul_div Hspm Hsp), abs_mul],
+        rewrite [-(mul_one 1), -(!field.div_mul_div Hspm Hsp), abs_mul],
         apply rat.mul_le_mul,
         rewrite -(s_inv_of_sep_gt_p Hs Hsep (le_of_not_gt Hmlt)),
         apply le_ps Hs Hsep,
@@ -239,11 +238,11 @@ theorem reg_inv_reg {s : seq} (Hs : regular s) (Hsep : sep s zero) : regular (s_
         apply Hnlt,
       rewrite [(s_inv_of_sep_gt_p Hs Hsep (le_of_not_gt Hnlt)),
               (s_inv_of_sep_gt_p Hs Hsep (le_of_not_gt Hmlt))],
-      rewrite [(div_sub_div Hspm Hspn), div_eq_mul_one_div, abs_mul, *one_mul, *mul_one],
+      rewrite [(!div_sub_div Hspm Hspn), div_eq_mul_one_div, abs_mul, *one_mul, *mul_one],
       apply rat.le.trans,
       apply rat.mul_le_mul,
       apply Hs,
-      rewrite [-(mul_one 1), -(div_mul_div Hspm Hspn), abs_mul],
+      rewrite [-(mul_one 1), -(!field.div_mul_div Hspm Hspn), abs_mul],
       apply rat.mul_le_mul,
       rewrite -(s_inv_of_sep_gt_p Hs Hsep (le_of_not_gt Hmlt)),
       apply le_ps Hs Hsep,
@@ -303,7 +302,7 @@ theorem mul_inv {s : seq} (Hs : regular s) (Hsep : sep s zero) : smul s (s_inv H
       s_ne_zero_of_ge_p Hs Hsep
         (show ps Hs Hsep ≤ ((ps Hs Hsep) * (ps Hs Hsep)) * ((K₂ s (s_inv Hs)) * 2 * n),
           by rewrite *pnat.mul.assoc; apply pnat.mul_le_mul_right),
-    rewrite [(s_inv_of_sep_gt_p Hs Hsep Hp), (div_div Hnz')],
+    rewrite [(s_inv_of_sep_gt_p Hs Hsep Hp), (division_ring.one_div_one_div Hnz')],
     apply rat.le.trans,
     apply rat.mul_le_mul_of_nonneg_left,
     apply Hs,

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -584,10 +584,10 @@ postfix [priority real.prio] `⁻¹` := inv
 theorem le_total (x y : ℝ) : x ≤ y ∨ y ≤ x :=
   quot.induction_on₂ x y (λ s t, s.r_le_total s t)
 
-theorem mul_inv' (x : ℝ) : x ≢ zero → x * x⁻¹ = one :=
+theorem mul_inv' (x : ℝ) : x ≢ 0 → x * x⁻¹ = 1 :=
   quot.induction_on x (λ s H, quot.sound (s.r_mul_inv s H))
 
-theorem inv_mul' (x : ℝ) : x ≢ zero → x⁻¹ * x = one :=
+theorem inv_mul' (x : ℝ) : x ≢ 0 → x⁻¹ * x = 1 :=
   by rewrite real.mul_comm; apply mul_inv'
 
 theorem neq_of_sep {x y : ℝ} (H : x ≢ y) : ¬ x = y :=
@@ -599,11 +599,11 @@ theorem sep_of_neq {x y : ℝ} : ¬ x = y → x ≢ y :=
 theorem sep_is_neq (x y : ℝ) : (x ≢ y) = (¬ x = y) :=
   propext (iff.intro neq_of_sep sep_of_neq)
 
-theorem mul_inv (x : ℝ) : x ≠ zero → x * x⁻¹ = one := !sep_is_neq ▸ !mul_inv'
+theorem mul_inv (x : ℝ) : x ≠ 0 → x * x⁻¹ = 1 := !sep_is_neq ▸ !mul_inv'
 
-theorem inv_mul (x : ℝ) : x ≠ zero → x⁻¹ * x = one := !sep_is_neq ▸ !inv_mul'
+theorem inv_mul (x : ℝ) : x ≠ 0 → x⁻¹ * x = 1 := !sep_is_neq ▸ !inv_mul'
 
-theorem inv_zero : zero⁻¹ = zero := quot.sound (s.r_inv_zero)
+theorem inv_zero : (0 : ℝ)⁻¹ = 0 := quot.sound (s.r_inv_zero)
 
 theorem lt_or_eq_of_le (x y : ℝ) : x ≤ y → x < y ∨ x = y :=
   quot.induction_on₂ x y (λ s t H, or.elim (s.r_lt_or_equiv_of_le s t H)

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -8,7 +8,6 @@ This construction follows Bishop and Bridges (1985).
 To do:
  o Rename things and possibly make theorems private
 -/
-
 import data.real.basic data.rat data.nat
 open -[coercions] rat
 open -[coercions] nat
@@ -881,9 +880,9 @@ theorem nat_inv_lt_rat {a : ℚ} (H : a > 0) : ∃ n : ℕ+, n⁻¹ < a :=
     apply lt_of_le_of_lt,
     rotate 1,
     apply div_two_lt_of_pos H,
-    rewrite -(@div_div' (a / (1 + 1))),
+    rewrite -(one_div_one_div (a / (1 + 1))),
     apply pceil_helper,
-    rewrite div_div',
+    rewrite one_div_one_div,
     apply pnat.le.refl,
     apply one_div_pos_of_pos,
     apply div_pos_of_pos_of_pos H dec_trivial

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -15,9 +15,7 @@ open -[coercions] nat
 open eq eq.ops pnat
 local notation 0 := rat.of_num 0
 local notation 1 := rat.of_num 1
-notation 2 := subtype.tag (of_num 2) dec_trivial
-
-----------------------------------------------------------------------------------------------------
+local notation 2 := subtype.tag (of_num 2) dec_trivial
 
 namespace s
 definition pos (s : seq) := ∃ n : ℕ+, n⁻¹ < (s n)
@@ -1026,8 +1024,8 @@ definition lt (x y : ℝ) := quot.lift_on₂ x y (λ a b, s.r_lt a b) s.r_lt_wel
 infix [priority real.prio] `<` := lt
 
 definition le (x y : ℝ) := quot.lift_on₂ x y (λ a b, s.r_le a b) s.r_le_well_defined
-infix [priority real.prio] `≤` := le
 infix [priority real.prio] `<=` := le
+infix [priority real.prio] `≤` := le
 
 definition gt [reducible] (a b : ℝ) := lt b a
 definition ge [reducible] (a b : ℝ) := le b a
@@ -1084,7 +1082,7 @@ theorem add_lt_add_left_var (x y z : ℝ) : x < y → z + x < z + y :=
 theorem add_lt_add_left (x y : ℝ) : x < y → ∀ z : ℝ, z + x < z + y :=
   take H z, add_lt_add_left_var x y z H
 
-theorem zero_lt_one : zero < one := s.r_zero_lt_one
+theorem zero_lt_one : (0 : ℝ) < (1 : ℝ) := s.r_zero_lt_one
 
 theorem le_of_lt_or_eq (x y : ℝ) : x < y ∨ x = y → x ≤ y :=
     (quot.induction_on₂ x y (λ s t H, or.elim H (take H', begin

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -82,7 +82,7 @@ theorem nonneg_of_bdd_within {s : seq} (Hs : regular s)
     cases H (pceil ((1 + 1) / ε)) with [N, HN],
     apply le.trans,
     rotate 1,
-    apply ge_sub_of_abs_sub_le_left,
+    apply sub_le_of_abs_sub_le_left,
     apply Hs,
     apply (max (pceil ((1+1)/ε)) N),
     rewrite [↑rat.sub, neg_add, {_ + (-k⁻¹ + _)}add.comm, *add.assoc],
@@ -115,7 +115,7 @@ theorem pos_of_pos_equiv {s t : seq} (Hs : regular s) (Heq : s ≡ t) (Hp : pos 
     existsi 2 * 2 * N,
     apply lt_of_lt_of_le,
     rotate 1,
-    apply ge_sub_of_abs_sub_le_right,
+    apply sub_le_of_abs_sub_le_right,
     apply Heq,
     have Hs4 : N⁻¹ ≤ s (2 * 2 * N), from HN _ (!mul_le_mul_left),
     apply lt_of_lt_of_le,
@@ -138,7 +138,7 @@ theorem nonneg_of_nonneg_equiv {s t : seq} (Hs : regular s) (Ht : regular t) (He
     intro m Hm,
     apply le.trans,
     rotate 1,
-    apply ge_sub_of_abs_sub_le_right,
+    apply sub_le_of_abs_sub_le_right,
     apply Heq,
     apply le.trans,
     rotate 1,
@@ -384,7 +384,7 @@ theorem le_and_sep_of_lt {s t : seq} (Hs : regular s) (Ht : regular t) (Lst : s_
     cases Lst with [N, HN],
     let Rns := reg_neg_reg Hs,
     let Rtns := reg_add_reg Ht Rns,
-    let Habs := ge_sub_of_abs_sub_le_right (Rtns N n),
+    let Habs := sub_le_of_abs_sub_le_right (Rtns N n),
     rewrite [sub_add_eq_sub_sub at Habs],
     exact (calc
       sadd t (sneg s) n ≥ sadd t (sneg s) N -  N⁻¹ - n⁻¹ : Habs
@@ -885,8 +885,8 @@ theorem nat_inv_lt_rat {a : ℚ} (H : a > 0) : ∃ n : ℕ+, n⁻¹ < a :=
     apply pceil_helper,
     rewrite div_div',
     apply pnat.le.refl,
-    apply div_pos_of_pos,
-    apply pos_div_of_pos_of_pos H dec_trivial
+    apply one_div_pos_of_pos,
+    apply div_pos_of_pos_of_pos H dec_trivial
   end
 
 

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -266,6 +266,25 @@ ext (take x, iff.intro
   (suppose x ∈ s, and.intro (ssubt this) this)
   (suppose x ∈ {x ∈ t | x ∈ s}, and.right this))
 
+/- complement -/
+
+definition complement (s : set X) : set X := {x | x ∉ s}
+prefix `-` := complement
+
+theorem mem_complement {s : set X} {x : X} (H : x ∉ s) : x ∈ -s := H
+
+theorem not_mem_of_mem_complement {s : set X} {x : X} (H : x ∈ -s) : x ∉ s := H
+
+section
+  open classical
+
+  theorem union_eq_comp_comp_inter_comp (s t : set X) : s ∪ t = -(-s ∩ -t) :=
+  ext (take x, !or_iff_not_and_not)
+
+  theorem inter_eq_comp_comp_union_comp (s t : set X) : s ∩ t = -(-s ∪ -t) :=
+  ext (take x, !and_iff_not_or_not)
+end
+
 /- set difference -/
 
 definition diff (s t : set X) : set X := {x ∈ s | x ∉ t}

--- a/library/init/nat.lean
+++ b/library/init/nat.lean
@@ -7,8 +7,9 @@ prelude
 import init.wf init.tactic init.num
 open eq.ops decidable or
 
+notation `ℕ` := nat
+
 namespace nat
-  notation `ℕ` := nat
 
   /- basic definitions on natural numbers -/
   inductive le (a : ℕ) : ℕ → Prop :=

--- a/library/logic/identities.lean
+++ b/library/logic/identities.lean
@@ -48,6 +48,14 @@ iff.intro
   (λH, by_cases (λa, or.inr (not.mto (and.intro a) H)) or.inl)
   (or.rec (not.mto and.left) (not.mto and.right))
 
+theorem or_iff_not_and_not {a b : Prop} [Da : decidable a] [Db : decidable b] :
+  a ∨ b ↔ ¬ (¬a ∧ ¬b) :=
+by rewrite [-not_or_iff_not_and_not, not_not_iff]
+
+theorem and_iff_not_or_not {a b : Prop} [Da : decidable a] [Db : decidable b] :
+  a ∧ b ↔ ¬ (¬ a ∨ ¬ b) :=
+by rewrite [-not_and_iff_not_or_not, not_not_iff]
+
 theorem imp_iff_not_or {a b : Prop} [Da : decidable a] : (a → b) ↔ ¬a ∨ b :=
 iff.intro
   (by_cases (λHa H, or.inr (H Ha)) (λHa H, or.inl Ha))

--- a/library/theories/number_theory/irrational_roots.lean
+++ b/library/theories/number_theory/irrational_roots.lean
@@ -73,8 +73,8 @@ section
   have b ≠ 0, from ne_of_gt (denom_pos q),
   have bnz : b ≠ (0 : ℚ), from assume H, `b ≠ 0` (of_int.inj H),
   have bnnz : (#rat b^n ≠ 0), from assume bneqz, bnz (eq_zero_of_pow_eq_zero bneqz),
-  have a^n / b^n = c, using bnz, by rewrite [*of_int_pow, -(!div_pow bnz), -eq_num_div_denom, -H],
-  have a^n = c * b^n, from eq.symm (mul_eq_of_eq_div bnnz this⁻¹),
+  have a^n / b^n = c, using bnz, by rewrite [*of_int_pow, -div_pow, -eq_num_div_denom, -H],
+  have a^n = c * b^n, from eq.symm (!mul_eq_of_eq_div bnnz this⁻¹),
   have a^n = c * b^n,  -- int version
     using this, by rewrite [-of_int_pow at this, -of_int_mul at this]; exact of_int.inj this,
   have (abs a)^n = abs c * (abs b)^n,


### PR DESCRIPTION
There are three things worth mentioning.

First, I modified the definition of the reals so that the numerals 0 and 1 are used by migrate; otherwise, e.g., `add_zero` is `x + zero = x`, and fails to rewrite `t + 0`. Getting migrate to work was tricky and I still don't fully understand what the issues are, though things seem to be o.k. now. See the commit message to 0385ba6.

Second, I renamed lots of theorems in fields and ordered_fields to be more consistent with conventions followed elsewhere in the library, and set implicit /explicit arguments. (@rlewis tended to leave everything implicit.) There are a lot of theorems that are proved for division rings and fields, and then proved in a stronger form for discrete fields, where we assume x / 0 = 0. I made an executive decision as to how to handle that (but can be talked out of it). See the commit message to cc67d59.

Finally, I defined "-s" to be set complement in set and finset. In `init`, we have

``` lean
reserve prefix `¬`:40
reserve prefix `~`:40

reserve prefix `-`:100
```

I think we set the binding power of `~` low because we intended to use it as an ASCII equivalent to ¬. But we never defined that notation. So we now have some options:
- use `~` for not
- set the prefix binding power of `~` to 100, and use it instead of `-` for set complement.
- keep `-` for set complement, and leave `~` unused for now.
  If nobody has any opinions about this, I'll stick with the third.
