### PR TITLE
Improve pretty printer spacing

### DIFF
--- a/library/algebra/complete_lattice.lean
+++ b/library/algebra/complete_lattice.lean
@@ -125,8 +125,8 @@ variable [C : complete_lattice A]
 include C
 prefix `⨅`:70 := Inf
 prefix `⨆`:65 := Sup
-infix `⊓` := inf
-infix `⊔` := sup
+infix ` ⊓ ` := inf
+infix ` ⊔ ` := sup
 
 variable {f : A → A}
 premise  (mono : ∀ x y : A, x ≤ y → f x ≤ f y)

--- a/library/algebra/field.lean
+++ b/library/algebra/field.lean
@@ -25,7 +25,7 @@ section division_ring
   include s
 
   definition divide (a b : A) : A := a * b⁻¹
-  infix [priority algebra.prio] `/` := divide
+  infix [priority algebra.prio] / := divide
 
   -- only in this file
   local attribute divide [reducible]

--- a/library/algebra/group.lean
+++ b/library/algebra/group.lean
@@ -36,8 +36,8 @@ structure has_inv [class] (A : Type) :=
 structure has_neg [class] (A : Type) :=
 (neg : A → A)
 
-infixl [priority algebra.prio] `*`   := has_mul.mul
-infixl [priority algebra.prio] `+`   := has_add.add
+infixl [priority algebra.prio] ` * `   := has_mul.mul
+infixl [priority algebra.prio] ` + `   := has_add.add
 postfix [priority algebra.prio] `⁻¹` := has_inv.inv
 prefix [priority algebra.prio] `-`   := has_neg.neg
 notation 1  := !has_one.one
@@ -287,8 +287,8 @@ section group
   definition conj_by (g a : A) := g * a * g⁻¹
   definition is_conjugate (a b : A) := ∃ x, conj_by x b = a
 
-  local infixl `~` := is_conjugate
-  local infixr `∘c`:55 := conj_by
+  local infixl ` ~ ` := is_conjugate
+  local infixr ` ∘c `:55 := conj_by
 
   lemma conj_compose (f g a : A) : f ∘c g ∘c a = f*g ∘c a :=
       calc f ∘c g ∘c a = f * (g * a * g⁻¹) * f⁻¹ : rfl
@@ -478,7 +478,7 @@ section add_group
   -- TODO: derive corresponding facts for div in a field
   definition sub [reducible] (a b : A) : A := a + -b
 
-  infix [priority algebra.prio] `-` := sub
+  infix [priority algebra.prio] - := sub
 
   theorem sub_eq_add_neg (a b : A) : a - b = a + -b := rfl
 

--- a/library/algebra/group_power.lean
+++ b/library/algebra/group_power.lean
@@ -28,7 +28,7 @@ definition pow (a : A) : ℕ → A
 | 0     := 1
 | (n+1) := a * pow n
 
-infix [priority algebra.prio] `^` := pow
+infix [priority algebra.prio] ` ^ ` := pow
 
 theorem pow_zero (a : A) : a^0 = 1 := rfl
 theorem pow_succ (a : A) (n : ℕ) : a^(succ n) = a * a^n := rfl

--- a/library/algebra/lattice.lean
+++ b/library/algebra/lattice.lean
@@ -23,8 +23,8 @@ structure lattice [class] (A : Type) extends weak_order A :=
 
 definition inf := @lattice.inf
 definition sup := @lattice.sup
-infix `⊓`:70 := inf
-infix `⊔`:65 := sup
+infix ` ⊓ `:70 := inf
+infix ` ⊔ `:65 := sup
 
 section
   variable [s : lattice A]

--- a/library/algebra/order.lean
+++ b/library/algebra/order.lean
@@ -20,9 +20,9 @@ structure has_le [class] (A : Type) :=
 structure has_lt [class] (A : Type) :=
 (lt : A → A → Prop)
 
-infixl [priority algebra.prio] `<=`  := has_le.le
-infixl [priority algebra.prio] `≤`   := has_le.le
-infixl [priority algebra.prio] `<`   := has_lt.lt
+infixl [priority algebra.prio] <=  := has_le.le
+infixl [priority algebra.prio] ≤   := has_le.le
+infixl [priority algebra.prio] <   := has_lt.lt
 
 definition has_le.ge [reducible] {A : Type} [s : has_le A] (a b : A) := b ≤ a
 notation [priority algebra.prio] a ≥ b := has_le.ge a b

--- a/library/data/equiv.lean
+++ b/library/data/equiv.lean
@@ -20,12 +20,12 @@ structure equiv [class] (A B : Type) :=
 namespace equiv
 definition perm [reducible] (A : Type) := equiv A A
 
-infix `≃`:50 := equiv
+infix ` ≃ `:50 := equiv
 
 definition fn {A B : Type} (e : equiv A B) : A → B :=
 @equiv.to_fun A B e
 
-infixr `∙`:100 := fn
+infixr ` ∙ `:100 := fn
 
 definition inv {A B : Type} [e : equiv A B] : B → A :=
 @equiv.inv_fun A B e
@@ -54,9 +54,9 @@ protected definition trans [trans] {A B C : Type} : A ≃ B → B ≃ C → A �
 abbreviation id {A : Type} := equiv.refl A
 
 namespace ops
-  postfix `⁻¹` := equiv.symm
-  postfix `⁻¹` := equiv.inv
-  notation e₁ `∘` e₂  := equiv.trans e₂ e₁
+  postfix ⁻¹ := equiv.symm
+  postfix ⁻¹ := equiv.inv
+  notation e₁ ∘ e₂  := equiv.trans e₂ e₁
 end ops
 open equiv.ops
 

