### PR TITLE
changes in HoTT

### DIFF
--- a/hott/algebra/category/adjoint.hlean
+++ b/hott/algebra/category/adjoint.hlean
@@ -4,12 +4,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 
-import algebra.category.constructions .constructions function arity
+import algebra.category.constructions function arity
 
-open category functor nat_trans eq is_trunc iso equiv prod trunc function
+open category functor nat_trans eq is_trunc iso equiv prod trunc function pi is_equiv
 
 namespace category
-  variables {C D : Precategory} {F : C ⇒ D}
+  variables {C D : Precategory} {F : C ⇒ D} {G : D ⇒ C}
 
   -- do we want to have a structure "is_adjoint" and define
   -- structure is_left_adjoint (F : C ⇒ D) :=
@@ -18,8 +18,8 @@ namespace category
 
   structure is_left_adjoint [class] (F : C ⇒ D) :=
     (G : D ⇒ C)
-    (η : functor.id ⟹ G ∘f F)
-    (ε : F ∘f G ⟹ functor.id)
+    (η : 1 ⟹ G ∘f F)
+    (ε : F ∘f G ⟹ 1)
     (H : Π(c : C), (ε (F c)) ∘ (F (η c)) = ID (F c))
     (K : Π(d : D), (G (ε d)) ∘ (η (G d)) = ID (G d))
 
@@ -39,31 +39,23 @@ namespace category
     (is_iso_unit : is_iso η)
     (is_iso_counit : is_iso ε)
 
+  abbreviation inverse := @is_equivalence.G
+  postfix `⁻¹` := inverse
+  --a second notation for the inverse, which is not overloaded
+  postfix [parsing-only] `⁻¹F`:std.prec.max_plus := inverse
+
   structure equivalence (C D : Precategory) :=
     (to_functor : C ⇒ D)
     (struct : is_equivalence to_functor)
 
   --TODO: review and change
-  --TODO: make some or all of these structures?
-  definition faithful (F : C ⇒ D) :=
-  Π⦃c c' : C⦄ (f f' : c ⟶ c'), F f = F f' → f = f'
-
-  definition full (F : C ⇒ D) := Π⦃c c' : C⦄ (g : F c ⟶ F c'), ∃(f : c ⟶ c'), F f = g
-
-  definition fully_faithful [reducible] (F : C ⇒ D) :=
-  Π⦃c c' : C⦄, is_equiv (@(to_fun_hom F) c c')
-
-  definition split_essentially_surjective (F : C ⇒ D) :=
-  Π⦃d : D⦄, Σ(c : C), F c ≅ d
-
-  definition essentially_surjective (F : C ⇒ D) :=
-  Π⦃d : D⦄, ∃(c : C), F c ≅ d
-
-  definition is_weak_equivalence (F : C ⇒ D) :=
-  fully_faithful F × essentially_surjective F
-
-  definition is_isomorphism (F : C ⇒ D) :=
-  fully_faithful F × is_equiv (to_fun_ob F)
+  definition faithful [class] (F : C ⇒ D) := Π⦃c c' : C⦄ ⦃f f' : c ⟶ c'⦄, F f = F f' → f = f'
+  definition full [class] (F : C ⇒ D) := Π⦃c c' : C⦄, is_surjective (@(to_fun_hom F) c c')
+  definition fully_faithful [class] (F : C ⇒ D) := Π(c c' : C), is_equiv (@(to_fun_hom F) c c')
+  definition split_essentially_surjective [class] (F : C ⇒ D) := Π(d : D), Σ(c : C), F c ≅ d
+  definition essentially_surjective [class] (F : C ⇒ D) := Π(d : D), ∃(c : C), F c ≅ d
+  definition is_weak_equivalence [class] (F : C ⇒ D) := fully_faithful F × essentially_surjective F
+  definition is_isomorphism [class] (F : C ⇒ D) := fully_faithful F × is_equiv (to_fun_ob F)
 
   structure isomorphism (C D : Precategory) :=
     (to_functor : C ⇒ D)
@@ -73,43 +65,115 @@ namespace category
   infix `⋍`:25 := equivalence -- \backsimeq or \equiv
   infix `≌`:25 := isomorphism -- \backcong or \iso
 
