### PR TITLE
fix(library/algebra/group.lean): mark add.assoc as definition

### DIFF
--- a/library/algebra/group.lean
+++ b/library/algebra/group.lean
@@ -57,7 +57,7 @@ abbreviation eq_of_mul_eq_mul_right' := @mul.right_cancel
 structure add_semigroup [class] (A : Type) extends has_add A :=
 (add_assoc : ∀a b c, add (add a b) c = add a (add b c))
 
-theorem add.assoc [add_semigroup A] (a b c : A) : a + b + c = a + (b + c) :=
+definition add.assoc [add_semigroup A] (a b c : A) : a + b + c = a + (b + c) :=
 !add_semigroup.add_assoc
 
 structure add_comm_semigroup [class] (A : Type) extends add_semigroup A :=


### PR DESCRIPTION
The previous version doesn't compile with `--to_axiom` option and
as a result it breaks lean.js build. Specifically, line 614 of the same file
generates an error. I found that this patch is an easy way to fix this problem.