--- a/library/data/examples/vector.lean
+++ b/library/data/examples/vector.lean
@@ -15,7 +15,7 @@ inductive vector (A : Type) : nat → Type :=
 
 namespace vector
   notation a :: b := cons a b
-  notation `[` l:(foldr `,` (h t, cons h t) nil `]`) := l
+  notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
 
   variables {A B C : Type}
 

--- a/library/data/finset/basic.lean
+++ b/library/data/finset/basic.lean
@@ -74,7 +74,7 @@ quot.lift_on s (λ l, a ∈ elt_of l)
    (λ ainl₁, mem_perm e ainl₁)
    (λ ainl₂, mem_perm (perm.symm e) ainl₂)))
 
-infix [priority finset.prio] `∈` := mem
+infix [priority finset.prio] ∈ := mem
 notation [priority finset.prio] a ∉ b := ¬ mem a b
 
 theorem mem_of_mem_list {a : A} {l : nodup_list A} : a ∈ elt_of l → a ∈ ⟦l⟧ :=
@@ -169,7 +169,7 @@ quot.lift_on s
   (λ (l₁ l₂ : nodup_list A) (p : l₁ ~ l₂), quot.sound (perm_insert a p))
 
 -- set builder notation
-notation [priority finset.prio] `'{`:max a:(foldr `,` (x b, insert x b) ∅) `}`:0 := a
+notation [priority finset.prio] `'{`:max a:(foldr `, ` (x b, insert x b) ∅) `}`:0 := a
 
 theorem mem_insert (a : A) (s : finset A) : a ∈ insert a s :=
 quot.induction_on s
@@ -546,7 +546,7 @@ quot.lift_on₂ s₁ s₂
     (λ s₁ a i, mem_perm p₂ (s₁ a (mem_perm (perm.symm p₁) i)))
     (λ s₂ a i, mem_perm (perm.symm p₂) (s₂ a (mem_perm p₁ i)))))
 
-infix [priority finset.prio] `⊆` := subset
+infix [priority finset.prio] ⊆ := subset
 
 theorem empty_subset (s : finset A) : ∅ ⊆ s :=
 quot.induction_on s (λ l, list.nil_sub (elt_of l))

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -125,7 +125,7 @@ quot.lift_on s
     (list.nodup_filter p (subtype.has_property l)))
   (λ l₁ l₂ u, quot.sound (perm.perm_filter u))
 
-notation [priority finset.prio] `{` binder ∈ s `|` r:(scoped:1 p, sep p s) `}` := r
+notation [priority finset.prio] `{` binder ` ∈ ` s ` | ` r:(scoped:1 p, sep p s) `}` := r
 
 theorem sep_empty : sep p ∅ = ∅ := rfl
 
@@ -178,7 +178,7 @@ variables {A : Type} [deceq : decidable_eq A]
 include deceq
 
 definition diff (s t : finset A) : finset A := {x ∈ s | x ∉ t}