-/-
-  definition is_hprop_is_left_adjoint {C : Category} {D : Precategory} (F : C ⇒ D)
-    : is_hprop (is_left_adjoint F) :=
-  begin
-    apply is_hprop.mk,
-    intro G G', cases G with G η ε H K, cases G' with G' η' ε' H' K',
-    fapply (apd011111 is_left_adjoint.mk),
-    { fapply functor_eq,
-      { intro d, apply eq_of_iso, fapply iso.MK,
-        { exact (G' (ε d) ∘ η' (G d))},
-        { exact (G (ε' d) ∘ η (G' d))},
-        { apply sorry /-rewrite [assoc, -{((G (ε' d)) ∘ (η (G' d))) ∘ (G' (ε d))}(assoc)],-/
---        apply concat, apply (ap (λc, c ∘ η' _)), rewrite -assoc, apply idp
-},
--- rewrite [-nat_trans.assoc] apply sorry
----assoc (G (ε' d)) (η (G' d)) (G' (ε d))
-        { apply sorry}},
-      { apply sorry},
-},
-    { apply sorry},
-    { apply sorry},
-    { apply is_hprop.elim},
-    { apply is_hprop.elim},
+  definition is_equiv_of_fully_faithful [instance] (F : C ⇒ D) [H : fully_faithful F] (c c' : C)
+    : is_equiv (@(to_fun_hom F) c c') :=
+  !H
+
+  definition is_iso_unit [instance] (F : C ⇒ D) (H : is_equivalence F) : is_iso (unit F) :=
+  !is_equivalence.is_iso_unit
+
+  definition is_iso_counit [instance] (F : C ⇒ D) (H : is_equivalence F) : is_iso (counit F) :=
+  !is_equivalence.is_iso_counit
+
+  -- theorem is_hprop_is_left_adjoint {C : Category} {D : Precategory} (F : C ⇒ D)
+  --   : is_hprop (is_left_adjoint F) :=
+  -- begin
+  --   apply is_hprop.mk,
+  --   intro G G', cases G with G η ε H K, cases G' with G' η' ε' H' K',
+  --   assert lem : Π(p : G = G'), p ▸ η = η' → p ▸ ε = ε'
+  --     → is_left_adjoint.mk G η ε H K = is_left_adjoint.mk G' η' ε' H' K',
+  --   { intros p q r, induction p, induction q, induction r, esimp,
+  --     apply apd011 (is_left_adjoint.mk G η ε) !is_hprop.elim !is_hprop.elim},
+  --   fapply lem,
+  --   { fapply functor.eq_of_pointwise_iso,
+  --     { fapply change_natural_map,
+  --       { exact (G' ∘fn1 ε) ∘n !assoc_natural_rev ∘n (η' ∘1nf G)},
+  --       { intro d, exact (G' (ε d) ∘ η' (G d))},
+  --       { intro d, exact ap (λx, _ ∘ x) !id_left}},
+  --     { intro d, fconstructor,
+  --       { exact (G (ε' d) ∘ η (G' d))},
+  --       { krewrite [▸*,assoc,-assoc (G (ε' d))],
+  --         krewrite [nf_fn_eq_fn_nf_pt' G' ε η d],
+  --         krewrite [assoc,-assoc],
+  --         rewrite [↑functor.compose, -respect_comp G],
+  --         krewrite [nf_fn_eq_fn_nf_pt ε ε' d,nf_fn_eq_fn_nf_pt η' η (G d),▸*],
+  --         rewrite [respect_comp G],
+  --         krewrite [assoc,-assoc (G (ε d))],
+  --         rewrite [↑functor.compose, -respect_comp G],
+  --         krewrite [H' (G d)],
+  --         rewrite [respect_id,id_right],
+  --         apply K},
+  --       { krewrite [▸*,assoc,-assoc (G' (ε d))],
+  --         krewrite [nf_fn_eq_fn_nf_pt' G ε' η' d],
+  --         krewrite [assoc,-assoc],
+  --         rewrite [↑functor.compose, -respect_comp G'],
+  --         krewrite [nf_fn_eq_fn_nf_pt ε' ε d,nf_fn_eq_fn_nf_pt η η' (G' d),▸*],
+  --         rewrite [respect_comp G'],
+  --         krewrite [assoc,-assoc (G' (ε' d))],
+  --         rewrite [↑functor.compose, -respect_comp G'],
+  --         krewrite [H (G' d)],
+  --         rewrite [respect_id,id_right],
+  --         apply K'}}},
+  --   { clear lem, refine transport_hom_of_eq_right _ η ⬝ _,
+  --     krewrite hom_of_eq_compose_right,
+  --     rewrite functor.hom_of_eq_eq_of_pointwise_iso,
+  --     apply nat_trans_eq, intro c, esimp,
+  --     refine !assoc⁻¹ ⬝ ap (λx, _ ∘ x) (nf_fn_eq_fn_nf_pt η η' c) ⬝ !assoc ⬝ _,
+  --     rewrite [▸*,-respect_comp G',H c,respect_id G',id_left]},
+  --   { clear lem, refine transport_hom_of_eq_left _ ε ⬝ _,
+  --     krewrite inv_of_eq_compose_left,
+  --     rewrite functor.inv_of_eq_eq_of_pointwise_iso,
+  --     apply nat_trans_eq, intro d, esimp,
+  --     rewrite [respect_comp,assoc,nf_fn_eq_fn_nf_pt ε' ε d,-assoc,▸*,H (G' d),id_right]},
+  -- end
+
+  section
+    variables (F G)
+    variables (η : G ∘f F ≅ 1) (ε : F ∘f G ≅ 1)
+    include η ε
+    --definition inverse_of_unit_counit
+
+    definition is_equivalence.mk : is_equivalence F :=
+    begin
+      exact sorry
+    end
+
   end
 
-  definition is_equivalence.mk (F : C ⇒ D) (G : D ⇒ C) (η : G ∘f F ≅ functor.id)
-    (ε : F ∘f G ≅ functor.id) : is_equivalence F :=
-  sorry
-
   definition full_of_fully_faithful (H : fully_faithful F) : full F :=
-  sorry --  λc c' g, exists.intro ((@(to_fun_hom F) c c')⁻¹ g) _
+  λc c', is_surjective.mk (λg, tr (fiber.mk ((@(to_fun_hom F) c c')⁻¹ᶠ g) !right_inv))
 
   definition faithful_of_fully_faithful (H : fully_faithful F) : faithful F :=
   λc c' f f' p, is_injective_of_is_embedding p
 
   definition fully_faithful_of_full_of_faithful (H : faithful F) (K : full F) : fully_faithful F :=
-  sorry
+  begin
+    intro c c',
+    apply is_equiv_of_is_surjective_of_is_embedding,
+    { apply is_embedding_of_is_injective,
+      intros f f' p, exact H p},
+    { apply K}
+  end
+
+  definition fully_faithful_of_is_equivalence (F : C ⇒ D) [H : is_equivalence F]
+    : fully_faithful F :=
+  begin
+    intro c c',
+    fapply adjointify,
+    { intro g, exact natural_map (@(iso.inverse (unit F)) !is_iso_unit) c' ∘ F⁻¹ g ∘ unit F c},
+    { intro g, rewrite [+respect_comp], exact sorry},
+    { exact sorry},
+  end
+
+  definition split_essentially_surjective_of_is_equivalence (F : C ⇒ D) [H : is_equivalence F]
+    : split_essentially_surjective F :=
+  begin
+   intro d, fconstructor,
+   { exact F⁻¹ d},
+   { exact componentwise_iso (@(iso.mk (counit F)) !is_iso_counit) d}
+  end
+
+/-
 
   definition fully_faithful_equiv (F : C ⇒ D) : fully_faithful F ≃ (faithful F × full F) :=
   sorry
@@ -132,12 +196,12 @@ namespace category
   sorry
 
   definition is_isomorphism_equiv1 (F : C ⇒ D) : is_equivalence F
-    ≃ Σ(G : D ⇒ C) (η : functor.id = G ∘f F) (ε : F ∘f G = functor.id),
+    ≃ Σ(G : D ⇒ C) (η : 1 = G ∘f F) (ε : F ∘f G = 1),
         sorry ▸ ap (λ(H : C ⇒ C), F ∘f H) η = ap (λ(H : D ⇒ D), H ∘f F) ε⁻¹ :=
   sorry
 
   definition is_isomorphism_equiv2 (F : C ⇒ D) : is_equivalence F
-    ≃ ∃(G : D ⇒ C), functor.id = G ∘f F × F ∘f G = functor.id :=
+    ≃ ∃(G : D ⇒ C), 1 = G ∘f F × F ∘f G = 1 :=
   sorry
 
   definition is_equivalence_of_isomorphism (H : is_isomorphism F) : is_equivalence F :=

--- a/hott/algebra/category/constructions/opposite.hlean
+++ b/hott/algebra/category/constructions/opposite.hlean
@@ -38,7 +38,7 @@ namespace category
   definition opposite_opposite : Opposite (Opposite C) = C :=
   (ap (Precategory.mk C) (opposite_opposite' C)) ⬝ !Precategory.eta
 
-  postfix `ᵒᵖ`:(max+1) := Opposite
+  postfix `ᵒᵖ`:(max+2) := Opposite
 
   definition opposite_functor [reducible] {C D : Precategory} (F : C ⇒ D) : Cᵒᵖ ⇒ Dᵒᵖ :=
   begin
@@ -47,6 +47,6 @@ namespace category
       intros, apply (@respect_comp C D)
   end
 
-  infixr `ᵒᵖᶠ`:(max+1) := opposite_functor
+  infixr `ᵒᵖᶠ`:(max+2) := opposite_functor
 
 end category

--- a/hott/algebra/category/functor.hlean
+++ b/hott/algebra/category/functor.hlean
@@ -26,7 +26,8 @@ namespace functor
 
   -- The following lemmas will later be used to prove that the type of
   -- precategories forms a precategory itself
-  protected definition compose [reducible] (G : functor D E) (F : functor C D) : functor C E :=
+  protected definition compose [reducible] [constructor] (G : functor D E) (F : functor C D)
+    : functor C E :=
   functor.mk
     (λ x, G (F x))
     (λ a b f, G (F f))
@@ -39,10 +40,11 @@ namespace functor
 
   infixr `∘f`:60 := functor.compose
 
-  protected definition id [reducible] {C : Precategory} : functor C C :=
+  protected definition id [reducible] [constructor] {C : Precategory} : functor C C :=
   mk (λa, a) (λ a b f, f) (λ a, idp) (λ a b c f g, idp)
 
-  protected definition ID [reducible] (C : Precategory) : functor C C := @functor.id C
+  protected definition ID [reducible] [constructor] (C : Precategory) : functor C C := @functor.id C
+  notation 1 := functor.id
 
   definition functor_mk_eq' {F₁ F₂ : C → D} {H₁ : Π(a b : C), hom a b → hom (F₁ a) (F₁ b)}
     {H₂ : Π(a b : C), hom a b → hom (F₂ a) (F₂ b)} (id₁ id₂ comp₁ comp₂)
@@ -53,7 +55,7 @@ namespace functor
   definition functor_eq' {F₁ F₂ : C ⇒ D}
     : Π(p : to_fun_ob F₁ = to_fun_ob F₂),
           (transport (λx, Πa b f, hom (x a) (x b)) p (to_fun_hom F₁) = to_fun_hom F₂) → F₁ = F₂ :=
-  functor.rec_on F₁ (λO₁ H₁ id₁ comp₁, functor.rec_on F₂ (λO₂ H₂ id₂ comp₂ p, !functor_mk_eq'))
+  by induction F₁; induction F₂; apply functor_mk_eq'
 
   definition functor_mk_eq {F₁ F₂ : C → D} {H₁ : Π(a b : C), hom a b → hom (F₁ a) (F₁ b)}
     {H₂ : Π(a b : C), hom a b → hom (F₂ a) (F₂ b)} (id₁ id₂ comp₁ comp₂) (pF : F₁ ~ F₂)
@@ -68,7 +70,7 @@ namespace functor
 
   definition functor_eq {F₁ F₂ : C ⇒ D} : Π(p : to_fun_ob F₁ ~ to_fun_ob F₂),
     (Π(a b : C) (f : hom a b), hom_of_eq (p b) ∘ F₁ f ∘ inv_of_eq (p a) = F₂ f) → F₁ = F₂ :=
-  functor.rec_on F₁ (λO₁ H₁ id₁ comp₁, functor.rec_on F₂ (λO₂ H₂ id₂ comp₂ p, !functor_mk_eq))
+  by induction F₁; induction F₂; apply functor_mk_eq
 
   definition functor_mk_eq_constant {F : C → D} {H₁ : Π(a b : C), hom a b → hom (F a) (F b)}
     {H₂ : Π(a b : C), hom a b → hom (F a) (F b)} (id₁ id₂ comp₁ comp₂)
@@ -108,13 +110,13 @@ namespace functor
       H ∘f (G ∘f F) = (H ∘f G) ∘f F :=
   !functor_mk_eq_constant (λa b f, idp)
 
-  protected definition id_left  (F : C ⇒ D) : functor.id ∘f F = F :=
+  protected definition id_left  (F : C ⇒ D) : 1 ∘f F = F :=
   functor.rec_on F (λF1 F2 F3 F4, !functor_mk_eq_constant (λa b f, idp))
 
-  protected definition id_right (F : C ⇒ D) : F ∘f functor.id = F :=
+  protected definition id_right (F : C ⇒ D) : F ∘f 1 = F :=
   functor.rec_on F (λF1 F2 F3 F4, !functor_mk_eq_constant (λa b f, idp))
 
-  protected definition comp_id_eq_id_comp (F : C ⇒ D) : F ∘f functor.id = functor.id ∘f F :=
+  protected definition comp_id_eq_id_comp (F : C ⇒ D) : F ∘f 1 = 1 ∘f F :=
   !functor.id_right ⬝ !functor.id_left⁻¹
 
   -- "functor C D" is equivalent to a certain sigma type

--- a/hott/algebra/category/iso.hlean
+++ b/hott/algebra/category/iso.hlean
@@ -206,7 +206,15 @@ namespace iso
     variables {X : Type} {x y : X} {F G : X → ob}
     definition transport_hom_of_eq (p : F = G) (f : hom (F x) (F y))
       : p ▸ f = hom_of_eq (apd10 p y) ∘ f ∘ inv_of_eq (apd10 p x) :=
-    eq.rec_on p !id_leftright⁻¹
+    by induction p; exact !id_leftright⁻¹
+
+    definition transport_hom_of_eq_right (p : x = y) (f : hom c (F x))
+      : p ▸ f = hom_of_eq (ap F p) ∘ f :=
+    by induction p; exact !id_left⁻¹
+
+    definition transport_hom_of_eq_left (p : x = y) (f : hom (F x) c)
+      : p ▸ f = f ∘ inv_of_eq (ap F p) :=
+    by induction p; exact !id_right⁻¹
 
     definition transport_hom (p : F ~ G) (f : hom (F x) (F y))
       : eq_of_homotopy p ▸ f = hom_of_eq (p y) ∘ f ∘ inv_of_eq (p x) :=

--- a/hott/book.md
+++ b/hott/book.md
@@ -23,7 +23,7 @@ The rows indicate the chapters, the columns the sections.
 | Ch 6  | . | + | + | + | + | ½ | ½ | ¼ | ¼ | ¼  | ¾  | -  | .  |    |    |
 | Ch 7  | + | + | + | - | - | - | - |   |   |    |    |    |    |    |    |
 | Ch 8  | ¾ | - | - | - | - | - | - | - | - | -  |    |    |    |    |    |
-| Ch 9  | ¾ | + | ¼ | ¼ | ½ | ½ | - | - | - |    |    |    |    |    |    |
+| Ch 9  | ¾ | + | + | ¼ | ½ | ½ | - | - | - |    |    |    |    |    |    |
 | Ch 10 | - | - | - | - | - |   |   |   |   |    |    |    |    |    |    |
 | Ch 11 | - | - | - | - | - | - |   |   |   |    |    |    |    |    |    |
 
@@ -155,7 +155,7 @@ Every file is in the folder [algebra.category](algebra/category/category.md)
 
 - 9.1 (Categories and precategories): [precategory](algebra/category/precategory.hlean), [iso](algebra/category/iso.hlean), [category](algebra/category/category.hlean), [groupoid](algebra/category/groupoid.hlean) (mostly)
 - 9.2 (Functors and transformations): [functor](algebra/category/functor.hlean), [nat_trans](algebra/category/nat_trans.hlean), [constructions.functor](algebra/category/constructions/functor.hlean)
-- 9.3 (Adjunctions): [adjoint](algebra/category/adjoint.hlean) (only definition)
+- 9.3 (Adjunctions): [adjoint](algebra/category/adjoint.hlean)
 - 9.4 (Equivalences): [adjoint](algebra/category/adjoint.hlean) (only definitions)
 - 9.5 (The Yoneda lemma): [constructions.opposite](algebra/category/constructions/opposite.hlean), [constructions.product](algebra/category/constructions/product.hlean), [yoneda](algebra/category/yoneda.hlean) (up to definition of Yoneda embedding)
 - 9.6 (Strict categories): [strict](algebra/category/strict.hlean) (only definition)

--- a/hott/book.md
+++ b/hott/book.md
@@ -17,7 +17,7 @@ The rows indicate the chapters, the columns the sections.
 |-------|---|---|---|---|---|---|---|---|---|----|----|----|----|----|----|
 | Ch 1  | . | . | . | . | + | + | + | + | + | .  | +  | +  |    |    |    |
 | Ch 2  | + | + | + | + | . | + | + | + | + | +  | +  | +  | +  | +  | +  |
-| Ch 3  | + | - | + | + | ½ | + | + | - | ½ | .  | +  |    |    |    |    |
+| Ch 3  | + | + | + | + | ½ | + | + | - | ½ | .  | +  |    |    |    |    |
 | Ch 4  | - | + | - | + | . | + | - | - | + |    |    |    |    |    |    |
 | Ch 5  | - | . | - | - | - | . | . | ½ |   |    |    |    |    |    |    |
 | Ch 6  | . | + | + | + | + | ½ | ½ | ¼ | ¼ | ¼  | ¾  | -  | .  |    |    |
@@ -69,8 +69,8 @@ Chapter 2: Homotopy type theory
 Chapter 3: Sets and logic
 ---------
 
-- 3.1 (Sets and n-types): [init.trunc](init/trunc.hlean)
-- 3.2 (Propositions as types?): not formalized
+- 3.1 (Sets and n-types): [init.trunc](init/trunc.hlean). Example 3.1.9 in [types.univ](types/univ.hlean)
+- 3.2 (Propositions as types?): [types.univ](types/univ.hlean)
 - 3.3 (Mere propositions): [init.trunc](init/trunc.hlean) and [hprop_trunc](hprop_trunc.hlean) (Lemma 3.3.5).
 - 3.4 (Classical vs. intuitionistic logic): decidable is defined in [init.logic](init/logic.hlean)
 - 3.5 (Subsets and propositional resizing): Lemma 3.5.1 is subtype_eq in [types.sigma](types/sigma.hlean), we don't have propositional resizing as axiom yet.

--- a/hott/book.md
+++ b/hott/book.md
@@ -17,7 +17,7 @@ The rows indicate the chapters, the columns the sections.
 |-------|---|---|---|---|---|---|---|---|---|----|----|----|----|----|----|
 | Ch 1  | . | . | . | . | + | + | + | + | + | .  | +  | +  |    |    |    |
 | Ch 2  | + | + | + | + | . | + | + | + | + | +  | +  | +  | +  | +  | +  |
-| Ch 3  | + | + | + | + | ½ | + | + | - | ½ | .  | +  |    |    |    |    |
+| Ch 3  | + | + | + | + | ½ | + | + | - | + | .  | +  |    |    |    |    |
 | Ch 4  | - | + | - | + | . | + | - | - | + |    |    |    |    |    |    |
 | Ch 5  | - | . | - | - | - | . | . | ½ |   |    |    |    |    |    |    |
 | Ch 6  | . | + | + | + | + | ½ | ½ | ¼ | ¼ | ¼  | ¾  | -  | .  |    |    |
@@ -77,7 +77,7 @@ Chapter 3: Sets and logic
 - 3.6 (The logic of mere propositions): in the corresponding file in the [types](types/types.md) folder. (is_trunc_prod is defined in [types.sigma](types/sigma.hlean))
 - 3.7 (Propositional truncation): [init.hit](init/hit.hlean) and [hit.trunc](hit/trunc.hlean)
 - 3.8 (The axiom of choice): not formalized
-- 3.9 (The principle of unique choice): Lemma 9.3.1 is equiv_trunc in [hit.trunc](hit/trunc.hlean), Lemma 9.3.2 is not formalized
+- 3.9 (The principle of unique choice): Lemma 9.3.1 in [hit.trunc](hit/trunc.hlean), Lemma 9.3.2 in [types.trunc](types/trunc.hlean)
 - 3.10 (When are propositions truncated?): no formalizable content
 - 3.11 (Contractibility): [init.trunc](init/trunc.hlean) (mostly), [types.pi](types/pi.hlean) (Lemma 3.11.6), [types.trunc](types/trunc.hlean) (Lemma 3.11.7), [types.sigma](types/sigma.hlean) (Lemma 3.11.9) 
 

--- a/hott/cubical/square.hlean
+++ b/hott/cubical/square.hlean
@@ -101,13 +101,102 @@ namespace eq
     square (p a) (p a') (ap f q) (ap g q) :=
   eq.rec_on q vrfl
 
+  /- canceling, whiskering and moving thinks along the sides of the square -/
   definition whisker_tl (p : a = a₀₀) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
     : square (p ⬝ p₁₀) p₁₂ (p ⬝ p₀₁) p₂₁ :=
-  by induction s₁₁;induction p;exact ids
+  by induction s₁₁;induction p;constructor
 
   definition whisker_br (p : a₂₂ = a) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
     : square p₁₀ (p₁₂ ⬝ p) p₀₁ (p₂₁ ⬝ p) :=
   by induction p;exact s₁₁
+
+  definition whisker_rt (p : a = a₂₀) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
+    : square (p₁₀ ⬝ p⁻¹) p₁₂ p₀₁ (p ⬝ p₂₁) :=
+  by induction s₁₁;induction p;constructor
+
+  definition whisker_tr (p : a₂₀ = a) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
+    : square (p₁₀ ⬝ p) p₁₂ p₀₁ (p⁻¹ ⬝ p₂₁) :=
+  by induction s₁₁;induction p;constructor
+
+  definition whisker_bl (p : a = a₀₂) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
+    : square p₁₀ (p ⬝ p₁₂) (p₀₁ ⬝ p⁻¹) p₂₁ :=
+  by induction s₁₁;induction p;constructor
+
+  definition whisker_lb (p : a₀₂ = a) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
+    : square p₁₀ (p⁻¹ ⬝ p₁₂) (p₀₁ ⬝ p) p₂₁ :=
+  by induction s₁₁;induction p;constructor
+
+  definition cancel_tl (p : a = a₀₀) (s₁₁ : square (p ⬝ p₁₀) p₁₂ (p ⬝ p₀₁) p₂₁)
+    : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction p; rewrite +idp_con at s₁₁; exact s₁₁
+
+  definition cancel_br (p : a₂₂ = a) (s₁₁ : square p₁₀ (p₁₂ ⬝ p) p₀₁ (p₂₁ ⬝ p))
+    : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction p;exact s₁₁
+
+  definition cancel_rt (p : a = a₂₀) (s₁₁ : square (p₁₀ ⬝ p⁻¹) p₁₂ p₀₁ (p ⬝ p₂₁))
+    : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction p; rewrite idp_con at s₁₁; exact s₁₁
+
+  definition cancel_tr (p : a₂₀ = a) (s₁₁ : square (p₁₀ ⬝ p) p₁₂ p₀₁ (p⁻¹ ⬝ p₂₁))
+    : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction p; rewrite [▸* at s₁₁,idp_con at s₁₁]; exact s₁₁
+
+  definition cancel_bl (p : a = a₀₂) (s₁₁ : square p₁₀ (p ⬝ p₁₂) (p₀₁ ⬝ p⁻¹) p₂₁)
+    : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction p; rewrite idp_con at s₁₁; exact s₁₁
+
+  definition cancel_lb (p : a₀₂ = a) (s₁₁ : square p₁₀ (p⁻¹ ⬝ p₁₂) (p₀₁ ⬝ p) p₂₁)
+    : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction p; rewrite [▸* at s₁₁,idp_con at s₁₁]; exact s₁₁
+
+  definition move_top_of_left   {p : a₀₀ = a} {q : a = a₀₂} (s : square p₁₀ p₁₂ (p ⬝ q) p₂₁)
+    : square (p⁻¹ ⬝ p₁₀) p₁₂ q p₂₁ :=
+  by apply cancel_tl p; rewrite con_inv_cancel_left; exact s
+
+  definition move_top_of_left'  {p : a = a₀₀} {q : a = a₀₂} (s : square p₁₀ p₁₂ (p⁻¹ ⬝ q) p₂₁)
+    : square (p ⬝ p₁₀) p₁₂ q p₂₁ :=
+  by apply cancel_tl p⁻¹; rewrite inv_con_cancel_left; exact s
+
+  definition move_left_of_top   {p : a₀₀ = a} {q : a = a₂₀} (s : square (p ⬝ q) p₁₂ p₀₁ p₂₁)
+    : square q p₁₂ (p⁻¹ ⬝ p₀₁) p₂₁ :=
+  by apply cancel_tl p; rewrite con_inv_cancel_left; exact s
+
+  definition move_left_of_top'  {p : a = a₀₀} {q : a = a₂₀} (s : square (p⁻¹ ⬝ q) p₁₂ p₀₁ p₂₁)
+    : square q p₁₂ (p ⬝ p₀₁) p₂₁ :=
+  by apply cancel_tl p⁻¹; rewrite inv_con_cancel_left; exact s
+
+  definition move_bot_of_right  {p : a₂₀ = a} {q : a = a₂₂} (s : square p₁₀ p₁₂ p₀₁ (p ⬝ q))
+    : square p₁₀ (p₁₂ ⬝ q⁻¹) p₀₁ p :=
+  by apply cancel_br q; rewrite inv_con_cancel_right; exact s
+
+  definition move_bot_of_right' {p : a₂₀ = a} {q : a₂₂ = a} (s : square p₁₀ p₁₂ p₀₁ (p ⬝ q⁻¹))
+    : square p₁₀ (p₁₂ ⬝ q) p₀₁ p :=
+  by apply cancel_br q⁻¹; rewrite con_inv_cancel_right; exact s
+
+  definition move_right_of_bot  {p : a₀₂ = a} {q : a = a₂₂} (s : square p₁₀ (p ⬝ q) p₀₁ p₂₁)
+    : square p₁₀ p p₀₁ (p₂₁ ⬝ q⁻¹) :=
+  by apply cancel_br q; rewrite inv_con_cancel_right; exact s
+
+  definition move_right_of_bot' {p : a₀₂ = a} {q : a₂₂ = a} (s : square p₁₀ (p ⬝ q⁻¹) p₀₁ p₂₁)
+    : square p₁₀ p p₀₁ (p₂₁ ⬝ q) :=
+  by apply cancel_br q⁻¹; rewrite con_inv_cancel_right; exact s
+
+  definition move_top_of_right  {p : a₂₀ = a} {q : a = a₂₂} (s : square p₁₀ p₁₂ p₀₁ (p ⬝ q))
+    : square (p₁₀ ⬝ p) p₁₂ p₀₁ q :=
+  by apply cancel_rt p; rewrite con_inv_cancel_right; exact s
+
+  definition move_right_of_top  {p : a₀₀ = a} {q : a = a₂₀} (s : square (p ⬝ q) p₁₂ p₀₁ p₂₁)
+    : square p p₁₂ p₀₁ (q ⬝ p₂₁) :=
+  by apply cancel_tr q; rewrite inv_con_cancel_left; exact s
+
+  definition move_bot_of_left   {p : a₀₀ = a} {q : a = a₀₂} (s : square p₁₀ p₁₂ (p ⬝ q) p₂₁)
+    : square  p₁₀ (q ⬝ p₁₂) p p₂₁ :=
+  by apply cancel_lb q; rewrite inv_con_cancel_left; exact s
+
+  definition move_left_of_bot   {p : a₀₂ = a} {q : a = a₂₂} (s : square p₁₀ (p ⬝ q) p₀₁ p₂₁)
+    : square p₁₀ q (p₀₁ ⬝ p) p₂₁ :=
+  by apply cancel_bl p; rewrite con_inv_cancel_right; exact s
 
   /- some higher ∞-groupoid operations -/
 
@@ -125,7 +214,7 @@ namespace eq
   by induction s₁₁; apply idp
 
   definition square_of_eq (r : p₁₀ ⬝ p₂₁ = p₀₁ ⬝ p₁₂) : square p₁₀ p₁₂ p₀₁ p₂₁ :=
-  by induction p₁₂; esimp [concat] at r; induction r; induction p₂₁; induction p₁₀; exact ids
+  by induction p₁₂; esimp at r; induction r; induction p₂₁; induction p₁₀; exact ids
 
   definition eq_top_of_square [unfold 10] (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
     : p₁₀ = p₀₁ ⬝ p₁₂ ⬝ p₂₁⁻¹ :=

--- a/hott/cubical/squareover.hlean
+++ b/hott/cubical/squareover.hlean
@@ -103,9 +103,17 @@ namespace eq
   square.rec_on q idso
 
   -- relating pathovers to squareovers
-  definition pathover_of_squareover (t₁₁ : squareover B s₁₁ q₁₀ q₁₂ q₀₁ q₂₁)
+  definition pathover_of_squareover' (t₁₁ : squareover B s₁₁ q₁₀ q₁₂ q₀₁ q₂₁)
     : q₁₀ ⬝o q₂₁ =[eq_of_square s₁₁] q₀₁ ⬝o q₁₂ :=
   by induction t₁₁; constructor
+
+  definition pathover_of_squareover {s : p₁₀ ⬝ p₂₁ = p₀₁ ⬝ p₁₂}
+    (t₁₁ : squareover B (square_of_eq s) q₁₀ q₁₂ q₀₁ q₂₁)
+    : q₁₀ ⬝o q₂₁ =[s] q₀₁ ⬝o q₁₂ :=
+  begin
+    revert s t₁₁, refine equiv_rect' !square_equiv_eq⁻¹ᵉ (λa b, squareover B b _ _ _ _ → _) _,
+    intro s, exact pathover_of_squareover'
+  end
 
   definition squareover_of_pathover {s : p₁₀ ⬝ p₂₁ = p₀₁ ⬝ p₁₂}
     (r : q₁₀ ⬝o q₂₁ =[s] q₀₁ ⬝o q₁₂) : squareover B (square_of_eq s) q₁₀ q₁₂ q₀₁ q₂₁ :=
@@ -119,6 +127,14 @@ namespace eq
   (r : q₁₀ =[s] q₀₁ ⬝o q₁₂ ⬝o q₂₁⁻¹ᵒ)
     : squareover B (square_of_eq_top s) q₁₀ q₁₂ q₀₁ q₂₁ :=
   by induction q₂₁; induction q₁₂; esimp at r;induction r;induction q₁₀;constructor
+
+  definition pathover_of_hdeg_squareover {p₀₁' : a₀₀ = a₀₂} {r : p₀₁ = p₀₁'} {q₀₁' : b₀₀ =[p₀₁'] b₀₂}
+    (t : squareover B (hdeg_square r) idpo idpo q₀₁ q₀₁') : q₀₁ =[r] q₀₁' :=
+  by induction r; induction q₀₁'; exact (pathover_of_squareover' t)⁻¹ᵒ
+
+  definition pathover_of_vdeg_squareover {p₁₀' : a₀₀ = a₂₀} {r : p₁₀ = p₁₀'} {q₁₀' : b₀₀ =[p₁₀'] b₂₀}
+    (t : squareover B (vdeg_square r) q₁₀ q₁₀' idpo idpo) : q₁₀ =[r] q₁₀' :=
+  by induction r; induction q₁₀'; exact pathover_of_squareover' t
 
   definition squareover_of_eq_top (r : change_path (eq_top_of_square s₁₁) q₁₀ = q₀₁ ⬝o q₁₂ ⬝o q₂₁⁻¹ᵒ)
     : squareover B s₁₁ q₁₀ q₁₂ q₀₁ q₂₁ :=

--- a/hott/function.hlean
+++ b/hott/function.hlean
@@ -91,6 +91,39 @@ namespace function
     exact H,
   end
 
+  -- definition is_hprop_is_split_surjective [instance] (f : A → B) : is_hprop (is_split_surjective f) :=
+  -- begin
+  --   have H : (Π(b : B), fiber f b) ≃ is_split_surjective f,
+  --   begin
+  --     fapply equiv.MK,
+  --       {exact is_split_surjective.mk},
+  --       {intro h, cases h, exact elim},
+  --       {intro h, cases h, apply idp},
+  --       {intro p, apply idp},
+  --   end,
+  --   apply is_trunc_equiv_closed,
+  --   exact H,
+  --   apply is_trunc_pi, intro b,
+  --   apply is_trunc_equiv_closed_rev,
+  --   apply fiber.sigma_char,
+  -- end
+
+  -- definition is_hprop_is_retraction [instance] (f : A → B) : is_hprop (is_retraction f) :=
+  -- begin
+  --   have H : (Σ(g : B → A), Πb, f (g b) = b) ≃ is_retraction f,
+  --   begin
+  --     fapply equiv.MK,
+  --       {intro x, induction x with g p, constructor, exact p},
+  --       {intro h, induction h, apply sigma.mk, assumption},
+  --       {intro h, induction h, reflexivity},
+  --       {intro x, induction x, reflexivity},
+  --   end,
+  --   apply is_trunc_equiv_closed,
+  --   exact H,
+  --   apply is_trunc_of_imp_is_trunc, intro x, induction x with g p,
+  --   apply is_contr_right_inverse
+  -- end
+
   definition is_embedding_of_is_equiv [instance] (f : A → B) [H : is_equiv f] : is_embedding f :=
   is_embedding.mk _
 

--- a/hott/function.hlean
+++ b/hott/function.hlean
@@ -26,6 +26,16 @@ structure is_retraction [class] (f : A → B) :=
   (sect : B → A)
   (right_inverse : Π(b : B), f (sect b) = b)
 
+definition is_weakly_constant [class] (f : A → B) (a a' : A) := f a = f a'
+
+structure is_constant [class] (f : A → B) :=
+  (pt : B)
+  (eq : Π(a : A), f a = pt)
+
+structure conditionally_constant [class] (f : A → B) :=
+  (g : ∥A∥ → B)
+  (eq : Π(a : A), f a = g (tr a))
+
 namespace function
 
   attribute is_embedding.elim [instance]

--- a/hott/hit/circle.hlean
+++ b/hott/hit/circle.hlean
@@ -144,7 +144,7 @@ namespace circle
 
   theorem elim_type_loop_inv (Pbase : Type) (Ploop : Pbase ≃ Pbase) :
     transport (circle.elim_type Pbase Ploop) loop⁻¹ = to_inv Ploop :=
-  by rewrite [tr_inv_fn,↑to_inv]; apply inv_eq_inv; apply elim_type_loop
+  by rewrite [tr_inv_fn]; apply inv_eq_inv; apply elim_type_loop
 end circle
 
 attribute circle.base1 circle.base2 circle.base [constructor]
@@ -245,7 +245,7 @@ namespace circle
   --the carrier of π₁(S¹) is the set-truncation of base = base.
   open core algebra trunc equiv.ops
   definition fg_carrier_equiv_int : π₁(S¹) ≃ ℤ :=
-  trunc_equiv_trunc 0 base_eq_base_equiv ⬝e !equiv_trunc⁻¹ᵉ
+  trunc_equiv_trunc 0 base_eq_base_equiv ⬝e !trunc_equiv
 
   definition con_comm_base (p q : base = base) : p ⬝ q = q ⬝ p :=
   eq_of_fn_eq_fn base_eq_base_equiv (by esimp;rewrite [+encode_con,add.comm])

--- a/hott/hit/trunc.hlean
+++ b/hott/hit/trunc.hlean
@@ -41,8 +41,8 @@ namespace trunc
              (λaa, trunc.rec_on aa (λa, idp))
              (λa, idp)
 
-  definition equiv_trunc [H : is_trunc n A] : A ≃ trunc n A :=
-  equiv.mk tr _
+  definition trunc_equiv [H : is_trunc n A] : trunc n A ≃ A :=
+  (equiv.mk tr _)⁻¹ᵉ
 
   definition is_trunc_of_is_equiv_tr [H : is_equiv (@tr n A)] : is_trunc n A :=
   is_trunc_is_equiv_closed n (@tr n _)⁻¹
@@ -128,7 +128,7 @@ namespace trunc
     : trunc n (Σ x, P x) ≃ Σ x, trunc n (P x) :=
   calc
     trunc n (Σ x, P x) ≃ trunc n (Σ x, trunc n (P x)) : trunc_sigma_equiv
-      ... ≃ Σ x, trunc n (P x) : equiv.symm !equiv_trunc
+      ... ≃ Σ x, trunc n (P x) : !trunc_equiv
   end
 
 end trunc

--- a/hott/init/equiv.hlean
+++ b/hott/init/equiv.hlean
@@ -69,7 +69,7 @@ namespace is_equiv
   parameters {A B : Type} (f : A → B) (g : B → A)
             (ret : Πb, f (g b) = b) (sec : Πa, g (f a) = a)
 
-  private definition adjointify_left_inv' (a : A) : g (f a) = a :=
+  private abbreviation adjointify_left_inv' (a : A) : g (f a) = a :=
   ap g (ap f (inverse (sec a))) ⬝ ap g (ret (f a)) ⬝ sec a
 
   private definition adjointify_adj' (a : A) : ret (f a) = ap f (adjointify_left_inv' a) :=
@@ -93,7 +93,7 @@ namespace is_equiv
       ... = (ap f (sec a)⁻¹ ⬝ (ret fgfa)⁻¹) ⬝ (fgretrfa ⬝ ap f (sec a))   : by rewrite ap_inv
       ... = ((ap f (sec a)⁻¹ ⬝ (ret fgfa)⁻¹) ⬝ fgretrfa) ⬝ ap f (sec a)   : by rewrite con.assoc'
       ... = ((retrfa⁻¹ ⬝ ap (f ∘ g) (ap f (sec a)⁻¹)) ⬝ fgretrfa) ⬝ ap f (sec a) : by rewrite con_ap_eq_con
-      ... = ((retrfa⁻¹ ⬝ fgfinvsect) ⬝ fgretrfa) ⬝ ap f (sec a)           : by rewrite ap_compose
+ ... = ((retrfa⁻¹ ⬝ fgfinvsect) ⬝ fgretrfa) ⬝ ap f (sec a)           : by rewrite ap_compose
       ... = (retrfa⁻¹ ⬝ (fgfinvsect ⬝ fgretrfa)) ⬝ ap f (sec a)           : by rewrite con.assoc'
       ... = retrfa⁻¹ ⬝ ap f (ap g (ap f (sec a)⁻¹) ⬝ ap g (ret (f a))) ⬝ ap f (sec a)   : by rewrite ap_con
       ... = retrfa⁻¹ ⬝ (ap f (ap g (ap f (sec a)⁻¹) ⬝ ap g (ret (f a))) ⬝ ap f (sec a)) : by rewrite con.assoc'
@@ -121,7 +121,8 @@ namespace is_equiv
              (λ b, ap f !Hty⁻¹ ⬝ right_inv f b)
              (λ a, !Hty⁻¹ ⬝ left_inv f a)
 
-  definition is_equiv_up [instance] [constructor] (A : Type) : is_equiv (up : A → lift A) :=
+  definition is_equiv_up [instance] [constructor] (A : Type)
+    : is_equiv (up : A → lift A) :=
   adjointify up down (λa, by induction a;reflexivity) (λa, idp)
 
   section
@@ -142,6 +143,12 @@ namespace is_equiv
 
   definition eq_of_fn_eq_fn' {x y : A} (q : f x = f y) : x = y :=
   (left_inv f x)⁻¹ ⬝ ap f⁻¹ q ⬝ left_inv f y
+
+  theorem ap_eq_of_fn_eq_fn' {x y : A} (q : f x = f y) : ap f (eq_of_fn_eq_fn' f q) = q :=
+  begin
+    rewrite [↑eq_of_fn_eq_fn',+ap_con,ap_inv,-+adj,-ap_compose,con.assoc,
+             ap_con_eq_con_ap (right_inv f) q,inv_con_cancel_left,ap_id],
+  end
 
   definition is_equiv_ap [instance] (x y : A) : is_equiv (ap f : x = y → f x = f y) :=
     adjointify
@@ -168,9 +175,11 @@ namespace is_equiv
   -- once pulled back along an equivalence f : A → B, then it has a section
   -- over all of B.
 
-  definition is_equiv_rect (P : B → Type) :
-      (Πx, P (f x)) → (Πy, P y) :=
-    (λg y, eq.transport _ (right_inv f y) (g (f⁻¹ y)))
+  definition is_equiv_rect (P : B → Type) (g : Πa, P (f a)) (b : B) : P b :=
+  right_inv f b ▸ g (f⁻¹ b)
+
+  definition is_equiv_rect' (P : A → B → Type) (g : Πb, P (f⁻¹ b) b) (a : A) : P a (f a) :=
+  left_inv f a ▸ g (f a)
 
   definition is_equiv_rect_comp (P : B → Type)
       (df : Π (x : A), P (f x)) (x : A) : is_equiv_rect f P df (f x) = df x :=
@@ -180,6 +189,13 @@ namespace is_equiv
         ... = ap f (left_inv f x) ▸ df (f⁻¹ (f x)) : by rewrite -adj
         ... = left_inv f x ▸ df (f⁻¹ (f x))        : by rewrite -tr_compose
         ... = df x                                 : by rewrite (apd df (left_inv f x))
+
+  theorem adj_inv (b : B) : left_inv f (f⁻¹ b) = ap f⁻¹ (right_inv f b) :=
+  is_equiv_rect f _
+    (λa,
+      eq.cancel_right (whisker_left _ !ap_id⁻¹ ⬝ (ap_con_eq_con_ap (left_inv f) (left_inv f a))⁻¹) ⬝
+      !ap_compose ⬝ ap02 f⁻¹ (adj f a)⁻¹)
+    b
 
   end
 
@@ -202,9 +218,28 @@ namespace is_equiv
   end
 
   --Transporting is an equivalence
-  definition is_equiv_tr [instance] [constructor] {A : Type} (P : A → Type) {x y : A} (p : x = y)
-    : (is_equiv (transport P p)) :=
+  definition is_equiv_tr [instance] [constructor] {A : Type} (P : A → Type) {x y : A}
+    (p : x = y) : (is_equiv (transport P p)) :=
   is_equiv.mk _ (transport P p⁻¹) (tr_inv_tr p) (inv_tr_tr p) (tr_inv_tr_lemma p)
+
+  section
+  variables {A : Type} {B C : A → Type} (f : Π{a}, B a → C a) [H : Πa, is_equiv (@f a)]
+    {g : A → A} (h : Π{a}, B a → B (g a)) (h' : Π{a}, C a → C (g a))
+  include H
+  definition inv_commute' (p : Π⦃a : A⦄ (b : B a), f (h b) = h' (f b)) {a : A} (c : C a) :
+    f⁻¹ (h' c) = h (f⁻¹ c) :=
+  eq_of_fn_eq_fn' f (right_inv f (h' c) ⬝ ap h' (right_inv f c)⁻¹ ⬝ (p (f⁻¹ c))⁻¹)
+
+  definition fun_commute_of_inv_commute' (p : Π⦃a : A⦄ (c : C a), f⁻¹ (h' c) = h (f⁻¹ c))
+    {a : A} (b : B a) : f (h b) = h' (f b) :=
+  eq_of_fn_eq_fn' f⁻¹ (left_inv f (h b) ⬝ ap h (left_inv f b)⁻¹ ⬝ (p (f b))⁻¹)
+
+  definition ap_inv_commute' (p : Π⦃a : A⦄ (b : B a), f (h b) = h' (f b)) {a : A} (c : C a) :
+    ap f (inv_commute' @f @h @h' p c)
+      = right_inv f (h' c) ⬝ ap h' (right_inv f c)⁻¹ ⬝ (p (f⁻¹ c))⁻¹ :=
+  !ap_eq_of_fn_eq_fn'
+
+  end
 
 end is_equiv
 open is_equiv
@@ -216,7 +251,7 @@ namespace eq
     p⁻¹ ▸ b = (transport B p)⁻¹ b := idp
 
   definition cast_inv_fn {A B : Type} (p : A = B) : cast p⁻¹ = (cast p)⁻¹ := idp
-  definition cast_inv {A B : Type} (p : A = B) (b : B) : cast p⁻¹ b = (cast p)⁻¹ b :=  idp
+  definition cast_inv {A B : Type} (p : A = B) (b : B) : cast p⁻¹ b = (cast p)⁻¹ b := idp
 end eq
 
 namespace equiv
@@ -228,6 +263,7 @@ namespace equiv
 
   infix `≃`:25 := equiv
 
+  section
   variables {A B C : Type}
 
   protected definition MK [reducible] [constructor] (f : A → B) (g : B → A)
@@ -291,9 +327,11 @@ namespace equiv
 
   definition equiv_lift (A : Type) : A ≃ lift A := equiv.mk up _
 
-  definition equiv_rect (f : A ≃ B) (P : B → Type) :
-      (Πx, P (f x)) → (Πy, P y) :=
-    (λg y, eq.transport _ (right_inv f y) (g (f⁻¹ y)))
+  definition equiv_rect (f : A ≃ B) (P : B → Type) (g : Πa, P (f a)) (b : B) : P b :=
+  right_inv f b ▸ g (f⁻¹ b)
+
+  definition equiv_rect' (f : A ≃ B) (P : A → B → Type) (g : Πb, P (f⁻¹ b) b) (a : A) : P a (f a) :=
+  left_inv f a ▸ g (f a)
 
   definition equiv_rect_comp (f : A ≃ B) (P : B → Type)
       (df : Π (x : A), P (f x)) (x : A) : equiv_rect f P df (f x) = df x :=
@@ -303,11 +341,34 @@ namespace equiv
         ... = ap f (left_inv f x) ▸ df (f⁻¹ (f x)) : by rewrite -adj
         ... = left_inv f x ▸ df (f⁻¹ (f x))        : by rewrite -tr_compose
         ... = df x                                 : by rewrite (apd df (left_inv f x))
+  end
+
+  section
+  variables {A : Type} {B C : A → Type} (f : Π{a}, B a ≃ C a)
+            {g : A → A} (h : Π{a}, B a → B (g a)) (h' : Π{a}, C a → C (g a))
+
+  definition inv_commute (p : Π⦃a : A⦄ (b : B a), f (h b) = h' (f b)) {a : A} (c : C a) :
+    f⁻¹ (h' c) = h (f⁻¹ c) :=
+  inv_commute' @f @h @h' p c
+
+  definition fun_commute_of_inv_commute (p : Π⦃a : A⦄ (c : C a), f⁻¹ (h' c) = h (f⁻¹ c))
+    {a : A} (b : B a) : f (h b) = h' (f b) :=
+  fun_commute_of_inv_commute' @f @h @h' p b
+  end
 
 
   namespace ops
     postfix `⁻¹` := equiv.symm -- overloaded notation for inverse
   end ops
 end equiv
+
+open equiv equiv.ops
+namespace is_equiv
+
+  definition is_equiv_of_equiv_of_homotopy [constructor] {A B : Type} (f : A ≃ B)
+    {f' : A → B} (Hty : f ~ f') : is_equiv f' :=
+  homotopy_closed f Hty
+
+end is_equiv
 
 export [unfold-hints] equiv [unfold-hints] is_equiv

--- a/hott/init/equiv.hlean
+++ b/hott/init/equiv.hlean
@@ -45,18 +45,19 @@ namespace is_equiv
   is_equiv.mk id id (λa, idp) (λa, idp) (λa, idp)
 
   -- The composition of two equivalences is, again, an equivalence.
-  definition is_equiv_compose [Hf : is_equiv f] [Hg : is_equiv g] : is_equiv (g ∘ f) :=
-    is_equiv.mk (g ∘ f) (f⁻¹ ∘ g⁻¹)
-               (λc, ap g (right_inv f (g⁻¹ c)) ⬝ right_inv g c)
-               (λa, ap (inv f) (left_inv g (f a)) ⬝ left_inv f a)
-               (λa, (whisker_left _ (adj g (f a))) ⬝
-                    (ap_con g _ _)⁻¹ ⬝
-                    ap02 g ((ap_con_eq_con (right_inv f) (left_inv g (f a)))⁻¹ ⬝
-                            (ap_compose f (inv f) _ ◾  adj f a) ⬝
-                            (ap_con f _ _)⁻¹
-                           ) ⬝
-                    (ap_compose g f _)⁻¹
-               )
+  definition is_equiv_compose [constructor] [Hf : is_equiv f] [Hg : is_equiv g]
+    : is_equiv (g ∘ f) :=
+  is_equiv.mk (g ∘ f) (f⁻¹ ∘ g⁻¹)
+             (λc, ap g (right_inv f (g⁻¹ c)) ⬝ right_inv g c)
+             (λa, ap (inv f) (left_inv g (f a)) ⬝ left_inv f a)
+             (λa, (whisker_left _ (adj g (f a))) ⬝
+                  (ap_con g _ _)⁻¹ ⬝
+                  ap02 g ((ap_con_eq_con (right_inv f) (left_inv g (f a)))⁻¹ ⬝
+                          (ap_compose f (inv f) _ ◾  adj f a) ⬝
+                          (ap_con f _ _)⁻¹
+                         ) ⬝
+                  (ap_compose g f _)⁻¹
+             )
 
   -- Any function equal to an equivalence is an equivlance as well.
   variable {f}
@@ -106,7 +107,7 @@ namespace is_equiv
   end
 
   -- Any function pointwise equal to an equivalence is an equivalence as well.
-  definition homotopy_closed [constructor] {A B : Type} {f f' : A → B} [Hf : is_equiv f]
+  definition homotopy_closed [constructor] {A B : Type} (f : A → B) {f' : A → B} [Hf : is_equiv f]
     (Hty : f ~ f') : is_equiv f' :=
   adjointify f'
              (inv f)
@@ -120,7 +121,7 @@ namespace is_equiv
              (λ b, ap f !Hty⁻¹ ⬝ right_inv f b)
              (λ a, !Hty⁻¹ ⬝ left_inv f a)
 
-  definition is_equiv_up [instance] (A : Type) : is_equiv (up : A → lift A) :=
+  definition is_equiv_up [instance] [constructor] (A : Type) : is_equiv (up : A → lift A) :=
   adjointify up down (λa, by induction a;reflexivity) (λa, idp)
 
   section
@@ -128,7 +129,7 @@ namespace is_equiv
   include Hf
 
   --The inverse of an equivalence is, again, an equivalence.
-  definition is_equiv_inv [instance] : is_equiv f⁻¹ :=
+  definition is_equiv_inv [instance] [constructor] : is_equiv f⁻¹ :=
   adjointify f⁻¹ f (left_inv f) (right_inv f)
 
   definition cancel_right (g : B → C) [Hgf : is_equiv (g ∘ f)] : (is_equiv g) :=
@@ -201,8 +202,9 @@ namespace is_equiv
   end
 
   --Transporting is an equivalence
-  definition is_equiv_tr [instance] {A : Type} (P : A → Type) {x y : A} (p : x = y) : (is_equiv (transport P p)) :=
-    is_equiv.mk _ (transport P p⁻¹) (tr_inv_tr p) (inv_tr_tr p) (tr_inv_tr_lemma p)
+  definition is_equiv_tr [instance] [constructor] {A : Type} (P : A → Type) {x y : A} (p : x = y)
+    : (is_equiv (transport P p)) :=
+  is_equiv.mk _ (transport P p⁻¹) (tr_inv_tr p) (inv_tr_tr p) (tr_inv_tr_lemma p)
 
 end is_equiv
 open is_equiv
@@ -241,10 +243,10 @@ namespace equiv
   protected definition refl [refl] [constructor] : A ≃ A :=
   equiv.mk id !is_equiv_id
 
-  protected definition symm [symm] [unfold 3] (f : A ≃ B) : B ≃ A :=
+  protected definition symm [symm] (f : A ≃ B) : B ≃ A :=
   equiv.mk f⁻¹ !is_equiv_inv
 
-  protected definition trans [trans] (f : A ≃ B) (g: B ≃ C) : A ≃ C :=
+  protected definition trans [trans] (f : A ≃ B) (g : B ≃ C) : A ≃ C :=
   equiv.mk (g ∘ f) !is_equiv_compose
 
   infixl `⬝e`:75 := equiv.trans
@@ -252,8 +254,12 @@ namespace equiv
     -- notation for inverse which is not overloaded
   abbreviation erfl [constructor] := @equiv.refl
 
+  definition to_inv_trans [reducible] [unfold-full] (f : A ≃ B) (g : B ≃ C)
+    : to_inv (f ⬝e g) = to_fun (g⁻¹ᵉ ⬝e f⁻¹ᵉ) :=
+  idp
+
   definition equiv_change_fun [constructor] (f : A ≃ B) {f' : A → B} (Heq : f ~ f') : A ≃ B :=
-  equiv.mk f' (is_equiv.homotopy_closed Heq)
+  equiv.mk f' (is_equiv.homotopy_closed f Heq)
 
   definition equiv_change_inv [constructor] (f : A ≃ B) {f' : B → A} (Heq : f⁻¹ ~ f')
     : A ≃ B :=

--- a/hott/init/logic.hlean
+++ b/hott/init/logic.hlean
@@ -9,7 +9,7 @@ import init.reserved_notation
 
 /- not -/
 
-definition not (a : Type) := a → empty
+definition not [reducible] (a : Type) := a → empty
 prefix `¬` := not
 
 definition absurd {a b : Type} (H₁ : a) (H₂ : ¬a) : b :=

--- a/hott/init/path.hlean
+++ b/hott/init/path.hlean
@@ -218,6 +218,9 @@ namespace eq
     (H1 : f ~ g) (H2 : g ~ h) : f ~ h :=
   λ x, H1 x ⬝ H2 x
 
+  definition homotopy_of_eq {f g : Πx, P x} (H1 : f = g) : f ~ g :=
+  H1 ▸ homotopy.refl f
+
   definition apd10 [unfold 5] {f g : Πx, P x} (H : f = g) : f ~ g :=
   λx, eq.rec_on H idp
 
@@ -298,6 +301,7 @@ namespace eq
   eq.rec_on p idp
 
   -- Naturality of [ap].
+  -- see also natural_square in cubical.square
   definition ap_con_eq_con_ap {f g : A → B} (p : f ~ g) {x y : A} (q : x = y) :
     ap f q ⬝ p y = p x ⬝ ap g q :=
   eq.rec_on q !idp_con
@@ -483,7 +487,6 @@ namespace eq
       (s : z = w) :
     ap (transport P p) s  ⬝  transport2 P r w = transport2 P r z  ⬝  ap (transport P q) s :=
   eq.rec_on r !idp_con⁻¹
-
 
   definition fn_tr_eq_tr_fn {P Q : A → Type} {x y : A} (p : x = y) (f : Πx, P x → Q x) (z : P x) :
     f y (p ▸ z) = (p ▸ (f x z)) :=

--- a/hott/init/pathover.hlean
+++ b/hott/init/pathover.hlean
@@ -205,6 +205,10 @@ namespace eq
   definition tr_pathover_of_eq (q : b₂ = b₂') : p⁻¹ ▸ b₂ =[p] b₂' :=
   by cases q;apply tr_pathover
 
+  definition apo (f : Πa, B a → B' a) (Ha : a = a₂) (Hb : b =[Ha] b₂)
+      : f a b =[Ha] f a₂ b₂ :=
+  by induction Hb; exact idpo
+
   definition apo011 (f : Πa, B a → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
       : f a b = f a₂ b₂ :=
   by cases Hb; exact idp
@@ -217,8 +221,12 @@ namespace eq
     {b : B a} {b₂ : B a₂} (q : b =[p] b₂) : f b =[apo011 C p q] g b₂ :=
   by cases r; apply (idp_rec_on q); exact idpo
 
-  definition apo10 {f : Πb, C a b} {g : Πb₂, C a₂ b₂} (r : f =[p] g)
-    {b : B a} : f b =[apo011 C p !pathover_tr] g (p ▸ b) :=
+  definition apdo10 {f : Πb, C a b} {g : Πb₂, C a₂ b₂} (r : f =[p] g)
+    (b : B a) : f b =[apo011 C p !pathover_tr] g (p ▸ b) :=
+  by cases r; exact idpo
+
+  definition apo10 {f : B a → B' a} {g : B a₂ → B' a₂} (r : f =[p] g)
+    (b : B a) : f b =[p] g (p ▸ b) :=
   by cases r; exact idpo
 
   definition cono.right_inv_eq (q : b = b')

--- a/hott/init/pathover.hlean
+++ b/hott/init/pathover.hlean
@@ -11,10 +11,10 @@ import .path .equiv
 
 open equiv is_equiv equiv.ops
 
-variables {A A' : Type} {B B' : A → Type} {C : Πa, B a → Type}
+variables {A A' : Type} {B B' : A → Type} {C : Π⦃a⦄, B a → Type}
           {a a₂ a₃ a₄ : A} {p p' : a = a₂} {p₂ : a₂ = a₃} {p₃ : a₃ = a₄}
           {b b' : B a} {b₂ b₂' : B a₂} {b₃ : B a₃} {b₄ : B a₄}
-          {c : C a b} {c₂ : C a₂ b₂}
+          {c : C b} {c₂ : C b₂}
 
 namespace eq
   inductive pathover.{l} (B : A → Type.{l}) (b : B a) : Π{a₂ : A}, a = a₂ → B a₂ → Type.{l} :=
@@ -26,10 +26,10 @@ namespace eq
   pathover.idpatho b
 
   /- equivalences with equality using transport -/
-  definition pathover_of_tr_eq (r : p ▸ b = b₂) : b =[p] b₂ :=
+  definition pathover_of_tr_eq [unfold 5 8] (r : p ▸ b = b₂) : b =[p] b₂ :=
   by cases p; cases r; exact idpo
 
-  definition pathover_of_eq_tr (r : b = p⁻¹ ▸ b₂) : b =[p] b₂ :=
+  definition pathover_of_eq_tr [unfold 5 8] (r : b = p⁻¹ ▸ b₂) : b =[p] b₂ :=
   by cases p; cases r; exact idpo
 
   definition tr_eq_of_pathover [unfold 8] (r : b =[p] b₂) : p ▸ b = b₂ :=
@@ -205,7 +205,17 @@ namespace eq
   definition tr_pathover_of_eq (q : b₂ = b₂') : p⁻¹ ▸ b₂ =[p] b₂' :=
   by cases q;apply tr_pathover
 
-  definition apo (f : Πa, B a → B' a) (Ha : a = a₂) (Hb : b =[Ha] b₂)
+  variable (C)
+  definition transporto (r : b =[p] b₂) (c : C b) : C b₂ :=
+  by induction r;exact c
+  infix `▸o`:75 := transporto _
+
+  definition fn_tro_eq_tro_fn (C' : Π ⦃a : A⦄, B a → Type) (q : b =[p] b₂)
+    (f : Π(b : B a), C b → C' b) (c : C b) : f b (q ▸o c) = (q ▸o (f b c)) :=
+  by induction q;reflexivity
+  variable {C}
+
+  definition apo (f : Πa, B a → B' a) {Ha : a = a₂} (Hb : b =[Ha] b₂)
       : f a b =[Ha] f a₂ b₂ :=
   by induction Hb; exact idpo
 
@@ -213,15 +223,15 @@ namespace eq
       : f a b = f a₂ b₂ :=
   by cases Hb; exact idp
 
-  definition apo0111 (f : Πa b, C a b → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
+  definition apo0111 (f : Πa b, C b → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
     (Hc : c =[apo011 C Ha Hb] c₂) : f a b c = f a₂ b₂ c₂ :=
   by cases Hb; apply (idp_rec_on Hc); apply idp
 
-  definition apo11 {f : Πb, C a b} {g : Πb₂, C a₂ b₂} (r : f =[p] g)
+  definition apo11 {f : Πb, C b} {g : Πb₂, C b₂} (r : f =[p] g)
     {b : B a} {b₂ : B a₂} (q : b =[p] b₂) : f b =[apo011 C p q] g b₂ :=
   by cases r; apply (idp_rec_on q); exact idpo
 
-  definition apdo10 {f : Πb, C a b} {g : Πb₂, C a₂ b₂} (r : f =[p] g)
+  definition apdo10 {f : Πb, C b} {g : Πb₂, C b₂} (r : f =[p] g)
     (b : B a) : f b =[apo011 C p !pathover_tr] g (p ▸ b) :=
   by cases r; exact idpo
 

--- a/hott/init/trunc.hlean
+++ b/hott/init/trunc.hlean
@@ -300,11 +300,14 @@ namespace is_trunc
   theorem is_hset.elimo (q q' : c =[p] c₂) [H : is_hset (C a)] : q = q' :=
   !is_hprop.elim
 
-  /- truncatedness of lift -/
-  definition is_trunc_lift [instance] (A : Type) (n : trunc_index) [H : is_trunc n A]
-    : is_trunc n (lift A) :=
-  is_trunc_equiv_closed _ !equiv_lift
-
   -- TODO: port "Truncated morphisms"
 
 end is_trunc
+
+/- truncatedness of lift -/
+namespace lift
+  open is_trunc equiv
+  definition is_trunc_lift [instance] [priority 1450] (A : Type) (n : trunc_index)
+    [H : is_trunc n A] : is_trunc n (lift A) :=
+  is_trunc_equiv_closed _ !equiv_lift
+end lift

--- a/hott/init/trunc.hlean
+++ b/hott/init/trunc.hlean
@@ -143,6 +143,16 @@ namespace is_trunc
            @is_trunc_succ_intro A m (λx y, IHm n (x = y) (trunc_index.le_of_succ_le_succ Hnm) _)),
   trunc_index.rec_on m base step n A Hnm Hn
 
+  definition is_trunc_of_imp_is_trunc {n : trunc_index} (H : A → is_trunc (n.+1) A)
+    : is_trunc (n.+1) A :=
+  @is_trunc_succ_intro _ _ (λx y, @is_trunc_eq _ _ (H x) x y)
+
+  definition is_trunc_of_imp_is_trunc_of_leq {n : trunc_index} (Hn : -1 ≤ n) (H : A → is_trunc n A)
+    : is_trunc n A :=
+  trunc_index.rec_on n (λHn H, empty.rec _ Hn)
+                       (λn IH Hn, is_trunc_of_imp_is_trunc)
+                       Hn H
+
   -- the following cannot be instances in their current form, because they are looping
   theorem is_trunc_of_is_contr (A : Type) (n : trunc_index) [H : is_contr A] : is_trunc n A :=
   trunc_index.rec_on n H _

--- a/hott/init/ua.hlean
+++ b/hott/init/ua.hlean
@@ -15,11 +15,16 @@ section
   universe variable l
   variables {A B : Type.{l}}
 
-  definition is_equiv_cast_of_eq (H : A = B) : is_equiv (cast H) :=
-    (@is_equiv_tr Type (λX, X) A B H)
+  definition is_equiv_cast_of_eq [constructor] (H : A = B) : is_equiv (cast H) :=
+  is_equiv_tr (λX, X) H
 
-  definition equiv_of_eq (H : A = B) : A ≃ B :=
-    equiv.mk _ (is_equiv_cast_of_eq H)
+  definition equiv_of_eq [constructor] (H : A = B) : A ≃ B :=
+  equiv.mk _ (is_equiv_cast_of_eq H)
+
+  definition equiv_of_eq_refl [reducible] [unfold-full] (A : Type)
+    : equiv_of_eq (refl A) = equiv.refl :=
+  idp
+
 
 end
 
@@ -50,6 +55,9 @@ definition eq_of_equiv_lift {A B : Type} (f : A ≃ B) : A = lift B :=
 ua (f ⬝e !equiv_lift)
 
 namespace equiv
+  definition ua_refl (A : Type) : ua erfl = idpath A :=
+  eq_of_fn_eq_fn !eq_equiv_equiv (right_inv !eq_equiv_equiv erfl)
+
   -- One consequence of UA is that we can transport along equivalencies of types
   -- We can use this for calculation evironments
   protected definition transport_of_equiv [subst] (P : Type → Type) {A B : Type} (H : A ≃ B)

--- a/hott/types/arrow.hlean
+++ b/hott/types/arrow.hlean
@@ -44,6 +44,9 @@ namespace pi
   definition arrow_equiv_arrow_left (f0 : A ≃ A') : (A → B) ≃ (A' → B) :=
   arrow_equiv_arrow f0 equiv.refl
 
+  definition arrow_equiv_arrow_right' (f1 : A → (B ≃ B')) : (A → B) ≃ (A → B') :=
+  pi_equiv_pi_id f1
+
   /- Transport -/
 
   definition arrow_transport {B C : A → Type} (p : a = a') (f : B a → C a)

--- a/hott/types/bool.hlean
+++ b/hott/types/bool.hlean
@@ -29,9 +29,6 @@ namespace bool
   assert H2 : bnot = id, from !cast_ua_fn⁻¹ ⬝ ap cast H,
   absurd (ap10 H2 tt) ff_ne_tt
 
-  definition not_is_hset_type : ¬is_hset Type₀ :=
-  assume H : is_hset Type₀,
-  absurd !is_hset.elim eq_bnot_ne_idp
 
   definition bool_equiv_option_unit : bool ≃ option unit :=
   begin

--- a/hott/types/bool.hlean
+++ b/hott/types/bool.hlean
@@ -13,7 +13,7 @@ namespace bool
   definition ff_ne_tt : ff = tt → empty
   | [none]
 
-  definition is_equiv_bnot [instance] [priority 500] : is_equiv bnot :=
+  definition is_equiv_bnot [constructor] [instance] [priority 500] : is_equiv bnot :=
   begin
     fapply is_equiv.mk,
       exact bnot,
@@ -21,7 +21,11 @@ namespace bool
 --      all_goals (focus (intro b;cases b;all_goals reflexivity)),
   end
 
-  definition equiv_bnot : bool ≃ bool := equiv.mk bnot _
+  definition bnot_ne : Π(b : bool), bnot b ≠ b
+  | bnot_ne tt := ff_ne_tt
+  | bnot_ne ff := ne.symm ff_ne_tt
+
+  definition equiv_bnot [constructor] : bool ≃ bool := equiv.mk bnot _
   definition eq_bnot    : bool = bool := ua equiv_bnot
 
   definition eq_bnot_ne_idp : eq_bnot ≠ idp :=

--- a/hott/types/equiv.hlean
+++ b/hott/types/equiv.hlean
@@ -109,7 +109,7 @@ end is_equiv
 
 namespace equiv
   open is_equiv
-  variables {A B : Type}
+  variables {A B C : Type}
 
   definition equiv_mk_eq {f f' : A → B} [H : is_equiv f] [H' : is_equiv f'] (p : f = f')
       : equiv.mk f H = equiv.mk f' H' :=
@@ -117,6 +117,15 @@ namespace equiv
 
   definition equiv_eq {f f' : A ≃ B} (p : to_fun f = to_fun f') : f = f' :=
   by (cases f; cases f'; apply (equiv_mk_eq p))
+
+  definition equiv_eq' {f f' : A ≃ B} (p : to_fun f ~ to_fun f') : f = f' :=
+  by apply equiv_eq;apply eq_of_homotopy p
+
+  definition trans_symm (f : A ≃ B) (g : B ≃ C) : (f ⬝e g)⁻¹ᵉ = g⁻¹ᵉ ⬝e f⁻¹ᵉ :> (C ≃ A) :=
+  equiv_eq idp
+
+  definition symm_symm (f : A ≃ B) : f⁻¹ᵉ⁻¹ᵉ = f :> (A ≃ B) :=
+  equiv_eq idp
 
   protected definition equiv.sigma_char [constructor]
     (A B : Type) : (A ≃ B) ≃ Σ(f : A → B), is_equiv f :=

--- a/hott/types/equiv.hlean
+++ b/hott/types/equiv.hlean
@@ -20,14 +20,14 @@ namespace is_equiv
     (fiber.mk (f⁻¹ b) (right_inv f b))
     (λz, fiber.rec_on z (λa p,
       fiber_eq ((ap f⁻¹ p)⁻¹ ⬝ left_inv f a) (calc
-        right_inv f b
-          = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ ((ap (f ∘ f⁻¹) p) ⬝ right_inv f b) : by rewrite inv_con_cancel_left
-      ... = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ (right_inv f (f a) ⬝ p)       : by rewrite ap_con_eq_con
-      ... = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ (ap f (left_inv f a) ⬝ p)    : by rewrite adj
-      ... = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ ap f (left_inv f a) ⬝ p      : by rewrite con.assoc
-      ... = (ap f (ap f⁻¹ p))⁻¹ ⬝ ap f (left_inv f a) ⬝ p     : by rewrite ap_compose
-      ... = ap f (ap f⁻¹ p)⁻¹ ⬝ ap f (left_inv f a) ⬝ p       : by rewrite ap_inv
-      ... = ap f ((ap f⁻¹ p)⁻¹ ⬝ left_inv f a) ⬝ p            : by rewrite ap_con)))
+        right_inv f b = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ ((ap (f ∘ f⁻¹) p) ⬝ right_inv f b)
+                                                           : by rewrite inv_con_cancel_left
+      ... = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ (right_inv f (f a) ⬝ p)   : by rewrite ap_con_eq_con
+      ... = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ (ap f (left_inv f a) ⬝ p) : by rewrite adj
+      ... = (ap (f ∘ f⁻¹) p)⁻¹ ⬝ ap f (left_inv f a) ⬝ p   : by rewrite con.assoc
+      ... = (ap f (ap f⁻¹ p))⁻¹ ⬝ ap f (left_inv f a) ⬝ p  : by rewrite ap_compose
+      ... = ap f (ap f⁻¹ p)⁻¹ ⬝ ap f (left_inv f a) ⬝ p    : by rewrite ap_inv
+      ... = ap f ((ap f⁻¹ p)⁻¹ ⬝ left_inv f a) ⬝ p         : by rewrite ap_con)))
 
   definition is_contr_right_inverse : is_contr (Σ(g : B → A), f ∘ g ~ id) :=
   begin
@@ -76,7 +76,8 @@ namespace is_equiv
   local attribute is_contr_right_coherence [instance] [priority 1600]
 
   theorem is_hprop_is_equiv [instance] : is_hprop (is_equiv f) :=
-  is_hprop_of_imp_is_contr (λ(H : is_equiv f), is_trunc_equiv_closed -2 (equiv.symm !is_equiv.sigma_char'))
+  is_hprop_of_imp_is_contr
+    (λ(H : is_equiv f), is_trunc_equiv_closed -2 (equiv.symm !is_equiv.sigma_char'))
 
   definition inv_eq_inv {A B : Type} {f f' : A → B} {Hf : is_equiv f} {Hf' : is_equiv f'}
     (p : f = f') : f⁻¹ = f'⁻¹ :=

--- a/hott/types/lift.hlean
+++ b/hott/types/lift.hlean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2015 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Floris van Doorn
+
+Theorems about lift
+-/
+
+import ..function
+open eq equiv equiv.ops is_equiv is_trunc
+
+namespace lift
+
+  universe variables u v
+  variables {A : Type.{u}} (z z' : lift.{u v} A)
+
+  protected definition eta : up (down z) = z :=
+  by induction z; reflexivity
+
+  protected definition code [unfold 2 3] : lift A → lift A → Type
+  | code (up a) (up a') := a = a'
+
+  protected definition decode [unfold 2 3] : Π(z z' : lift A), lift.code z z' → z = z'
+  | decode (up a) (up a') := λc, ap up c
+
+  variables {z z'}
+  protected definition encode [unfold 3 4 5] (p : z = z') : lift.code z z' :=
+  by induction p; induction z; esimp
+
+  variables (z z')
+  definition lift_eq_equiv : (z = z') ≃ lift.code z z' :=
+  equiv.MK lift.encode
+           !lift.decode
+           abstract begin
+             intro c, induction z with a, induction z' with a', esimp at *, induction c,
+             reflexivity
+           end end
+           abstract begin
+             intro p, induction p, induction z, reflexivity
+           end end
+
+
+  section
+  variables {a a' : A}
+  definition eq_of_up_eq_up [unfold 4] (p : up a = up a') : a = a' :=
+  lift.encode p
+
+  definition lift_transport {P : A → Type} (p : a = a') (z : lift (P a))
+    : p ▸ z = up (p ▸ down z) :=
+  by induction p; induction z; reflexivity
+  end
+
+  variables {A' : Type} (f : A → A') (g : lift A → lift A')
+  definition lift_functor [unfold 4] : lift A → lift A'
+  | lift_functor (up a) := up (f a)
+
+  definition is_equiv_lift_functor [constructor] [Hf : is_equiv f] : is_equiv (lift_functor f) :=
+  adjointify (lift_functor f)
+             (lift_functor f⁻¹)
+             abstract begin
+               intro z', induction z' with a',
+               esimp, exact ap up !right_inv
+             end end
+             abstract begin
+               intro z, induction z with a,
+               esimp, exact ap up !left_inv
+             end end
+
+  definition lift_equiv_lift_of_is_equiv [constructor] [Hf : is_equiv f] : lift A ≃ lift A' :=
+  equiv.mk _ (is_equiv_lift_functor f)
+
+  definition lift_equiv_lift [constructor] (f : A ≃ A') : lift A ≃ lift A' :=
+  equiv.mk _ (is_equiv_lift_functor f)
+
+  definition lift_equiv_lift_refl (A : Type) : lift_equiv_lift (erfl : A ≃ A) = erfl :=
+  by apply equiv_eq'; intro z; induction z with a; reflexivity
+
+  definition lift_inv_functor [unfold-full] (a : A) : A' :=
+  down (g (up a))
+
+  definition is_equiv_lift_inv_functor [constructor] [Hf : is_equiv g]
+    : is_equiv (lift_inv_functor g) :=
+  adjointify (lift_inv_functor g)
+             (lift_inv_functor g⁻¹)
+             abstract begin
+               intro z', rewrite [▸*,lift.eta,right_inv g],
+             end end
+             abstract begin
+               intro z', rewrite [▸*,lift.eta,left_inv g],
+             end end
+
+  definition equiv_of_lift_equiv_lift [constructor] (g : lift A ≃ lift A') : A ≃ A' :=
+  equiv.mk _ (is_equiv_lift_inv_functor g)
+
+  definition lift_functor_left_inv  : lift_inv_functor (lift_functor f) = f :=
+  eq_of_homotopy (λa, idp)
+
+  definition lift_functor_right_inv : lift_functor (lift_inv_functor g) = g :=
+  begin
+    apply eq_of_homotopy, intro z, induction z with a, esimp, apply lift.eta
+  end
+
+  variables (A A')
+  definition is_equiv_lift_functor_fn [constructor]
+    : is_equiv (lift_functor : (A → A') → (lift A → lift A')) :=
+  adjointify lift_functor
+             lift_inv_functor
+             lift_functor_right_inv
+             lift_functor_left_inv
+
+  definition lift_imp_lift_equiv [constructor] : (lift A → lift A') ≃ (A → A') :=
+  (equiv.mk _ (is_equiv_lift_functor_fn A A'))⁻¹ᵉ
+
+  -- can we deduce this from lift_imp_lift_equiv?
+  definition lift_equiv_lift_equiv [constructor] : (lift A ≃ lift A') ≃ (A ≃ A') :=
+  equiv.MK equiv_of_lift_equiv_lift
+           lift_equiv_lift
+           abstract begin
+             intro f, apply equiv_eq, reflexivity
+           end end
+           abstract begin
+             intro g, apply equiv_eq, esimp, apply eq_of_homotopy, intro z,
+             induction z with a, esimp, apply lift.eta
+           end end
+
+  definition lift_eq_lift_equiv.{u1 u2} (A A' : Type.{u1})
+    : (lift.{u1 u2} A = lift.{u1 u2} A') ≃ (A = A') :=
+  !eq_equiv_equiv ⬝e !lift_equiv_lift_equiv ⬝e !eq_equiv_equiv⁻¹ᵉ
+
+  definition is_embedding_lift [instance] : is_embedding lift :=
+  begin
+    apply is_embedding.mk, intro A A', fapply is_equiv.homotopy_closed,
+      exact to_inv !lift_eq_lift_equiv,
+      exact _,
+    { intro p, induction p,
+      esimp [lift_eq_lift_equiv,equiv.trans,equiv.symm,eq_equiv_equiv],
+      rewrite [equiv_of_eq_refl,lift_equiv_lift_refl],
+      apply ua_refl}
+  end
+
+end lift

--- a/hott/types/lift.hlean
+++ b/hott/types/lift.hlean
@@ -138,4 +138,7 @@ namespace lift
       apply ua_refl}
   end
 
+  -- is_trunc_lift is defined in init.trunc
+
+
 end lift

--- a/hott/types/nat/basic.hlean
+++ b/hott/types/nat/basic.hlean
@@ -59,8 +59,7 @@ rfl
 definition eq_zero_or_eq_succ_pred (n : ℕ) : n = 0 ⊎ n = succ (pred n) :=
 nat.rec_on n
   (sum.inl rfl)
-  (take m IH, sum.inr
-    (show succ m = succ (pred (succ m)), from ap succ !pred_succ⁻¹))
+  (take m IH, sum.inr rfl)
 
 definition exists_eq_succ_of_ne_zero {n : ℕ} (H : n ≠ 0) : Σk : ℕ, n = succ k :=
 sigma.mk _ (sum_resolve_right !eq_zero_or_eq_succ_pred H)
@@ -118,11 +117,8 @@ nat.rec_on n
 
 definition succ_add (n m : ℕ) : (succ n) + m = succ (n + m) :=
 nat.rec_on m
-    (!add_zero ▸ !add_zero)
-    (take k IH, calc
-      succ n + succ k = succ (succ n + k)    : add_succ
-                  ... = succ (succ (n + k))  : IH
-                  ... = succ (n + succ k)    : add_succ)
+    (rfl)
+    (take k IH, eq.ap succ IH)
 
 definition add.comm (n m : ℕ) : n + m = m + n :=
 nat.rec_on m

--- a/hott/types/pi.hlean
+++ b/hott/types/pi.hlean
@@ -228,6 +228,9 @@ namespace pi
     apply eq_equiv_homotopy
   end
 
+  definition is_trunc_not [instance] (n : trunc_index) (A : Type) : is_trunc (n.+1) ¬A :=
+  by unfold not;exact _
+
   definition is_hprop_pi_eq [instance] [priority 490] (a : A) : is_hprop (Π(a' : A), a = a') :=
   is_hprop_of_imp_is_contr
   ( assume (f : Πa', a = a'),

--- a/hott/types/pi.hlean
+++ b/hott/types/pi.hlean
@@ -47,7 +47,8 @@ namespace pi
 
   definition pi_eq_equiv (f g : Πx, B x) : (f = g) ≃ (f ~ g) := !eq_equiv_homotopy
 
-  definition is_equiv_eq_of_homotopy (f g : Πx, B x) : is_equiv (@eq_of_homotopy _ _ f g) :=
+  definition is_equiv_eq_of_homotopy (f g : Πx, B x)
+    : is_equiv (eq_of_homotopy : f ~ g → f = g) :=
   _
 
   definition homotopy_equiv_eq (f g : Πx, B x) : (f ~ g) ≃ (f = g) :=
@@ -57,15 +58,14 @@ namespace pi
   /- Transport -/
 
   definition pi_transport (p : a = a') (f : Π(b : B a), C a b)
-    : (transport (λa, Π(b : B a), C a b) p f)
-      ~ (λb, transport (C a') !tr_inv_tr (transportD _ p _ (f (p⁻¹ ▸ b)))) :=
-  eq.rec_on p (λx, idp)
+    : (transport (λa, Π(b : B a), C a b) p f) ~ (λb, !tr_inv_tr ▸ (p ▸D (f (p⁻¹ ▸ b)))) :=
+  by induction p; reflexivity
 
   /- A special case of [transport_pi] where the type [B] does not depend on [A],
       and so it is just a fixed type [B]. -/
   definition pi_transport_constant {C : A → A' → Type} (p : a = a') (f : Π(b : A'), C a b) (b : A')
     : (transport _ p f) b = p ▸ (f b) :=
-  eq.rec_on p idp
+  by induction p; reflexivity
 
   /- Pathovers -/
 
@@ -171,7 +171,7 @@ namespace pi
   /- Equivalences -/
 
   definition is_equiv_pi_functor [instance] [H0 : is_equiv f0]
-    [H1 : Πa', @is_equiv (B (f0 a')) (B' a') (f1 a')] : is_equiv (pi_functor f0 f1) :=
+    [H1 : Πa', is_equiv (f1 a')] : is_equiv (pi_functor f0 f1) :=
   begin
     apply (adjointify (pi_functor f0 f1) (pi_functor f0⁻¹
           (λ(a : A) (b' : B' (f0⁻¹ a)), transport B (right_inv f0 a) ((f1 (f0⁻¹ a))⁻¹ b')))),
@@ -188,7 +188,7 @@ namespace pi
   end
 
   definition pi_equiv_pi_of_is_equiv [H : is_equiv f0]
-    [H1 : Πa', @is_equiv (B (f0 a')) (B' a') (f1 a')] : (Πa, B a) ≃ (Πa', B' a') :=
+    [H1 : Πa', is_equiv (f1 a')] : (Πa, B a) ≃ (Πa', B' a') :=
   equiv.mk (pi_functor f0 f1) _
 
   definition pi_equiv_pi (f0 : A' ≃ A) (f1 : Πa', (B (to_fun f0 a') ≃ B' a'))
@@ -237,8 +237,11 @@ namespace pi
     assert H : is_contr A, from is_contr.mk a f,
     _)
 
+  definition is_hprop_neg (A : Type) : is_hprop (¬A) := _
+
   /- Symmetry of Π -/
-  definition is_equiv_flip [instance] {P : A → A' → Type} : is_equiv (@function.flip A A' P) :=
+  definition is_equiv_flip [instance] {P : A → A' → Type}
+    : is_equiv (@function.flip A A' P) :=
   begin
     fapply is_equiv.mk,
     exact (@function.flip _ _ (function.flip P)),

--- a/hott/types/prod.hlean
+++ b/hott/types/prod.hlean
@@ -68,14 +68,14 @@ namespace prod
   definition prod_eq_unc_eta (p : u = v) : prod_eq_unc (p..1, p..2) = p :=
   prod_eq_eta p
 
-  definition is_equiv_prod_eq [instance] (u v : A × B)
+  definition is_equiv_prod_eq [instance] [constructor] (u v : A × B)
     : is_equiv (prod_eq_unc : u.1 = v.1 × u.2 = v.2 → u = v) :=
   adjointify prod_eq_unc
              (λp, (p..1, p..2))
              prod_eq_unc_eta
              pair_prod_eq_unc
 
-  definition prod_eq_equiv (u v : A × B) : (u = v) ≃ (u.1 = v.1 × u.2 = v.2) :=
+  definition prod_eq_equiv [constructor] (u v : A × B) : (u = v) ≃ (u.1 = v.1 × u.2 = v.2) :=
   (equiv.mk prod_eq_unc _)⁻¹ᵉ
 
   /- Transport -/
@@ -96,7 +96,7 @@ namespace prod
 
   /- Equivalences -/
 
-  definition is_equiv_prod_functor [instance] [H : is_equiv f] [H : is_equiv g]
+  definition is_equiv_prod_functor [instance] [constructor] [H : is_equiv f] [H : is_equiv g]
     : is_equiv (prod_functor f g) :=
   begin
     apply adjointify _ (prod_functor f⁻¹ g⁻¹),
@@ -104,33 +104,34 @@ namespace prod
       intro u, induction u, rewrite [▸*,left_inv f,left_inv g],
   end
 
-  definition prod_equiv_prod_of_is_equiv [H : is_equiv f] [H : is_equiv g]
+  definition prod_equiv_prod_of_is_equiv [constructor] [H : is_equiv f] [H : is_equiv g]
     : A × B ≃ A' × B' :=
   equiv.mk (prod_functor f g) _
 
-  definition prod_equiv_prod (f : A ≃ A') (g : B ≃ B') : A × B ≃ A' × B' :=
+  definition prod_equiv_prod [constructor] (f : A ≃ A') (g : B ≃ B') : A × B ≃ A' × B' :=
   equiv.mk (prod_functor f g) _
 
-  definition prod_equiv_prod_left (g : B ≃ B') : A × B ≃ A × B' :=
+  definition prod_equiv_prod_left [constructor] (g : B ≃ B') : A × B ≃ A × B' :=
   prod_equiv_prod equiv.refl g
 
-  definition prod_equiv_prod_right (f : A ≃ A') : A × B ≃ A' × B :=
+  definition prod_equiv_prod_right [constructor] (f : A ≃ A') : A × B ≃ A' × B :=
   prod_equiv_prod f equiv.refl
 
   /- Symmetry -/
 
-  definition is_equiv_flip [instance] (A B : Type) : is_equiv (@flip A B) :=
+  definition is_equiv_flip [instance] [constructor] (A B : Type)
+    : is_equiv (flip : A × B → B × A) :=
   adjointify flip
              flip
              (λu, destruct u (λb a, idp))
              (λu, destruct u (λa b, idp))
 
-  definition prod_comm_equiv (A B : Type) : A × B ≃ B × A :=
+  definition prod_comm_equiv [constructor] (A B : Type) : A × B ≃ B × A :=
   equiv.mk flip _
 
   /- Associativity -/
 
-  definition prod_assoc_equiv (A B C : Type) : A × (B × C) ≃ (A × B) × C :=
+  definition prod_assoc_equiv [constructor] (A B C : Type) : A × (B × C) ≃ (A × B) × C :=
   begin
     fapply equiv.MK,
     { intro z, induction z with a z, induction z with b c, exact (a, b, c)},
@@ -139,24 +140,24 @@ namespace prod
     { intro z, induction z with a z, induction z with b c, reflexivity},
   end
 
-  definition prod_contr_equiv (A B : Type) [H : is_contr B] : A × B ≃ A :=
+  definition prod_contr_equiv [constructor] (A B : Type) [H : is_contr B] : A × B ≃ A :=
   equiv.MK pr1
            (λx, (x, !center))
            (λx, idp)
            (λx, by cases x with a b; exact pair_eq idp !center_eq)
 
-  definition prod_unit_equiv (A : Type) : A × unit ≃ A :=
+  definition prod_unit_equiv [constructor] (A : Type) : A × unit ≃ A :=
   !prod_contr_equiv
 
   /- Universal mapping properties -/
-  definition is_equiv_prod_rec [instance] (P : A × B → Type)
+  definition is_equiv_prod_rec [instance] [constructor] (P : A × B → Type)
     : is_equiv (prod.rec : (Πa b, P (a, b)) → Πu, P u) :=
   adjointify _
              (λg a b, g (a, b))
              (λg, eq_of_homotopy (λu, by induction u;reflexivity))
              (λf, idp)
 
-  definition equiv_prod_rec (P : A × B → Type) : (Πa b, P (a, b)) ≃ (Πu, P u) :=
+  definition equiv_prod_rec [constructor] (P : A × B → Type) : (Πa b, P (a, b)) ≃ (Πu, P u) :=
   equiv.mk prod.rec _
 
   definition imp_imp_equiv_prod_imp (A B C : Type) : (A → B → C) ≃ (A × B → C) :=
@@ -166,17 +167,19 @@ namespace prod
     : P a × Q a :=
   (u.1 a, u.2 a)
 
-  definition is_equiv_prod_corec (P Q : A → Type)
+  definition is_equiv_prod_corec [constructor] (P Q : A → Type)
     : is_equiv (prod_corec_unc : (Πa, P a) × (Πa, Q a) → Πa, P a × Q a) :=
   adjointify _
              (λg, (λa, (g a).1, λa, (g a).2))
              (by intro g; apply eq_of_homotopy; intro a; esimp; induction (g a); reflexivity)
              (by intro h; induction h with f g; reflexivity)
 
-  definition equiv_prod_corec (P Q : A → Type) : ((Πa, P a) × (Πa, Q a)) ≃ (Πa, P a × Q a) :=
+  definition equiv_prod_corec [constructor] (P Q : A → Type)
+    : ((Πa, P a) × (Πa, Q a)) ≃ (Πa, P a × Q a) :=
   equiv.mk _ !is_equiv_prod_corec
 
-  definition imp_prod_imp_equiv_imp_prod (A B C : Type) : (A → B) × (A → C) ≃ (A → (B × C)) :=
+  definition imp_prod_imp_equiv_imp_prod [constructor] (A B C : Type)
+    : (A → B) × (A → C) ≃ (A → (B × C)) :=
   !equiv_prod_corec
 
   definition is_trunc_prod (A B : Type) (n : trunc_index) [HA : is_trunc n A] [HB : is_trunc n B]

--- a/hott/types/prod.hlean
+++ b/hott/types/prod.hlean
@@ -9,10 +9,12 @@ Theorems about products
 
 open eq equiv is_equiv is_trunc prod prod.ops unit equiv.ops
 
-variables {A A' B B' C D : Type}
+variables {A A' B B' C D : Type} {P Q : A → Type}
           {a a' a'' : A} {b b₁ b₂ b' b'' : B} {u v w : A × B}
 
 namespace prod
+
+  /- Paths in a product space -/
 
   protected definition eta (u : A × B) : (pr₁ u, pr₂ u) = u :=
   by cases u; apply idp
@@ -22,8 +24,6 @@ namespace prod
 
   definition prod_eq [unfold 3 4 5 6] (H₁ : u.1 = v.1) (H₂ : u.2 = v.2) : u = v :=
   by cases u; cases v; exact pair_eq H₁ H₂
-
-  /- Projections of paths from a total space -/
 
   definition eq_pr1 (p : u = v) : u.1 = v.1 :=
   ap pr1 p
@@ -50,8 +50,7 @@ namespace prod
   definition prod_eq_eta (p : u = v) : prod_eq (p..1) (p..2) = p :=
   by induction p; induction u; reflexivity
 
-  /- the uncurried version of prod_eq. We will prove that this is an equivalence -/
-
+  -- the uncurried version of prod_eq. We will prove that this is an equivalence
   definition prod_eq_unc (H : u.1 = v.1 × u.2 = v.2) : u = v :=
   by cases H with H₁ H₂;exact prod_eq H₁ H₂
 
@@ -80,9 +79,28 @@ namespace prod
 
   /- Transport -/
 
-  definition prod_transport {P Q : A → Type} {a a' : A} (p : a = a') (u : P a × Q a)
+  definition prod_transport (p : a = a') (u : P a × Q a)
     : p ▸ u = (p ▸ u.1, p ▸ u.2) :=
   by induction p; induction u; reflexivity
+
+  /- Pathovers -/
+
+  definition etao (p : a = a') (bc : P a × Q a) : bc =[p] (p ▸ bc.1, p ▸ bc.2) :=
+  by induction p; induction bc; apply idpo
+
+  definition prod_pathover (p : a = a') (u : P a × Q a) (v : P a' × Q a')
+    (r : u.1 =[p] v.1) (s : u.2 =[p] v.2) : u =[p] v :=
+  begin
+    induction u, induction v, esimp at *, induction r,
+    induction s using idp_rec_on,
+    apply idpo
+  end
+
+  /-
+    TODO:
+    * define the projections from the type u =[p] v
+    * show that the uncurried version of prod_pathover is an equivalence
+  -/
 
   /- Functorial action -/
 

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -341,18 +341,22 @@ namespace sigma
   equiv.mk sigma.coind_unc _
   end
 
-  /- ** Subtypes (sigma types whose second components are hprops) -/
+  /- Subtypes (sigma types whose second components are hprops) -/
+
+  definition subtype [reducible] {A : Type} (P : A → Type) [H : Πa, is_hprop (P a)] :=
+  Σ(a : A), P a
+  notation [parsing-only] `{` binder `|` r:(scoped:1 P, subtype P) `}` := r
 
   /- To prove equality in a subtype, we only need equality of the first component. -/
-  definition subtype_eq [H : Πa, is_hprop (B a)] (u v : Σa, B a) : u.1 = v.1 → u = v :=
+  definition subtype_eq [H : Πa, is_hprop (B a)] (u v : {a | B a}) : u.1 = v.1 → u = v :=
   sigma_eq_unc ∘ inv pr1
 
-  definition is_equiv_subtype_eq [H : Πa, is_hprop (B a)] (u v : Σa, B a)
+  definition is_equiv_subtype_eq [H : Πa, is_hprop (B a)] (u v : {a | B a})
       : is_equiv (subtype_eq u v) :=
   !is_equiv_compose
   local attribute is_equiv_subtype_eq [instance]
 
-  definition equiv_subtype [H : Πa, is_hprop (B a)] (u v : Σa, B a) : (u.1 = v.1) ≃ (u = v) :=
+  definition equiv_subtype [H : Πa, is_hprop (B a)] (u v : {a | B a}) : (u.1 = v.1) ≃ (u = v) :=
   equiv.mk !subtype_eq _
 
   /- truncatedness -/

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -18,6 +18,8 @@ namespace sigma
 
   definition destruct := @sigma.cases_on
 
+  /- Paths in a sigma-type -/
+
   protected definition eta : Π (u : Σa, B a), ⟨u.1 , u.2⟩ = u
   | eta ⟨u₁, u₂⟩ := idp
 
@@ -32,8 +34,6 @@ namespace sigma
 
   definition sigma_eq (p : u.1 = v.1) (q : u.2 =[p] v.2) : u = v :=
   by induction u; induction v; exact (dpair_eq_dpair p q)
-
-  /- Projections of paths from a total space -/
 
   definition eq_pr1 (p : u = v) : u.1 = v.1 :=
   ap pr1 p
@@ -176,7 +176,7 @@ namespace sigma
 
   /- Pathovers -/
 
-  definition eta_pathover (p : a = a') (bc : Σ(b : B a), C a b)
+  definition etao (p : a = a') (bc : Σ(b : B a), C a b)
     : bc =[p] ⟨p ▸ bc.1, p ▸D bc.2⟩ :=
   by induction p; induction bc; apply idpo
 
@@ -187,7 +187,8 @@ namespace sigma
     esimp [apo011] at s, induction s using idp_rec_on, apply idpo
   end
 
-  /- TODO:
+  /-
+    TODO:
     * define the projections from the type u =[p] v
     * show that the uncurried version of sigma_pathover is an equivalence
   -/

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -9,7 +9,7 @@ Theorems about sigma-types (dependent sums)
 
 import types.prod
 
-open eq sigma sigma.ops equiv is_equiv function
+open eq sigma sigma.ops equiv is_equiv function is_trunc
 
 namespace sigma
   variables {A A' : Type} {B : A → Type} {B' : A' → Type} {C : Πa, B a → Type}
@@ -35,7 +35,7 @@ namespace sigma
   definition sigma_eq (p : u.1 = v.1) (q : u.2 =[p] v.2) : u = v :=
   by induction u; induction v; exact (dpair_eq_dpair p q)
 
-  definition eq_pr1 (p : u = v) : u.1 = v.1 :=
+  definition eq_pr1 [unfold 5] (p : u = v) : u.1 = v.1 :=
   ap pr1 p
 
   postfix `..1`:(max+1) := eq_pr1
@@ -162,8 +162,8 @@ namespace sigma
   by induction p; induction bc; reflexivity
 
   /- The special case when the second variable doesn't depend on the first is simpler. -/
-  definition sigma_transport_nondep {B : Type} {C : A → B → Type} (p : a = a') (bc : Σ(b : B), C a b)
-      : p ▸ bc = ⟨bc.1, p ▸ bc.2⟩ :=
+  definition sigma_transport_nondep {B : Type} {C : A → B → Type} (p : a = a')
+    (bc : Σ(b : B), C a b) : p ▸ bc = ⟨bc.1, p ▸ bc.2⟩ :=
   by induction p; induction bc; reflexivity
 
   /- Or if the second variable contains a first component that doesn't depend on the first. -/
@@ -242,7 +242,7 @@ namespace sigma
   -- by induction u; induction v; apply ap_sigma_functor_eq_dpair
 
   /- definition 3.11.9(i): Summing up a contractible family of types does nothing. -/
-  open is_trunc
+
   definition is_equiv_pr1 [instance] (B : A → Type) [H : Π a, is_contr (B a)]
       : is_equiv (@pr1 A B) :=
   adjointify pr1

--- a/hott/types/sum.hlean
+++ b/hott/types/sum.hlean
@@ -31,7 +31,7 @@ namespace sum
   by induction p; induction z; all_goals exact up idp
 
   variables (z z')
-  definition sum_eq_equiv : (z = z') ≃ sum.code z z' :=
+  definition sum_eq_equiv [constructor] : (z = z') ≃ sum.code z z' :=
   equiv.MK sum.encode
            !sum.decode
            abstract begin
@@ -63,7 +63,8 @@ namespace sum
   | sum_functor (inl a) := inl (f a)
   | sum_functor (inr b) := inr (g b)
 
-  definition is_equiv_sum_functor [Hf : is_equiv f] [Hg : is_equiv g] : is_equiv (sum_functor f g) :=
+  definition is_equiv_sum_functor [constructor] [Hf : is_equiv f] [Hg : is_equiv g]
+    : is_equiv (sum_functor f g) :=
   adjointify (sum_functor f   g)
              (sum_functor f⁻¹ g⁻¹)
              abstract begin
@@ -75,23 +76,24 @@ namespace sum
                all_goals (esimp; (apply ap inl | apply ap inr); apply right_inv)
              end end
 
-  definition sum_equiv_sum_of_is_equiv [Hf : is_equiv f] [Hg : is_equiv g] : A + B ≃ A' + B' :=
+  definition sum_equiv_sum_of_is_equiv [constructor] [Hf : is_equiv f] [Hg : is_equiv g]
+    : A + B ≃ A' + B' :=
   equiv.mk _ (is_equiv_sum_functor f g)
 
-  definition sum_equiv_sum (f : A ≃ A') (g : B ≃ B') : A + B ≃ A' + B' :=
+  definition sum_equiv_sum [constructor] (f : A ≃ A') (g : B ≃ B') : A + B ≃ A' + B' :=
   equiv.mk _ (is_equiv_sum_functor f g)
 
-  definition sum_equiv_sum_left (g : B ≃ B') : A + B ≃ A + B' :=
+  definition sum_equiv_sum_left [constructor] (g : B ≃ B') : A + B ≃ A + B' :=
   sum_equiv_sum equiv.refl g
 
-  definition sum_equiv_sum_right (f : A ≃ A') : A + B ≃ A' + B :=
+  definition sum_equiv_sum_right [constructor] (f : A ≃ A') : A + B ≃ A' + B :=
   sum_equiv_sum f equiv.refl
 
-  definition flip : A + B → B + A
+  definition flip [unfold 3] : A + B → B + A
   | flip (inl a) := inr a
   | flip (inr b) := inl b
 
-  definition sum_comm_equiv (A B : Type) : A + B ≃ B + A :=
+  definition sum_comm_equiv [constructor] (A B : Type) : A + B ≃ B + A :=
   begin
     fapply equiv.MK,
       exact flip,
@@ -107,7 +109,7 @@ namespace sum
   --     all_goals try (repeat (apply inl | apply inr | assumption); now),
   -- end
 
-  definition sum_empty_equiv (A : Type) : A + empty ≃ A :=
+  definition sum_empty_equiv [constructor] (A : Type) : A + empty ≃ A :=
   begin
     fapply equiv.MK,
       intro z, induction z, assumption, contradiction,
@@ -119,7 +121,7 @@ namespace sum
   definition sum_rec_unc {P : A + B → Type} (fg : (Πa, P (inl a)) × (Πb, P (inr b))) : Πz, P z :=
   sum.rec fg.1 fg.2
 
-  definition is_equiv_sum_rec (P : A + B → Type)
+  definition is_equiv_sum_rec [constructor] (P : A + B → Type)
     : is_equiv (sum_rec_unc : (Πa, P (inl a)) × (Πb, P (inr b)) → Πz, P z) :=
   begin
      apply adjointify sum_rec_unc (λf, (λa, f (inl a), λb, f (inr b))),
@@ -127,13 +129,15 @@ namespace sum
        intro h, induction h with f g, reflexivity
   end
 
-  definition equiv_sum_rec (P : A + B → Type) : (Πa, P (inl a)) × (Πb, P (inr b)) ≃ Πz, P z :=
+  definition equiv_sum_rec [constructor] (P : A + B → Type)
+    : (Πa, P (inl a)) × (Πb, P (inr b)) ≃ Πz, P z :=
   equiv.mk _ !is_equiv_sum_rec
 
-  definition imp_prod_imp_equiv_sum_imp (A B C : Type) : (A → C) × (B → C) ≃ (A + B → C) :=
+  definition imp_prod_imp_equiv_sum_imp [constructor] (A B C : Type)
+    : (A → C) × (B → C) ≃ (A + B → C) :=
   !equiv_sum_rec
 
-  definition is_trunc_sum  (n : trunc_index) [HA : is_trunc (n.+2) A]  [HB : is_trunc (n.+2) B]
+  definition is_trunc_sum (n : trunc_index) [HA : is_trunc (n.+2) A]  [HB : is_trunc (n.+2) B]
     : is_trunc (n.+2) (A + B) :=
   begin
     apply is_trunc_succ_intro, intro z z',
@@ -150,7 +154,8 @@ namespace sum
   definition sigma_bool_of_sum {A B : Type} (z : A + B) : Σ(b : bool), bool.rec A B b :=
   by induction z with a b; exact ⟨ff, a⟩; exact ⟨tt, b⟩
 
-  definition sum_equiv_sigma_bool (A B : Type) : A + B ≃ Σ(b : bool), bool.rec A B b :=
+  definition sum_equiv_sigma_bool [constructor] (A B : Type)
+    : A + B ≃ Σ(b : bool), bool.rec A B b :=
   equiv.MK sigma_bool_of_sum
            sum_of_sigma_bool
            begin intro v, induction v with b x, induction b, all_goals reflexivity end

--- a/hott/types/trunc.hlean
+++ b/hott/types/trunc.hlean
@@ -16,14 +16,6 @@ open eq sigma sigma.ops pi function equiv is_trunc.trunctype
 namespace is_trunc
   variables {A B : Type} {n : trunc_index}
 
-  definition is_trunc_succ_of_imp_is_trunc_succ (H : A → is_trunc (n.+1) A) : is_trunc (n.+1) A :=
-  @is_trunc_succ_intro _ _ (λx y, @is_trunc_eq _ _ (H x) x y)
-
-  definition is_trunc_of_imp_is_trunc_of_leq (Hn : -1 ≤ n) (H : A → is_trunc n A) : is_trunc n A :=
-  trunc_index.rec_on n (λHn H, empty.rec _ Hn)
-                       (λn IH Hn, is_trunc_succ_of_imp_is_trunc_succ)
-                       Hn H
-
   /- theorems about trunctype -/
   protected definition trunctype.sigma_char.{l} (n : trunc_index) :
     (trunctype.{l} n) ≃ (Σ (A : Type.{l}), is_trunc n A) :=

--- a/hott/types/trunc.hlean
+++ b/hott/types/trunc.hlean
@@ -227,7 +227,7 @@ namespace trunc
   begin
     revert A m H, eapply (trunc_index.rec_on n),
     { clear n, intro A m H, apply is_contr_equiv_closed,
-      { apply equiv_trunc, apply (@is_trunc_of_leq _ -2), exact unit.star} },
+      { apply equiv.symm, apply trunc_equiv, apply (@is_trunc_of_leq _ -2), exact unit.star} },
     { clear n, intro n IH A m H, induction m with m,
       { apply (@is_trunc_of_leq _ -2), exact unit.star},
       { apply is_trunc_succ_intro, intro aa aa',
@@ -237,6 +237,12 @@ namespace trunc
         { apply tr_eq_tr_equiv},
         { exact (IH _ _ _)}}}
   end
+
+  open equiv.ops
+  definition unique_choice {P : A → Type} [H : Πa, is_hprop (P a)] (f : Πa, ∥ P a ∥) (a : A)
+    : P a :=
+  !trunc_equiv (f a)
+
 
 end trunc open trunc
 

--- a/hott/types/univ.hlean
+++ b/hott/types/univ.hlean
@@ -10,17 +10,75 @@ Theorems about the universe
 
 import .bool .trunc .lift
 
-open is_trunc bool lift unit
+open is_trunc bool lift unit eq pi equiv equiv.ops sum
 
 namespace univ
+
+  universe variable u
+  variables {A B : Type.{u}} {a : A} {b : B}
+
+  /- Pathovers -/
+
+  definition eq_of_pathover_ua {f : A ≃ B} (p : a =[ua f] b) : f a = b :=
+  !cast_ua⁻¹ ⬝ tr_eq_of_pathover p
+
+  definition pathover_ua {f : A ≃ B} (p : f a = b) : a =[ua f] b :=
+  pathover_of_tr_eq (!cast_ua ⬝ p)
+
+  definition pathover_ua_equiv (f : A ≃ B) : (a =[ua f] b) ≃ (f a = b) :=
+  equiv.MK eq_of_pathover_ua
+           pathover_ua
+           abstract begin
+             intro p, unfold [pathover_ua,eq_of_pathover_ua],
+             rewrite [to_right_inv !pathover_equiv_tr_eq, inv_con_cancel_left]
+           end end
+           abstract begin
+             intro p, unfold [pathover_ua,eq_of_pathover_ua],
+             rewrite [con_inv_cancel_left, to_left_inv !pathover_equiv_tr_eq]
+           end end
+
+  /- Properties which can be disproven for the universe -/
 
   definition not_is_hset_type0 : ¬is_hset Type₀ :=
   assume H : is_hset Type₀,
   absurd !is_hset.elim eq_bnot_ne_idp
 
-  definition not_is_hset_type.{u} : ¬is_hset Type.{u} :=
+  definition not_is_hset_type.{v} : ¬is_hset Type.{v} :=
   assume H : is_hset Type,
   absurd (is_trunc_is_embedding_closed lift star) not_is_hset_type0
+
+  --set_option pp.notation false
+  definition not_double_negation_elimination0 : ¬Π(A : Type₀), ¬¬A → A :=
+  begin
+    intro f,
+    have u : ¬¬bool, by exact (λg, g tt),
+    let H1 := apdo f eq_bnot,
+    let H2 := apo10 H1 u,
+    have p : eq_bnot ▸ u = u, from !is_hprop.elim,
+    rewrite p at H2,
+    let H3 := eq_of_pathover_ua H2, esimp at H3, --TODO: use apply ... at after #700
+    exact absurd H3 (bnot_ne (f bool u)),
+  end
+
+  definition not_double_negation_elimination : ¬Π(A : Type), ¬¬A → A :=
+  begin
+    intro f,
+    apply not_double_negation_elimination0,
+    intro A nna, refine down (f _ _),
+    intro na,
+    have ¬A, begin intro a, exact absurd (up a) na end,
+    exact absurd this nna
+  end
+
+  definition not_excluded_middle : ¬Π(A : Type), A + ¬A :=
+  begin
+    intro f,
+    apply not_double_negation_elimination,
+    intro A nna,
+    induction (f A) with a na,
+      exact a,
+      exact absurd na nna
+  end
 
 
 end univ

--- a/hott/types/univ.hlean
+++ b/hott/types/univ.hlean
@@ -1,0 +1,26 @@
+/-
+Copyright (c) 2015 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Floris van Doorn
+
+Theorems about the universe
+-/
+
+-- see also init.ua
+
+import .bool .trunc .lift
+
+open is_trunc bool lift unit
+
+namespace univ
+
+  definition not_is_hset_type0 : ¬is_hset Type₀ :=
+  assume H : is_hset Type₀,
+  absurd !is_hset.elim eq_bnot_ne_idp
+
+  definition not_is_hset_type.{u} : ¬is_hset Type.{u} :=
+  assume H : is_hset Type,
+  absurd (is_trunc_is_embedding_closed lift star) not_is_hset_type0
+
+
+end univ

--- a/library/library.md
+++ b/library/library.md
@@ -27,8 +27,8 @@ The `standard` library does not rely on any axioms beyond this framework, and is
 hence constructive. It includes theories of the natural numbers, integers,
 lists, and so on.
 
-The `classical` library imports the law of the excluded middle, choice functions,
-and propositional extensionality. See `logic/axioms` for details.
+The `classical` library also imports a choice function axiom, which implies 
+the law of the excluded middle and propositional extensionality. See [logic.choice](logic/choice.lean) for details.
 
 See also the [hott library](../hott/hott.md), a library for homotopy
 type theory based on a predicative foundation.

--- a/src/emacs/lean-syntax.el
+++ b/src/emacs/lean-syntax.el
@@ -160,7 +160,7 @@
                 "refine" "repeat" "whnf" "rotate" "rotate_left" "rotate_right" "inversion" "cases" "rewrite"
                 "xrewrite" "krewrite" "simp" "esimp" "unfold" "change" "check_expr" "contradiction"
                 "exfalso" "split" "existsi" "constructor" "fconstructor" "left" "right" "injection" "congruence" "reflexivity"
-                "symmetry" "transitivity" "state" "induction" "induction_using"
+                "symmetry" "transitivity" "state" "induction" "induction_using" "fail" "append"
                 "substvars" "now" "with_options"))
            word-end)
       (1 'font-lock-constant-face))

--- a/src/emacs/lean-syntax.el
+++ b/src/emacs/lean-syntax.el
@@ -20,7 +20,7 @@
     "using" "namespace" "section" "fields" "find_decl"
     "attribute" "local" "set_option" "extends" "include" "omit" "classes"
     "instances" "coercions" "metaclasses" "raw" "migrate" "replacing"
-    "calc" "have" "show" "suffices" "by" "in" "at" "let" "forall" "fun"
+    "calc" "have" "show" "suffices" "by" "in" "at" "let" "forall" "Pi" "fun"
     "exists" "if" "dif" "then" "else" "assume" "assert" "take"
     "obtain" "from")
   "lean keywords ending with 'word' (not symbol)")


### PR DESCRIPTION
I've been working on many different things in the HoTT library again: some refactoring, some more theorems from chapter 3 of the book, some more category theory.

I have one concern. [This proof](https://github.com/fpvandoorn/lean/blob/ad9cceddde69fad7d5dd1f61007db4f51791308d/hott/algebra/category/adjoint.hlean#L78-L128) in the category theory library takes ~10 seconds to compile because of multiple times using `krewrite`. Because of that I've commented it out for now, but I will need to use it in the future. I don't really know what to do with it, I'm afraid it will be annoying to compile it every time if it is uncommented.
