### PR TITLE
Fix markdown links

### DIFF
--- a/doc/make/split-stack.md
+++ b/doc/make/split-stack.md
@@ -13,7 +13,7 @@ with libraries that do not. However, it did not work in our experiments.
 To be able to compile Lean with split-stacks, we also have to compile
 GMP, MPFR and Lua using split-stacks.
 
-We also had to use the [gold linker](http://en.wikipedia.org/wiki/Gold_(linker).
+We also had to use the [gold linker](<http://en.wikipedia.org/wiki/Gold_(linker)>).
 
 Gold linker
 -----------

--- a/hott/algebra/algebra.md
+++ b/hott/algebra/algebra.md
@@ -3,18 +3,18 @@ algebra
 
 The following files are [ported](../port.md) from the standard library. If anything needs to be changed, it is probably a good idea to change it in the standard library and then port the file again (see also [script/port.pl](../../script/port.pl)).
 
-* [priority](priority.lean) : priority for algebraic operations
-* [relation](relation.lean)
-* [binary](binary.lean) : binary operations
-* [order](order.lean)
-* [lattice](lattice.lean)
-* [group](group.lean)
-* [ring](ring.lean)
-* [ordered_group](ordered_group.lean)
-* [ordered_ring](ordered_ring.lean)
-* [field](field.lean)
-* [ordered_field](ordered_field.lean)
-* [bundled](bundled.lean) : bundled versions of the algebraic structures
+* [priority](priority.hlean) : priority for algebraic operations
+* [relation](relation.hlean)
+* [binary](binary.hlean) : binary operations
+* [order](order.hlean)
+* [lattice](lattice.hlean)
+* [group](group.hlean)
+* [ring](ring.hlean)
+* [ordered_group](ordered_group.hlean)
+* [ordered_ring](ordered_ring.hlean)
+* [field](field.hlean)
+* [ordered_field](ordered_field.hlean)
+* [bundled](bundled.hlean) : bundled versions of the algebraic structures
 
 Files which are HoTT specific:
 

--- a/hott/algebra/category/limits/limits.md
+++ b/hott/algebra/category/limits/limits.md
@@ -3,6 +3,5 @@ algebra.category.limits
 
 * [limits](limits.hlean) : Limits in a category, defined as terminal object in the cone category
 * [colimits](colimits.hlean) : Colimits in a category, defined as the limit of the opposite functor
-* [complete](complete.hlean) : Categories which are (co)complete or constructions which preserve (co)completeness
 * [functor_preserve](functor_preserve.hlean) : Functors which preserve limits and colimits
 * [adjoint](adjoint.hlean) : the (co)limit functor is adjoint to the diagonal map

--- a/hott/book.md
+++ b/hott/book.md
@@ -115,13 +115,13 @@ Chapter 6: Higher inductive types
 - 6.2 (Induction principles and dependent paths): dependent paths in [init.pathover](init/pathover.hlean), circle in [homotopy.circle](homotopy/circle.hlean)
 - 6.3 (The interval): [homotopy.interval](homotopy/interval.hlean)
 - 6.4 (Circles and spheres): [homotopy.sphere](homotopy/sphere.hlean) and [homotopy.circle](homotopy/circle.hlean)
-- 6.5 (Suspensions): [homotopy.suspension](homotopy/suspension.hlean) (we define the circle to be the suspension of bool, but Lemma 6.5.1 is similar to proving the ordinary induction principle for the circle in [homotopy.circle](homotopy/circle.hlean)) and a bit in [homotopy.sphere](homotopy/sphere.hlean) and [types.pointed](types/pointed.hlean)
+- 6.5 (Suspensions): [homotopy.suspension](homotopy/susp.hlean) (we define the circle to be the suspension of bool, but Lemma 6.5.1 is similar to proving the ordinary induction principle for the circle in [homotopy.circle](homotopy/circle.hlean)) and a bit in [homotopy.sphere](homotopy/sphere.hlean) and [types.pointed](types/pointed.hlean)
 - 6.6 (Cell complexes): we define the torus using the quotient, see [hit.two_quotient](hit/two_quotient.hlean) and [homotopy.torus](homotopy/torus.hlean) (no dependent eliminator defined yet)
 - 6.7 (Hubs and spokes): [hit.two_quotient](hit/two_quotient.hlean) and [homotopy.torus](homotopy/torus.hlean) (no dependent eliminator defined yet)
 - 6.8 (Pushouts): [hit.pushout](hit/pushout.hlean). Some of the "standard homotopy-theoretic constructions" have separate files, although not all of them have been defined explicitly yet
 - 6.9 (Truncations): [hit.trunc](hit/trunc.hlean) (except Lemma 6.9.3)
 - 6.10 (Quotients): [hit.set_quotient](hit/set_quotient.hlean) (up to 6.10.3). We define integers differently, to make them compute, in the folder [types.int](types/int/int.md). 6.10.13 is in [types.int.hott](types/int/hott.hlean)
-- 6.11 (Algebra): [algebra.group](algebra/group.hlean), [algebra.fundamental_group](algebra/fundamental_group.hlean) (no homotopy groups yet)
+- 6.11 (Algebra): [algebra.group](algebra/group.hlean), [algebra.homotopy_group](algebra/homotopy_group.hlean)
 - 6.12 (The flattening lemma): [hit.quotient](hit/quotient.hlean) (for quotients instead of homotopy coequalizers, but these are practically the same)
 - 6.13 (The general syntax of higher inductive definitions): no formalizable content
 

--- a/hott/init/init.md
+++ b/hott/init/init.md
@@ -9,7 +9,6 @@ Syntax declarations:
 
 * [reserved_notation](reserved_notation.hlean)
 * [tactic](tactic.hlean)
-* [priority](priority.hlean)
 
 Datatypes and logic:
 

--- a/hott/tools/tools.md
+++ b/hott/tools/tools.md
@@ -3,4 +3,4 @@ tools
 
 Various additional tools.
 
-* [helper_tactics](helper_tactics.lean) : useful tactics
+* [helper_tactics](helper_tactics.hlean) : useful tactics

--- a/hott/types/int/int.md
+++ b/hott/types/int/int.md
@@ -1,7 +1,7 @@
 types.int
 =========
 
-The integers. Note: most of these files are ported from the standard library. If anything needs to be changed, it is probably a good idea to change it in the standard library and then port the file again (see also [script/port.pl](../../script/port.pl)).
+The integers. Note: most of these files are ported from the standard library. If anything needs to be changed, it is probably a good idea to change it in the standard library and then port the file again (see also [script/port.pl](../../../script/port.pl)).
 
 * [basic](basic.hlean) : the integers, with basic operations
 * [hott](hott.hlean) : facts about the integers specific to the HoTT library

--- a/hott/types/nat/nat.md
+++ b/hott/types/nat/nat.md
@@ -1,7 +1,7 @@
 types.nat
 =========
 
-The natural numbers. Note: all these files are ported from the standard library. If anything needs to be changed, it is probably a good idea to change it in the standard library and then port the file again (see also [script/port.pl](../../script/port.pl)).
+The natural numbers. Note: all these files are ported from the standard library. If anything needs to be changed, it is probably a good idea to change it in the standard library and then port the file again (see also [script/port.pl](../../../script/port.pl)).
 
 * [basic](basic.hlean) : the natural numbers, with succ, pred, addition, and multiplication
 * [order](order.hlean) : less-than, less-then-or-equal, etc.

--- a/library/data/data.md
+++ b/library/data/data.md
@@ -25,13 +25,11 @@ Constructors:
 * [sigma](sigma.lean) : the dependent product
 * [uprod](uprod.lean) : unordered pairs
 * [option](option.lean)
-* [subtype](subtype.lean)
 * [squash](squash.lean) : propositional truncation
 * [list](list/list.md)
 * [finset](finset/finset.md) : finite sets
 * [stream](stream.lean)
 * [set](set/set.md)
-* [vector](vector.lean)
 
 Types with extra information:
 

--- a/library/data/int/int.md
+++ b/library/data/int/int.md
@@ -8,4 +8,3 @@ The integers.
 * [div](div.lean) : div and mod
 * [power](power.lean) 
 * [gcd](gcd.lean) : gcd, lcm, and coprime    
-* [bigops](bigops.lean)

--- a/library/data/rat/rat.md
+++ b/library/data/rat/rat.md
@@ -5,4 +5,3 @@ The rational numbers.
 
 * [basic](basic.lean) : the rationals as a field
 * [order](order.lean) : the order relations and the sign function
-* [bigops](bigops.lean)

--- a/library/data/real/real.md
+++ b/library/data/real/real.md
@@ -7,4 +7,3 @@ The real numbers: classically, as a quotient type; constructively, as a setoid.
 * [order](order.lean) : the reals as an ordered ring (constructive)
 * [division](division.lean) : the reals as a discrete linear ordered field (classical)
 * [complete](complete.lean) : the reals are Cauchy complete (classical)
-* [bigops](bigops.lean)

--- a/library/init/init.md
+++ b/library/init/init.md
@@ -9,12 +9,12 @@ Syntax declarations:
 
 * [reserved_notation](reserved_notation.lean)
 * [tactic](tactic.lean)
-* [priority](priority.lean)
 
 Datatypes and logic:
 
 * [datatypes](datatypes.lean)
 * [logic](logic.lean)
+* [classical](classical.lean)
 * [bool](bool.lean)
 * [num](num.lean)
 * [nat](nat.lean)
@@ -42,3 +42,8 @@ logic.axioms.hilbert) the two are equivalent. Type class inferences
 are set up to use "inhabited" however, so users should use that to
 declare that types have an element. Use "nonempty" in the hypothesis
 of a theorem when the theorem does not depend on the witness chosen.
+
+Module init.classical declares a choice axiom, and uses it to
+prove the excluded middle, propositional completeness, axiom of
+choice, and prove that the decidable class is trivial when the
+choice axiom is assumed.

--- a/library/library.md
+++ b/library/library.md
@@ -7,7 +7,7 @@ The Lean standard library is contained in the following files and directories:
 * [logic](logic/logic.md) : logical constructs and axioms
 * [data](data/data.md) : concrete datatypes and type constructors
 * [algebra](algebra/algebra.md) : algebraic structures
-* [theories](theories.md) : more domain-specific theories
+* [theories](theories/theories.md) : more domain-specific theories
 * [tools](tools/tools.md) : additional tools
 
 The files in `init` are loaded by default, and hence do not need to be

--- a/library/logic/examples/examples.md
+++ b/library/logic/examples/examples.md
@@ -2,4 +2,3 @@ logic.examples
 ==============
 
 * [nuprl_examples](nuprl_examples.lean) : examples from "Logical investigations with the Nuprl Proof Assistant"
-* [instances_test](instances_test.lean)

--- a/library/logic/logic.md
+++ b/library/logic/logic.md
@@ -11,16 +11,7 @@ The command `import logic` does not import any axioms by default.
 * [cast](cast.lean) : casts and heterogeneous equality
 * [quantifiers](quantifiers.lean) : existential and universal quantifiers
 * [identities](identities.lean) : some useful identities
-* [instances](instances.lean) : class instances for eq and iff
-* [subsingleton](subsingleton.lean)
 * [default](default.lean)
-
-The file `choice.lean` declares a choice axiom, and uses it to
-prove the excluded middle, propositional completeness, axiom of
-choice, and prove that the decidable class is trivial when the
-choice axiom is assumed.
-
-* [choice](choice.lean)
 
 Subfolders:
 

--- a/script/check_md_links.py
+++ b/script/check_md_links.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+import argparse
+import collections
+import os
+import sys
+import urllib.error
+import urllib.request
+try:
+    import mistune
+except ImportError:
+    print("Mistune package not found. Install e.g. via `pip install mistune`.")
+
+parser = argparse.ArgumentParser(description="Check all *.md files of the current directory's subtree for broken links.")
+parser.add_argument('--http', help="also check external links (can be slow)", action='store_true')
+parser.add_argument('--check-missing', help="also find unreferenced lean files", action='store_true')
+args = parser.parse_args()
+
+lean_root = os.path.join(os.path.dirname(__file__), os.path.pardir)
+lean_root = os.path.normpath(lean_root)
+result = {}
+
+def check_link(link, root):
+    if link.startswith('http'):
+        if not args.http:
+            return True
+        if link not in result:
+            try:
+                urllib.request.urlopen(link)
+                result[link] = True
+            except:
+                result[link] = False
+        return result[link]
+    else:
+        if link.startswith('/'):
+            # project root-relative link
+            path = lean_root + link
+        else:
+            path = os.path.join(root, link)
+
+        path = os.path.normpath(path) # should make it work on Windows
+
+        result[path] = os.path.exists(path)
+        return result[path]
+
+# check all .md files
+for root, _, files in os.walk('.'):
+    for f in files:
+        if not f.endswith('.md'):
+            continue
+
+        path = os.path.join(root, f)
+
+        class CheckLinks(mistune.Renderer):
+            def link(self, link, title, content):
+                if not check_link(link, root):
+                    print("Broken link", link, "in file", path)
+
+        mistune.Markdown(renderer=CheckLinks())(open(path).read())
+
+if args.check_missing:
+    # check all .(h)lean files
+    for root, _, files in os.walk('.'):
+        for f in files:
+            path = os.path.normpath(os.path.join(root, f))
+            if (path.endswith('.lean') or path.endswith('.hlean')) and path not in result:
+                result[path] = False
+                print("Missing file", path)
+
+if not all(result.values()):
+    sys.exit(1)

--- a/src/emacs/README.md
+++ b/src/emacs/README.md
@@ -33,7 +33,7 @@ automatically the first time you use ``lean-mode``, if you follow the
 installation instructions below.
 
 [company]: http://company-mode.github.io/
-[flycheck]: http://flycheck.readthedocs.org/en/latest
+[flycheck]: http://www.flycheck.org/manual/latest/index.html
 [fci]: https://github.com/alpaker/Fill-Column-Indicator
 [lua-mode]: http://immerrr.github.io/lua-mode/
 [mmm-mode]: https://github.com/purcell/mmm-mode


### PR DESCRIPTION
I stumbled over a broken link in library.md, so I wrote a quick Python script for checking all of them: https://gist.github.com/Kha/d8b4b0006db50f2e90c7

I can add the script as a test case if you think that would be helpful. When the documentation is more complete, a reverse test - find files that aren't mentioned in .md files - would probably also be interesting.
