### PR TITLE
casts, metric spaces, etc.

### DIFF
--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -434,37 +434,37 @@ section discrete_linear_ordered_field
       absurd Hl' (ne_of_lt Hl)),
     lt_of_le_of_ne H1 Hn
 
-  theorem div_lt_div_of_lt (Ha : 0 < a) (H : a < b) : 1 / b < 1 / a :=
+  theorem one_div_lt_one_div_of_lt (Ha : 0 < a) (H : a < b) : 1 / b < 1 / a :=
     lt_of_not_ge
       (assume H',
       absurd H (not_lt_of_ge (le_of_one_div_le_one_div Ha H')))
 
-  theorem div_le_div_of_le (Ha : 0 < a) (H : a ≤ b) : 1 / b ≤ 1 / a :=
+  theorem one_div_le_one_div_of_le (Ha : 0 < a) (H : a ≤ b) : 1 / b ≤ 1 / a :=
     le_of_not_gt
       (assume H',
       absurd H (not_le_of_gt (lt_of_one_div_lt_one_div Ha H')))
 
-  theorem div_lt_div_of_lt_neg (Hb : b < 0) (H : a < b) : 1 / b < 1 / a :=
+  theorem one_div_lt_one_div_of_lt_of_neg (Hb : b < 0) (H : a < b) : 1 / b < 1 / a :=
     lt_of_not_ge
       (assume H',
       absurd H (not_lt_of_ge (le_of_one_div_le_one_div_of_neg Hb H')))
 
-  theorem div_le_div_of_le_neg (Hb : b < 0) (H : a ≤ b) : 1 / b ≤ 1 / a :=
+  theorem one_div_le_one_div_of_le_of_neg (Hb : b < 0) (H : a ≤ b) : 1 / b ≤ 1 / a :=
     le_of_not_gt
       (assume H',
       absurd H (not_le_of_gt (lt_of_one_div_lt_one_div_of_neg Hb H')))
 
   theorem one_lt_one_div (H1 : 0 < a) (H2 : a < 1) : 1 < 1 / a :=
-    one_div_one ▸ div_lt_div_of_lt H1 H2
+    one_div_one ▸ one_div_lt_one_div_of_lt H1 H2
 
   theorem one_le_one_div (H1 : 0 < a) (H2 : a ≤ 1) : 1 ≤ 1 / a :=
-    one_div_one ▸ div_le_div_of_le H1 H2
+    one_div_one ▸ one_div_le_one_div_of_le H1 H2
 
   theorem one_div_lt_neg_one (H1 : a < 0) (H2 : -1 < a) : 1 / a < -1 :=
-    one_div_neg_one_eq_neg_one ▸ div_lt_div_of_lt_neg H1 H2
+    one_div_neg_one_eq_neg_one ▸ one_div_lt_one_div_of_lt_of_neg H1 H2
 
   theorem one_div_le_neg_one (H1 : a < 0) (H2 : -1 ≤ a) : 1 / a ≤ -1 :=
-    one_div_neg_one_eq_neg_one ▸ div_le_div_of_le_neg H1 H2
+    one_div_neg_one_eq_neg_one ▸ one_div_le_one_div_of_le_of_neg H1 H2
 
   theorem div_lt_div_of_pos_of_lt_of_pos (Hb : 0 < b) (H : b < a) (Hc : 0 < c) : c / a < c / b :=
     begin
@@ -473,7 +473,7 @@ section discrete_linear_ordered_field
       apply mul_neg_of_pos_of_neg,
       exact Hc,
       apply iff.mpr !sub_neg_iff_lt,
-      apply div_lt_div_of_lt,
+      apply one_div_lt_one_div_of_lt,
       repeat assumption
     end
 

--- a/library/algebra/ordered_group.lean
+++ b/library/algebra/ordered_group.lean
@@ -698,6 +698,10 @@ section
   theorem abs_eq_zero_iff_eq_zero (a : A) : abs a = 0 ↔ a = 0 :=
   iff.intro eq_zero_of_abs_eq_zero (assume H, congr_arg abs H ⬝ !abs_zero)
 
+  theorem eq_of_abs_sub_eq_zero {a b : A} (H : abs (a - b) = 0) : a = b :=
+  have a - b = 0, from eq_zero_of_abs_eq_zero H,
+  show a = b, from eq_of_sub_eq_zero this
+
   theorem abs_pos_of_ne_zero (H : a ≠ 0) : abs a > 0 :=
   or.elim (lt_or_gt_of_ne H) abs_pos_of_neg abs_pos_of_pos
 
@@ -770,6 +774,12 @@ section
         ... ≤ abs (a - b) + abs b   : abs_add_le_abs_add_abs,
   algebra.le_of_add_le_add_right H1
 
+  theorem abs_sub_le (a b c : A) : abs (a - c) ≤ abs (a - b) + abs (b - c) :=
+  calc
+    abs (a - c) = abs (a - b + (b - c))     :
+                    by rewrite [sub_eq_add_neg, add.assoc, neg_add_cancel_left]
+            ... ≤ abs (a - b) + abs (b - c) : abs_add_le_abs_add_abs
+
   theorem abs_add_three (a b c : A) : abs (a + b + c) ≤ abs a + abs b + abs c :=
     begin
       apply le.trans,
@@ -780,7 +790,7 @@ section
       apply le.refl
     end
 
-theorem dist_bdd_within_interval {a b lb ub : A} (H : lb < ub) (Hal : lb ≤ a) (Hau : a ≤ ub)
+  theorem dist_bdd_within_interval {a b lb ub : A} (H : lb < ub) (Hal : lb ≤ a) (Hau : a ≤ ub)
         (Hbl : lb ≤ b) (Hbu : b ≤ ub) : abs (a - b) ≤ ub - lb :=
   begin
     cases (decidable.em (b ≤ a)) with [Hba, Hba],

--- a/library/data/int/basic.lean
+++ b/library/data/int/basic.lean
@@ -87,7 +87,10 @@ infix  [priority int.prio] *  := int.mul
 theorem of_nat.inj {m n : ℕ} (H : of_nat m = of_nat n) : m = n :=
 int.no_confusion H imp.id
 
-theorem of_nat_eq_of_nat (m n : ℕ) : of_nat m = of_nat n ↔ m = n :=
+theorem eq_of_of_nat_eq_of_nat {m n : ℕ} (H : of_nat m = of_nat n) : m = n :=
+of_nat.inj H
+
+theorem of_nat_eq_of_nat_iff (m n : ℕ) : of_nat m = of_nat n ↔ m = n :=
 iff.intro of_nat.inj !congr_arg
 
 theorem neg_succ_of_nat.inj {m n : ℕ} (H : neg_succ_of_nat m = neg_succ_of_nat n) : m = n :=
@@ -97,7 +100,7 @@ theorem neg_succ_of_nat_eq (n : ℕ) : -[1+ n] = -(n + 1) := rfl
 
 private definition has_decidable_eq₂ : Π (a b : ℤ), decidable (a = b)
 | (of_nat m) (of_nat n) := decidable_of_decidable_of_iff
-    (nat.has_decidable_eq m n) (iff.symm (of_nat_eq_of_nat m n))
+    (nat.has_decidable_eq m n) (iff.symm (of_nat_eq_of_nat_iff m n))
 | (of_nat m) -[1+ n]    := inr (by contradiction)
 | -[1+ m]    (of_nat n) := inr (by contradiction)
 | -[1+ m]    -[1+ n]    := if H : m = n then

--- a/library/data/int/div.lean
+++ b/library/data/int/div.lean
@@ -288,7 +288,7 @@ obtain m (Hm : a = of_nat m), from exists_eq_of_nat H1,
 obtain n (Hn : b = of_nat n), from exists_eq_of_nat (le_of_lt (lt_of_le_of_lt H1 H2)),
 begin
   revert H2,
-  rewrite [Hm, Hn, of_nat_mod, of_nat_lt_of_nat, of_nat_eq_of_nat],
+  rewrite [Hm, Hn, of_nat_mod, of_nat_lt_of_nat_iff, of_nat_eq_of_nat_iff],
   apply nat.mod_eq_of_lt
 end
 
@@ -481,21 +481,21 @@ nat.by_cases_zero_pos n
         assume H4 : of_nat n' = of_nat m * c,
         have H5 : c > 0, from pos_of_mul_pos_left (H4 ▸ H2) !of_nat_nonneg,
         obtain k (H6 : c = of_nat k), from exists_eq_of_nat (le_of_lt H5),
-        have H7 : n' = (#nat m * k), from (!iff.mp !of_nat_eq_of_nat (H6 ▸ H4)),
+        have H7 : n' = (#nat m * k), from (of_nat.inj (H6 ▸ H4)),
         nat.dvd.intro H7⁻¹))
 
 theorem of_nat_dvd_of_nat_of_dvd {m n : ℕ} (H : #nat m ∣ n) : of_nat m ∣ of_nat n :=
 nat.dvd.elim H
   (take k, assume H1 : #nat n = m * k,
-    dvd.intro (!iff.mpr !of_nat_eq_of_nat H1⁻¹))
+    dvd.intro (H1⁻¹ ▸ rfl))
 
-theorem of_nat_dvd_of_nat (m n : ℕ) : of_nat m ∣ of_nat n ↔ (#nat m ∣ n) :=
+theorem of_nat_dvd_of_nat_iff (m n : ℕ) : of_nat m ∣ of_nat n ↔ (#nat m ∣ n) :=
 iff.intro dvd_of_of_nat_dvd_of_nat of_nat_dvd_of_nat_of_dvd
 
 theorem dvd.antisymm {a b : ℤ} (H1 : a ≥ 0) (H2 : b ≥ 0) : a ∣ b → b ∣ a → a = b :=
 begin
   rewrite [-abs_of_nonneg H1, -abs_of_nonneg H2, -*of_nat_nat_abs],
-  rewrite [*of_nat_dvd_of_nat, *of_nat_eq_of_nat],
+  rewrite [*of_nat_dvd_of_nat_iff, *of_nat_eq_of_nat_iff],
   apply nat.dvd.antisymm
 end
 

--- a/library/data/int/gcd.lean
+++ b/library/data/int/gcd.lean
@@ -63,7 +63,7 @@ by rewrite [↑gcd, nat.gcd_self, of_nat_nat_abs]
 
 theorem gcd_dvd_left (a b : ℤ) : gcd a b ∣ a :=
 have gcd a b ∣ abs a,
-  by rewrite [↑gcd, -of_nat_nat_abs, of_nat_dvd_of_nat]; apply nat.gcd_dvd_left,
+  by rewrite [↑gcd, -of_nat_nat_abs, of_nat_dvd_of_nat_iff]; apply nat.gcd_dvd_left,
 iff.mp !dvd_abs_iff this
 
 theorem gcd_dvd_right (a b : ℤ) : gcd a b ∣ b :=
@@ -72,7 +72,7 @@ by rewrite gcd.comm; apply gcd_dvd_left
 theorem dvd_gcd {a b c : ℤ} : a ∣ b → a ∣ c → a ∣ gcd b c :=
 begin
   rewrite [↑gcd, -*(abs_dvd_iff a), -(dvd_abs_iff _ b), -(dvd_abs_iff _ c), -*of_nat_nat_abs],
-  rewrite [*of_nat_dvd_of_nat] ,
+  rewrite [*of_nat_dvd_of_nat_iff] ,
   apply nat.dvd_gcd
 end
 
@@ -212,21 +212,21 @@ theorem lcm_self (a : ℤ) : lcm a a = abs a :=
 by krewrite [↑lcm, nat.lcm_self, of_nat_nat_abs]
 
 theorem dvd_lcm_left (a b : ℤ) : a ∣ lcm a b :=
-by rewrite [↑lcm, -abs_dvd_iff, -of_nat_nat_abs, of_nat_dvd_of_nat]; apply nat.dvd_lcm_left
+by rewrite [↑lcm, -abs_dvd_iff, -of_nat_nat_abs, of_nat_dvd_of_nat_iff]; apply nat.dvd_lcm_left
 
 theorem dvd_lcm_right (a b : ℤ) : b ∣ lcm a b :=
 !lcm.comm ▸ !dvd_lcm_left
 
 theorem gcd_mul_lcm (a b : ℤ) : gcd a b * lcm a b = abs (a * b) :=
 begin
-  rewrite [↑gcd, ↑lcm, -of_nat_nat_abs, -of_nat_mul, of_nat_eq_of_nat, nat_abs_mul],
+  rewrite [↑gcd, ↑lcm, -of_nat_nat_abs, -of_nat_mul, of_nat_eq_of_nat_iff, nat_abs_mul],
   apply nat.gcd_mul_lcm
 end
 
 theorem lcm_dvd {a b c : ℤ} : a ∣ c → b ∣ c → lcm a b ∣ c :=
 begin
   rewrite [↑lcm, -(abs_dvd_iff a), -(abs_dvd_iff b), -*(dvd_abs_iff _ c), -*of_nat_nat_abs],
-  rewrite [*of_nat_dvd_of_nat] ,
+  rewrite [*of_nat_dvd_of_nat_iff] ,
   apply nat.lcm_dvd
 end
 
@@ -261,7 +261,7 @@ dvd_of_coprime_of_dvd_mul_right H1 (!mul.comm ▸ H2)
 theorem gcd_mul_left_cancel_of_coprime {c : ℤ} (a : ℤ) {b : ℤ} (H : coprime c b) :
    gcd (c * a) b = gcd a b :=
 begin
-  revert H, rewrite [↑coprime, ↑gcd, *of_nat_eq_of_nat, nat_abs_mul],
+  revert H, rewrite [↑coprime, ↑gcd, *of_nat_eq_of_nat_iff, nat_abs_mul],
   apply nat.gcd_mul_left_cancel_of_coprime
 end
 

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -45,7 +45,7 @@ theorem le.total (a b : ℤ) : a ≤ b ∨ b ≤ a :=
 or.imp_right
   (assume H : nonneg (-(b - a)),
    have -(b - a) = a - b, from !neg_sub,
-   show nonneg (a - b), from this ▸ H)   -- too bad: can't do it in one step
+   show nonneg (a - b), from this ▸ H)
   (nonneg_or_nonneg_neg (b - a))
 
 theorem of_nat_le_of_nat_of_le {m n : ℕ} (H : #nat m ≤ n) : of_nat m ≤ of_nat n :=
@@ -57,7 +57,7 @@ obtain (k : ℕ) (Hk : of_nat m + of_nat k = of_nat n), from le.elim H,
 have m + k = n, from of_nat.inj (of_nat_add m k ⬝ Hk),
 nat.le.intro this
 
-theorem of_nat_le_of_nat (m n : ℕ) : of_nat m ≤ of_nat n ↔ m ≤ n :=
+theorem of_nat_le_of_nat_iff (m n : ℕ) : of_nat m ≤ of_nat n ↔ m ≤ n :=
 iff.intro le_of_of_nat_le_of_nat of_nat_le_of_nat_of_le
 
 theorem lt_add_succ (a : ℤ) (n : ℕ) : a < a + succ n :=
@@ -78,18 +78,18 @@ have a + succ n = b, from
            ... = b         : Hn,
 exists.intro n this
 
-theorem of_nat_lt_of_nat (n m : ℕ) : of_nat n < of_nat m ↔ n < m :=
+theorem of_nat_lt_of_nat_iff (n m : ℕ) : of_nat n < of_nat m ↔ n < m :=
 calc
   of_nat n < of_nat m ↔ of_nat n + 1 ≤ of_nat m : iff.refl
     ... ↔ of_nat (nat.succ n) ≤ of_nat m        : of_nat_succ n ▸ !iff.refl
-    ... ↔ nat.succ n ≤ m                        : of_nat_le_of_nat
+    ... ↔ nat.succ n ≤ m                        : of_nat_le_of_nat_iff
     ... ↔ n < m                                 : iff.symm (lt_iff_succ_le _ _)
 
 theorem lt_of_of_nat_lt_of_nat {m n : ℕ} (H : of_nat m < of_nat n) : #nat m < n :=
-iff.mp !of_nat_lt_of_nat H
+iff.mp !of_nat_lt_of_nat_iff H
 
 theorem of_nat_lt_of_nat_of_lt {m n : ℕ} (H : #nat m < n) : of_nat m < of_nat n :=
-iff.mpr !of_nat_lt_of_nat H
+iff.mpr !of_nat_lt_of_nat_iff H
 
 /- show that the integers form an ordered additive group -/
 
@@ -388,7 +388,6 @@ dvd.elim H'
   (take b,
     suppose 1 = a * b,
     eq_one_of_mul_eq_one_right H this⁻¹)
---
 
 theorem ex_smallest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P] (Hbdd : ∃ b : ℤ, ∀ z : ℤ, z ≤ b → ¬ P z)
         (Hinh : ∃ z : ℤ, P z) : ∃ lb : ℤ, P lb ∧ (∀ z : ℤ, z < lb → ¬ P z) :=
@@ -418,7 +417,7 @@ theorem ex_smallest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P] (Hbdd : �
     have Hk : nat_abs (z - b) < least (λ n, P (b + of_nat n)) (nat.succ (nat_abs (elt - b))), begin
      let Hz' := iff.mp !int.lt_add_iff_sub_lt_left Hz,
      rewrite [-of_nat_nat_abs_of_nonneg (int.le_of_lt Hpos) at Hz'],
-     apply iff.mp !int.of_nat_lt_of_nat Hz'
+     apply lt_of_of_nat_lt_of_nat Hz'
     end,
     let Hk' := nat.not_le_of_gt Hk,
     rewrite Hzbk,
@@ -455,7 +454,7 @@ theorem ex_largest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P] (Hbdd : ∃
     have Hk : nat_abs (b - z) < least (λ n, P (b - of_nat n)) (nat.succ (nat_abs (b - elt))), begin
       let Hz' := iff.mp !int.lt_add_iff_sub_lt_left (iff.mpr !int.lt_add_iff_sub_lt_right Hz),
       rewrite [-of_nat_nat_abs_of_nonneg (int.le_of_lt Hpos) at Hz'],
-      apply iff.mp !int.of_nat_lt_of_nat Hz'
+      apply lt_of_of_nat_lt_of_nat Hz'
     end,
     let Hk' := nat.not_le_of_gt Hk,
     rewrite Hzbk,

--- a/library/data/int/order.lean
+++ b/library/data/int/order.lean
@@ -389,7 +389,8 @@ dvd.elim H'
     suppose 1 = a * b,
     eq_one_of_mul_eq_one_right H this⁻¹)
 
-theorem ex_smallest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P] (Hbdd : ∃ b : ℤ, ∀ z : ℤ, z ≤ b → ¬ P z)
+theorem exists_least_of_bdd {P : ℤ → Prop} [HP : decidable_pred P]
+    (Hbdd : ∃ b : ℤ, ∀ z : ℤ, z ≤ b → ¬ P z)
         (Hinh : ∃ z : ℤ, P z) : ∃ lb : ℤ, P lb ∧ (∀ z : ℤ, z < lb → ¬ P z) :=
   begin
     cases Hbdd with [b, Hb],
@@ -426,7 +427,8 @@ theorem ex_smallest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P] (Hbdd : �
     apply least_lt _ !lt_succ_self H'
   end
 
-theorem ex_largest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P] (Hbdd : ∃ b : ℤ, ∀ z : ℤ, z ≥ b → ¬ P z)
+theorem exists_greatest_of_bdd {P : ℤ → Prop} [HP : decidable_pred P]
+    (Hbdd : ∃ b : ℤ, ∀ z : ℤ, z ≥ b → ¬ P z)
         (Hinh : ∃ z : ℤ, P z) : ∃ ub : ℤ, P ub ∧ (∀ z : ℤ, z > ub → ¬ P z) :=
   begin
     cases Hbdd with [b, Hb],

--- a/library/data/pnat.lean
+++ b/library/data/pnat.lean
@@ -116,7 +116,7 @@ theorem inv_pos (n : ℕ+) : n⁻¹ > 0 := one_div_pos_of_pos !rat_of_pnat_is_po
 theorem inv_le_one (n : ℕ+) : n⁻¹ ≤ (1 : ℚ) :=
   begin
     rewrite [↑inv, -one_div_one],
-    apply div_le_div_of_le,
+    apply one_div_le_one_div_of_le,
     apply rat.zero_lt_one,
     apply rat_of_pnat_ge_one
   end
@@ -124,7 +124,7 @@ theorem inv_le_one (n : ℕ+) : n⁻¹ ≤ (1 : ℚ) :=
 theorem inv_lt_one_of_gt {n : ℕ+} (H : n~ > 1) : n⁻¹ < (1 : ℚ) :=
   begin
     rewrite [↑inv, -one_div_one],
-    apply div_lt_div_of_lt,
+    apply one_div_lt_one_div_of_lt,
     apply rat.zero_lt_one,
     rewrite pnat.to_rat_of_nat,
     apply (of_nat_lt_of_nat_of_lt H)
@@ -158,7 +158,7 @@ theorem one_lt_two : pone < 2 := !nat.le.refl
 theorem inv_two_mul_lt_inv (n : ℕ+) : (2 * n)⁻¹ < n⁻¹ :=
   begin
     rewrite ↑inv,
-    apply div_lt_div_of_lt,
+    apply one_div_lt_one_div_of_lt,
     apply rat_of_pnat_is_pos,
     have H : n~ < (2 * n)~, begin
       rewrite -one_mul at {1},
@@ -172,10 +172,10 @@ theorem inv_two_mul_lt_inv (n : ℕ+) : (2 * n)⁻¹ < n⁻¹ :=
 theorem inv_two_mul_le_inv (n : ℕ+) : (2 * n)⁻¹ ≤ n⁻¹ := rat.le_of_lt !inv_two_mul_lt_inv
 
 theorem inv_ge_of_le {p q : ℕ+} (H : p ≤ q) : q⁻¹ ≤ p⁻¹ :=
-  div_le_div_of_le !rat_of_pnat_is_pos (rat_of_pnat_le_of_pnat_le H)
+  one_div_le_one_div_of_le !rat_of_pnat_is_pos (rat_of_pnat_le_of_pnat_le H)
 
 theorem inv_gt_of_lt {p q : ℕ+} (H : p < q) : q⁻¹ < p⁻¹ :=
-  div_lt_div_of_lt !rat_of_pnat_is_pos (rat_of_pnat_lt_of_pnat_lt H)
+  one_div_lt_one_div_of_lt !rat_of_pnat_is_pos (rat_of_pnat_lt_of_pnat_lt H)
 
 theorem ge_of_inv_le {p q : ℕ+} (H : p⁻¹ ≤ q⁻¹) : q ≤ p :=
   pnat_le_of_rat_of_pnat_le (le_of_one_div_le_one_div !rat_of_pnat_is_pos H)
@@ -274,10 +274,10 @@ theorem pnat_cancel' (n m : ℕ+) : (n * n * m)⁻¹ * (rat_of_pnat n * rat_of_p
 definition pceil (a : ℚ) : ℕ+ := tag (ubound a) !ubound_pos
 
 theorem pceil_helper {a : ℚ} {n : ℕ+} (H : pceil a ≤ n) (Ha : a > 0) : n⁻¹ ≤ 1 / a :=
-  rat.le.trans (inv_ge_of_le H) (div_le_div_of_le Ha (ubound_ge a))
+  rat.le.trans (inv_ge_of_le H) (one_div_le_one_div_of_le Ha (ubound_ge a))
 
 theorem inv_pceil_div (a b : ℚ) (Ha : a > 0) (Hb : b > 0) : (pceil (a / b))⁻¹ ≤ b / a :=
-  !one_div_one_div ▸ div_le_div_of_le
+  !one_div_one_div ▸ one_div_le_one_div_of_le
     (one_div_pos_of_pos (div_pos_of_pos_of_pos Hb Ha))
     (!div_div_eq_mul_div⁻¹ ▸ !rat.one_mul⁻¹ ▸ !ubound_ge)
 

--- a/library/data/pnat.lean
+++ b/library/data/pnat.lean
@@ -88,16 +88,16 @@ theorem pnat.to_rat_of_nat (n : ℕ+) : rat_of_pnat n = of_nat n~ := rfl
 theorem rat_of_nat_nonneg (n : ℕ) : 0 ≤ of_nat n := trivial
 
 theorem rat_of_pnat_ge_one (n : ℕ+) : rat_of_pnat n ≥ 1 :=
-  (iff.mpr !of_nat_le_of_nat) (pnat_pos n)
+  of_nat_le_of_nat_of_le (pnat_pos n)
 
 theorem rat_of_pnat_is_pos (n : ℕ+) : rat_of_pnat n > 0 :=
-  (iff.mpr !of_nat_pos) (pnat_pos n)
+  of_nat_lt_of_nat_of_lt (pnat_pos n)
 
 theorem of_nat_le_of_nat_of_le {m n : ℕ} (H : m ≤ n) : of_nat m ≤ of_nat n :=
-  (iff.mpr !of_nat_le_of_nat) H
+  of_nat_le_of_nat_of_le H
 
 theorem of_nat_lt_of_nat_of_lt {m n : ℕ} (H : m < n) : of_nat m < of_nat n :=
-  (iff.mpr !of_nat_lt_of_nat) H
+  of_nat_lt_of_nat_of_lt H
 
 theorem rat_of_pnat_le_of_pnat_le {m n : ℕ+} (H : m ≤ n) : rat_of_pnat m ≤ rat_of_pnat n :=
   of_nat_le_of_nat_of_le H
@@ -106,7 +106,7 @@ theorem rat_of_pnat_lt_of_pnat_lt {m n : ℕ+} (H : m < n) : rat_of_pnat m < rat
   of_nat_lt_of_nat_of_lt H
 
 theorem pnat_le_of_rat_of_pnat_le {m n : ℕ+} (H : rat_of_pnat m ≤ rat_of_pnat n) : m ≤ n :=
-  (iff.mp !of_nat_le_of_nat) H
+  le_of_of_nat_le_of_nat H
 
 definition inv (n : ℕ+) : ℚ := (1 : ℚ) / rat_of_pnat n
 postfix `⁻¹` := inv

--- a/library/data/rat/basic.lean
+++ b/library/data/rat/basic.lean
@@ -349,8 +349,8 @@ namespace rat
 /- operations -/
 
 definition of_int [coercion] (i : ℤ) : ℚ := ⟦prerat.of_int i⟧
-definition of_nat [coercion] (n : ℕ) : ℚ := ⟦prerat.of_int n⟧
-definition of_num [coercion] [reducible] (n : num) : ℚ := of_int (int.of_num n)
+definition of_nat [coercion] (n : ℕ) : ℚ := nat.to.rat n
+definition of_num [coercion] [reducible] (n : num) : ℚ := num.to.rat n
 
 definition add : ℚ → ℚ → ℚ :=
 quot.lift₂
@@ -413,16 +413,28 @@ calc
 theorem of_int.inj {a b : ℤ} (H : of_int a = of_int b) : a = b :=
 prerat.of_int.inj (quot.exact H)
 
+theorem eq_of_of_int_eq_of_int {a b : ℤ} (H : of_int a = of_int b) : a = b :=
+of_int.inj H
+
 theorem of_nat_eq (a : ℕ) : of_nat a = of_int (int.of_nat a) := rfl
 
 theorem of_nat_add (a b : ℕ) : of_nat (#nat a + b) = of_nat a + of_nat b :=
-by rewrite [*of_nat_eq, int.of_nat_add, rat.of_int_add]
+by rewrite [of_nat_eq, int.of_nat_add, rat.of_int_add]
 
 theorem of_nat_mul (a b : ℕ) : of_nat (#nat a * b) = of_nat a * of_nat b :=
-by rewrite [*of_nat_eq, int.of_nat_mul, rat.of_int_mul]
+by rewrite [of_nat_eq, int.of_nat_mul, rat.of_int_mul]
 
 theorem of_nat_sub {a b : ℕ} (H : #nat a ≥ b) : of_nat (#nat a - b) = of_nat a - of_nat b :=
-by rewrite [*of_nat_eq, int.of_nat_sub H, rat.of_int_sub]
+by rewrite [of_nat_eq, int.of_nat_sub H, rat.of_int_sub]
+
+theorem of_nat.inj {a b : ℕ} (H : of_nat a = of_nat b) : a = b :=
+int.of_nat.inj (of_int.inj H)
+
+theorem eq_of_of_nat_eq_of_nat {a b : ℕ} (H : of_nat a = of_nat b) : a = b :=
+of_nat.inj H
+
+theorem of_nat_eq_of_nat_iff (a b : ℕ) : of_nat a = of_nat b ↔ a = b :=
+iff.intro of_nat.inj !congr_arg
 
 theorem add.comm (a b : ℚ) : a + b = b + a :=
 quot.induction_on₂ a b (take u v, quot.sound !prerat.add.comm)

--- a/library/data/rat/basic.lean
+++ b/library/data/rat/basic.lean
@@ -541,8 +541,6 @@ section migrate_algebra
   definition divide (a b : rat) := algebra.divide a b
   infix [priority rat.prio] `/` := divide
 
-  definition dvd (a b : rat) := algebra.dvd a b
-
   definition pow (a : ℚ) (n : ℕ) : ℚ := algebra.pow a n
   infix [priority rat.prio] ^ := pow
   definition nmul (n : ℕ) (a : ℚ) : ℚ := algebra.nmul n a
@@ -550,7 +548,11 @@ section migrate_algebra
   definition imul (i : ℤ) (a : ℚ) : ℚ := algebra.imul i a
 
   migrate from algebra with rat
-    replacing sub → rat.sub, divide → divide, dvd → dvd, pow → pow, nmul → nmul, imul → imul
+    hiding dvd, dvd.elim, dvd.elim_left, dvd.intro, dvd.intro_left, dvd.refl, dvd.trans,
+      dvd_mul_left, dvd_mul_of_dvd_left, dvd_mul_of_dvd_right, dvd_mul_right, dvd_neg_iff_dvd,
+      dvd_neg_of_dvd, dvd_of_dvd_neg, dvd_of_mul_left_dvd, dvd_of_mul_left_eq,
+      dvd_of_mul_right_dvd, dvd_of_mul_right_eq, dvd_of_neg_dvd, dvd_sub, dvd_zero
+    replacing sub → rat.sub, divide → divide, pow → pow, nmul → nmul, imul → imul
 
 end migrate_algebra
 
@@ -558,7 +560,7 @@ theorem eq_num_div_denom (a : ℚ) : a = num a / denom a :=
 have H : of_int (denom a) ≠ 0, from assume H', ne_of_gt (denom_pos a) (of_int.inj H'),
 iff.mpr (!eq_div_iff_mul_eq H) (mul_denom a)
 
-theorem of_int_div {a b : ℤ} (H : b ∣ a) : of_int (a div b) = of_int a / of_int b :=
+theorem of_int_div {a b : ℤ} (H : (#int b ∣ a)) : of_int (a div b) = of_int a / of_int b :=
 decidable.by_cases
   (assume bz : b = 0,
     by rewrite [bz, div_zero, int.div_zero])
@@ -570,11 +572,18 @@ decidable.by_cases
           by rewrite [Hc, !int.mul_div_cancel_left bnz, mul.comm]),
     iff.mpr (!eq_div_iff_mul_eq bnz') H')
 
+theorem of_nat_div {a b : ℕ} (H : (#nat b ∣ a)) : of_nat (#nat a div b) = of_nat a / of_nat b :=
+have H' : (#int int.of_nat b ∣ int.of_nat a), by rewrite [int.of_nat_dvd_of_nat_iff]; exact H,
+by+ rewrite [of_nat_eq, int.of_nat_div, of_int_div H']
+
 theorem of_int_pow (a : ℤ) (n : ℕ) : of_int (a^n) = (of_int a)^n :=
 begin
   induction n with n ih,
     apply eq.refl,
   rewrite [pow_succ, int.pow_succ, of_int_mul, ih]
 end
+
+theorem of_nat_pow (a : ℕ) (n : ℕ) : of_nat (#nat a^n) = (of_nat a)^n :=
+by rewrite [of_nat_eq, int.of_nat_pow, of_int_pow]
 
 end rat

--- a/library/data/rat/order.lean
+++ b/library/data/rat/order.lean
@@ -152,35 +152,52 @@ infix [priority rat.prio] >= := rat.ge
 infix [priority rat.prio] ≥  := rat.ge
 infix [priority rat.prio] >  := rat.gt
 
-theorem of_int_lt_of_int (a b : ℤ) : of_int a < of_int b ↔ (#int a < b) :=
+theorem of_int_lt_of_int_iff (a b : ℤ) : of_int a < of_int b ↔ (#int a < b) :=
 iff.symm (calc
   (#int a < b) ↔ (#int b - a > 0)          : iff.symm !int.sub_pos_iff_lt
            ... ↔ pos (of_int (#int b - a)) : iff.symm !pos_of_int
            ... ↔ pos (of_int b - of_int a) : !of_int_sub ▸ iff.rfl
            ... ↔ of_int a < of_int b       : iff.rfl)
 
-theorem of_int_le_of_int (a b : ℤ) : of_int a ≤ of_int b ↔ (#int a ≤ b) :=
+theorem of_int_lt_of_int_of_lt {a b : ℤ} (H : (#int a < b)) : of_int a < of_int b :=
+iff.mpr !of_int_lt_of_int_iff H
+
+theorem lt_of_of_int_lt_of_int {a b : ℤ} (H : of_int a < of_int b) : (#int a < b) :=
+iff.mp !of_int_lt_of_int_iff H
+
+theorem of_int_le_of_int_iff (a b : ℤ) : of_int a ≤ of_int b ↔ (#int a ≤ b) :=
 iff.symm (calc
   (#int a ≤ b) ↔ (#int b - a ≥ 0)             : iff.symm !int.sub_nonneg_iff_le
            ... ↔ nonneg (of_int (#int b - a)) : iff.symm !nonneg_of_int
            ... ↔ nonneg (of_int b - of_int a) : !of_int_sub ▸ iff.rfl
            ... ↔ of_int a ≤ of_int b          : iff.rfl)
 
-theorem of_int_pos (a : ℤ) : (of_int a > 0) ↔ (#int a > 0) := !of_int_lt_of_int
+theorem of_int_le_of_int_of_le {a b : ℤ} (H : (#int a ≤ b)) : of_int a ≤ of_int b :=
+iff.mpr !of_int_le_of_int_iff H
 
-theorem of_int_nonneg (a : ℤ) : (of_int a ≥ 0) ↔ (#int a ≥ 0) := !of_int_le_of_int
+theorem le_of_of_int_le_of_int {a b : ℤ} (H : of_int a ≤ of_int b) : (#int a ≤ b) :=
+iff.mp !of_int_le_of_int_iff H
 
-theorem of_nat_lt_of_nat (a b : ℕ) : of_nat a < of_nat b ↔ (#nat a < b) :=
-by rewrite [*of_nat_eq, propext !of_int_lt_of_int]; apply int.of_nat_lt_of_nat
+theorem of_nat_lt_of_nat_iff (a b : ℕ) : of_nat a < of_nat b ↔ (#nat a < b) :=
+by rewrite [*of_nat_eq, of_int_lt_of_int_iff, int.of_nat_lt_of_nat_iff]
 
-theorem of_nat_le_of_nat (a b : ℕ) : of_nat a ≤ of_nat b ↔ (#nat a ≤ b) :=
-by rewrite [*of_nat_eq, propext !of_int_le_of_int]; apply int.of_nat_le_of_nat
+theorem of_nat_lt_of_nat_of_lt {a b : ℕ} (H : (#nat a < b)) : of_nat a < of_nat b :=
+iff.mpr !of_nat_lt_of_nat_iff H
 
-theorem of_nat_pos (a : ℕ) : (of_nat a > 0) ↔ (#nat a > nat.zero) :=
-!of_nat_lt_of_nat
+theorem lt_of_of_nat_lt_of_nat {a b : ℕ} (H : of_nat a < of_nat b) : (#nat a < b) :=
+iff.mp !of_nat_lt_of_nat_iff H
+
+theorem of_nat_le_of_nat_iff (a b : ℕ) : of_nat a ≤ of_nat b ↔ (#nat a ≤ b) :=
+by rewrite [*of_nat_eq, of_int_le_of_int_iff, int.of_nat_le_of_nat_iff]
+
+theorem of_nat_le_of_nat_of_le {a b : ℕ} (H : (#nat a ≤ b)) : of_nat a ≤ of_nat b :=
+iff.mpr !of_nat_le_of_nat_iff H
+
+theorem le_of_of_nat_le_of_nat {a b : ℕ} (H : of_nat a ≤ of_nat b) : (#nat a ≤ b) :=
+iff.mp !of_nat_le_of_nat_iff H
 
 theorem of_nat_nonneg (a : ℕ) : (of_nat a ≥ 0) :=
-iff.mpr !of_nat_le_of_nat !nat.zero_le
+of_nat_le_of_nat_of_le !nat.zero_le
 
 theorem le.refl (a : ℚ) : a ≤ a :=
 by rewrite [↑rat.le, sub_self]; apply nonneg_zero
@@ -328,8 +345,8 @@ end migrate_algebra
 theorem rat_of_nat_abs (a : ℤ) : abs (of_int a) = of_nat (int.nat_abs a) :=
 assert ∀ n : ℕ, of_int (int.neg_succ_of_nat n) = - of_nat (nat.succ n), from λ n, rfl,
 int.induction_on a
-  (take b, abs_of_nonneg (!of_nat_nonneg))
-  (take b, by rewrite [this, abs_neg, abs_of_nonneg (!of_nat_nonneg)])
+  (take b, abs_of_nonneg !of_nat_nonneg)
+  (take b, by rewrite [this, abs_neg, abs_of_nonneg !of_nat_nonneg])
 
 section
   open int
@@ -341,40 +358,40 @@ section
     begin
       rewrite [-mul_denom],
       apply mul_nonneg H,
-      rewrite [of_int_le_of_int],
+      rewrite [of_int_le_of_int_iff],
       exact int.le_of_lt !denom_pos
     end,
-  show num q ≥ 0, from iff.mp !of_int_le_of_int this
+  show num q ≥ 0, from le_of_of_int_le_of_int this
 
   theorem num_pos_of_pos {q : ℚ} (H : q > 0) : num q > 0 :=
   have of_int (num q) > of_int 0,
     begin
       rewrite [-mul_denom],
       apply mul_pos H,
-      rewrite [of_int_lt_of_int],
+      rewrite [of_int_lt_of_int_iff],
       exact !denom_pos
     end,
-  show num q > 0, from iff.mp !of_int_lt_of_int this
+  show num q > 0, from lt_of_of_int_lt_of_int this
 
   theorem num_neg_of_neg {q : ℚ} (H : q < 0) : num q < 0 :=
   have of_int (num q) < of_int 0,
     begin
       rewrite [-mul_denom],
       apply mul_neg_of_neg_of_pos H,
-      rewrite [of_int_lt_of_int],
+      rewrite [of_int_lt_of_int_iff],
       exact !denom_pos
     end,
-  show num q < 0, from iff.mp !of_int_lt_of_int this
+  show num q < 0, from lt_of_of_int_lt_of_int this
 
   theorem num_nonpos_of_nonpos {q : ℚ} (H : q ≤ 0) : num q ≤ 0 :=
   have of_int (num q) ≤ of_int 0,
     begin
       rewrite [-mul_denom],
       apply mul_nonpos_of_nonpos_of_nonneg H,
-      rewrite [of_int_le_of_int],
+      rewrite [of_int_le_of_int_iff],
       exact int.le_of_lt !denom_pos
     end,
-  show num q ≤ 0, from iff.mp !of_int_le_of_int this
+  show num q ≤ 0, from le_of_of_int_le_of_int this
 end
 
 definition ubound : ℚ → ℕ := λ a : ℚ, nat.succ (int.nat_abs (num a))
@@ -382,10 +399,10 @@ definition ubound : ℚ → ℕ := λ a : ℚ, nat.succ (int.nat_abs (num a))
 theorem ubound_ge (a : ℚ) : of_nat (ubound a) ≥ a :=
 have h : abs a * abs (of_int (denom a)) = abs (of_int (num a)), from
   !abs_mul ▸ !mul_denom ▸ rfl,
-assert of_int (denom a) > 0, from (iff.mpr !of_int_pos) !denom_pos,
+assert of_int (denom a) > 0, from of_int_lt_of_int_of_lt !denom_pos,
 have 1 ≤ abs (of_int (denom a)), begin
     rewrite (abs_of_pos this),
-    apply iff.mpr !of_int_le_of_int,
+    apply of_int_le_of_int_of_le,
     apply denom_pos
   end,
 have abs a ≤ abs (of_int (num a)), from

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -1161,4 +1161,7 @@ theorem of_nat_mul (a b : ℕ) : of_nat (#nat a * b) = of_nat a * of_nat b :=
 theorem add_half_of_rat (n : ℕ+) : of_rat (2 * n)⁻¹ + of_rat (2 * n)⁻¹ = of_rat (n⁻¹) :=
   by rewrite [-of_rat_add, pnat.add_halves]
 
+theorem one_add_one : 1 + 1 = (2 : ℝ) :=
+by rewrite -of_rat_add
+
 end real

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -1061,11 +1061,11 @@ theorem one_mul (x : ℝ) : 1 * x = x :=
 theorem mul_one (x : ℝ) : x * 1 = x :=
   quot.induction_on x (λ s, quot.sound (r_mul_one s))
 
-theorem distrib (x y z : ℝ) : x * (y + z) = x * y + x * z :=
+theorem left_distrib (x y z : ℝ) : x * (y + z) = x * y + x * z :=
   quot.induction_on₃ x y z (λ s t u, quot.sound (r_distrib s t u))
 
-theorem distrib_l (x y z : ℝ) : (x + y) * z = x * z + y * z :=
-  by rewrite [mul_comm, distrib, {x * _}mul_comm, {y * _}mul_comm] -- this shouldn't be necessary
+theorem right_distrib (x y z : ℝ) : (x + y) * z = x * z + y * z :=
+  by rewrite [mul_comm, left_distrib, {x * _}mul_comm, {y * _}mul_comm] -- this shouldn't be necessary
 
 theorem zero_ne_one : ¬ (0 : ℝ) = 1 :=
   take H : 0 = 1,
@@ -1087,8 +1087,8 @@ protected definition comm_ring [reducible] : algebra.comm_ring ℝ :=
     apply of_num 1,
     apply one_mul,
     apply mul_one,
-    apply distrib,
-    apply distrib_l,
+    apply left_distrib,
+    apply right_distrib,
     apply mul_comm
   end
 

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -232,7 +232,7 @@ theorem cauchy_of_converges_to {X : r_seq} {a : ℝ} {N : ℕ+ → ℕ+} (Hc : c
     krewrite abs_neg,
     apply Hc,
     apply Hn,
-    xrewrite of_rat_add,
+    xrewrite -of_rat_add,
     apply of_rat_le_of_rat_of_le,
     rewrite pnat.add_halves,
     apply rat.le.refl
@@ -270,7 +270,7 @@ private theorem lim_seq_reg_helper {m n : ℕ+} (Hmn : M (2 * n) ≤M (2 * m)) :
     apply pnat.le.trans,
     apply Hmn,
     apply Nb_spec_right,
-    rewrite [*of_rat_add, rat.add.assoc, pnat.add_halves],
+    rewrite [-*of_rat_add, rat.add.assoc, pnat.add_halves],
     apply of_rat_le_of_rat_of_le,
     apply rat.add_le_add_right,
     apply inv_ge_of_le,
@@ -281,8 +281,8 @@ theorem lim_seq_reg : rat_seq.regular lim_seq :=
   begin
     rewrite ↑rat_seq.regular,
     intro m n,
-    apply le_of_rat_le_of_rat,
-    rewrite [abs_const, -of_rat_sub, (rewrite_helper10 (X (Nb M m)) (X (Nb M n)))],
+    apply le_of_of_rat_le_of_rat,
+    rewrite [abs_const, of_rat_sub, (rewrite_helper10 (X (Nb M m)) (X (Nb M n)))],
     apply real.le.trans,
     apply abs_add_three,
     cases em (M (2 * m) ≥ M (2 * n)) with [Hor1, Hor2],
@@ -345,7 +345,7 @@ theorem converges_of_cauchy : converges_to X lim (Nb M) :=
     rewrite ↑lim_seq,
     apply approx_spec,
     apply lim_spec,
-    rewrite 2 of_rat_add,
+    rewrite [-*of_rat_add],
     apply of_rat_le_of_rat_of_le,
     apply rat.le.trans,
     apply rat.add_le_add_three,
@@ -375,7 +375,7 @@ section ints
 
 open int
 
-theorem archimedean_upper (x : ℝ) : ∃ z : ℤ, x ≤ of_rat (of_int z) :=
+theorem archimedean_upper (x : ℝ) : ∃ z : ℤ, x ≤ of_int z :=
   begin
     apply quot.induction_on x,
     intro s,
@@ -392,36 +392,35 @@ theorem archimedean_upper (x : ℝ) : ∃ z : ℤ, x ≤ of_rat (of_int z) :=
     apply H
   end
 
-theorem archimedean_upper_strict (x : ℝ) : ∃ z : ℤ, x < of_rat (of_int z) :=
+theorem archimedean_upper_strict (x : ℝ) : ∃ z : ℤ, x < of_int z :=
   begin
     cases archimedean_upper x with [z, Hz],
     existsi z + 1,
     apply lt_of_le_of_lt,
     apply Hz,
-    apply of_rat_lt_of_rat_of_lt,
     apply of_int_lt_of_int_of_lt,
     apply int.lt_add_of_pos_right,
     apply dec_trivial
   end
 
-theorem archimedean_lower (x : ℝ) : ∃ z : ℤ, x ≥ of_rat (of_int z) :=
+theorem archimedean_lower (x : ℝ) : ∃ z : ℤ, x ≥ of_int z :=
   begin
     cases archimedean_upper (-x) with [z, Hz],
     existsi -z,
-    rewrite [of_int_neg, of_rat_neg],
+    rewrite [of_int_neg],
     apply iff.mp !neg_le_iff_neg_le Hz
   end
 
-theorem archimedean_lower_strict (x : ℝ) : ∃ z : ℤ, x > of_rat (of_int z) :=
+theorem archimedean_lower_strict (x : ℝ) : ∃ z : ℤ, x > of_int z :=
   begin
     cases archimedean_upper_strict (-x) with [z, Hz],
     existsi -z,
-    rewrite [of_int_neg, of_rat_neg],
+    rewrite [of_int_neg],
     apply iff.mp !neg_lt_iff_neg_lt Hz
   end
 
 definition ex_floor (x : ℝ) :=
-  (@ex_largest_of_bdd (λ z, x ≥ of_rat (of_int z)) _
+  (@ex_largest_of_bdd (λ z, x ≥ of_int z) _
     (begin
       existsi some (archimedean_upper_strict x),
       let Har := some_spec (archimedean_upper_strict x),
@@ -429,8 +428,7 @@ definition ex_floor (x : ℝ) :=
       apply not_le_of_gt,
       apply lt_of_lt_of_le,
       apply Har,
-      have H : of_rat (of_int (some (archimedean_upper_strict x))) ≤ of_rat (of_int z), begin
-        apply of_rat_le_of_rat_of_le,
+      have H : of_int (some (archimedean_upper_strict x)) ≤ of_int z, begin
         apply of_int_le_of_int_of_le,
         apply Hz
       end,
@@ -443,28 +441,28 @@ noncomputable definition floor (x : ℝ) : ℤ :=
 
 noncomputable definition ceil (x : ℝ) : ℤ := - floor (-x)
 
-theorem floor_spec (x : ℝ) : of_rat (of_int (floor x)) ≤ x :=
+theorem floor_spec (x : ℝ) : of_int (floor x) ≤ x :=
   and.left (some_spec (ex_floor x))
 
-theorem floor_largest {x : ℝ} {z : ℤ} (Hz : z > floor x) : x < of_rat (of_int z) :=
+theorem floor_largest {x : ℝ} {z : ℤ} (Hz : z > floor x) : x < of_int z :=
   begin
     apply lt_of_not_ge,
     cases some_spec (ex_floor x),
     apply a_1 _ Hz
   end
 
-theorem ceil_spec (x : ℝ) : of_rat (of_int (ceil x)) ≥ x :=
+theorem ceil_spec (x : ℝ) : of_int (ceil x) ≥ x :=
   begin
-    rewrite [↑ceil, of_int_neg, of_rat_neg],
+    rewrite [↑ceil, of_int_neg],
     apply iff.mp !le_neg_iff_le_neg,
     apply floor_spec
   end
 
-theorem ceil_smallest {x : ℝ} {z : ℤ} (Hz : z < ceil x) : x > of_rat (of_int z) :=
+theorem ceil_smallest {x : ℝ} {z : ℤ} (Hz : z < ceil x) : x > of_int z :=
   begin
     rewrite ↑ceil at Hz,
     let Hz' := floor_largest (iff.mp !int.lt_neg_iff_lt_neg Hz),
-    rewrite [of_int_neg at Hz', of_rat_neg at Hz'],
+    rewrite [of_int_neg at Hz'],
     apply lt_of_neg_lt_neg Hz'
   end
 
@@ -474,10 +472,10 @@ theorem floor_succ (x : ℝ) : (floor x) + 1 = floor (x + 1) :=
     intro H,
     cases int.lt_or_gt_of_ne H with [Hlt, Hgt],
     let Hl := floor_largest (iff.mp !int.add_lt_iff_lt_sub_right Hlt),
-    rewrite [of_int_sub at Hl, -of_rat_sub at Hl],
+    rewrite [of_int_sub at Hl],
     apply not_le_of_gt (iff.mpr !add_lt_iff_lt_sub_right Hl) !floor_spec,
     let Hl := floor_largest Hgt,
-    rewrite [of_int_add at Hl, -of_rat_add at Hl],
+    rewrite [of_int_add at Hl],
     apply not_le_of_gt (lt_of_add_lt_add_right Hl) !floor_spec
   end
 
@@ -548,11 +546,10 @@ noncomputable definition bisect (ab : ℚ × ℚ) :=
   else
     (avg (pr1 ab) (pr2 ab), pr2 ab)
 
-noncomputable definition under : ℚ := of_int (floor (elt - 1))
+noncomputable definition under : ℚ := rat.of_int (floor (elt - 1))
 
 theorem under_spec1 : of_rat under < elt :=
-  have H : of_rat under < of_rat (of_int (floor elt)), begin
-    apply of_rat_lt_of_rat_of_lt,
+  have H : of_rat under < of_int (floor elt), begin
     apply of_int_lt_of_int_of_lt,
     apply floor_succ_lt
   end,
@@ -569,11 +566,10 @@ theorem under_spec : ¬ ub under :=
     apply not_le_of_gt under_spec1
   end
 
-noncomputable definition over : ℚ := of_int (ceil (bound + 1)) -- b
+noncomputable definition over : ℚ := rat.of_int (ceil (bound + 1)) -- b
 
 theorem over_spec1 : bound < of_rat over :=
-  have H : of_rat (of_int (ceil bound)) < of_rat over, begin
-    apply of_rat_lt_of_rat_of_lt,
+  have H : of_int (ceil bound) < of_rat over, begin
     apply of_int_lt_of_int_of_lt,
     apply ceil_succ
   end,
@@ -651,11 +647,11 @@ theorem width (n : ℕ) : over_seq n - under_seq n = (over - under) / (rat.pow 2
               rat.sub_self_div_two]
     end)
 
-theorem binary_nat_bound (a : ℕ) : of_nat a ≤ (rat.pow 2 a) :=
+theorem binary_nat_bound (a : ℕ) : rat.of_nat a ≤ (rat.pow 2 a) :=
   nat.induction_on a (rat.zero_le_one)
    (take n, assume Hn,
     calc
-     of_nat (succ n) = (of_nat n) + 1 : of_nat_add
+     rat.of_nat (succ n) = (rat.of_nat n) + 1 : rat.of_nat_add
        ... ≤ rat.pow 2 n + 1 : rat.add_le_add_right Hn
        ... ≤ rat.pow 2 n + rat.pow 2 n :
              rat.add_le_add_left (rat.pow_ge_one_of_ge_one rat.two_ge_one _)
@@ -663,7 +659,7 @@ theorem binary_nat_bound (a : ℕ) : of_nat a ≤ (rat.pow 2 a) :=
 
 theorem binary_bound (a : ℚ) : ∃ n : ℕ, a ≤ rat.pow 2 n :=
   exists.intro (ubound a) (calc
-      a ≤ of_nat (ubound a) : ubound_ge
+      a ≤ rat.of_nat (ubound a) : ubound_ge
     ... ≤ rat.pow 2 (ubound a) : binary_nat_bound)
 
 theorem rat_power_two_le (k : ℕ+) : rat_of_pnat k ≤ rat.pow 2 k~ :=
@@ -739,7 +735,7 @@ theorem under_lt_over : under < over :=
   begin
     cases exists_not_of_not_forall under_spec with [x, Hx],
     cases iff.mp not_implies_iff_and_not Hx with [HXx, Hxu],
-    apply lt_of_rat_lt_of_rat,
+    apply lt_of_of_rat_lt_of_rat,
     apply lt_of_lt_of_le,
     apply lt_of_not_ge Hxu,
     apply over_spec _ HXx
@@ -750,7 +746,7 @@ theorem under_seq_lt_over_seq : ∀ m n : ℕ, under_seq m < over_seq n :=
     intros,
     cases exists_not_of_not_forall (PA m) with [x, Hx],
     cases iff.mp not_implies_iff_and_not Hx with [HXx, Hxu],
-    apply lt_of_rat_lt_of_rat,
+    apply lt_of_of_rat_lt_of_rat,
     apply lt_of_lt_of_le,
     apply lt_of_not_ge Hxu,
     apply PB,

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -509,7 +509,7 @@ have H₁ : succ n ≥ ceil (2 / ε), from of_int_le_of_int_of_le this,
 have H₂ : succ n ≥ 2 / ε, from !le.trans !le_ceil H₁,
 have H₃ : 2 / ε > 0, from div_pos_of_pos_of_pos two_pos H,
 have 1 / succ n < ε, from calc
-  1 / succ n ≤ 1 / (2 / ε) : div_le_div_of_le H₃ H₂
+  1 / succ n ≤ 1 / (2 / ε) : one_div_le_one_div_of_le H₃ H₂
     ... = ε / 2       : one_div_div
     ... < ε           : div_two_lt_of_pos H,
 exists.intro n this
@@ -832,7 +832,7 @@ theorem over_seq_mono (i j : ℕ) (H : i ≤ j) : over_seq j ≤ over_seq i :=
   end
 
 theorem rat_power_two_inv_ge (k : ℕ+) : 1 / rat.pow 2 k~ ≤ k⁻¹ :=
-  rat.div_le_div_of_le !rat_of_pnat_is_pos !rat_power_two_le
+  rat.one_div_le_one_div_of_le !rat_of_pnat_is_pos !rat_power_two_le
 
 open rat_seq
 theorem regular_lemma_helper {s : seq} {m n : ℕ+} (Hm : m ≤ n)

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -423,7 +423,7 @@ theorem archimedean_lower_strict (x : ℝ) : ∃ z : ℤ, x > of_int z :=
   end
 
 private definition ex_floor (x : ℝ) :=
-  (@ex_largest_of_bdd (λ z, x ≥ of_int z) _
+  (@exists_greatest_of_bdd (λ z, x ≥ of_int z) _
     (begin
       existsi some (archimedean_upper_strict x),
       let Har := some_spec (archimedean_upper_strict x),

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -399,7 +399,7 @@ theorem archimedean_upper_strict (x : ℝ) : ∃ z : ℤ, x < of_rat (of_int z) 
     apply lt_of_le_of_lt,
     apply Hz,
     apply of_rat_lt_of_rat_of_lt,
-    apply iff.mpr !of_int_lt_of_int,
+    apply of_int_lt_of_int_of_lt,
     apply int.lt_add_of_pos_right,
     apply dec_trivial
   end
@@ -431,7 +431,7 @@ definition ex_floor (x : ℝ) :=
       apply Har,
       have H : of_rat (of_int (some (archimedean_upper_strict x))) ≤ of_rat (of_int z), begin
         apply of_rat_le_of_rat_of_le,
-        apply iff.mpr !of_int_le_of_int,
+        apply of_int_le_of_int_of_le,
         apply Hz
       end,
       exact H
@@ -553,7 +553,7 @@ noncomputable definition under : ℚ := of_int (floor (elt - 1))
 theorem under_spec1 : of_rat under < elt :=
   have H : of_rat under < of_rat (of_int (floor elt)), begin
     apply of_rat_lt_of_rat_of_lt,
-    apply iff.mpr !of_int_lt_of_int,
+    apply of_int_lt_of_int_of_lt,
     apply floor_succ_lt
   end,
   lt_of_lt_of_le H !floor_spec
@@ -574,7 +574,7 @@ noncomputable definition over : ℚ := of_int (ceil (bound + 1)) -- b
 theorem over_spec1 : bound < of_rat over :=
   have H : of_rat (of_int (ceil bound)) < of_rat over, begin
     apply of_rat_lt_of_rat_of_lt,
-    apply iff.mpr !of_int_lt_of_int,
+    apply of_int_lt_of_int_of_lt,
     apply ceil_succ
   end,
   lt_of_le_of_lt !ceil_spec H

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -676,4 +676,37 @@ by rewrite [of_int_eq, rat.of_int_div H, of_rat_divide]
 theorem of_nat_div (x y : ℕ) (H : (#nat y ∣ x)) : of_nat (#nat x div y) = of_nat x / of_nat y :=
 by rewrite [of_nat_eq, rat.of_nat_div H, of_rat_divide]
 
+/- useful for proving equalities -/
+
+theorem eq_zero_of_nonneg_of_forall_lt {x : ℝ} (xnonneg : x ≥ 0) (H : ∀ ε : ℝ, ε > 0 → x < ε) :
+  x = 0 :=
+decidable.by_contradiction
+  (suppose x ≠ 0,
+   have x > 0, from real.lt_of_le_of_ne xnonneg (ne.symm this),
+   have x < x, from H x this,
+   show false, from !lt.irrefl this)
+
+theorem eq_zero_of_nonneg_of_forall_le {x : ℝ} (xnonneg : x ≥ 0) (H : ∀ ε : ℝ, ε > 0 → x ≤ ε) :
+  x = 0 :=
+have ∀ ε : ℝ, ε > 0 → x < ε, from
+  take ε, suppose ε > 0,
+  have e2pos : ε / 2 > 0, from div_pos_of_pos_of_pos `ε > 0` two_pos,
+  have ε / 2 < ε, from div_two_lt_of_pos `ε > 0`,
+  calc
+    x ≤ ε / 2 : H _ e2pos
+      ... < ε : div_two_lt_of_pos (by assumption),
+eq_zero_of_nonneg_of_forall_lt xnonneg this
+
+theorem eq_zero_of_forall_abs_le {x : ℝ} (H : ∀ ε : ℝ, ε > 0 → abs x ≤ ε) :
+  x = 0 :=
+by_contradiction
+  (suppose x ≠ 0,
+   have abs x = 0, from eq_zero_of_nonneg_of_forall_le !abs_nonneg H,
+   show false, from `x ≠ 0` (eq_zero_of_abs_eq_zero this))
+
+theorem eq_of_forall_abs_sub_le {x y : ℝ} (H : ∀ ε : ℝ, ε > 0 → abs (x - y) ≤ ε) :
+  x = y :=
+have x - y = 0, from eq_zero_of_forall_abs_le H,
+eq_of_sub_eq_zero this
+
 end real

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -653,10 +653,27 @@ section migrate_algebra
   noncomputable definition divide (a b : ℝ): ℝ := algebra.divide a b
 
   migrate from algebra with real
-    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, abs → abs, sign → sign, dvd → dvd,
+    hiding dvd, dvd.elim, dvd.elim_left, dvd.intro, dvd.intro_left, dvd.refl, dvd.trans,
+      dvd_mul_left, dvd_mul_of_dvd_left, dvd_mul_of_dvd_right, dvd_mul_right, dvd_neg_iff_dvd,
+      dvd_neg_of_dvd, dvd_of_dvd_neg, dvd_of_mul_left_dvd, dvd_of_mul_left_eq,
+      dvd_of_mul_right_dvd, dvd_of_mul_right_eq, dvd_of_neg_dvd, dvd_sub, dvd_zero
+    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, abs → abs, sign → sign,
       divide → divide, max → max, min → min, pow → pow, nmul → nmul, imul → imul
 end migrate_algebra
 
 infix / := divide
+
+theorem of_rat_divide (x y : ℚ) : of_rat (x / y) = of_rat x / of_rat y :=
+by_cases
+  (assume yz : y = 0, by rewrite [yz, rat.div_zero, real.div_zero])
+  (assume ynz : y ≠ 0,
+    have ynz' : of_rat y ≠ 0, from assume yz', ynz (of_rat.inj yz'),
+    !eq_div_of_mul_eq ynz' (by rewrite [-of_rat_mul, !rat.div_mul_cancel ynz]))
+
+theorem of_int_div (x y : ℤ) (H : (#int y ∣ x)) : of_int (#int x div y) = of_int x / of_int y :=
+by rewrite [of_int_eq, rat.of_int_div H, of_rat_divide]
+
+theorem of_nat_div (x y : ℕ) (H : (#nat y ∣ x)) : of_nat (#nat x div y) = of_nat x / of_nat y :=
+by rewrite [of_nat_eq, rat.of_nat_div H, of_rat_divide]
 
 end real

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -669,7 +669,6 @@ theorem not_lt_self (s : seq) : ¬ s_lt s s :=
     apply absurd Hn (rat.not_lt_of_ge (rat.le_of_lt !inv_pos))
   end
 
-
 theorem not_sep_self (s : seq) : ¬ s ≢ s :=
   begin
     intro Hsep,
@@ -738,7 +737,6 @@ theorem lt_well_defined {s t u v : seq} (Hs : regular s) (Ht : regular t) (Hu : 
     repeat (apply reg_add_reg | apply reg_neg_reg | assumption)
   end)
 
-
 theorem sep_well_defined {s t u v : seq} (Hs : regular s) (Ht : regular t) (Hu : regular u)
         (Hv : regular v) (Hsu : s ≡ u) (Htv : t ≡ v) : s ≢ t ↔ u ≢ v :=
   begin
@@ -765,7 +763,6 @@ theorem sep_well_defined {s t u v : seq} (Hs : regular s) (Ht : regular t) (Hu :
     apply iff.mpr (lt_well_defined Ht Hs Hv Hu Htv Hsu),
     assumption
   end
-
 
 theorem s_lt_of_lt_of_le {s t u : seq} (Hs : regular s) (Ht : regular t) (Hu : regular u)
         (Hst : s_lt s t) (Htu : s_le t u) : s_lt s u :=
@@ -1117,8 +1114,6 @@ section migrate_algebra
 
   definition sub (a b : ℝ) : ℝ := algebra.sub a b
   infix [priority real.prio] - := real.sub
-  definition dvd (a b : ℝ) : Prop := algebra.dvd a b
-  notation [priority real.prio] a ∣ b := real.dvd a b
   definition pow (a : ℝ) (n : ℕ) : ℝ := algebra.pow a n
   notation [priority real.prio] a^n := real.pow a n
   definition nmul (n : ℕ) (a : ℝ) : ℝ := algebra.nmul n a
@@ -1126,26 +1121,91 @@ section migrate_algebra
   definition imul (i : ℤ) (a : ℝ) : ℝ := algebra.imul i a
 
   migrate from algebra with real
-    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, dvd → dvd, divide → divide,
+    hiding dvd, dvd.elim, dvd.elim_left, dvd.intro, dvd.intro_left, dvd.refl, dvd.trans,
+      dvd_mul_left, dvd_mul_of_dvd_left, dvd_mul_of_dvd_right, dvd_mul_right, dvd_neg_iff_dvd,
+      dvd_neg_of_dvd, dvd_of_dvd_neg, dvd_of_mul_left_dvd, dvd_of_mul_left_eq,
+      dvd_of_mul_right_dvd, dvd_of_mul_right_eq, dvd_of_neg_dvd, dvd_sub, dvd_zero
+    replacing has_le.ge → ge, has_lt.gt → gt, sub → sub, divide → divide,
               pow → pow, nmul → nmul, imul → imul
 
   attribute le.trans lt.trans lt_of_lt_of_le lt_of_le_of_lt ge.trans gt.trans gt_of_gt_of_ge
                    gt_of_ge_of_gt [trans]
 end migrate_algebra
 
-theorem of_rat_le_of_rat_of_le (a b : ℚ) : a ≤ b → of_rat a ≤ of_rat b :=
+theorem of_rat_sub (a b : ℚ) : of_rat (a - b) = of_rat a - of_rat b := rfl
+
+theorem of_int_sub (a b : ℤ) : of_int (#int a - b) = of_int a - of_int b :=
+  by rewrite [of_int_eq, rat.of_int_sub, of_rat_sub]
+
+theorem of_rat_le_of_rat_of_le {a b : ℚ} : a ≤ b → of_rat a ≤ of_rat b :=
   rat_seq.r_const_le_const_of_le
 
-theorem le_of_rat_le_of_rat (a b : ℚ) : of_rat a ≤ of_rat b → a ≤ b :=
+theorem le_of_of_rat_le_of_rat {a b : ℚ} : of_rat a ≤ of_rat b → a ≤ b :=
   rat_seq.r_le_of_const_le_const
 
-theorem of_rat_lt_of_rat_of_lt (a b : ℚ) : a < b → of_rat a < of_rat b :=
+theorem of_rat_le_of_rat_iff (a b : ℚ) : of_rat a ≤ of_rat b ↔ a ≤ b :=
+  iff.intro le_of_of_rat_le_of_rat of_rat_le_of_rat_of_le
+
+theorem of_rat_lt_of_rat_of_lt {a b : ℚ} : a < b → of_rat a < of_rat b :=
   rat_seq.r_const_lt_const_of_lt
 
-theorem lt_of_rat_lt_of_rat (a b : ℚ) : of_rat a < of_rat b → a < b :=
+theorem lt_of_of_rat_lt_of_rat {a b : ℚ} : of_rat a < of_rat b → a < b :=
   rat_seq.r_lt_of_const_lt_const
 
-theorem of_rat_sub (a b : ℚ) : of_rat a - of_rat b = of_rat (a - b) := rfl
+theorem of_rat_lt_of_rat_iff (a b : ℚ) : of_rat a < of_rat b ↔ a < b :=
+  iff.intro lt_of_of_rat_lt_of_rat of_rat_lt_of_rat_of_lt
+
+theorem of_int_le_of_int_iff (a b : ℤ) : of_int a ≤ of_int b ↔ (#int a ≤ b) :=
+  by rewrite [*of_int_eq, of_rat_le_of_rat_iff, rat.of_int_le_of_int_iff]
+
+theorem of_int_le_of_int_of_le {a b : ℤ} : (#int a ≤ b) → of_int a ≤ of_int b :=
+  iff.mpr !of_int_le_of_int_iff
+
+theorem le_of_of_int_le_of_int {a b : ℤ} : of_int a ≤ of_int b → (#int a ≤ b) :=
+  iff.mp !of_int_le_of_int_iff
+
+theorem of_int_lt_of_int_iff (a b : ℤ) : of_int a < of_int b ↔ (#int a < b) :=
+  by rewrite [*of_int_eq, of_rat_lt_of_rat_iff, rat.of_int_lt_of_int_iff]
+
+theorem of_int_lt_of_int_of_lt {a b : ℤ} : (#int a < b) → of_int a < of_int b :=
+  iff.mpr !of_int_lt_of_int_iff
+
+theorem lt_of_of_int_lt_of_int {a b : ℤ} : of_int a < of_int b → (#int a < b) :=
+  iff.mp !of_int_lt_of_int_iff
+
+theorem of_nat_le_of_nat_iff (a b : ℕ) : of_nat a ≤ of_nat b ↔ (#nat a ≤ b) :=
+  by rewrite [*of_nat_eq, of_rat_le_of_rat_iff, rat.of_nat_le_of_nat_iff]
+
+theorem of_nat_le_of_nat_of_le {a b : ℕ} : (#nat a ≤ b) → of_nat a ≤ of_nat b :=
+  iff.mpr !of_nat_le_of_nat_iff
+
+theorem le_of_of_nat_le_of_nat {a b : ℕ} : of_nat a ≤ of_nat b → (#nat a ≤ b) :=
+  iff.mp !of_nat_le_of_nat_iff
+
+theorem of_nat_lt_of_nat_iff (a b : ℕ) : of_nat a < of_nat b ↔ (#nat a < b) :=
+  by rewrite [*of_nat_eq, of_rat_lt_of_rat_iff, rat.of_nat_lt_of_nat_iff]
+
+theorem of_nat_lt_of_nat_of_lt {a b : ℕ} : (#nat a < b) → of_nat a < of_nat b :=
+  iff.mpr !of_nat_lt_of_nat_iff
+
+theorem lt_of_of_nat_lt_of_nat {a b : ℕ} : of_nat a < of_nat b → (#nat a < b) :=
+  iff.mp !of_nat_lt_of_nat_iff
+
+theorem of_nat_nonneg (a : ℕ) : of_nat a ≥ 0 :=
+of_rat_le_of_rat_of_le !rat.of_nat_nonneg
+
+theorem of_rat_pow (a : ℚ) (n : ℕ) : of_rat (a^n) = (of_rat a)^n :=
+begin
+  induction n with n ih,
+    apply eq.refl,
+  rewrite [pow_succ, rat.pow_succ, of_rat_mul, ih]
+end
+
+theorem of_int_pow (a : ℤ) (n : ℕ) : of_int (#int a^n) = (of_int a)^n :=
+by rewrite [of_int_eq, rat.of_int_pow, of_rat_pow]
+
+theorem of_nat_pow (a : ℕ) (n : ℕ) : of_nat (#nat a^n) = (of_nat a)^n :=
+by rewrite [of_nat_eq, rat.of_nat_pow, of_rat_pow]
 
 open rat_seq
 theorem le_of_le_reprs (x : ℝ) (t : seq) (Ht : regular t) : (∀ n : ℕ+, x ≤ t n) →
@@ -1154,7 +1214,6 @@ theorem le_of_le_reprs (x : ℝ) (t : seq) (Ht : regular t) : (∀ n : ℕ+, x �
     show r_le s (reg_seq.mk t Ht), from
       have H' : ∀ n : ℕ+, r_le s (r_const (t n)), from Hs,
       by apply r_le_of_le_reprs; apply Hs)
-
 
 theorem le_of_reprs_le (x : ℝ) (t : seq) (Ht : regular t) : (∀ n : ℕ+, t n ≤ x) →
         quot.mk (reg_seq.mk t Ht) ≤ x :=

--- a/library/logic/quantifiers.lean
+++ b/library/logic/quantifiers.lean
@@ -14,15 +14,18 @@ iff.intro (λ e x H, e (exists.intro x H)) Exists.rec
 theorem forall_iff_not_exists {A : Type} {P : A → Prop} : (¬ ∃ a : A, P a) ↔ ∀ a : A, ¬ P a :=
 exists_imp_distrib
 
-theorem not_forall_not_of_exists {A : Type} {p : A → Prop} (H : ∃x, p x) : ¬ ∀ x, ¬ p x :=
+theorem not_forall_not_of_exists {A : Type} {p : A → Prop} (H : ∃ x, p x) : ¬ ∀ x, ¬ p x :=
 assume H1 : ∀ x, ¬ p x,
   obtain (w : A) (Hw : p w), from H,
   absurd Hw (H1 w)
 
-theorem not_exists_not_of_forall {A : Type} {p : A → Prop} (H2 : ∀x, p x) : ¬ ∃ x, ¬p x :=
+theorem not_exists_not_of_forall {A : Type} {p : A → Prop} (H2 : ∀ x, p x) : ¬ ∃ x, ¬p x :=
 assume H1 : ∃ x, ¬ p x,
   obtain (w : A) (Hw : ¬ p w), from H1,
   absurd (H2 w) Hw
+
+theorem not_forall_of_exists_not {A : Type} {P : A → Prop} (H : ∃ a : A, ¬ P a) : ¬ ∀ a : A, P a :=
+assume H', not_exists_not_of_forall H' H
 
 theorem forall_congr {A : Type} {φ ψ : A → Prop} : (∀ x, φ x ↔ ψ x) → ((∀ x, φ x) ↔ (∀ x, ψ x)) :=
 forall_iff_forall

--- a/library/logic/quantifiers.lean
+++ b/library/logic/quantifiers.lean
@@ -14,43 +14,43 @@ iff.intro (λ e x H, e (exists.intro x H)) Exists.rec
 theorem forall_iff_not_exists {A : Type} {P : A → Prop} : (¬ ∃ a : A, P a) ↔ ∀ a : A, ¬ P a :=
 exists_imp_distrib
 
-theorem not_forall_not_of_exists {A : Type} {p : A → Prop} (H : ∃x, p x) : ¬∀x, ¬p x :=
-assume H1 : ∀x, ¬p x,
+theorem not_forall_not_of_exists {A : Type} {p : A → Prop} (H : ∃x, p x) : ¬ ∀ x, ¬ p x :=
+assume H1 : ∀ x, ¬ p x,
   obtain (w : A) (Hw : p w), from H,
   absurd Hw (H1 w)
 
-theorem not_exists_not_of_forall {A : Type} {p : A → Prop} (H2 : ∀x, p x) : ¬∃x, ¬p x :=
-assume H1 : ∃x, ¬p x,
-  obtain (w : A) (Hw : ¬p w), from H1,
+theorem not_exists_not_of_forall {A : Type} {p : A → Prop} (H2 : ∀x, p x) : ¬ ∃ x, ¬p x :=
+assume H1 : ∃ x, ¬ p x,
+  obtain (w : A) (Hw : ¬ p w), from H1,
   absurd (H2 w) Hw
 
-theorem forall_congr {A : Type} {φ ψ : A → Prop} : (∀x, φ x ↔ ψ x) → ((∀x, φ x) ↔ (∀x, ψ x)) :=
+theorem forall_congr {A : Type} {φ ψ : A → Prop} : (∀ x, φ x ↔ ψ x) → ((∀ x, φ x) ↔ (∀ x, ψ x)) :=
 forall_iff_forall
 
-theorem exists_congr {A : Type} {φ ψ : A → Prop} : (∀x, φ x ↔ ψ x) → ((∃x, φ x) ↔ (∃x, ψ x)) :=
+theorem exists_congr {A : Type} {φ ψ : A → Prop} : (∀ x, φ x ↔ ψ x) → ((∃ x, φ x) ↔ (∃ x, ψ x)) :=
 exists_iff_exists
 
-theorem forall_true_iff_true (A : Type) : (∀x : A, true) ↔ true :=
+theorem forall_true_iff_true (A : Type) : (∀ x : A, true) ↔ true :=
 iff_true_intro (λH, trivial)
 
-theorem forall_p_iff_p (A : Type) [H : inhabited A] (p : Prop) : (∀x : A, p) ↔ p :=
-iff.intro (inhabited.destruct H) (λHr x, Hr)
+theorem forall_p_iff_p (A : Type) [H : inhabited A] (p : Prop) : (∀ x : A, p) ↔ p :=
+iff.intro (inhabited.destruct H) (λ Hr x, Hr)
 
-theorem exists_p_iff_p (A : Type) [H : inhabited A] (p : Prop) : (∃x : A, p) ↔ p :=
-iff.intro (Exists.rec (λx Hp, Hp)) (inhabited.destruct H exists.intro)
+theorem exists_p_iff_p (A : Type) [H : inhabited A] (p : Prop) : (∃ x : A, p) ↔ p :=
+iff.intro (Exists.rec (λ x Hp, Hp)) (inhabited.destruct H exists.intro)
 
 theorem forall_and_distribute {A : Type} (φ ψ : A → Prop) :
-  (∀x, φ x ∧ ψ x) ↔ (∀x, φ x) ∧ (∀x, ψ x) :=
+  (∀ x, φ x ∧ ψ x) ↔ (∀ x, φ x) ∧ (∀ x, ψ x) :=
 iff.intro
   (assume H, and.intro (take x, and.left (H x)) (take x, and.right (H x)))
   (assume H x, and.intro (and.left H x) (and.right H x))
 
 theorem exists_or_distribute {A : Type} (φ ψ : A → Prop) :
-  (∃x, φ x ∨ ψ x) ↔ (∃x, φ x) ∨ (∃x, ψ x) :=
+  (∃ x, φ x ∨ ψ x) ↔ (∃ x, φ x) ∨ (∃ x, ψ x) :=
 iff.intro
-  (Exists.rec (λx, or.imp !exists.intro !exists.intro))
-  (or.rec (exists_imp_exists (λx, or.inl))
-          (exists_imp_exists (λx, or.inr)))
+  (Exists.rec (λ x, or.imp !exists.intro !exists.intro))
+  (or.rec (exists_imp_exists (λ x, or.inl))
+          (exists_imp_exists (λ x, or.inr)))
 
 section
   open decidable eq.ops
@@ -83,19 +83,54 @@ theorem exists_unique.elim {A : Type} {p : A → Prop} {b : Prop}
 obtain w Hw, from H2,
 H1 w (and.left Hw) (and.right Hw)
 
+theorem exists_unique_of_exists_of_unique {A : Type} {p : A → Prop}
+    (Hex : ∃ x, p x) (Hunique : ∀ y₁ y₂, p y₁ → p y₂ → y₁ = y₂) :
+  ∃! x, p x :=
+obtain x px, from Hex,
+exists_unique.intro x px (take y, suppose p y, show y = x, from !Hunique this px)
+
+theorem exists_of_exists_unique {A : Type} {p : A → Prop} (H : ∃! x, p x) :
+  ∃ x, p x :=
+obtain x Hx, from H,
+exists.intro x (and.left Hx)
+
+theorem unique_of_exists_unique {A : Type} {p : A → Prop}
+    (H : ∃! x, p x) {y₁ y₂ : A} (py₁ : p y₁) (py₂ : p y₂) :
+  y₁ = y₂ :=
+exists_unique.elim H
+  (take x, suppose p x,
+    assume unique : ∀ y, p y → y = x,
+    show y₁ = y₂, from eq.trans (unique _ py₁) (eq.symm (unique _ py₂)))
+
+/- definite description -/
+
+section
+  open classical
+
+  noncomputable definition the {A : Type} {p : A → Prop} (H : ∃! x, p x) : A :=
+  some (exists_of_exists_unique H)
+
+  theorem the_spec {A : Type} {p : A → Prop} (H : ∃! x, p x) : p (the H) :=
+  some_spec (exists_of_exists_unique H)
+
+  theorem eq_the {A : Type} {p : A → Prop} (H : ∃! x, p x) {y : A} (Hy : p y) :
+    y = the H :=
+  unique_of_exists_unique H Hy (the_spec H)
+end
+
 /- congruences -/
 
 section
-  variables {A : Type} {p₁ p₂ : A → Prop} (H : ∀x, p₁ x ↔ p₂ x)
+  variables {A : Type} {p₁ p₂ : A → Prop} (H : ∀ x, p₁ x ↔ p₂ x)
 
-  theorem congr_forall : (∀x, p₁ x) ↔ (∀x, p₂ x) :=
+  theorem congr_forall : (∀ x, p₁ x) ↔ (∀ x, p₂ x) :=
   forall_congr H
 
-  theorem congr_exists : (∃x, p₁ x) ↔ (∃x, p₂ x) :=
+  theorem congr_exists : (∃ x, p₁ x) ↔ (∃ x, p₂ x) :=
   exists_congr H
 
   include H
-  theorem congr_exists_unique : (∃!x, p₁ x) ↔ (∃!x, p₂ x) :=
+  theorem congr_exists_unique : (∃! x, p₁ x) ↔ (∃! x, p₂ x) :=
    congr_exists (λx, congr_and (H x) (congr_forall
      (λy, congr_imp (H y) iff.rfl)))
 end

--- a/library/theories/analysis/analysis.md
+++ b/library/theories/analysis/analysis.md
@@ -1,0 +1,5 @@
+theories.analysis
+=================
+
+* [metric_space](metric_space.lean)
+* [real_limit](real_limit.lean)

--- a/library/theories/analysis/metric_space.lean
+++ b/library/theories/analysis/metric_space.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Metric spaces.
+-/
+import data.real.division
+open real eq.ops classical
+
+structure metric_space [class] (M : Type) : Type :=
+  (dist : M → M → ℝ)
+  (dist_self : ∀ x : M, dist x x = 0)
+  (eq_of_dist_eq_zero : ∀ {x y : M}, dist x y = 0 → x = y)
+  (dist_comm : ∀ x y : M, dist x y = dist y x)
+  (dist_triangle : ∀ x y z : M, dist x y + dist y z ≥ dist x z)
+
+namespace metric_space
+
+section metric_space_M
+variables {M : Type} [strucM : metric_space M]
+include strucM
+
+proposition dist_eq_zero_iff (x y : M) : dist x y = 0 ↔ x = y :=
+iff.intro eq_of_dist_eq_zero (suppose x = y, this ▸ !dist_self)
+
+proposition dist_nonneg (x y : M) : 0 ≤ dist x y :=
+have dist x y + dist y x ≥ 0, by rewrite -(dist_self x); apply dist_triangle,
+have 2 * dist x y ≥ 0, using this,
+  by rewrite [-real.one_add_one, right_distrib, +one_mul, dist_comm at {2}]; apply this,
+nonneg_of_mul_nonneg_left this two_pos
+
+proposition dist_pos_of_ne {x y : M} (H : x ≠ y) : dist x y > 0 :=
+lt_of_le_of_ne !dist_nonneg (suppose 0 = dist x y, H (iff.mp !dist_eq_zero_iff this⁻¹))
+
+proposition eq_of_forall_dist_le {x y : M} (H : ∀ ε, ε > 0 → dist x y ≤ ε) : x = y :=
+eq_of_dist_eq_zero (eq_zero_of_nonneg_of_forall_le !dist_nonneg H)
+
+open nat
+
+definition converges_to_seq (X : ℕ → M) (y : M) : Prop :=
+∀ ⦃ε : ℝ⦄, ε > 0 → ∃ N : ℕ, ∀ {n}, n ≥ N → dist (X n) y < ε
+
+-- the same, with ≤ in place of <; easier to prove, harder to use
+definition converges_to_seq.intro {X : ℕ → M} {y : M}
+    (H : ∀ ⦃ε : ℝ⦄, ε > 0 → ∃ N : ℕ, ∀ {n}, n ≥ N → dist (X n) y ≤ ε) :
+  converges_to_seq X y :=
+take ε, assume epos : ε > 0,
+  have e2pos : ε / 2 > 0, from  div_pos_of_pos_of_pos `ε > 0` two_pos,
+  obtain N HN, from H e2pos,
+  exists.intro N
+    (take n, suppose n ≥ N,
+      calc
+        dist (X n) y ≤ ε / 2 : HN _ `n ≥ N`
+                 ... < ε     : div_two_lt_of_pos epos)
+
+notation X `⟶` y `in` `ℕ` := converges_to_seq X y
+
+definition converges_seq [class] (X : ℕ → M) : Prop := ∃ y, X ⟶ y in ℕ
+
+noncomputable definition limit_seq (X : ℕ → M) [H : converges_seq X] : M := some H
+
+proposition converges_to_limit_seq (X : ℕ → M) [H : converges_seq X] :
+  (X ⟶ limit_seq X in ℕ) :=
+some_spec H
+
+proposition converges_to_seq_unique {X : ℕ → M} {y₁ y₂ : M}
+  (H₁ : X ⟶ y₁ in ℕ) (H₂ : X ⟶ y₂ in ℕ) : y₁ = y₂ :=
+eq_of_forall_dist_le
+  (take ε, suppose ε > 0,
+    have e2pos : ε / 2 > 0, from  div_pos_of_pos_of_pos `ε > 0` two_pos,
+    obtain N₁ (HN₁ : ∀ {n}, n ≥ N₁ → dist (X n) y₁ < ε / 2), from H₁ e2pos,
+    obtain N₂ (HN₂ : ∀ {n}, n ≥ N₂ → dist (X n) y₂ < ε / 2), from H₂ e2pos,
+    let N := max N₁ N₂ in
+    have dN₁ : dist (X N) y₁ < ε / 2, from HN₁ !le_max_left,
+    have dN₂ : dist (X N) y₂ < ε / 2, from HN₂ !le_max_right,
+    have dist y₁ y₂ < ε, from calc
+      dist y₁ y₂ ≤ dist y₁ (X N) + dist (X N) y₂ : dist_triangle
+             ... = dist (X N) y₁ + dist (X N) y₂ : dist_comm
+             ... < ε / 2 + ε / 2                 : add_lt_add dN₁ dN₂
+             ... = ε                             : add_halves,
+    show dist y₁ y₂ ≤ ε, from le_of_lt this)
+
+proposition eq_limit_of_converges_to_seq {X : ℕ → M} (y : M) (H : X ⟶ y in ℕ) :
+  y = @limit_seq M _ X (exists.intro y H) :=
+converges_to_seq_unique H (@converges_to_limit_seq M _ X (exists.intro y H))
+
+proposition converges_to_seq_constant (y : M) : (λn, y) ⟶ y in ℕ :=
+take ε, assume egt0 : ε > 0,
+  exists.intro 0
+    (take n, suppose n ≥ 0,
+      calc
+        dist y y = 0 : !dist_self
+             ... < ε : egt0)
+
+definition cauchy (X : ℕ → M) : Prop :=
+∀ ε : ℝ, ε > 0 → ∃ N, ∀ m n, m ≥ N → n ≥ N → dist (X m) (X n) < ε
+
+proposition cauchy_of_converges_seq (X : ℕ → M) [H : converges_seq X] : cauchy X :=
+take ε, suppose ε > 0,
+  obtain y (Hy : converges_to_seq X y), from H,
+  have e2pos : ε / 2 > 0, from div_pos_of_pos_of_pos `ε > 0` two_pos,
+  obtain N₁ (HN₁ : ∀ {n}, n ≥ N₁ → dist (X n) y < ε / 2), from Hy e2pos,
+  obtain N₂ (HN₂ : ∀ {n}, n ≥ N₂ → dist (X n) y < ε / 2), from Hy e2pos,
+  let N := max N₁ N₂ in
+    exists.intro N
+      (take m n, suppose m ≥ N, suppose n ≥ N,
+        have m ≥ N₁, from le.trans !le_max_left `m ≥ N`,
+        have n ≥ N₂, from le.trans !le_max_right `n ≥ N`,
+        have dN₁ : dist (X m) y < ε / 2, from HN₁ `m ≥ N₁`,
+        have dN₂ : dist (X n) y < ε / 2, from HN₂ `n ≥ N₂`,
+        show dist (X m) (X n) < ε, from calc
+          dist (X m) (X n) ≤ dist (X m) y + dist y (X n) : dist_triangle
+                       ... = dist (X m) y + dist (X n) y : dist_comm
+                       ... < ε / 2 + ε / 2               : add_lt_add dN₁ dN₂
+                       ... = ε                           : add_halves)
+
+end metric_space_M
+
+section metric_space_M_N
+variables {M N : Type} [strucM : metric_space M] [strucN : metric_space N]
+include strucM strucN
+
+definition converges_to_at (f : M → N) (y : N) (x : M) :=
+∀ ⦃ε⦄, ε > 0 → ∃ δ, δ > 0 ∧ ∀ x', x ≠ x' ∧ dist x x' < δ → dist (f x') y < ε
+
+notation f `⟶` y `at` x := converges_to_at f y x
+
+definition converges_at [class] (f : M → N) (x : M) :=
+∃ y, converges_to_at f y x
+
+noncomputable definition limit_at (f : M → N) (x : M) [H : converges_at f x] : N :=
+some H
+
+proposition converges_to_limit_at (f : M → N) (x : M) [H : converges_at f x] :
+  (f ⟶ limit_at f x at x) :=
+some_spec H
+
+end metric_space_M_N
+
+end metric_space

--- a/library/theories/analysis/real_limit.lean
+++ b/library/theories/analysis/real_limit.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2015 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Instantiates the reals as a metric space, and expresses completeness, sup, and inf in
+a manner that is less constructive, but more convenient, than the way it is done in
+data.real.complete.
+
+The definitions here are noncomputable, for various reasons:
+
+(1) We rely on the nonconstructive definition of abs.
+(2) The theory of the reals uses the "some" operator e.g. to define the ceiling function.
+    This can't be defined constructively as an operation on the quotient, because
+    such a function is not continuous.
+(3) We use "forall" and "exists" to say that a series converges, rather than carrying
+    around rates of convergence explicitly. We then use "some" whenever we need to extract
+    information, such as the limit.
+
+These could be avoided in a constructive theory of analysis, but here we will not
+follow that route.
+-/
+import .metric_space data.real.complete
+open real eq.ops classical
+noncomputable theory
+
+namespace real
+
+/- the reals form a metric space -/
+
+protected definition to_metric_space [instance] : metric_space ℝ :=
+⦃ metric_space,
+  dist               := λ x y, abs (x - y),
+  dist_self          := λ x, abstract by rewrite [sub_self, abs_zero] end,
+  eq_of_dist_eq_zero := @eq_of_abs_sub_eq_zero,
+  dist_comm          := abs_sub,
+  dist_triangle      := abs_sub_le
+⦄
+
+open nat
+
+definition converges_to_seq (X : ℕ → ℝ) (y : ℝ) : Prop :=
+∀ ⦃ε : ℝ⦄, ε > 0 → ∃ N : ℕ, ∀ {n}, n ≥ N → abs (X n - y) < ε
+
+proposition converges_to_seq.intro {X : ℕ → ℝ} {y : ℝ}
+    (H : ∀ ⦃ε : ℝ⦄, ε > 0 → ∃ N : ℕ, ∀ {n}, n ≥ N → abs (X n - y) ≤ ε) :
+  converges_to_seq X y :=
+metric_space.converges_to_seq.intro H
+
+notation X `⟶` y `in` `ℕ` := converges_to_seq X y
+
+definition converges_seq [class] (X : ℕ → ℝ) : Prop := ∃ y, X ⟶ y in ℕ
+
+definition limit_seq (X : ℕ → ℝ) [H : converges_seq X] : ℝ := some H
+
+proposition converges_to_limit_seq (X : ℕ → ℝ) [H : converges_seq X] :
+  (X ⟶ limit_seq X in ℕ) :=
+some_spec H
+
+proposition converges_to_seq_unique {X : ℕ → ℝ} {y₁ y₂ : ℝ}
+  (H₁ : X ⟶ y₁ in ℕ) (H₂ : X ⟶ y₂ in ℕ) : y₁ = y₂ :=
+metric_space.converges_to_seq_unique H₁ H₂
+
+proposition eq_limit_of_converges_to_seq {X : ℕ → ℝ} (y : ℝ) (H : X ⟶ y in ℕ) :
+  y = @limit_seq X (exists.intro y H) :=
+converges_to_seq_unique H (@converges_to_limit_seq X (exists.intro y H))
+
+proposition converges_to_seq_constant (y : ℝ) : (λn, y) ⟶ y in ℕ :=
+metric_space.converges_to_seq_constant y
+
+/- the completeness of the reals, "translated" from data.real.complete -/
+
+definition cauchy (X : ℕ → ℝ) := metric_space.cauchy X
+
+section
+  open pnat subtype
+
+  private definition pnat.succ (n : ℕ) : ℕ+ := tag (succ n) !succ_pos
+
+  private definition r_seq_of (X : ℕ → ℝ) : r_seq := λ n, X (elt_of n)
+
+  private lemma rate_of_cauchy_aux {X : ℕ → ℝ} (H : cauchy X) :
+    ∀ k : ℕ+, ∃ N : ℕ+, ∀ m n : ℕ+,
+      m ≥ N → n ≥ N → abs (X (elt_of m) - X (elt_of n)) ≤ of_rat k⁻¹ :=
+  take k : ℕ+,
+  have H1 : (rat.gt k⁻¹ (rat.of_num 0)), from !inv_pos,
+  have H2 : (of_rat k⁻¹ > of_rat (rat.of_num 0)), from !of_rat_lt_of_rat_of_lt H1,
+  obtain (N : ℕ) (H : ∀ m n, m ≥ N → n ≥ N → abs (X m - X n) < of_rat k⁻¹), from H _ H2,
+  exists.intro (pnat.succ N)
+    (take m n : ℕ+,
+      assume Hm : m ≥ (pnat.succ N),
+      assume Hn : n ≥ (pnat.succ N),
+      have Hm' : elt_of m ≥ N, from nat.le.trans !le_succ Hm,
+      have Hn' : elt_of n ≥ N, from nat.le.trans !le_succ Hn,
+      show abs (X (elt_of m) - X (elt_of n)) ≤ of_rat k⁻¹, from le_of_lt (H _ _ Hm' Hn'))
+
+  private definition rate_of_cauchy {X : ℕ → ℝ} (H : cauchy X) (k : ℕ+) : ℕ+ :=
+  some (rate_of_cauchy_aux H k)
+
+  private lemma cauchy_with_rate_of_cauchy {X : ℕ → ℝ} (H : cauchy X) :
+    cauchy_with_rate (r_seq_of X) (rate_of_cauchy H) :=
+  take k : ℕ+,
+  some_spec (rate_of_cauchy_aux H k)
+
+  private lemma converges_to_with_rate_of_cauchy {X : ℕ → ℝ} (H : cauchy X) :
+    ∃ l Nb, converges_to_with_rate (r_seq_of X) l Nb :=
+  begin
+    apply exists.intro,
+    apply exists.intro,
+    apply converges_to_with_rate_of_cauchy_with_rate,
+    exact cauchy_with_rate_of_cauchy H
+  end
+
+theorem converges_seq_of_cauchy {X : ℕ → ℝ} (H : cauchy X) : converges_seq X :=
+obtain l Nb (conv : converges_to_with_rate (r_seq_of X) l Nb),
+  from converges_to_with_rate_of_cauchy H,
+exists.intro l
+  (take ε : ℝ,
+    suppose ε > 0,
+    obtain (k' : ℕ) (Hn : 1 / succ k' < ε), from archimedean_small `ε > 0`,
+    let k : ℕ+ := tag (succ k') !succ_pos,
+        N : ℕ+ := Nb k in
+    have Hk : real.of_rat k⁻¹ < ε,
+      by rewrite [↑pnat.inv, of_rat_divide]; exact Hn,
+    exists.intro (elt_of N)
+      (take n : ℕ,
+        assume Hn : n ≥ elt_of N,
+        let n' : ℕ+ := tag n (nat.lt_of_lt_of_le (has_property N) Hn) in
+        have abs (X n - l) ≤ real.of_rat k⁻¹, from conv k n' Hn,
+        show abs (X n - l) < ε, from lt_of_le_of_lt this Hk))
+
+/- sup and inf -/
+
+open set
+
+private definition exists_is_sup {X : set ℝ} (H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → x ≤ b)) :
+  ∃ y, is_sup X y :=
+let x := some (and.left H), b := some (and.right H) in
+  exists_is_sup_of_inh_of_bdd X x (some_spec (and.left H)) b (some_spec (and.right H))
+
+private definition sup_aux {X : set ℝ} (H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → x ≤ b)) :=
+some (exists_is_sup H)
+
+private definition sup_aux_spec {X : set ℝ} (H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → x ≤ b)) :
+  is_sup X (sup_aux H) :=
+some_spec (exists_is_sup H)
+
+definition sup (X : set ℝ) : ℝ :=
+if H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → x ≤ b) then sup_aux H else 0
+
+proposition le_sup {x : ℝ} {X : set ℝ} (Hx : x ∈ X) {b : ℝ} (Hb : ∀ x, x ∈ X → x ≤ b) :
+  x ≤ sup X :=
+have H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → x ≤ b),
+  from and.intro (exists.intro x Hx) (exists.intro b Hb),
+by+ rewrite [↑sup, dif_pos H]; exact and.left (sup_aux_spec H) x Hx
+
+proposition sup_le {X : set ℝ} (HX : ∃ x, x ∈ X) {b : ℝ} (Hb : ∀ x, x ∈ X → x ≤ b) :
+  sup X ≤ b :=
+have H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → x ≤ b),
+  from and.intro HX (exists.intro b Hb),
+by+ rewrite [↑sup, dif_pos H]; exact and.right (sup_aux_spec H) b Hb
+
+private definition exists_is_inf {X : set ℝ} (H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → b ≤ x)) :
+  ∃ y, is_inf X y :=
+let x := some (and.left H), b := some (and.right H) in
+  exists_is_inf_of_inh_of_bdd X x (some_spec (and.left H)) b (some_spec (and.right H))
+
+private definition inf_aux {X : set ℝ} (H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → b ≤ x)) :=
+some (exists_is_inf H)
+
+private definition inf_aux_spec {X : set ℝ} (H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → b ≤ x)) :
+  is_inf X (inf_aux H) :=
+some_spec (exists_is_inf H)
+
+definition inf (X : set ℝ) : ℝ :=
+if H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → b ≤ x) then inf_aux H else 0
+
+proposition inf_le {x : ℝ} {X : set ℝ} (Hx : x ∈ X) {b : ℝ} (Hb : ∀ x, x ∈ X → b ≤ x) :
+  inf X ≤ x :=
+have H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → b ≤ x),
+  from and.intro (exists.intro x Hx) (exists.intro b Hb),
+by+ rewrite [↑inf, dif_pos H]; exact and.left (inf_aux_spec H) x Hx
+
+proposition le_inf {X : set ℝ} (HX : ∃ x, x ∈ X) {b : ℝ} (Hb : ∀ x, x ∈ X → b ≤ x) :
+  b ≤ inf X :=
+have H : (∃ x, x ∈ X) ∧ (∃ b, ∀ x, x ∈ X → b ≤ x),
+  from and.intro HX (exists.intro b Hb),
+by+ rewrite [↑inf, dif_pos H]; exact and.right (inf_aux_spec H) b Hb
+
+end
+
+/-
+proposition converges_to_at_unique {f : M → N} {y₁ y₂ : N} {x : M}
+  (H₁ : f ⟶ y₁ '[at x]) (H₂ : f ⟶ y₂ '[at x]) : y₁ = y₂ :=
+eq_of_forall_dist_le
+  (take ε, suppose ε > 0,
+    have e2pos : ε / 2 > 0, from  div_pos_of_pos_of_pos `ε > 0` two_pos,
+    obtain δ₁ [(δ₁pos : δ₁ > 0) (Hδ₁ : ∀ x', x ≠ x' ∧ dist x x' < δ₁ → dist (f x') y₁ < ε / 2)],
+      from H₁ e2pos,
+    obtain δ₂ [(δ₂pos : δ₂ > 0) (Hδ₂ : ∀ x', x ≠ x' ∧ dist x x' < δ₂ → dist (f x') y₂ < ε / 2)],
+      from H₂ e2pos,
+    let δ := min δ₁ δ₂ in
+    have δ > 0, from lt_min δ₁pos δ₂pos,
+
+-/
+
+end real

--- a/library/theories/group_theory/group_theory.md
+++ b/library/theories/group_theory/group_theory.md
@@ -3,16 +3,10 @@ theories.group_theory
 
 Group theory (especially finite group theory).
 
-[subgroup](subgroup.lean) : general subgroup theories, quotient group using quot
-
-[finsubg](finsubg.lean)   : finite subgroups (finset and fintype), Lagrange theorem, finite cosets and lcoset_type, normalizer for finite groups, coset product and quotient group based on lcoset_type, semidirect product
-
-[hom](hom.lean) 	  : homomorphism and isomorphism, kernel, first isomorphism theorem
-
-[perm](perm.lean)	  : permutation group
-
-[cyclic](cyclic.lean)	  : cyclic subgroup, finite generator, order of generator, sequence and rotation
-
-[action](action.lean)	  : fixed point, action, stabilizer, orbit stabilizer theorem, orbit partition, Cayley theorem, action on lcoset, cardinality of permutation group
-
-[pgroup](pgroup.lean)	  : subgroup with order of prime power, Cauchy theorem, first Sylow theorem
+* [subgroup](subgroup.lean) : general subgroup theories, quotient group using quot
+* [finsubg](finsubg.lean) : finite subgroups (finset and fintype), Lagrange theorem, finite cosets and lcoset_type, normalizer for finite groups, coset product and quotient group based on lcoset_type, semidirect product
+* [hom](hom.lean) : homomorphism and isomorphism, kernel, first isomorphism theorem
+* [perm](perm.lean) : permutation group
+* [cyclic](cyclic.lean) : cyclic subgroup, finite generator, order of generator, sequence and rotation
+* [action](action.lean)	: fixed point, action, stabilizer, orbit stabilizer theorem, orbit partition, Cayley theorem, action on lcoset, cardinality of permutation group
+* [pgroup](pgroup.lean)	: subgroup with order of prime power, Cauchy theorem, first Sylow theorem

--- a/library/theories/number_theory/irrational_roots.lean
+++ b/library/theories/number_theory/irrational_roots.lean
@@ -81,7 +81,7 @@ section
     using this, by rewrite [-int.abs_pow, this, int.abs_mul, int.abs_pow],
   have H₁ : (nat_abs a)^n = nat_abs c * (nat_abs b)^n,
     using this,
-      by apply int.of_nat.inj; rewrite [int.of_nat_mul, +of_nat_pow, +of_nat_nat_abs]; assumption,
+      by apply int.of_nat.inj; rewrite [int.of_nat_mul, +int.of_nat_pow, +of_nat_nat_abs]; assumption,
   have H₂ : nat.coprime (nat_abs a) (nat_abs b), from of_nat.inj !coprime_num_denom,
   have nat_abs b = 1, from
     by_cases

--- a/library/theories/number_theory/irrational_roots.lean
+++ b/library/theories/number_theory/irrational_roots.lean
@@ -24,7 +24,7 @@ section
   have even b, from even_of_even_pow this,
   have 2 ∣ gcd a b, from dvd_gcd (dvd_of_even `even a`) (dvd_of_even `even b`),
   have 2 ∣ 1, from co ▸ this,
-  absurd `2 ∣ 1` dec_trivial
+  show false, from absurd `2 ∣ 1` dec_trivial
 end
 
 /-
@@ -81,7 +81,7 @@ section
     using this, by rewrite [-int.abs_pow, this, int.abs_mul, int.abs_pow],
   have H₁ : (nat_abs a)^n = nat_abs c * (nat_abs b)^n,
     using this,
-      by apply of_nat.inj; rewrite [int.of_nat_mul, +of_nat_pow, +of_nat_nat_abs]; assumption,
+      by apply int.of_nat.inj; rewrite [int.of_nat_mul, +of_nat_pow, +of_nat_nat_abs]; assumption,
   have H₂ : nat.coprime (nat_abs a) (nat_abs b), from of_nat.inj !coprime_num_denom,
   have nat_abs b = 1, from
     by_cases

--- a/library/theories/theories.md
+++ b/library/theories/theories.md
@@ -3,3 +3,5 @@ theories
 
 * [number_theory](number_theory.md)
 * [combinatorics](combinatorics.md)
+* [group_theory](group_theory.md)
+* [analysis](analysis.md)


### PR DESCRIPTION
This commit improves casts between `nat`, `int`, `rat`, and `real`. Rather than use the names generated by the coercion package, we have `of_nat`, `of_int`, and `of_rat` at each larger type, and we now have the translations between any pair for `add`, `mul`, `neg`, `sub`, `divide` (or `div`, in the case of int and nat), `pow`, equality, `lt`, and `le` (as well as `mod`, `gcd`, `lcm`, and `dvd` with int and nat). The theorem names are uniform and we have all the necessary variants. This has already simplified some proofs.

We still need the cast properties for finite sums and products, etc. I will do that soon.

Leo recently asked me if we should think about having a "migrate" that would translate functions and theorems on e.g. nat and int to functions and theorems on the reals, with predicates `is_nat` and `is_int`. The idea is that it might be easier to do calculations and automate them in one domain, the reals.

I thought about it a little, and now I don't think we need to do this. For many calculations we do can do tricks like apply the translation rules in one direction to push the coercions as low as possible. More generally, we may be able to get automation to match "up to" coercions, i.e. treat "real.of_int i + real.of_int j = real.of_int (i + j)" as the same. This is just a special case of matching up to a set of equations.

I think we will need migrate for reasoning about instances of algebraic structures, because finding instances can be slow. Dealing with coercions between the number types seems to me much more controlled. It is not clear to me that tracking types with predicates rather than coercions will make much of a difference.

I made a small start on metric spaces and real limits, but now I think things will move more quickly, now that the basic infrastructure is settling.

The file "real_limits" expresses the completeness of the reals and defines sup and inf in a manner that is less constructive than in data/real/complete.lean, but easier to work with. I will discuss with Rob how to package things to make the interface and intended uses apparent to users. (I renamed `cauchy` in complete.lean to `cauchy_with_rate` and similarly for `converges_to`. In the classical library, `cauchy_with_rate` and `converges_to_with_rate` will not be used much. They are hard to use because they involve natural numbers, pnats, rationals, and reals.) 

I have been finicky with names. I renamed some theorems to follow these conventions:
- use "exists" rather than "ex" in theorem names. (In the library we do both, but we use "exists" more often. These theorems are usually used with "obtain", and saving a few characters doesn't seem to be a great virtue.)
- use "least" and "greatest" rather than "smallest" and "largest"
- always favor descriptions with "lt" and "le" over "gt" and "ge"