-infix [priority finset.prio] `\`:70 := diff
+infix [priority finset.prio] ` \ `:70 := diff
 
 theorem mem_of_mem_diff {s t : finset A} {x : A} (H : x ∈ s \ t) : x ∈ s :=
 mem_of_mem_sep H

--- a/library/data/hf.lean
+++ b/library/data/hf.lean
@@ -64,7 +64,7 @@ of_finset (finset.insert a (to_finset s))
 definition mem (a : hf) (s : hf) : Prop :=
 finset.mem a (to_finset s)
 
-infix `∈` := mem
+infix ∈ := mem
 notation [priority finset.prio] a ∉ b := ¬ mem a b
 
 lemma insert_lt_of_not_mem {a s : hf} : a ∉ s → s < insert a s :=
@@ -314,7 +314,7 @@ end
 definition subset (s₁ s₂ : hf) : Prop :=
 finset.subset (to_finset s₁) (to_finset s₂)
 
-infix [priority hf.prio] `⊆` := subset
+infix [priority hf.prio] ⊆ := subset
 
 theorem empty_subset (s : hf) : ∅ ⊆ s :=
 begin unfold [empty, subset], rewrite to_finset_of_finset, apply finset.empty_subset (to_finset s) end

--- a/library/data/int/basic.lean
+++ b/library/data/int/basic.lean
@@ -45,7 +45,7 @@ namespace int
 
 attribute int.of_nat [coercion]
 
-notation `-[1+` n `]` := int.neg_succ_of_nat n    -- for pretty-printing output
+notation `-[1+ ` n `]` := int.neg_succ_of_nat n    -- for pretty-printing output
 
 /- definitions of basic functions -/
 
@@ -137,7 +137,7 @@ theorem eq_zero_of_nat_abs_eq_zero : Π {a : ℤ}, nat_abs a = 0 → a = 0
 
 protected definition equiv (p q : ℕ × ℕ) : Prop :=  pr1 p + pr2 q = pr2 p + pr1 q
 
-local infix `≡` := int.equiv
+local infix ≡ := int.equiv
 
 protected theorem equiv.refl [refl] {p : ℕ × ℕ} : p ≡ p := !add.comm
 

--- a/library/data/int/div.lean
+++ b/library/data/int/div.lean
@@ -26,7 +26,7 @@ notation [priority int.prio] a div b := divide a b
 
 definition modulo (a b : ℤ) : ℤ := a - a div b * b
 notation [priority int.prio] a mod b := modulo a b
-notation [priority int.prio] a `≡` b `[mod`:100 c `]`:0 := a mod c = b mod c
+notation [priority int.prio] a ≡ b `[mod `:100 c `]`:0 := a mod c = b mod c
 
 /- div  -/
 

--- a/library/data/int/power.lean
+++ b/library/data/int/power.lean
@@ -19,7 +19,7 @@ section migrate_algebra
   definition pow (a : ℤ) (n : ℕ) : ℤ := algebra.pow a n
   infix [priority int.prio] ^ := pow
   definition nmul (n : ℕ) (a : ℤ) : ℤ := algebra.nmul n a
-  infix [priority int.prio] `⬝` := nmul
+  infix [priority int.prio] ⬝ := nmul
   definition imul (i : ℤ) (a : ℤ) : ℤ := algebra.imul i a
 
   migrate from algebra with int

--- a/library/data/list/basic.lean
+++ b/library/data/list/basic.lean
@@ -17,7 +17,7 @@ inhabited.mk list.nil
 
 namespace list
 notation h :: t  := cons h t
-notation `[` l:(foldr `,` (h t, cons h t) nil `]`) := l
+notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
 
 variable {T : Type}
 
@@ -352,7 +352,7 @@ assume P, and.intro (ne_of_not_mem_cons P) (not_mem_of_not_mem_cons P)
 
 definition sublist (l₁ l₂ : list T) := ∀ ⦃a : T⦄, a ∈ l₁ → a ∈ l₂
 
-infix `⊆` := sublist
+infix ⊆ := sublist
 
 theorem nil_sub [simp] (l : list T) : [] ⊆ l :=
 λ b i, false.elim (iff.mp (mem_nil_iff b) i)

--- a/library/data/matrix.lean
+++ b/library/data/matrix.lean
@@ -17,7 +17,7 @@ definition val [reducible] (M : matrix A m n) (i : fin m) (j : fin n) : A :=
 M i j
 
 namespace ops
-notation M `[` i `,` j `]` := val M i j
+notation M `[` i `, ` j `]` := val M i j
 end ops
 
 open ops

--- a/library/data/nat/basic.lean
+++ b/library/data/nat/basic.lean
@@ -14,7 +14,7 @@ namespace nat
 
 definition addl (x y : ℕ) : ℕ :=
 nat.rec y (λ n r, succ r) x
-infix `⊕`:65 := addl
+infix ` ⊕ `:65 := addl
 
 theorem addl_succ_right (n m : ℕ) : n ⊕ succ m = succ (n ⊕ m) :=
 nat.induction_on n

--- a/library/data/nat/div.lean
+++ b/library/data/nat/div.lean
@@ -78,7 +78,7 @@ if H : 0 < y ∧ y ≤ x then f (x - y) (div_rec_lemma H) y else x
 
 definition modulo := fix mod.F
 notation a mod b := modulo a b
-notation a `≡` b `[mod`:100 c `]`:0 := a mod c = b mod c
+notation a ≡ b `[mod `:100 c `]`:0 := a mod c = b mod c
 
 theorem modulo_def (x y : nat) : modulo x y = if 0 < y ∧ y ≤ x then modulo (x - y) y else x :=
 congr_fun (fix_eq mod.F x) y

--- a/library/data/nat/find.lean
+++ b/library/data/nat/find.lean
@@ -31,7 +31,7 @@ private lemma lbp_succ {x : nat} : lbp x → ¬ p x → lbp (succ x) :=
 private definition gtb (a b : nat) : Prop :=
 a > b ∧ lbp a
 
-local infix `≺`:50 := gtb
+local infix ` ≺ `:50 := gtb
 
 private lemma acc_of_px {x : nat} : p x → acc gtb x :=
 assume h,

--- a/library/data/nat/gcd.lean
+++ b/library/data/nat/gcd.lean
@@ -17,7 +17,7 @@ private definition pair_nat.lt.wf : well_founded pair_nat.lt :=
 intro_k (measure.wf pr₂) 20  -- we use intro_k to be able to execute gcd efficiently in the kernel
 
 local attribute pair_nat.lt.wf [instance]      -- instance will not be saved in .olean
-local infixl `≺`:50 := pair_nat.lt
+local infixl ` ≺ `:50 := pair_nat.lt
 
 private definition gcd.lt.dec (x y₁ : nat) : (succ y₁, x mod succ y₁) ≺ (x, succ y₁) :=
 !mod_lt (succ_pos y₁)

--- a/library/data/num.lean
+++ b/library/data/num.lean
@@ -77,7 +77,7 @@ namespace pos_num
     end
 
   local notation a < b         := (lt a b = tt)
-  local notation a `≮`:50 b:50 := (lt a b = ff)
+  local notation a ` ≮ `:50 b:50 := (lt a b = ff)
 
   theorem lt_one_right_eq_ff : ∀ a : pos_num, a ≮ one
   | one      := rfl

--- a/library/data/pnat.lean
+++ b/library/data/pnat.lean
@@ -27,18 +27,18 @@ theorem pnat_pos (p : ℕ+) : p~ > 0 := has_property p
 
 definition add (p q : ℕ+) : ℕ+ :=
   tag (p~ + q~) (nat.add_pos (pnat_pos p) (pnat_pos q))
-infix `+` := add
+infix + := add
 
 definition mul (p q : ℕ+) : ℕ+ :=
   tag (p~ * q~) (nat.mul_pos (pnat_pos p) (pnat_pos q))
-infix `*` := mul
+infix * := mul
 
 definition le (p q : ℕ+) := p~ ≤ q~
-infix `≤` := le
-notation p `≥` q := q ≤ p
+infix ≤ := le
+notation p ≥ q := q ≤ p
 
 definition lt (p q : ℕ+) := p~ < q~
-infix `<` := lt
+infix < := lt
 
 protected theorem pnat.eq {p q : ℕ+} : p~ = q~ → p = q :=
   subtype.eq

--- a/library/data/rat/basic.lean
+++ b/library/data/rat/basic.lean
@@ -22,7 +22,7 @@ namespace prerat
 
 definition equiv (a b : prerat) : Prop := num a * denom b = num b * denom a
 
-infix `≡` := equiv
+infix ≡ := equiv
 
 theorem equiv.refl [refl] (a : prerat) : a ≡ a := rfl
 
@@ -539,12 +539,12 @@ section migrate_algebra
   local attribute rat.discrete_field [instance]
 
   definition divide (a b : rat) := algebra.divide a b
-  infix [priority rat.prio] `/` := divide
+  infix [priority rat.prio] / := divide
 
   definition pow (a : ℚ) (n : ℕ) : ℚ := algebra.pow a n
   infix [priority rat.prio] ^ := pow
   definition nmul (n : ℕ) (a : ℚ) : ℚ := algebra.nmul n a
-  infix [priority rat.prio] `⬝` := nmul
+  infix [priority rat.prio] ⬝ := nmul
   definition imul (i : ℤ) (a : ℚ) : ℚ := algebra.imul i a
 
   migrate from algebra with rat

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -936,16 +936,16 @@ definition requiv.trans (s t u : reg_seq) (H : requiv s t) (H2 : requiv t u) : r
 definition radd (s t : reg_seq) : reg_seq :=
   reg_seq.mk (sadd (reg_seq.sq s) (reg_seq.sq t))
              (reg_add_reg (reg_seq.is_reg s) (reg_seq.is_reg t))
-infix `+` := radd
+infix + := radd
 
 definition rmul (s t : reg_seq) : reg_seq :=
   reg_seq.mk (smul (reg_seq.sq s) (reg_seq.sq t))
              (reg_mul_reg (reg_seq.is_reg s) (reg_seq.is_reg t))
-infix `*` := rmul
+infix * := rmul
 
 definition rneg (s : reg_seq) : reg_seq :=
   reg_seq.mk (sneg (reg_seq.sq s)) (reg_neg_reg (reg_seq.is_reg s))
-prefix `-` := rneg
+prefix - := rneg
 
 definition radd_well_defined {s t u v : reg_seq} (H : requiv s u) (H2 : requiv t v) :
            requiv (s + t) (u + v) :=
@@ -1025,13 +1025,13 @@ definition add (x y : ℝ) : ℝ :=
                      (take a b c d : reg_seq, take Hab : requiv a c, take Hcd : requiv b d,
                        quot.sound (radd_well_defined Hab Hcd)))
 protected definition prio := num.pred rat.prio
-infix [priority real.prio] `+` := add
+infix [priority real.prio] + := add
 
 definition mul (x y : ℝ) : ℝ :=
   (quot.lift_on₂ x y (λ a b, quot.mk (a * b))
                      (take a b c d : reg_seq, take Hab : requiv a c, take Hcd : requiv b d,
                        quot.sound (rmul_well_defined Hab Hcd)))
-infix [priority real.prio] `*` := mul
+infix [priority real.prio] * := mul
 
 definition neg (x : ℝ) : ℝ :=
   (quot.lift_on x (λ a, quot.mk (-a)) (take a b : reg_seq, take Hab : requiv a b,

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -15,17 +15,17 @@ variable {X : Type}
 /- membership and subset -/
 
 definition mem [reducible] (x : X) (a : set X) := a x
-infix `∈` := mem
+infix ∈ := mem
 notation a ∉ b := ¬ mem a b
 
 theorem ext {a b : set X} (H : ∀x, x ∈ a ↔ x ∈ b) : a = b :=
 funext (take x, propext (H x))
 
 definition subset (a b : set X) := ∀⦃x⦄, x ∈ a → x ∈ b
-infix `⊆` := subset
+infix ⊆ := subset
 
 definition superset [reducible] (s t : set X) : Prop := t ⊆ s
-infix `⊇` := superset
+infix ⊇ := superset
 
 theorem subset.refl (a : set X) : a ⊆ a := take x, assume H, H
 
@@ -45,7 +45,7 @@ assume h₁ h₂, h₁ _ h₂
 /- strict subset -/
 
 definition strict_subset (a b : set X) := a ⊆ b ∧ a ≠ b
-infix `⊂`:50 := strict_subset
+infix ` ⊂ `:50 := strict_subset
 
 theorem strict_subset.irrefl (a : set X) : ¬ a ⊂ a :=
 assume h, absurd rfl (and.elim_right h)
@@ -235,18 +235,18 @@ ext (take x, !or.right_distrib)
 
 -- {x : X | P}
 definition set_of [reducible] (P : X → Prop) : set X := P
-notation `{` binder `|` r:(scoped:1 P, set_of P) `}` := r
+notation `{` binder ` | ` r:(scoped:1 P, set_of P) `}` := r
 
 -- {x ∈ s | P}
 definition sep (P : X → Prop) (s : set X) : set X := λx, x ∈ s ∧ P x
-notation `{` binder ∈ s `|` r:(scoped:1 p, sep p s) `}` := r
+notation `{` binder ` ∈ ` s ` | ` r:(scoped:1 p, sep p s) `}` := r
 
 /- insert -/
 
 definition insert (x : X) (a : set X) : set X := {y : X | y = x ∨ y ∈ a}
 
 -- '{x, y, z}
-notation `'{`:max a:(foldr `,` (x b, insert x b) ∅) `}`:0 := a
+notation `'{`:max a:(foldr `, ` (x b, insert x b) ∅) `}`:0 := a
 
 theorem subset_insert (x : X) (a : set X) : a ⊆ insert x a :=
 take y, assume ys, or.inr ys

