### PR TITLE
Add Galois connections

### DIFF
--- a/library/algebra/algebra.md
+++ b/library/algebra/algebra.md
@@ -10,6 +10,7 @@ Algebraic structures.
 * [interval](interval.lean)
 * [lattice](lattice.lean)
 * [complete lattice](complete_lattice.lean)
+* [galois_connection](galois_connection.lean)
 * [group](group.lean)
 * [group_power](group_power.lean) : nat and int powers
 * [group_bigops](group_bigops.lean) : products and sums over lists, finsets and sets

--- a/library/algebra/complete_lattice.lean
+++ b/library/algebra/complete_lattice.lean
@@ -278,7 +278,7 @@ open eq.ops complete_lattice
 
 definition complete_lattice_fun [instance] (A B : Type) [complete_lattice B] :
     complete_lattice (A → B) :=
-⦃ complete_lattice, lattice_fun,
+⦃ complete_lattice, lattice_fun A B,
   Inf := λS x, Inf ((λf, f x) ' S),
   le_Inf := take f S H x,
     le_Inf (take y Hy, obtain g `g ∈ S` `g x = y`, from Hy, `g x = y` ▸ H g `g ∈ S` x),

--- a/library/algebra/complete_lattice.lean
+++ b/library/algebra/complete_lattice.lean
@@ -276,7 +276,7 @@ end complete_lattice
 section
 open eq.ops complete_lattice
 
-definition complete_lattice_fun [instance] {A B : Type} [complete_lattice B] :
+definition complete_lattice_fun [instance] (A B : Type) [complete_lattice B] :
     complete_lattice (A → B) :=
 ⦃ complete_lattice, lattice_fun,
   Inf := λS x, Inf ((λf, f x) ' S),
@@ -308,7 +308,7 @@ definition complete_lattice_Prop [instance] : complete_lattice Prop :=
     H _ Ht true.intro
 ⦄
 
-lemma sInter_eq_fun_Inf {A : Type} (S : set (set A)) : ⋂₀ S = @Inf (A → Prop) _ S :=
+lemma sInter_eq_Inf_fun {A : Type} (S : set (set A)) : ⋂₀ S = @Inf (A → Prop) _ S :=
 funext (take x,
   calc
     (⋂₀ S) x = ∀₀ P ∈ S, P x : rfl
@@ -322,19 +322,19 @@ funext (take x,
     end
     ... = @Inf (A → Prop) _ S x : rfl)
 
-lemma sUnion_eq_fun_Sup {A : Type} (S : set (set A)) : ⋃₀ S = @Sup (A → Prop) _ S :=
+lemma sUnion_eq_Sup_fun {A : Type} (S : set (set A)) : ⋃₀ S = @Sup (A → Prop) _ S :=
 funext (take x,
   calc
     (⋃₀ S) x = ∃₀ P ∈ S, P x : rfl
     ... = (∃₀ P ∈ S, P x = true) :
-    begin 
+    begin
       apply bounded_exists_congr,
       intros,
       rewrite eq_true
     end
     ... = @Sup (A → Prop) _ S x : rfl)
 
-definition complete_lattice_set [instance] {A : Type} : complete_lattice (set A) :=
+definition complete_lattice_set [instance] (A : Type) : complete_lattice (set A) :=
 ⦃ complete_lattice,
   le := subset,
   le_refl := @le_refl (A → Prop) _,
@@ -350,10 +350,10 @@ definition complete_lattice_set [instance] {A : Type} : complete_lattice (set A)
   sup_le := @sup_le (A → Prop) _,
   Inf := sInter,
   Sup := sUnion,
-  le_Inf := begin intros X S H, rewrite sInter_eq_fun_Inf, apply (@le_Inf (A → Prop) _), exact H end,
-  Inf_le := begin intros X S H, rewrite sInter_eq_fun_Inf, apply (@Inf_le (A → Prop) _), exact H end,
-  le_Sup := begin intros X S H, rewrite sUnion_eq_fun_Sup, apply (@le_Sup (A → Prop) _), exact H end,
-  Sup_le := begin intros X S H, rewrite sUnion_eq_fun_Sup, apply (@Sup_le (A → Prop) _), exact H end
+  le_Inf := begin intros X S H, rewrite sInter_eq_Inf_fun, apply (@le_Inf (A → Prop) _), exact H end,
+  Inf_le := begin intros X S H, rewrite sInter_eq_Inf_fun, apply (@Inf_le (A → Prop) _), exact H end,
+  le_Sup := begin intros X S H, rewrite sUnion_eq_Sup_fun, apply (@le_Sup (A → Prop) _), exact H end,
+  Sup_le := begin intros X S H, rewrite sUnion_eq_Sup_fun, apply (@Sup_le (A → Prop) _), exact H end
 ⦄
 
 end

--- a/library/algebra/complete_lattice.lean
+++ b/library/algebra/complete_lattice.lean
@@ -270,3 +270,92 @@ have le₂ : ⨅ univ ≤ ⨆ (∅ : set A), from
 le.antisymm le₁ le₂
 
 end complete_lattice
+
+/- complete lattice instances  -/
+
+section
+open eq.ops complete_lattice
+
+definition complete_lattice_fun [instance] {A B : Type} [complete_lattice B] :
+    complete_lattice (A → B) :=
+⦃ complete_lattice, lattice_fun,
+  Inf := λS x, Inf ((λf, f x) ' S),
+  le_Inf := take f S H x,
+    le_Inf (take y Hy, obtain g `g ∈ S` `g x = y`, from Hy, `g x = y` ▸ H g `g ∈ S` x),
+  Inf_le := take f S `f ∈ S` x,
+    Inf_le (exists.intro f (and.intro `f ∈ S` rfl)),
+  Sup := λS x, Sup ((λf, f x) ' S),
+  le_Sup := take f S `f ∈ S` x,
+    le_Sup (exists.intro f (and.intro `f ∈ S` rfl)),
+  Sup_le := take f S H x,
+    Sup_le (take y Hy, obtain g `g ∈ S` `g x = y`, from Hy, `g x = y` ▸ H g `g ∈ S` x)
+⦄
+
+section
+open classical -- Prop and set are only in the classical setting a complete lattice
+
+definition complete_lattice_Prop [instance] : complete_lattice Prop :=
+⦃ complete_lattice, lattice_Prop,
+  Inf := λS, false ∉ S,
+  le_Inf := take x S H Hx Hf,
+    H _ Hf Hx,
+  Inf_le := take x S Hx Hf,
+    (classical.cases_on x (take x, true.intro) Hf) Hx,
+  Sup := λS, true ∈ S,
+  le_Sup := take x S Hx H,
+    iff_subst (iff.intro (take H, true.intro) (take H', H)) Hx,
+  Sup_le := take x S H Ht,
+    H _ Ht true.intro
+⦄
+
+lemma sInter_eq_fun_Inf {A : Type} (S : set (set A)) : ⋂₀ S = @Inf (A → Prop) _ S :=
+funext (take x,
+  calc
+    (⋂₀ S) x = ∀₀ P ∈ S, P x : rfl
+    ... = ¬ (∃₀ P ∈ S, P x = false) :
+    begin
+      rewrite not_bounded_exists,
+      apply bounded_forall_congr,
+      intros,
+      rewrite eq_false,
+      rewrite not_not_iff
+    end
+    ... = @Inf (A → Prop) _ S x : rfl)
+
+lemma sUnion_eq_fun_Sup {A : Type} (S : set (set A)) : ⋃₀ S = @Sup (A → Prop) _ S :=
+funext (take x,
+  calc
+    (⋃₀ S) x = ∃₀ P ∈ S, P x : rfl
+    ... = (∃₀ P ∈ S, P x = true) :
+    begin 
+      apply bounded_exists_congr,
+      intros,
+      rewrite eq_true
+    end
+    ... = @Sup (A → Prop) _ S x : rfl)
+
+definition complete_lattice_set [instance] {A : Type} : complete_lattice (set A) :=
+⦃ complete_lattice,
+  le := subset,
+  le_refl := @le_refl (A → Prop) _,
+  le_trans := @le_trans (A → Prop) _,
+  le_antisymm := @le_antisymm (A → Prop) _,
+  inf := inter,
+  sup := union,
+  inf_le_left := @inf_le_left (A → Prop) _,
+  inf_le_right := @inf_le_right (A → Prop) _,
+  le_inf := @le_inf (A → Prop) _,
+  le_sup_left := @le_sup_left (A → Prop) _,
+  le_sup_right := @le_sup_right (A → Prop) _,
+  sup_le := @sup_le (A → Prop) _,
+  Inf := sInter,
+  Sup := sUnion,
+  le_Inf := begin intros X S H, rewrite sInter_eq_fun_Inf, apply (@le_Inf (A → Prop) _), exact H end,
+  Inf_le := begin intros X S H, rewrite sInter_eq_fun_Inf, apply (@Inf_le (A → Prop) _), exact H end,
+  le_Sup := begin intros X S H, rewrite sUnion_eq_fun_Sup, apply (@le_Sup (A → Prop) _), exact H end,
+  Sup_le := begin intros X S H, rewrite sUnion_eq_fun_Sup, apply (@Sup_le (A → Prop) _), exact H end
+⦄
+
+end
+
+end

--- a/library/algebra/galois_connection.lean
+++ b/library/algebra/galois_connection.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2016 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Johannes Hölzl
+
+Galois connections - order theoretic adjoints.
+-/
+import standard
+open classical eq.ops algebra set function complete_lattice
+
+/- Move to set? -/
+definition kern_image {X Y : Type} (f : X → Y) (S : set X) : set Y := {y | ∀x, f x = y → x ∈ S }
+
+/- Order theoretic definitions -/
+
+/- TODO: move to order? -/
+section order
+variables {A B : Type} {S : set A} {a a' : A} {b b' : B} {f : A → B} [weak_order A] [weak_order B]
+
+definition increasing (f : A → A) := ∀⦃a⦄, a ≤ f a
+definition decreasing (f : A → A) := ∀⦃a⦄, f a ≤ a
+
+definition upper_bounds (S : set A) : set A := { x | ∀₀ s ∈ S, s ≤ x }
+definition lower_bounds (S : set A) : set A := { x | ∀₀ s ∈ S, x ≤ s }
+definition is_least (S : set A) (a : A) := a ∈ S ∧ a ∈ lower_bounds S
+definition is_greatest (S : set A) (a : A) := a ∈ S ∧ a ∈ upper_bounds S
+
+definition monotone (f : A → B) := ∀⦃a b⦄, a ≤ b → f a ≤ f b
+
+lemma is_least_unique (Ha : is_least S a) (Hb : is_least S a') : a = a' :=
+le.antisymm
+  begin apply (and.elim_right Ha), apply (and.elim_left Hb) end
+  begin apply (and.elim_right Hb), apply (and.elim_left Ha) end
+
+lemma is_least_unique_iff (Ha : is_least S a) : is_least S a' ↔ a = a' :=
+iff.intro (is_least_unique Ha) begin intro H, cases H, apply Ha end
+
+lemma is_greatest_unique (Ha : is_greatest S a) (Hb : is_greatest S a') : a = a' :=
+le.antisymm
+  begin apply (and.elim_right Hb), apply (and.elim_left Ha) end
+  begin apply (and.elim_right Ha), apply (and.elim_left Hb) end
+
+lemma is_greatest_unique_iff (Ha : is_greatest S a) : is_greatest S a' ↔ a = a' :=
+iff.intro (is_greatest_unique Ha) begin intro H, cases H, apply Ha end
+
+definition is_lub (S : set A) := is_least (upper_bounds S)
+definition is_glb (S : set A) := is_greatest (lower_bounds S)
+
+lemma is_lub_unique : is_lub S a → is_lub S a' → a = a' :=
+!is_least_unique
+
+lemma is_lub_unique_iff : is_lub S a → (is_lub S a' ↔ a = a') :=
+!is_least_unique_iff
+
+lemma is_glb_unique : is_glb S a → is_glb S a' → a = a' :=
+!is_greatest_unique
+
+lemma is_glb_unique_iff : is_glb S a → (is_glb S a' ↔ a = a') :=
+!is_greatest_unique_iff
+
+lemma upper_bounds_image (Hf : monotone f) (Ha : a ∈ upper_bounds S) : f a ∈ upper_bounds (f ' S) :=
+forall_image_implies_forall (take x H, Hf (Ha `x ∈ S`))
+
+lemma lower_bounds_image (Hf : monotone f) (Ha : a ∈ lower_bounds S) : f a ∈ lower_bounds (f ' S) :=
+forall_image_implies_forall (take x H, Hf (Ha `x ∈ S`))
+
+end order
+
+definition galois_connection {A B : Type} [weak_order A] [weak_order B] (l : A → B) (u : B → A) :=
+  ∀{a b}, l a ≤ b ↔ a ≤ u b
+
+namespace galois_connection
+
+section
+parameters {A B : Type} [weak_order A] [weak_order B] (l : A → B) (u : B → A)
+
+lemma monotone_intro (Mu : monotone u) (Ml : monotone l)
+    (Iul : increasing (u ∘ l)) (Dlu : decreasing (l ∘ u)) : galois_connection l u :=
+begin
+  intros a b,
+  apply iff.intro,
+  { intro H, apply le.trans, apply Iul, apply Mu, assumption },
+  { intro H, apply le.trans, apply Ml, assumption, apply Dlu }
+end
+
+parameter (gc : galois_connection l u)
+include gc
+
+lemma l_le {a : A} {b : B} : a ≤ u b → l a ≤ b :=
+and.elim_right !gc
+
+lemma le_u {a : A} {b : B} : l a ≤ b → a ≤ u b :=
+and.elim_left !gc
+
+lemma increasing_u_l : increasing (u ∘ l) :=
+take a, le_u !le.refl
+
+lemma decreasing_l_u : decreasing (l ∘ u) :=
+take a, l_le !le.refl
+
+lemma monotone_u : monotone u :=
+take a b H, le_u (le.trans !decreasing_l_u H)
+
+lemma monotone_l : monotone l :=
+take a b H, l_le (le.trans H !increasing_u_l)
+
+lemma u_l_u_eq_u : u ∘ l ∘ u = u :=
+funext (take x, le.antisymm (monotone_u !decreasing_l_u) !increasing_u_l)
+
+lemma l_u_l_eq_l : l ∘ u ∘ l = l :=
+funext (take x, le.antisymm !decreasing_l_u (monotone_l !increasing_u_l))
+
+lemma u_upper_bounds {S : set A} {b : B} (H : b ∈ upper_bounds (l ' S)) : u b ∈ upper_bounds S :=
+take c, suppose c ∈ S, le_u (H (!mem_image_of_mem `c ∈ S`))
+
+lemma l_lower_bounds {S : set B} {a : A} (H : a ∈ lower_bounds (u ' S)) : l a ∈ lower_bounds S :=
+take c, suppose c ∈ S, l_le (H (!mem_image_of_mem `c ∈ S`))
+
+lemma l_preserves_lub {S : set A} {a : A} (H : is_lub S a) : is_lub (l ' S) (l a) :=
+and.intro
+  (upper_bounds_image monotone_l (and.elim_left `is_lub S a`))
+  (take b Hb, l_le (and.elim_right `is_lub S a` _ (u_upper_bounds Hb)))
+
+lemma u_preserves_glb {S : set B} {b : B} (H : is_glb S b) : is_glb (u ' S) (u b) :=
+and.intro
+  (lower_bounds_image monotone_u (and.elim_left `is_glb S b`))
+  (take a Ha, le_u (and.elim_right `is_glb S b` _ (l_lower_bounds Ha)))
+
+lemma l_is_glb {a : A} : is_glb { b | a ≤ u b } (l a) :=
+begin
+  apply and.intro,
+  { intro b, apply l_le },
+  { intro b H, apply H, apply increasing_u_l }  
+end
+
+lemma u_is_lub {b : B} : is_lub { a | l a ≤ b } (u b) :=
+begin
+  apply and.intro,
+  { intro a, apply le_u },
+  { intro a H, apply H, apply decreasing_l_u }  
+end
+
+end
+
+/- Constructing Galois connections -/
+
+lemma id {A : Type} [weak_order A] : @galois_connection A A _ _ id id :=
+take a b, iff.intro (λx, x) (λx, x)
+
+lemma dual {A B : Type} [woA : weak_order A] [woB : weak_order B]
+  (l : A → B) (u : B → A) (gc : galois_connection l u) :
+  @galois_connection B A (weak_order_dual woB) (weak_order_dual woA) u l :=
+take a b,
+begin
+  apply iff.symm,
+  rewrite dual,
+  rewrite dual,  
+  exact gc, 
+end
+
+lemma compose {A B C : Type} [weak_order A] [weak_order B] [weak_order C]
+  (l1 : A → B) (u1 : B → A) (l2 : B → C) (u2 : C → B)
+  (gc1 : galois_connection l1 u1) (gc2 : galois_connection l2 u2) :
+  galois_connection (l2 ∘ l1) (u1 ∘ u2) :=
+by intros; rewrite gc2; rewrite gc1
+
+section 
+  variables {A B : Type} {f : A → B}
+
+  lemma image_preimage : galois_connection (image f) (preimage f) :=
+    @image_subset_iff A B f
+
+  lemma preimage_kern_image : galois_connection (preimage f) (kern_image f) :=
+  begin
+    intros X Y, apply iff.intro, all_goals (intro H x Hx),
+    { intro x' eq, apply H, cases eq, exact Hx },
+    { apply H,
+      esimp [preimage, mem, set_of] at Hx, exact Hx, -- TODO: why is esimp necessary?
+      exact rfl }
+  end
+end
+
+end galois_connection
+
+/- Bounds on complete lattices -/
+/- TODO: move to complete lattices? -/
+
+section
+variables {A : Type} (S : set A) {a b : A} [complete_lattice A]
+
+lemma is_lub_sup : is_lub '{a, b} (sup a b) :=
+and.intro
+  begin
+    xrewrite [+forall_insert_iff, bounded_forall_empty_iff, and_true],
+    exact (and.intro !le_sup_left !le_sup_right)
+  end
+  begin
+    intro x Hx,
+    xrewrite [+forall_insert_iff at Hx, bounded_forall_empty_iff at Hx, and_true at Hx],
+    apply sup_le,
+    apply (and.elim_left Hx),
+    apply (and.elim_right Hx),
+  end
+
+lemma is_lub_Sup : is_lub S (⨆S) :=
+and.intro (take x, le_Sup) (take x, Sup_le)
+
+lemma is_lub_Sup_iff {a : A} : is_lub S a ↔ (⨆S) = a :=
+!is_lub_unique_iff !is_lub_Sup
+
+lemma is_glb_Inf : is_glb S (⨅S) :=
+and.intro (take a, Inf_le) (take a, le_Inf)
+
+lemma is_glb_Inf_iff : is_glb S a ↔ (⨅S) = a :=
+!is_glb_unique_iff !is_glb_Inf
+
+end

--- a/library/algebra/galois_connection.lean
+++ b/library/algebra/galois_connection.lean
@@ -27,42 +27,42 @@ definition is_greatest (S : set A) (a : A) := a ∈ S ∧ a ∈ upper_bounds S
 
 definition monotone (f : A → B) := ∀⦃a b⦄, a ≤ b → f a ≤ f b
 
-lemma is_least_unique (Ha : is_least S a) (Hb : is_least S a') : a = a' :=
+lemma eq_of_is_least_of_is_least (Ha : is_least S a) (Hb : is_least S a') : a = a' :=
 le.antisymm
   begin apply (and.elim_right Ha), apply (and.elim_left Hb) end
   begin apply (and.elim_right Hb), apply (and.elim_left Ha) end
 
-lemma is_least_unique_iff (Ha : is_least S a) : is_least S a' ↔ a = a' :=
-iff.intro (is_least_unique Ha) begin intro H, cases H, apply Ha end
+lemma is_least_iff_eq_of_is_least (Ha : is_least S a) : is_least S a' ↔ a = a' :=
+iff.intro (eq_of_is_least_of_is_least Ha) begin intro H, cases H, apply Ha end
 
-lemma is_greatest_unique (Ha : is_greatest S a) (Hb : is_greatest S a') : a = a' :=
+lemma eq_of_is_greatest_of_is_greatest (Ha : is_greatest S a) (Hb : is_greatest S a') : a = a' :=
 le.antisymm
   begin apply (and.elim_right Hb), apply (and.elim_left Ha) end
   begin apply (and.elim_right Ha), apply (and.elim_left Hb) end
 
-lemma is_greatest_unique_iff (Ha : is_greatest S a) : is_greatest S a' ↔ a = a' :=
-iff.intro (is_greatest_unique Ha) begin intro H, cases H, apply Ha end
+lemma is_greatest_iff_eq_of_is_greatest (Ha : is_greatest S a) : is_greatest S a' ↔ a = a' :=
+iff.intro (eq_of_is_greatest_of_is_greatest Ha) begin intro H, cases H, apply Ha end
 
 definition is_lub (S : set A) := is_least (upper_bounds S)
 definition is_glb (S : set A) := is_greatest (lower_bounds S)
 
-lemma is_lub_unique : is_lub S a → is_lub S a' → a = a' :=
-!is_least_unique
+lemma eq_of_is_lub_of_is_lub : is_lub S a → is_lub S a' → a = a' :=
+!eq_of_is_least_of_is_least
 
-lemma is_lub_unique_iff : is_lub S a → (is_lub S a' ↔ a = a') :=
-!is_least_unique_iff
+lemma is_lub_iff_eq_of_is_lub : is_lub S a → (is_lub S a' ↔ a = a') :=
+!is_least_iff_eq_of_is_least
 
-lemma is_glb_unique : is_glb S a → is_glb S a' → a = a' :=
-!is_greatest_unique
+lemma eq_of_is_glb_of_is_glb : is_glb S a → is_glb S a' → a = a' :=
+!eq_of_is_greatest_of_is_greatest
 
-lemma is_glb_unique_iff : is_glb S a → (is_glb S a' ↔ a = a') :=
-!is_greatest_unique_iff
+lemma is_glb_iff_eq_of_is_glb : is_glb S a → (is_glb S a' ↔ a = a') :=
+!is_greatest_iff_eq_of_is_greatest
 
-lemma upper_bounds_image (Hf : monotone f) (Ha : a ∈ upper_bounds S) : f a ∈ upper_bounds (f ' S) :=
-forall_image_implies_forall (take x H, Hf (Ha `x ∈ S`))
+lemma mem_upper_bounds_image (Hf : monotone f) (Ha : a ∈ upper_bounds S) : f a ∈ upper_bounds (f ' S) :=
+bounded_forall_image_of_bounded_forall (take x H, Hf (Ha `x ∈ S`))
 
-lemma lower_bounds_image (Hf : monotone f) (Ha : a ∈ lower_bounds S) : f a ∈ lower_bounds (f ' S) :=
-forall_image_implies_forall (take x H, Hf (Ha `x ∈ S`))
+lemma mem_lower_bounds_image (Hf : monotone f) (Ha : a ∈ lower_bounds S) : f a ∈ lower_bounds (f ' S) :=
+bounded_forall_image_of_bounded_forall (take x H, Hf (Ha `x ∈ S`))
 
 end order
 
@@ -110,30 +110,30 @@ funext (take x, le.antisymm (monotone_u !decreasing_l_u) !increasing_u_l)
 lemma l_u_l_eq_l : l ∘ u ∘ l = l :=
 funext (take x, le.antisymm !decreasing_l_u (monotone_l !increasing_u_l))
 
-lemma u_upper_bounds {S : set A} {b : B} (H : b ∈ upper_bounds (l ' S)) : u b ∈ upper_bounds S :=
+lemma u_mem_upper_bounds {S : set A} {b : B} (H : b ∈ upper_bounds (l ' S)) : u b ∈ upper_bounds S :=
 take c, suppose c ∈ S, le_u (H (!mem_image_of_mem `c ∈ S`))
 
-lemma l_lower_bounds {S : set B} {a : A} (H : a ∈ lower_bounds (u ' S)) : l a ∈ lower_bounds S :=
+lemma l_mem_lower_bounds {S : set B} {a : A} (H : a ∈ lower_bounds (u ' S)) : l a ∈ lower_bounds S :=
 take c, suppose c ∈ S, l_le (H (!mem_image_of_mem `c ∈ S`))
 
-lemma l_preserves_lub {S : set A} {a : A} (H : is_lub S a) : is_lub (l ' S) (l a) :=
+lemma is_lub_l_image {S : set A} {a : A} (H : is_lub S a) : is_lub (l ' S) (l a) :=
 and.intro
-  (upper_bounds_image monotone_l (and.elim_left `is_lub S a`))
-  (take b Hb, l_le (and.elim_right `is_lub S a` _ (u_upper_bounds Hb)))
+  (mem_upper_bounds_image monotone_l (and.elim_left `is_lub S a`))
+  (take b Hb, l_le (and.elim_right `is_lub S a` _ (u_mem_upper_bounds Hb)))
 
-lemma u_preserves_glb {S : set B} {b : B} (H : is_glb S b) : is_glb (u ' S) (u b) :=
+lemma is_glb_u_image {S : set B} {b : B} (H : is_glb S b) : is_glb (u ' S) (u b) :=
 and.intro
-  (lower_bounds_image monotone_u (and.elim_left `is_glb S b`))
-  (take a Ha, le_u (and.elim_right `is_glb S b` _ (l_lower_bounds Ha)))
+  (mem_lower_bounds_image monotone_u (and.elim_left `is_glb S b`))
+  (take a Ha, le_u (and.elim_right `is_glb S b` _ (l_mem_lower_bounds Ha)))
 
-lemma l_is_glb {a : A} : is_glb { b | a ≤ u b } (l a) :=
+lemma is_glb_l {a : A} : is_glb { b | a ≤ u b } (l a) :=
 begin
   apply and.intro,
   { intro b, apply l_le },
   { intro b H, apply H, apply increasing_u_l }  
 end
 
-lemma u_is_lub {b : B} : is_lub { a | l a ≤ b } (u b) :=
+lemma is_lub_u {b : B} : is_lub { a | l a ≤ b } (u b) :=
 begin
   apply and.intro,
   { intro a, apply le_u },
@@ -144,21 +144,21 @@ end
 
 /- Constructing Galois connections -/
 
-lemma id {A : Type} [weak_order A] : @galois_connection A A _ _ id id :=
+protected lemma id {A : Type} [weak_order A] : @galois_connection A A _ _ id id :=
 take a b, iff.intro (λx, x) (λx, x)
 
-lemma dual {A B : Type} [woA : weak_order A] [woB : weak_order B]
+protected lemma dual {A B : Type} [woA : weak_order A] [woB : weak_order B]
   (l : A → B) (u : B → A) (gc : galois_connection l u) :
   @galois_connection B A (weak_order_dual woB) (weak_order_dual woA) u l :=
 take a b,
 begin
   apply iff.symm,
-  rewrite dual,
-  rewrite dual,  
+  rewrite le_dual_eq_le,
+  rewrite le_dual_eq_le,
   exact gc, 
 end
 
-lemma compose {A B C : Type} [weak_order A] [weak_order B] [weak_order C]
+protected lemma compose {A B C : Type} [weak_order A] [weak_order B] [weak_order C]
   (l1 : A → B) (u1 : B → A) (l2 : B → C) (u2 : C → B)
   (gc1 : galois_connection l1 u1) (gc2 : galois_connection l2 u2) :
   galois_connection (l2 ∘ l1) (u1 ∘ u2) :=
@@ -167,10 +167,10 @@ by intros; rewrite gc2; rewrite gc1
 section 
   variables {A B : Type} {f : A → B}
 
-  lemma image_preimage : galois_connection (image f) (preimage f) :=
+  protected lemma image_preimage : galois_connection (image f) (preimage f) :=
     @image_subset_iff A B f
 
-  lemma preimage_kern_image : galois_connection (preimage f) (kern_image f) :=
+  protected lemma preimage_kern_image : galois_connection (preimage f) (kern_image f) :=
   begin
     intros X Y, apply iff.intro, all_goals (intro H x Hx),
     { intro x' eq, apply H, cases eq, exact Hx },
@@ -191,12 +191,12 @@ variables {A : Type} (S : set A) {a b : A} [complete_lattice A]
 lemma is_lub_sup : is_lub '{a, b} (sup a b) :=
 and.intro
   begin
-    xrewrite [+forall_insert_iff, bounded_forall_empty_iff, and_true],
+    xrewrite [+bounded_forall_insert_iff, bounded_forall_empty_iff, and_true],
     exact (and.intro !le_sup_left !le_sup_right)
   end
   begin
     intro x Hx,
-    xrewrite [+forall_insert_iff at Hx, bounded_forall_empty_iff at Hx, and_true at Hx],
+    xrewrite [+bounded_forall_insert_iff at Hx, bounded_forall_empty_iff at Hx, and_true at Hx],
     apply sup_le,
     apply (and.elim_left Hx),
     apply (and.elim_right Hx),
@@ -205,13 +205,13 @@ and.intro
 lemma is_lub_Sup : is_lub S (⨆S) :=
 and.intro (take x, le_Sup) (take x, Sup_le)
 
-lemma is_lub_Sup_iff {a : A} : is_lub S a ↔ (⨆S) = a :=
-!is_lub_unique_iff !is_lub_Sup
+lemma is_lub_iff_Sup_eq {a : A} : is_lub S a ↔ (⨆S) = a :=
+!is_lub_iff_eq_of_is_lub !is_lub_Sup
 
 lemma is_glb_Inf : is_glb S (⨅S) :=
 and.intro (take a, Inf_le) (take a, le_Inf)
 
-lemma is_glb_Inf_iff : is_glb S a ↔ (⨅S) = a :=
-!is_glb_unique_iff !is_glb_Inf
+lemma is_glb_iff_Inf_eq : is_glb S a ↔ (⨅S) = a :=
+!is_glb_iff_eq_of_is_glb !is_glb_Inf
 
 end

--- a/library/algebra/lattice.lean
+++ b/library/algebra/lattice.lean
@@ -121,8 +121,8 @@ definition lattice_Prop [instance] : lattice Prop :=
   le_sup_right := @or.intro_right
 ⦄
 
-definition lattice_fun [instance] {A B : Type} [lattice B] : lattice (A → B) :=
-⦃ lattice, weak_order_fun,
+definition lattice_fun [instance] (A B : Type) [lattice B] : lattice (A → B) :=
+⦃ lattice, weak_order_fun A B,
   inf          := λf g x, inf (f x) (g x),
   le_inf       := take f g h Hf Hg x, le_inf (Hf x) (Hg x),
   inf_le_left  := take f g x, !inf_le_left,

--- a/library/algebra/lattice.lean
+++ b/library/algebra/lattice.lean
@@ -106,3 +106,35 @@ section
   theorem sup_eq_right {a b : A} (H : a ≤ b) : a ⊔ b = b :=
   eq.subst !sup.comm (sup_eq_left H)
 end
+
+/- lattice instances  -/
+
+definition lattice_Prop [instance] : lattice Prop :=
+⦃ lattice, weak_order_Prop,
+  inf          := and,
+  le_inf       := take a b c Ha Hb Hc, and.intro (Ha Hc) (Hb Hc),
+  inf_le_left  := @and.elim_left,
+  inf_le_right := @and.elim_right,
+  sup          := or,
+  sup_le       := @or.rec,
+  le_sup_left  := @or.intro_left,
+  le_sup_right := @or.intro_right
+⦄
+
+definition lattice_fun [instance] {A B : Type} [lattice B] : lattice (A → B) :=
+⦃ lattice, weak_order_fun,
+  inf          := λf g x, inf (f x) (g x),
+  le_inf       := take f g h Hf Hg x, le_inf (Hf x) (Hg x),
+  inf_le_left  := take f g x, !inf_le_left,
+  inf_le_right := take f g x, !inf_le_right,
+  sup          := λf g x, sup (f x) (g x),
+  sup_le       := take f g h Hf Hg x, sup_le (Hf x) (Hg x),
+  le_sup_left  := take f g x, !le_sup_left,
+  le_sup_right := take t g x, !le_sup_right
+⦄
+
+/-
+  Should we add a trans-instance from total orders to lattices?
+  If we added we should add it with lower priority:
+    Prop is added as a lattice, but in the classical case it is a total order!
+-/

--- a/library/algebra/order.lean
+++ b/library/algebra/order.lean
@@ -434,3 +434,35 @@ section
     (assume H : a ≤ b, by rewrite (max_eq_right H); apply H₂)
     (assume H : a > b, by rewrite (max_eq_left_of_lt H); apply H₁)
 end
+
+/- order instances -/
+
+definition weak_order_Prop [instance] : weak_order Prop :=
+⦃ weak_order,
+  le           := λx y, x → y,
+  le_refl      := λx, id,
+  le_trans     := λa b c H1 H2 x, H2 (H1 x),
+  le_antisymm  := λf g H1 H2, propext (and.intro H1 H2)
+⦄
+
+definition weak_order_fun [instance] {A B : Type} [weak_order B] : weak_order (A → B) :=
+⦃ weak_order,
+  le := λx y, ∀b, x b ≤ y b,
+  le_refl := λf b, !le.refl,
+  le_trans := λf g h H1 H2 b, !le.trans (H1 b) (H2 b),
+  le_antisymm := λf g H1 H2, funext (λb, !le.antisymm (H1 b) (H2 b))
+⦄
+
+definition weak_order_dual {A : Type} (wo : weak_order A) : weak_order A :=
+⦃ weak_order,
+  le := λx y, y ≤ x,
+  le_refl := le.refl,
+  le_trans := take a b c `b ≤ a` `c ≤ b`, le.trans `c ≤ b` `b ≤ a`,
+  le_antisymm := take a b `b ≤ a` `a ≤ b`, le.antisymm `a ≤ b` `b ≤ a` ⦄
+
+lemma dual {A : Type} (wo : weak_order A) (a b : A) :
+  @le _ (@weak_order.to_has_le _ (weak_order_dual wo)) a b =
+  @le _ (@weak_order.to_has_le _ wo) b a :=
+rfl
+
+-- what to do with the strict variants?

--- a/library/algebra/order.lean
+++ b/library/algebra/order.lean
@@ -445,7 +445,7 @@ definition weak_order_Prop [instance] : weak_order Prop :=
   le_antisymm  := λf g H1 H2, propext (and.intro H1 H2)
 ⦄
 
-definition weak_order_fun [instance] {A B : Type} [weak_order B] : weak_order (A → B) :=
+definition weak_order_fun [instance] (A B : Type) [weak_order B] : weak_order (A → B) :=
 ⦃ weak_order,
   le := λx y, ∀b, x b ≤ y b,
   le_refl := λf b, !le.refl,

--- a/library/algebra/order.lean
+++ b/library/algebra/order.lean
@@ -460,7 +460,7 @@ definition weak_order_dual {A : Type} (wo : weak_order A) : weak_order A :=
   le_trans := take a b c `b ≤ a` `c ≤ b`, le.trans `c ≤ b` `b ≤ a`,
   le_antisymm := take a b `b ≤ a` `a ≤ b`, le.antisymm `a ≤ b` `b ≤ a` ⦄
 
-lemma dual {A : Type} (wo : weak_order A) (a b : A) :
+lemma le_dual_eq_le {A : Type} (wo : weak_order A) (a b : A) :
   @le _ (@weak_order.to_has_le _ (weak_order_dual wo)) a b =
   @le _ (@weak_order.to_has_le _ wo) b a :=
 rfl

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -339,7 +339,7 @@ theorem forall_of_forall_insert {P : X → Prop} {a : X} {s : set X}
   ∀ x, x ∈ s → P x :=
 λ x xs, H x (!mem_insert_of_mem xs)
 
-lemma forall_insert_iff {P : X → Prop} {a : X} {s : set X} :
+lemma bounded_forall_insert_iff {P : X → Prop} {a : X} {s : set X} :
   (∀₀x ∈ insert a s, P x) ↔ P a ∧ (∀₀x ∈ s, P x) :=
 begin
   apply iff.intro, all_goals (intro H),
@@ -585,8 +585,8 @@ theorem complement_complement_image (S : set (set X)) :
   complement ' (complement ' S) = S :=
 by rewrite [-image_compose, complement_compose_complement, image_id]
 
-lemma forall_image_implies_forall {f : X → Y} {S : set X} {P : Y → Prop} (H : ∀₀ x ∈ S, P (f x)) :
-  ∀₀ y ∈ f ' S, P y :=
+lemma bounded_forall_image_of_bounded_forall {f : X → Y} {S : set X} {P : Y → Prop}
+  (H : ∀₀ x ∈ S, P (f x)) : ∀₀ y ∈ f ' S, P y :=
 begin
   intro x' Hx;
   cases Hx with x Hx;
@@ -596,9 +596,9 @@ begin
   assumption
 end
 
-lemma forall_image_iff {f : X → Y} {S : set X} {P : Y → Prop} :
+lemma bounded_forall_image_iff {f : X → Y} {S : set X} {P : Y → Prop} :
   (∀₀ y ∈ f ' S, P y) ↔ (∀₀ x ∈ S, P (f x)) :=
-iff.intro (take H x Hx, H _ (!mem_image_of_mem `x ∈ S`)) forall_image_implies_forall
+iff.intro (take H x Hx, H _ (!mem_image_of_mem `x ∈ S`)) bounded_forall_image_of_bounded_forall
 
 lemma image_insert_eq {f : X → Y} {a : X} {S : set X} :
   f ' insert a S = insert (f a) (f ' S) :=
@@ -622,7 +622,7 @@ definition preimage {A B:Type} (f : A → B) (Y : set B) : set A := { x | f x �
 
 lemma image_subset_iff {A B : Type} {f : A → B} {X : set A} {Y : set B} :
   f ' X ⊆ Y ↔ X ⊆ preimage f Y :=
-@forall_image_iff A B f X Y
+@bounded_forall_image_iff A B f X Y
 
 /- collections of disjoint sets -/
 

--- a/library/init/classical.lean
+++ b/library/init/classical.lean
@@ -159,6 +159,18 @@ propext (iff.intro
   (assume H, eq.of_iff H)
   (assume H, iff.of_eq H))
 
+lemma eq_false {a : Prop} : (a = false) = (¬ a) :=
+begin
+  rewrite ((@iff_eq_eq a false)⁻¹),
+  rewrite iff_false
+end
+
+lemma eq_true {a : Prop} : (a = true) = a :=
+begin
+  rewrite ((@iff_eq_eq a true)⁻¹),
+  rewrite iff_true
+end
+
 end aux
 
 /- All propositions are decidable -/

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -342,6 +342,11 @@ iff.intro
   (λHab Hc, iff.mp H2 (Hab (iff.mpr H1 Hc)))
   (λHcd Ha, iff.mpr H2 (Hcd (iff.mp H1 Ha)))
 
+theorem imp_congr_right (H : a → (b ↔ c)) : (a → b) ↔ (a → c) :=
+iff.intro
+  (take Hab Ha, iff.elim_left (H Ha) (Hab Ha))
+  (take Hab Ha, iff.elim_right (H Ha) (Hab Ha))
+
 theorem not_not_intro (Ha : a) : ¬¬a :=
 assume Hna : ¬a, Hna Ha
 
@@ -391,6 +396,11 @@ and.rec (λHa Hb, and.intro (H₂ Ha) (H₃ Hb))
 
 theorem and_congr [congr] (H1 : a ↔ c) (H2 : b ↔ d) : (a ∧ b) ↔ (c ∧ d) :=
 iff.intro (and.imp (iff.mp H1) (iff.mp H2)) (and.imp (iff.mpr H1) (iff.mpr H2))
+
+theorem and_congr_right (H : a → (b ↔ c)) : (a ∧ b) ↔ (a ∧ c) :=
+iff.intro
+  (take Hab, obtain `a` `b`, from Hab, and.intro `a` (iff.elim_left (H `a`) `b`))
+  (take Hac, obtain `a` `c`, from Hac, and.intro `a` (iff.elim_right (H `a`) `c`))
 
 theorem and.comm [simp] : a ∧ b ↔ b ∧ a :=
 iff.intro and.swap and.swap


### PR DESCRIPTION
This is a small theory to play with Lean and learning to prove in it. I want to use Galois connections to show that `generated_by` from topologies / sigma-algebras from Galois connections with the set of open sets / measurable sets.

@avigad: I tried to follow the library conventions I hope the theorem and constant names are okay and the theorems are at the right place. I'm also not absolutely sure if my usage of section/variable/parameter/include is correct. Also I'm not sure about my definition-style for structures, should I put the proofs in a new line?

`complete_lattice_set` is quite strange, but with a working simplifier this should work quite straight forward. I didn't simply unfold set and then use `complete_lattice_Prop` as then `Inf` and `Sup` are not any more definitionally equivalent to `sInter` and `sUnion`.

I tried to use blast or simp, but somehow it never worked. Maybe next month :-)
