### PR TITLE
feat(library/blast/forward/ematch): basic support for heq classes

### DIFF
--- a/src/library/blast/congruence_closure.cpp
+++ b/src/library/blast/congruence_closure.cpp
@@ -1855,6 +1855,10 @@ expr congruence_closure::get_next(name const & R, expr const & e) const {
     }
 }
 
+bool congruence_closure::eq_class_heterogeneous(expr const & e) const {
+    return has_heq_proofs(get_root(get_eq_name(), e));
+}
+
 unsigned congruence_closure::get_mt(name const & R, expr const & e) const {
     if (auto n = m_entries.find(eqc_key(R, e))) {
         return n->m_mt;

--- a/src/library/blast/congruence_closure.h
+++ b/src/library/blast/congruence_closure.h
@@ -252,6 +252,8 @@ public:
     expr get_root(name const & R, expr const & e) const;
     expr get_next(name const & R, expr const & e) const;
 
+    bool eq_class_heterogeneous(expr const & e) const;
+
     /** \brief Mark the root of each equivalence class as an "abstract value"
         After this method is invoked, proof production is disabled. Moreover,
         merging two different partitions will trigger an inconsistency. */

--- a/tests/lean/run/blast_vector_test.lean
+++ b/tests/lean/run/blast_vector_test.lean
@@ -91,6 +91,6 @@ lemma vplus.def2 [simp] {n : ℕ} (v₁ v₂ : vector ℕ n) (a₁ a₂ : ℕ) :
 
 lemma vplus_weird {n₁ n₂ : ℕ} (v₁ : vector ℕ n₁) (v₂ : vector ℕ n₂) (a b : ℕ) :
   vplus (a :: append v₁ v₂) ⟨b :: append v₂ v₁⟩ == (a + b) :: vplus (append v₁ v₂) ⟨append v₂ v₁⟩ :=
-sorry -- TODO need to traverse equivalence class when matching against a meta-variable
+  by inst_simp
 
 end vector


### PR DESCRIPTION
There are two strategies in the e-matcher that miss simple solutions in the presence of heterogeneous equivalence classes. First, it is no longer sufficient to only try matching against congruence roots, and second, we must now backtrack on leaf assignments, since some members of a heterogeneous equivalence class may succeed where others failed.

As a result of this commit, we can prove the strange dot-product theorem from http://sf.snu.ac.kr/gil.hur/publications/heq.pdf that requires casting in two places to even state. 

Remark: this is not designed to be a permanent solution. We may need to reconsider many design decisions of the e-matcher once our congruence closure module stabilizes. One issue to flag: with these changes, the e-matcher will only find a cast if the casted term has already been internalized by the congruence closure module; we may eventually want the e-matcher to be able to introduce its own casts.