--- a/library/data/sum.lean
+++ b/library/data/sum.lean
@@ -13,8 +13,8 @@ notation A ⊎ B := sum A B
 namespace sum
   notation A + B := sum A B
   namespace low_precedence_plus
-    reserve infixr `+`:25  -- conflicts with notation for addition
-    infixr `+` := sum
+    reserve infixr ` + `:25  -- conflicts with notation for addition
+    infixr + := sum
   end low_precedence_plus
 
   variables {A B : Type}

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -152,7 +152,7 @@ section
   ne_false_of_self trivial
 end
 
-infixl `==`:50 := heq
+infixl ` == `:50 := heq
 
 namespace heq
   universe variable u
@@ -233,7 +233,7 @@ and.rec H₂ H₁
 
 /- or -/
 
-notation a `\/` b := or a b
+notation a \/ b := or a b
 notation a ∨ b := or a b
 
 namespace or
@@ -321,8 +321,8 @@ intro : ∀ (a : A), P a → Exists P
 
 definition exists.intro := @Exists.intro
 
-notation `exists` binders `,` r:(scoped P, Exists P) := r
-notation `∃` binders `,` r:(scoped P, Exists P) := r
+notation `exists` binders `, ` r:(scoped P, Exists P) := r
+notation `∃` binders `, ` r:(scoped P, Exists P) := r
 
 theorem exists.elim {A : Type} {p : A → Prop} {B : Prop}
   (H1 : ∃x, p x) (H2 : ∀ (a : A), p a → B) : B :=

