### PR TITLE
fix(src/util/file_lock): ignore failure to create locks on read-only file systems

### DIFF
--- a/src/util/file_lock.cpp
+++ b/src/util/file_lock.cpp
@@ -78,7 +78,7 @@ file_lock::file_lock(char const * fname, bool exclusive):
     m_fname += ".lock";
     m_fd = open(m_fname.c_str(), O_CREAT, 0xFFFF);
     if (m_fd == -1) {
-        if (errno == EACCES) {
+        if (errno == EACCES || errno == EROFS) {
             // We don't have permission to create the file, the folder containing fname is probably readonly.
             // fname is probably part of the Lean installation in a system directory.
             // So, we ignore the file_lock in this case.


### PR DESCRIPTION
Right now, `file_lock` ignores the `EACCES` error when creating lock files, assuming that the file to be locked is part of a system-wide installation.  On NixOS however, the file system containing system packages is even mounted read-only, so `open` returns `EROFS`.  This results for example in the following error:

```
/home/gebner/lean/library/examples/ex.lean:4:0: error: failed to lock file '/nix/store/fxc0cvnv0j6kc1yc2ygngz7c805n10j5-lean-20160116/lib/lean/library/init/default.olean'
```

This PR ignores `EROFS` in addition to `EACCES`.
