### PR TITLE
Various additions to real analysis

### DIFF
--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -121,6 +121,12 @@ section linear_ordered_field
   theorem mul_lt_of_gt_div_of_neg (Hc : c < 0) (H : a > b / c) : a * c < b :=
     !div_mul_cancel (ne_of_lt Hc) ▸ mul_lt_mul_of_neg_right H Hc
 
+  theorem div_lt_of_mul_lt_of_pos (Hc : c > 0) (H : b < a * c) : b / c < a :=
+    calc
+      a   = a * c * (1 / c) : !mul_mul_div (ne_of_gt Hc)
+      ... > b * (1 / c)     : mul_lt_mul_of_pos_right H (one_div_pos_of_pos Hc)
+      ... = b / c           : div_eq_mul_one_div
+
   theorem div_lt_of_mul_gt_of_neg (Hc : c < 0) (H : a * c < b) : b / c < a :=
     calc
       a   = a * c * (1 / c) : !mul_mul_div (ne_of_lt Hc)
@@ -462,6 +468,21 @@ section discrete_linear_ordered_field
     le_of_not_gt
       (assume H',
       absurd H (not_le_of_gt (lt_of_one_div_lt_one_div_of_neg Hb H')))
+
+  theorem one_div_le_of_one_div_le_of_pos (Ha : a > 0) (H : 1 / a ≤ b) : 1 / b ≤ a :=
+    begin
+      rewrite -(one_div_one_div a),
+      apply one_div_le_one_div_of_le,
+      apply one_div_pos_of_pos,
+      repeat assumption
+    end
+
+  theorem one_div_le_of_one_div_le_of_neg (Ha : b < 0) (H : 1 / a ≤ b) : 1 / b ≤ a :=
+    begin
+      rewrite -(one_div_one_div a),
+      apply one_div_le_one_div_of_le_of_neg,
+      repeat assumption
+    end
 
   theorem one_lt_one_div (H1 : 0 < a) (H2 : a < 1) : 1 < 1 / a :=
     one_div_one ▸ one_div_lt_one_div_of_lt H1 H2

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -549,4 +549,22 @@ section discrete_linear_ordered_field
                 ... = ((a * 2) / 2) / 2         : by rewrite -div_div_eq_div_mul
                 ... = a / 2                     : by rewrite (mul_div_cancel a two_ne_zero)
 
+  lemma div_two_add_div_four_lt {a : A} (H : a > 0) : a / 2 + a / 4 < a :=
+  begin
+    replace (4 : A) with (2 : A) + 2,
+    have Hne : (2 + 2 : A) ≠ 0, from ne_of_gt four_pos,
+    krewrite (div_add_div _ _ two_ne_zero Hne),
+    have Hnum : (2 + 2 + 2) / (2 * (2 + 2)) = (3 : A) / 4, by norm_num,
+    rewrite [{2 * a}mul.comm, -left_distrib, mul_div_assoc, -mul_one a at {2}], krewrite Hnum,
+    apply mul_lt_mul_of_pos_left,
+    apply div_lt_of_mul_lt_of_pos,
+    apply four_pos,
+    rewrite one_mul,
+    replace (3 : A) with (2 : A) + 1,
+    replace (4 : A) with (2 : A) + 2,
+    apply add_lt_add_left,
+    apply two_gt_one,
+    exact H
+  end
+
 end discrete_linear_ordered_field

--- a/library/algebra/ordered_field.lean
+++ b/library/algebra/ordered_field.lean
@@ -317,10 +317,15 @@ section linear_ordered_field
   symm (iff.mpr (!eq_div_iff_mul_eq (ne_of_gt (add_pos zero_lt_one zero_lt_one)))
        (by krewrite [left_distrib, *mul_one]))
 
-  theorem two_ge_one : (2:A) ≥ 1 :=
+  theorem two_gt_one : (2:A) > 1 :=
   calc (2:A) = 1+1 : one_add_one_eq_two
-       ...   ≥ 1+0 : add_le_add_left (le_of_lt zero_lt_one)
+       ...   > 1+0 : add_lt_add_left zero_lt_one
        ...   = 1   : add_zero
+
+  theorem two_ge_one : (2:A) ≥ 1 :=
+  le_of_lt two_gt_one
+
+  theorem four_pos : (4 : A) > 0 := add_pos two_pos two_pos
 
   theorem mul_le_mul_of_mul_div_le (H : a * (b / c) ≤ d) (Hc : c > 0) : b * a ≤ d * c :=
   begin
@@ -533,5 +538,15 @@ section discrete_linear_ordered_field
     (suppose a ≠ 0,
       have abs a ≠ 0, from assume H, this (eq_zero_of_abs_eq_zero H),
       !eq_div_of_mul_eq this !eq_sign_mul_abs⁻¹)
+
+  theorem add_quarters (a : A) : a / 4 + a / 4 = a / 2 :=
+    have H4 [visible] : (4 : A) = 2 * 2, by norm_num,
+    calc
+      a / 4 + a / 4 = (a + a) / (2 * 2)         : by rewrite [-H4, div_add_div_same]
+                ... = (a * 1 + a * 1) / (2 * 2) : by rewrite mul_one
+                ... = (a * (1 + 1)) / (2 * 2)   : by rewrite left_distrib
+                ... = (a * 2) / (2 * 2)         : rfl
+                ... = ((a * 2) / 2) / 2         : by rewrite -div_div_eq_div_mul
+                ... = a / 2                     : by rewrite (mul_div_cancel a two_ne_zero)
 
 end discrete_linear_ordered_field

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -68,6 +68,16 @@ theorem length_map [simp] (f : A → B) : ∀ l : list A, length (map f l) = len
   show length (map f l) + 1 = length l + 1,
   by rewrite (length_map l)
 
+theorem map_ne_nil_of_ne_nil (f : A → B) {l : list A} (H : l ≠ nil) : map f l ≠ nil :=
+suppose map f l = nil,
+have length (map f l) = length l, from !length_map,
+have 0 = length l, from calc
+     0 = length nil  : length_nil
+   ... = length (map f l) : {eq.symm `map f l = nil`}
+   ... = length l : this,
+have l = nil, from eq_nil_of_length_eq_zero (eq.symm this),
+H this
+
 theorem mem_map {A B : Type} (f : A → B) : ∀ {a l}, a ∈ l → f a ∈ map f l
 | a []      i := absurd i !not_mem_nil
 | a (x::xs) i := or.elim (eq_or_mem_of_mem_cons i)

--- a/library/data/list/set.lean
+++ b/library/data/list/set.lean
@@ -462,6 +462,15 @@ theorem length_upto : ∀ n, length (upto n) = n
 | 0        := rfl
 | (succ n) := by rewrite [upto_succ, length_cons, length_upto]
 
+theorem upto_ne_nil_of_ne_zero {n : ℕ} (H : n ≠ 0) : upto n ≠ nil :=
+suppose upto n = nil,
+have upto n = upto 0, from upto_nil ▸ this,
+have n = 0, from calc
+     n = length (upto n) : length_upto
+   ... = length (upto 0) : this
+   ... = 0 : length_upto,
+H this
+
 theorem upto_less : ∀ n, all (upto n) (λ i, i < n)
 | 0        := trivial
 | (succ n) :=

--- a/library/data/list/sort.lean
+++ b/library/data/list/sort.lean
@@ -10,7 +10,7 @@ import data.list.comb data.list.set data.list.perm data.list.sorted logic.connec
 namespace list
 open decidable nat
 
-variable  {A : Type}
+variables  {B A : Type}
 variable  (R : A → A → Prop)
 variable  [decR : decidable_rel R]
 include decR
@@ -111,6 +111,22 @@ lemma min_mem : ∀ (l : list A) (h : l ≠ nil), min R l h ∈ l
     suppose min_core R l a ∈ l, mem_cons_of_mem _ this,
     suppose min_core R l a = a, by rewrite this; apply mem_cons
   end
+
+
+lemma min_map (f : B → A) {l : list B} (h : l ≠ nil) :
+      all l (λ b, (R (min R (map f l) (map_ne_nil_of_ne_nil _ h))) (f b)):=
+  using to tr rf,
+  begin
+    apply all_of_forall,
+    intro b Hb,
+    have Hfa : all (map f l) (R (min R (map f l) (map_ne_nil_of_ne_nil _ h))), from min_lemma to tr rf _,
+    have Hfb : f b ∈ map f l, from mem_map _ Hb,
+    exact of_mem_of_all Hfb Hfa
+  end
+
+lemma min_map_all (f : B → A) {l : list B} (h : l ≠ nil) {b : B} (Hb : b ∈ l) :
+      R (min R (map f l) ((map_ne_nil_of_ne_nil _ h))) (f b) :=
+  of_mem_of_all Hb (min_map _ to tr rf f h)
 
 omit decR
 private lemma ne_nil {l : list A} {n : nat} : length l = succ n → l ≠ nil :=

--- a/library/data/real/basic.lean
+++ b/library/data/real/basic.lean
@@ -1206,6 +1206,10 @@ theorem of_rat_neg (a : ℚ) : of_rat (-a) = -of_rat a :=
 theorem of_rat_mul (a b : ℚ) : of_rat (a * b) = of_rat a * of_rat b :=
   quot.sound (r_mul_consts a b)
 
+theorem of_rat_zero : of_rat 0 = 0 := rfl
+
+theorem of_rat_one : of_rat 1 = 1 := rfl
+
 open int
 
 theorem of_int_add (a b : ℤ) : of_int (a + b) = of_int a + of_int b :=

--- a/library/data/real/complete.lean
+++ b/library/data/real/complete.lean
@@ -213,6 +213,56 @@ theorem approx_spec (x : ℝ) (n : ℕ+) : abs (x - (of_rat (approx x n))) ≤ o
 theorem approx_spec' (x : ℝ) (n : ℕ+) : abs ((of_rat (approx x n)) - x) ≤ of_rat n⁻¹ :=
   by rewrite abs_sub; apply approx_spec
 
+theorem ex_rat_pos_lower_bound_of_pos {x : ℝ} (H : x > 0) : ∃ q : ℚ, q > 0 ∧ of_rat q ≤ x :=
+  if Hgeo : x ≥ 1 then
+    exists.intro 1 (and.intro zero_lt_one Hgeo)
+  else
+    have Hdp : 1 / x > 0, from one_div_pos_of_pos H,
+    begin
+      cases rat_approx (1 / x) 2 with q Hq,
+      have Hqp : q > 0, begin
+        apply lt_of_not_ge,
+        intro Hq2,
+        note Hx' := one_div_lt_one_div_of_lt H (lt_of_not_ge Hgeo),
+        rewrite div_one at Hx',
+        have Horqn : of_rat q ≤ 0, begin
+          krewrite -of_rat_zero,
+          apply of_rat_le_of_rat_of_le Hq2
+        end,
+        have Hgt1 : 1 / x - of_rat q > 1, from calc
+          1 / x - of_rat q = 1 / x + -of_rat q : sub_eq_add_neg
+                       ... ≥ 1 / x             : le_add_of_nonneg_right (neg_nonneg_of_nonpos Horqn)
+                       ... > 1                 : Hx',
+        have Hpos : 1 / x - of_rat q > 0, from gt.trans Hgt1 zero_lt_one,
+        rewrite [abs_of_pos Hpos at Hq],
+        apply not_le_of_gt Hgt1,
+        apply le.trans,
+        apply Hq,
+        krewrite -of_rat_one,
+        apply of_rat_le_of_rat_of_le,
+        apply inv_le_one
+      end,
+      existsi 1 / (2⁻¹ + q),
+      split,
+      apply div_pos_of_pos_of_pos,
+      exact zero_lt_one,
+      apply add_pos,
+      apply pnat.inv_pos,
+      exact Hqp,
+      note Hle2 := sub_le_of_abs_sub_le_right Hq,
+      note Hle3 := le_add_of_sub_left_le Hle2,
+      note Hle4 := one_div_le_of_one_div_le_of_pos H Hle3,
+      rewrite [of_rat_divide, of_rat_add],
+      exact Hle4
+    end
+
+theorem ex_rat_neg_upper_bound_of_neg {x : ℝ} (H : x < 0) : ∃ q : ℚ, q < 0 ∧ x ≤ of_rat q :=
+  have H' : -x > 0, from neg_pos_of_neg H,
+  obtain q [Hq1 Hq2], from ex_rat_pos_lower_bound_of_pos H',
+  exists.intro (-q) (and.intro
+    (neg_neg_of_pos Hq1)
+    (le_neg_of_le_neg Hq2))
+
 notation `r_seq` := ℕ+ → ℝ
 
 noncomputable definition converges_to_with_rate (X : r_seq) (a : ℝ) (N : ℕ+ → ℕ+) :=

--- a/library/data/real/division.lean
+++ b/library/data/real/division.lean
@@ -649,10 +649,6 @@ protected noncomputable definition discrete_linear_ordered_field [reducible] [tr
     decidable_lt    := dec_lt
    ⦄
 
-theorem of_rat_zero : of_rat (0:rat) = (0:real) := rfl
-
-theorem of_rat_one : of_rat (1:rat) = (1:real) := rfl
-
 theorem of_rat_divide (x y : ℚ) : of_rat (x / y) = of_rat x / of_rat y :=
 by_cases
   (assume yz : y = 0, by krewrite [yz, div_zero, +of_rat_zero, div_zero])

--- a/library/data/real/order.lean
+++ b/library/data/real/order.lean
@@ -1165,8 +1165,23 @@ theorem of_nat_lt_of_nat_of_lt {a b : ℕ} : (a < b) → of_nat a < of_nat b :=
 theorem lt_of_of_nat_lt_of_nat {a b : ℕ} : of_nat a < of_nat b → (a < b) :=
   iff.mp !of_nat_lt_of_nat_iff
 
+theorem of_rat_pos_of_pos {q : ℚ} (Hq : q > 0) : of_rat q > 0 :=
+  of_rat_lt_of_rat_of_lt Hq
+
+theorem of_rat_nonneg_of_nonneg {q : ℚ} (Hq : q ≥ 0) : of_rat q ≥ 0 :=
+  of_rat_le_of_rat_of_le Hq
+
+theorem of_rat_neg_of_neg {q : ℚ} (Hq : q < 0) : of_rat q < 0 :=
+  of_rat_lt_of_rat_of_lt Hq
+
+theorem of_rat_nonpos_of_nonpos {q : ℚ} (Hq : q ≤ 0) : of_rat q ≤ 0 :=
+  of_rat_le_of_rat_of_le Hq
+
 theorem of_nat_nonneg (a : ℕ) : of_nat a ≥ 0 :=
 of_rat_le_of_rat_of_le !rat.of_nat_nonneg
+
+theorem of_nat_succ_pos (k : ℕ) : 0 < of_nat k + 1 :=
+  add_pos_of_nonneg_of_pos (of_nat_nonneg k) real.zero_lt_one
 
 theorem of_rat_pow (a : ℚ) (n : ℕ) : of_rat (a^n) = (of_rat a)^n :=
 begin

--- a/library/theories/analysis/ivt.lean
+++ b/library/theories/analysis/ivt.lean
@@ -235,3 +235,85 @@ theorem intermediate_value_decr {f : ℝ → ℝ} (Hf : continuous f) {a b : ℝ
   obtain c Hc, from Hiv,
   exists.intro c
     (and.intro (and.left Hc) (and.intro (and.left (and.right Hc)) (eq_of_sub_eq_zero (and.right (and.right Hc)))))
+
+theorem intermediate_value_incr_weak {f : ℝ → ℝ} (Hf : continuous f) {a b : ℝ} (Hab : a ≤ b) {v : ℝ}
+        (Hav : f a ≤ v) (Hbv : f b ≥ v) : ∃ c, a ≤ c ∧ c ≤ b ∧ f c = v :=
+  begin
+    cases lt_or_eq_of_le Hab with Hlt Heq,
+    cases lt_or_eq_of_le Hav with Hlt' Heq',
+    cases lt_or_eq_of_le Hbv with Hlt'' Heq'',
+    cases intermediate_value_incr Hf Hlt Hlt' Hlt'' with c Hc,
+    cases Hc with Hc1 Hc2,
+    cases Hc2 with Hc2 Hc3,
+    existsi c,
+    repeat (split; apply le_of_lt; assumption),
+    assumption,
+    existsi b,
+    split,
+    apply le_of_lt,
+    assumption,
+    split,
+    apply le.refl,
+    rewrite Heq'',
+    existsi a,
+    split,
+    apply le.refl,
+    split,
+    apply le_of_lt,
+    repeat assumption,
+    existsi a,
+    split,
+    apply le.refl,
+    split,
+    assumption,
+    apply eq_of_le_of_ge,
+    apply Hav,
+    rewrite Heq,
+    apply Hbv
+  end
+
+section roots
+
+private definition sqr_lb (x : ℝ) : ℝ := 0
+
+private theorem sqr_lb_is_lb (x : ℝ) (H : x ≥ 0) : (sqr_lb x) * (sqr_lb x) ≤ x :=
+  by rewrite [↑sqr_lb, zero_mul]; assumption
+
+private definition sqr_ub (x : ℝ) : ℝ := x + 1
+
+private theorem sqr_ub_is_ub (x : ℝ) (H : x ≥ 0) : (sqr_ub x) * (sqr_ub x) ≥ x :=
+  begin
+    rewrite [↑sqr_ub, left_distrib, mul_one, right_distrib, one_mul, {x + 1}add.comm, -*add.assoc],
+    apply le_add_of_nonneg_left,
+    repeat apply add_nonneg,
+    apply mul_nonneg,
+    repeat assumption,
+    apply zero_le_one
+  end
+
+private theorem lb_le_ub (x : ℝ) (H : x ≥ 0) : sqr_lb x ≤ sqr_ub x :=
+  begin
+    rewrite [↑sqr_lb, ↑sqr_ub],
+    apply add_nonneg,
+    assumption,
+    apply zero_le_one
+  end
+
+private lemma sqr_cts : continuous (λ x : ℝ, x * x) := continuous_mul_of_continuous id_continuous id_continuous
+
+definition sqrt (x : ℝ) : ℝ :=
+  if H : x ≥ 0 then
+    some (intermediate_value_incr_weak sqr_cts (lb_le_ub x H) (sqr_lb_is_lb x H) (sqr_ub_is_ub x H))
+  else 0
+
+theorem sqrt_spec (x : ℝ) (H : x ≥ 0) : sqrt x * sqrt x = x :=
+  begin
+    rewrite [↑sqrt, dif_pos H],
+    note Hs := some_spec
+           (intermediate_value_incr_weak sqr_cts (lb_le_ub x H) (sqr_lb_is_lb x H) (sqr_ub_is_ub x H)),
+    cases Hs with Hs1 Hs2,
+    cases Hs2,
+    assumption
+  end
+
+end roots

--- a/library/theories/analysis/metric_space.lean
+++ b/library/theories/analysis/metric_space.lean
@@ -5,7 +5,7 @@ Author: Jeremy Avigad
 
 Metric spaces.
 -/
-import data.real.complete data.pnat data.list.sort data.fin
+import data.real.complete data.pnat data.list.sort
 open nat real eq.ops classical
 
 structure metric_space [class] (M : Type) : Type :=
@@ -314,7 +314,8 @@ open pnat rat
 section
 omit strucM
 
-theorem of_rat_rat_of_pnat_eq_of_nat_nat_of_pnat {p : pnat} : of_rat (rat_of_pnat p) = of_nat (nat_of_pnat p) :=
+private lemma of_rat_rat_of_pnat_eq_of_nat_nat_of_pnat (p : pnat) :
+        of_rat (rat_of_pnat p) = of_nat (nat_of_pnat p) :=
   rfl
 
 end
@@ -459,9 +460,6 @@ theorem converges_seq_comp_of_converges_seq_of_cts [instance] (X : ℕ → M) [H
     cases Hxlim (and.left Hδ) with B HB,
     existsi B,
     intro n Hn,
-    cases em (xlim = X n),
-    rewrite [a, dist_self],
-    assumption,
     apply and.right Hδ,
     apply HB Hn
   end
@@ -495,7 +493,7 @@ complete_metric_space.complete X H
 
 end analysis
 
-/- the reals form a metris space -/
+/- the reals form a metric space -/
 
 noncomputable definition metric_space_real [instance] : metric_space ℝ :=
 ⦃ metric_space,

--- a/library/theories/analysis/real_limit.lean
+++ b/library/theories/analysis/real_limit.lean
@@ -263,24 +263,6 @@ proposition mul_right_converges_to_seq (c : ℝ) (HX : X ⟶ x in ℕ) :
 have (λ n, X n * c) = (λ n, c * X n), from funext (take x, !mul.comm),
 by+ rewrite [this, mul.comm]; apply mul_left_converges_to_seq c HX
 
-protected lemma add_half_quarter {a : ℝ} (H : a > 0) : a / 2 + a / 4 < a :=
-  begin
-    replace (4 : ℝ) with (2 : ℝ) + 2,
-    have Hne : (2 + 2 : ℝ) ≠ 0, from ne_of_gt four_pos,
-    krewrite (div_add_div _ _ two_ne_zero Hne),
-    have Hnum : (2 + 2 + 2) / (2 * (2 + 2)) = (3 : ℝ) / 4, by norm_num,
-    rewrite [{2 * a}mul.comm, -left_distrib, mul_div_assoc, -mul_one a at {2}], krewrite Hnum,
-    apply mul_lt_mul_of_pos_left,
-    apply div_lt_of_mul_lt_of_pos,
-    apply four_pos,
-    rewrite one_mul,
-    replace (3 : ℝ) with (2 : ℝ) + 1,
-    replace (4 : ℝ) with (2 : ℝ) + 2,
-    apply add_lt_add_left,
-    apply two_gt_one,
-    exact H
-  end
-
 theorem converges_to_seq_squeeze (HX : X ⟶ x in ℕ) (HY : Y ⟶ x in ℕ) {Z : ℕ → ℝ} (HZX : ∀ n, X n ≤ Z n)
         (HZY : ∀ n, Z n ≤ Y n) : Z ⟶ x in ℕ :=
   begin
@@ -320,7 +302,7 @@ theorem converges_to_seq_squeeze (HX : X ⟶ x in ℕ) (HY : Y ⟶ x in ℕ) {Z 
       apply HZX,
       apply HN1,
       apply ge.trans Hn !le_max_left,
-      apply add_half_quarter Hε
+      apply div_two_add_div_four_lt Hε
     end,
     exact H
   end


### PR DESCRIPTION
This commit includes various things I've been playing around with in the analysis theory, and related additions. Some of these theorems will be generalized when we adopt the filter approach in the analysis theory, but the proofs might be useful.

Perhaps most importantly, the definition of `converges_to_at` in analysis.metric_space was wrong; this commit fixes that.

Noteworthy additions:

In real.complete

``` lean
theorem ex_rat_pos_lower_bound_of_pos {x : ℝ} (H : x > 0) : ∃ q : ℚ, q > 0 ∧ of_rat q ≤ x 
```

In analysis.ivt (is there a better place for this?)

``` lean
definition sqrt (x : ℝ) : ℝ 
theorem sqrt_spec (x : ℝ) (H : x ≥ 0) : sqrt x * sqrt x = x
```

In analysis.metric_space

``` lean
proposition bounded_of_converges_seq {X : ℕ → M} {x : M} (H : X ⟶ x in ℕ) :
            ∃ K : ℝ, ∀ n : ℕ, dist (X n) x ≤ K

theorem cnv_real_of_cnv_nat {X : ℕ → M} {c : M} (H : ∀ n : ℕ, dist (X n) c < 1 / (real.of_nat n + 1)) :
        ∀ ε : ℝ, ε > 0 → ∃ N : ℕ, ∀ n : ℕ, n ≥ N → dist (X n) c < ε

theorem all_conv_seqs_of_converges_to_at {f : M → N} {c : M} {l : N} (Hconv : f ⟶ l at c) :
        ∀ X : ℕ → M, ((∀ n : ℕ, ((X n) ≠ c) ∧ (X ⟶ c in ℕ)) → ((λ n : ℕ, f (X n)) ⟶ l in ℕ)) 

theorem converges_to_at_of_all_conv_seqs {f : M → N} (c : M) (l : N)
  (Hseq : ∀ X : ℕ → M, ((∀ n : ℕ, ((X n) ≠ c) ∧ (X ⟶ c in ℕ)) → ((λ n : ℕ, f (X n)) ⟶ l in ℕ)))
  : f ⟶ l at c
```

(There's a nasty part in `bounded_of_converges_seq` where different decision procedures are inferred for the same proposition. My current solution is ugly, I'm trying to find a nicer way around this.)

In analysis.real_limit

``` lean
theorem converges_to_seq_squeeze (HX : X ⟶ x in ℕ) (HY : Y ⟶ x in ℕ) {Z : ℕ → ℝ} (HZX : ∀ n, X n ≤ Z n)
        (HZY : ∀ n, Z n ≤ Y n) : Z ⟶ x in ℕ

proposition mul_converges_to_seq (HX : X ⟶ x in ℕ) (HY : Y ⟶ y in ℕ) :
            (λ n, X n * Y n) ⟶ x * y in ℕ

theorem mul_converges_to_at (Hf : f ⟶ a at x) (Hg : g ⟶ b at x) : (λ z, f z * g z) ⟶ a * b at x
```