--- a/library/init/nat.lean
+++ b/library/init/nat.lean
@@ -16,15 +16,15 @@ namespace nat
   | refl : le a a
   | step : Π {b}, le a b → le a (succ b)
 
-  infix `≤` := le
+  infix ≤ := le
   attribute le.refl [refl]
 
   definition lt [reducible] (n m : ℕ) := succ n ≤ m
   definition ge [reducible] (n m : ℕ) := m ≤ n
   definition gt [reducible] (n m : ℕ) := succ m ≤ n
-  infix `<` := lt
-  infix `≥` := ge
-  infix `>` := gt
+  infix < := lt
+  infix ≥ := ge
+  infix > := gt
 
   definition pred [unfold 1] (a : nat) : nat :=
   nat.cases_on a zero (λ a₁, a₁)

--- a/library/init/prod.lean
+++ b/library/init/prod.lean
@@ -9,7 +9,7 @@ import init.num init.wf
 definition pair [constructor] := @prod.mk
 notation A × B := prod A B
 -- notation for n-ary tuples
-notation `(` h `,` t:(foldl `,` (e r, prod.mk r e) h) `)` := t
+notation `(` h `, ` t:(foldl `, ` (e r, prod.mk r e) h) `)` := t
 
 namespace prod
   notation [parsing-only] A * B := prod A B

