### PR TITLE
Updates to IVT

### DIFF
--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -296,6 +296,14 @@ section linear_ordered_field
   theorem sub_self_div_two (a : A) : a - a / 2 = a / 2 :=
     by rewrite [-{a}add_halves at {1}, add_sub_cancel]
 
+  theorem add_midpoint {a b : A} (H : a < b) : a + (b - a) / 2 < b :=
+  begin
+    rewrite [-div_sub_div_same, sub_eq_add_neg, {b / 2 + _}add.comm, -add.assoc, -sub_eq_add_neg],
+    apply add_lt_of_lt_sub_right,
+    rewrite *sub_self_div_two,
+    apply div_lt_div_of_lt_of_pos H two_pos
+  end
+
   theorem div_two_sub_self (a : A) : a / 2 - a = - (a / 2) :=
     by rewrite [-{a}add_halves at {2}, sub_add_eq_sub_sub, sub_self, zero_sub]
 

--- a/library/theories/analysis/metric_space.lean
+++ b/library/theories/analysis/metric_space.lean
@@ -150,13 +150,11 @@ exists.intro δ (and.intro
    if Heq : x = x' then
      by rewrite [Heq, dist_self]; assumption
    else
-     (suffices dist x x' < δ, from and.right Hδ _ (and.intro Heq this),
+     (suffices dist x x' < δ, from and.right Hδ x' (and.intro Heq this),
       this)))
 
-definition image_seq (X : ℕ → M) (f : M → N) : ℕ → N := λ n, f (X n)
-
 theorem image_seq_converges_of_converges [instance] (X : ℕ → M) [HX : converges_seq X] {f : M → N} (Hf : continuous f) :
-        converges_seq (image_seq X f) :=
+        converges_seq (λ n, f (X n)) :=
   begin
     cases HX with xlim Hxlim,
     existsi f xlim,
@@ -168,9 +166,8 @@ theorem image_seq_converges_of_converges [instance] (X : ℕ → M) [HX : conver
     existsi B,
     intro n Hn,
     cases em (xlim = X n),
-    rewrite [↑image_seq, a, dist_self],
+    rewrite [a, dist_self],
     assumption,
-    rewrite ↑image_seq,
     apply and.right Hδ,
     split,
     exact a,


### PR DESCRIPTION
I've split some useful theorems out of the proof of the IVT, and made some changes so that it compiles significantly faster. Most noticeably, when the `x` in real_limit.lean line 376 was implicit, Lean took nearly a second to infer it. I'm guessing this is just a quirk of the unification process, but it looks like a straightforward inference.
