### PR TITLE
fix(library/data/rat/order): declare decidable_le an instance

### DIFF
--- a/library/data/rat/order.lean
+++ b/library/data/rat/order.lean
@@ -321,6 +321,8 @@ section migrate_algebra
   attribute le.trans lt.trans lt_of_lt_of_le lt_of_le_of_lt ge.trans gt.trans gt_of_gt_of_ge
                    gt_of_ge_of_gt [trans]
 
+  attribute decidable_le [instance]
+
 end migrate_algebra
 
 theorem rat_of_nat_abs (a : ℤ) : abs (of_int a) = of_nat (int.nat_abs a) :=


### PR DESCRIPTION
Lean does not infer that rat has decidable weak inequality. There is a theorem rat.decidable_le that is present, but seems to not be tagged as an instance.

Before this commit:

``` lean
import data.rat
open rat

example (a b : ℚ) : decidable (a < b) := _   -- this works
example (a b : ℚ) : decidable (a ≤ b) := _   -- fails to infer the placeholder
example (a b : ℚ) : decidable (a ≤ b) := decidable_le   -- this works
```

Does migrate not carry over instances? I wouldn't be surprised if there were other places in the library we have similar issues.