--- a/library/init/reserved_notation.lean
+++ b/library/init/reserved_notation.lean
@@ -33,65 +33,65 @@ num.succ (num.succ (num.succ (num.succ (num.succ (num.succ (num.succ (num.succ (
 /- Logical operations and relations -/
 
 reserve prefix `¬`:40
-reserve prefix `~`:40
-reserve infixr `∧`:35
-reserve infixr `/\`:35
-reserve infixr `\/`:30
-reserve infixr `∨`:30
-reserve infix `<->`:20
-reserve infix `↔`:20
-reserve infix `=`:50
-reserve infix `≠`:50
-reserve infix `≈`:50
-reserve infix `~`:50
-reserve infix `≡`:50
+reserve prefix ` ~ `:40
+reserve infixr ` ∧ `:35
+reserve infixr ` /\ `:35
+reserve infixr ` \/ `:30
+reserve infixr ` ∨ `:30
+reserve infix ` <-> `:20
+reserve infix ` ↔ `:20
+reserve infix ` = `:50
+reserve infix ` ≠ `:50
+reserve infix ` ≈ `:50
+reserve infix ` ~ `:50
+reserve infix ` ≡ `:50
 
-reserve infixr `∘`:60                   -- input with \comp
+reserve infixr ` ∘ `:60                 -- input with \comp
 reserve postfix `⁻¹`:std.prec.max_plus  -- input with \sy or \-1 or \inv
 
-reserve infixl `⬝`:75
-reserve infixr `▸`:75
-reserve infixr `▹`:75
+reserve infixl ` ⬝ `:75
+reserve infixr ` ▸ `:75
+reserve infixr ` ▹ `:75
 
 /- types and type constructors -/
 
-reserve infixl `⊎`:25
-reserve infixl `×`:30
+reserve infixl ` ⊎ `:25
+reserve infixl ` × `:30
 
 /- arithmetic operations -/
 
-reserve infixl `+`:65
-reserve infixl `-`:65
-reserve infixl `*`:70
-reserve infixl `div`:70
-reserve infixl `mod`:70
-reserve infixl `/`:70
+reserve infixl ` + `:65
+reserve infixl ` - `:65
+reserve infixl ` * `:70
+reserve infixl ` div `:70
+reserve infixl ` mod `:70
+reserve infixl ` / `:70
 reserve prefix `-`:100
-reserve infix `^`:80
+reserve infix ` ^ `:80
 
-reserve infix `<=`:50
-reserve infix `≤`:50
-reserve infix `<`:50
-reserve infix `>=`:50
-reserve infix `≥`:50
-reserve infix `>`:50
+reserve infix ` <= `:50
+reserve infix ` ≤ `:50
+reserve infix ` < `:50
+reserve infix ` >= `:50
+reserve infix ` ≥ `:50
+reserve infix ` > `:50
 
 /- boolean operations -/
 
-reserve infixl `&&`:70
-reserve infixl `||`:65
+reserve infixl ` && `:70
+reserve infixl ` || `:65
 
 /- set operations -/
 
-reserve infix `∈`:50
-reserve infix `∉`:50
-reserve infixl `∩`:70
-reserve infixl `∪`:65
-reserve infix `⊆`:50
-reserve infix `⊇`:50
+reserve infix ` ∈ `:50
+reserve infix ` ∉ `:50
+reserve infixl ` ∩ `:70
+reserve infixl ` ∪ `:65
+reserve infix ` ⊆ `:50
+reserve infix ` ⊇ `:50
 
 /- other symbols -/
 
-reserve infix `∣`:50
-reserve infixl `++`:65
-reserve infixr `::`:65
+reserve infix ` ∣ `:50
+reserve infixl ` ++ `:65
+reserve infixr ` :: `:65

--- a/library/init/sigma.lean
+++ b/library/init/sigma.lean
@@ -7,9 +7,9 @@ prelude
 import init.datatypes init.num init.wf init.logic init.tactic
 
 definition dpair := @sigma.mk
-notation `Σ` binders `,` r:(scoped P, sigma P) := r
+notation `Σ` binders `, ` r:(scoped P, sigma P) := r
 -- notation for n-ary tuples; input ⟨ ⟩ as \< \>
-notation `⟨`:max t:(foldr `,` (e r, sigma.mk e r)) `⟩`:0 := t
+notation `⟨`:max t:(foldr `, ` (e r, sigma.mk e r)) `⟩`:0 := t
 
 lemma ex_of_sig {A : Type} {P : A → Prop} : (Σ x, P x) → ∃ x, P x :=
 assume h, obtain x hx, from h, exists.intro x hx

--- a/library/init/subtype.lean
+++ b/library/init/subtype.lean
@@ -12,7 +12,7 @@ set_option structure.proj_mk_thm true
 structure subtype {A : Type} (P : A → Prop) :=
 tag :: (elt_of : A) (has_property : P elt_of)
 
-notation `{` binder `|` r:(scoped:1 P, subtype P) `}` := r
+notation `{` binder ` | ` r:(scoped:1 P, subtype P) `}` := r
 
 definition ex_of_sub {A : Type} {P : A → Prop} : { x | P x } → ∃ x, P x
 | (subtype.tag a h) := exists.intro a h

--- a/src/frontends/lean/parse_table.cpp
+++ b/src/frontends/lean/parse_table.cpp
@@ -327,7 +327,7 @@ action replace(action const & a, std::function<expr(expr const &)> const & f) {
 }
 
 transition replace(transition const & t, std::function<expr(expr const &)> const & f) {
-    return transition(t.get_token(), replace(t.get_action(), f));
+    return transition(t.get_token(), replace(t.get_action(), f), t.get_pp_token());
 }
 
 struct parse_table::cell {

--- a/src/frontends/lean/parse_table.h
+++ b/src/frontends/lean/parse_table.h
@@ -173,7 +173,7 @@ public:
         return add(ts.size(), ts.begin(), a, LEAN_DEFAULT_NOTATION_PRIORITY, true);
     }
     parse_table merge(parse_table const & s, bool overload) const;\
-    list<pair<action, parse_table>> find(name const & tk) const;
+    list<pair<transition, parse_table>> find(name const & tk) const;
     list<accepting> const & is_accepting() const;
     void for_each(std::function<void(unsigned, transition const *, list<accepting> const &)> const & fn) const;
 

--- a/src/frontends/lean/parse_table.h
+++ b/src/frontends/lean/parse_table.h
@@ -114,11 +114,13 @@ action replace(action const & a, std::function<expr(expr const &)> const & f);
 
 class transition {
     name           m_token;
+    name           m_pp_token;
     action         m_action;
 public:
-    transition(name const & t, action const & a):
-        m_token(t), m_action(a) {}
+    transition(name const & t, action const & a, name pp_token = name::anonymous()):
+        m_token(t), m_pp_token(pp_token ? pp_token : t), m_action(a) {}
     name const & get_token() const { return m_token; }
+    name const & get_pp_token() const { return m_pp_token; }
     action const & get_action() const { return m_action; }
     bool is_simple() const { return m_action.is_simple(); }
     bool is_safe_ascii() const { return m_token.is_safe_ascii(); }

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -8,6 +8,7 @@ Author: Leonardo de Moura
 #include <string>
 #include <limits>
 #include <vector>
+#include <util/utf8.h>
 #include "util/interrupt.h"
 #include "util/script_exception.h"
 #include "util/sstream.h"
@@ -1266,7 +1267,8 @@ expr parser::parse_notation_core(parse_table t, expr * left, bool as_tactic) {
             auto terminator = a.get_terminator();
             if (!terminator || !curr_is_token(*terminator)) {
                 r_args.push_back(parse_expr_or_tactic(a.rbp(), as_tactic));
-                while (curr_is_token(a.get_sep())) {
+                name sep = utf8_trim(a.get_sep().to_string());
+                while (curr_is_token(sep)) {
                     next();
                     r_args.push_back(parse_expr_or_tactic(a.rbp(), as_tactic));
                 }

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -204,14 +204,15 @@ action read_action(deserializer & d) {
 }
 
 serializer & operator<<(serializer & s, transition const & t) {
-    s << t.get_token() << t.get_action();
+    s << t.get_token() << t.get_pp_token() << t.get_action();
     return s;
 }
 
 transition read_transition(deserializer & d) {
-    name   n = read_name(d);
-    action a = read_action(d);
-    return transition(n, a);
+    name   n  = read_name(d);
+    name   pp = read_name(d);
+    action a  = read_action(d);
+    return transition(n, a, pp);
 }
 
 struct notation_state {

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -1221,6 +1221,8 @@ auto pretty_fn::pp_notation(expr const & e) -> optional<result> {
     if (!m_notation || is_var(e))
         return optional<result>();
     for (notation_entry const & entry : get_notation_entries(m_env, head_index(e))) {
+        if (entry.group() != notation_entry_group::Main)
+            continue;
         if (!m_unicode && !entry.is_safe_ascii())
             continue; // ignore this notation declaration since unicode support is not enabled
         unsigned num_params = get_num_parameters(entry);

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -1029,7 +1029,7 @@ auto pretty_fn::pp_notation(notation_entry const & entry, buffer<optional<expr>>
             format curr;
             notation::action const & a = ts[i].get_action();
             name const & tk = ts[i].get_token();
-            format tk_fmt = format(tk);
+            format tk_fmt = format(ts[i].get_pp_token());
             switch (a.kind()) {
             case notation::action_kind::Skip:
                 curr = tk_fmt;

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -93,6 +93,7 @@ private:
     optional<result> pp_notation(expr const & e);
 
     result add_paren_if_needed(result const & r, unsigned bp);
+    bool needs_space_sep(std::string const &s1, std::string const &s2) const;
 
     result pp_overriden_local_ref(expr const & e);
     bool ignore_local_ref(expr const & e);

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -93,7 +93,7 @@ private:
     optional<result> pp_notation(expr const & e);
 
     result add_paren_if_needed(result const & r, unsigned bp);
-    bool needs_space_sep(std::string const &s1, std::string const &s2) const;
+    std::pair<bool, token_table const *> needs_space_sep(token_table const * t, std::string const &s1, std::string const &s2) const;
 
     result pp_overriden_local_ref(expr const & e);
     bool ignore_local_ref(expr const & e);

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -314,10 +314,10 @@ static bool is_id_first(buffer<char> const & cs, unsigned i) {
     return is_letter_like_unicode(u);
 }
 
-static bool is_id_rest(buffer<char> const & cs, unsigned i)  {
-    if (std::isalnum(cs[i]) || cs[i] == '_' || cs[i] == '\'')
+bool is_id_rest(char const * begin, char const * end) {
+    if (std::isalnum(*begin) || *begin == '_' || *begin == '\'')
         return true;
-    unsigned u = utf8_to_unicode(cs.begin() + i, cs.end());
+    unsigned u = utf8_to_unicode(begin, end);
     return is_letter_like_unicode(u) || is_super_sub_script_alnum_unicode(u);
 }
 
@@ -337,7 +337,7 @@ auto scanner::read_key_cmd_id() -> token_kind {
             unsigned i = id_sz;
             next_utf(cs);
             num_utfs++;
-            if (is_id_rest(cs, i)) {
+            if (is_id_rest(&cs[i], cs.end())) {
             } else if (cs[i] == '.') {
                 next_utf(cs);
                 num_utfs++;

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -157,9 +157,10 @@ auto scanner::read_quoted_symbol() -> token_kind {
         if (c == '`') {
             m_name_val = name(m_buffer.c_str());
             return token_kind::QuotedSymbol;
-        } else if (c != ' ' && c != '\"' && c != '\n' && c != '\t') {
+        } else if (c != '\"' && c != '\n' && c != '\t') {
             m_buffer += c;
         } else {
+            // TODO: intra-token space
             throw_exception("invalid quoted symbol, invalid character");
         }
     }

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -92,6 +92,7 @@ public:
     };
 };
 std::ostream & operator<<(std::ostream & out, scanner::token_kind k);
+bool is_id_rest(char const * begin, char const * end);
 void initialize_scanner();
 void finalize_scanner();
 }

--- a/src/util/sexpr/format.cpp
+++ b/src/util/sexpr/format.cpp
@@ -182,10 +182,11 @@ std::tuple<sexpr, sexpr const *> format::separate_tokens(sexpr const & s, sexpr 
 ) const {
     switch (sexpr_kind(s)) {
         case format_kind::NIL:
-        case format_kind::LINE:
         case format_kind::COLOR_BEGIN:
         case format_kind::COLOR_END:
             return std::make_tuple(s, last);
+        case format_kind::LINE:
+            return std::make_tuple(s, nullptr);
         case format_kind::COMPOSE:
         case format_kind::FLAT_COMPOSE:
         {

--- a/src/util/sexpr/format.h
+++ b/src/util/sexpr/format.h
@@ -120,6 +120,10 @@ private:
         return sexpr(sexpr(format::format_kind::LINE), sexpr());
     }
 
+    std::tuple<sexpr, sexpr const *> separate_tokens(sexpr const & s, sexpr const * last,
+                                                     std::function<bool(sexpr const &, sexpr const &)> sep //NOLINT
+    ) const;
+
     // Functions used inside of pretty printing
     static bool space_upto_line_break_list_exceeded(sexpr const & s, int available, std::vector<pair<sexpr, unsigned>> const & todo);
     static int space_upto_line_break(sexpr const & s, int available, bool & found);
@@ -168,6 +172,8 @@ public:
     }
     bool is_nil_fmt() const { return kind() == format_kind::NIL; }
     unsigned hash() const { return m_value.hash(); }
+
+    format separate_tokens(std::function<bool(sexpr const &, sexpr const &)> sep) const; // NOLINT
 
     friend format compose(format const & f1, format const & f2);
     friend format nest(int i, format const & f);

--- a/src/util/sexpr/format.h
+++ b/src/util/sexpr/format.h
@@ -121,8 +121,7 @@ private:
     }
 
     std::tuple<sexpr, sexpr const *> separate_tokens(sexpr const & s, sexpr const * last,
-                                                     std::function<bool(sexpr const &, sexpr const &)> sep //NOLINT
-    ) const;
+                                                     std::function<bool(sexpr const &, sexpr const &)> sep) const; //NOLINT
 
     // Functions used inside of pretty printing
     static bool space_upto_line_break_list_exceeded(sexpr const & s, int available, std::vector<pair<sexpr, unsigned>> const & todo);

--- a/src/util/sexpr/sexpr_fn.h
+++ b/src/util/sexpr/sexpr_fn.h
@@ -32,7 +32,8 @@ sexpr map(sexpr const & l, F f) {
         return l;
     } else {
         lean_assert(is_cons(l));
-        return sexpr(f(head(l)), map(tail(l), f));
+        auto x = f(head(l)); // force left-to-right evaluation order
+        return sexpr(x, map(tail(l), f));
     }
 }
 

--- a/src/util/utf8.cpp
+++ b/src/util/utf8.cpp
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include <cstdlib>
+#include <string>
 #include "util/debug.h"
 
 namespace lean {
@@ -48,5 +49,22 @@ char const * get_utf8_last_char(char const * str) {
         str += sz;
     } while (*str != 0);
     return r;
+}
+
+std::string utf8_trim(std::string const & s) {
+    int start = -1, stop = -1;
+    for (unsigned i = 0; i < s.size(); i += get_utf8_size(s[i])) {
+        if (s[i] == ' ') {
+            if (stop == -1)
+                stop = i;
+        } else {
+            if (start == -1)
+                start = i;
+            stop = -1;
+        }
+    }
+    if (stop == -1)
+        stop = s.size();
+    return s.substr(start, stop - start);
 }
 }

--- a/src/util/utf8.cpp
+++ b/src/util/utf8.cpp
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include <cstdlib>
+#include "util/debug.h"
 
 namespace lean {
 bool is_utf8_next(unsigned char c) { return (c & 0xC0) == 0x80; }
@@ -35,6 +36,17 @@ size_t utf8_strlen(char const * str) {
         r++;
         str += sz;
     }
+    return r;
+}
+
+char const * get_utf8_last_char(char const * str) {
+    char const * r;
+    lean_assert(*str != 0);
+    do {
+        r = str;
+        unsigned sz = get_utf8_size(*str);
+        str += sz;
+    } while (*str != 0);
     return r;
 }
 }

--- a/src/util/utf8.h
+++ b/src/util/utf8.h
@@ -9,4 +9,5 @@ namespace lean {
 bool is_utf8_next(unsigned char c);
 unsigned get_utf8_size(unsigned char c);
 size_t utf8_strlen(char const * str);
+char const * get_utf8_last_char(char const * str);
 }

--- a/src/util/utf8.h
+++ b/src/util/utf8.h
@@ -5,9 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #pragma once
+#include <string>
+
 namespace lean {
 bool is_utf8_next(unsigned char c);
 unsigned get_utf8_size(unsigned char c);
 size_t utf8_strlen(char const * str);
 char const * get_utf8_last_char(char const * str);
+std::string utf8_trim(std::string const & s);
 }

--- a/tests/lean/test_single.sh
+++ b/tests/lean/test_single.sh
@@ -25,7 +25,7 @@ echo "-- testing $f"
 sed "/warning: imported file uses 'sorry'/d" "$f.produced.out.1" | sed "/warning: using 'sorry'/d" > "$f.produced.out"
 rm -f "$f.produced.out.1"
 if test -f "$f.expected.out"; then
-    if diff --ignore-all-space -I "executing external script" "$f.produced.out" "$f.expected.out"; then
+    if diff -I "executing external script" "$f.produced.out" "$f.expected.out"; then
         echo "-- checked"
         exit 0
     else
@@ -36,7 +36,7 @@ if test -f "$f.expected.out"; then
                 echo "-- mismath was fixed"
             fi
         else
-            diff --ignore-all-space -I "executing external script" "$f.produced.out" "$f.expected.out"
+            diff -I "executing external script" "$f.produced.out" "$f.expected.out"
         fi
         exit 1
     fi


### PR DESCRIPTION
The recent mailing list discussion about the need to improve the pretty printer's space insertion heuristic got me interested since it sounded like a relatively isolated problem. Well, it quickly became apparent that the problem of inserting a minimal number of spaces to correctly separate tokens can't be solved exactly by using a fixed-size sliding window, so I reverted to implementing a conservative approximation: The pull request separates to adjacent tokens `s` and `t` if
- the last char of `s` and the first one of `t` are both `id_rest` chars, ie `s + t` may be an identifier, or
- the longest prefix match of `s + t` in the token table is not `s`, or
- `s + t` is a prefix of a token (an approximation because of the limited lookahead)
  Looking at the test outputs, the only failure of the heuristic I could find was `[ n]` (and any other lists starting with an identifier that is a prefix of an attribute name), where `[` and `n` are separated because they are a prefix of `[none]`.

Implementing this as a transformation on the pretty-printed format sexpr looked like the most simple way.

Since the pretty printer output with minimal spacing wasn't quite appealing, I've also added some quick proof-of-concept code that allows defining spacing via quoted symbols, eg `infix ` + `` or `notation `[` l:(foldr `, ` (h t, cons h t) nil `]`)`. I've also removed `--ignore-all-space` from the test script for better comparison. Most of the resulting test failures are because of missing hints in the hott library or test itself and the aforementioned `[ n]` issue.
