### PR TITLE
homomorphisms, monotone functions, and compose -> comp

### DIFF
--- a/library/algebra/algebra.md
+++ b/library/algebra/algebra.md
@@ -24,4 +24,5 @@ Algebraic structures.
 * [ring_bigops](ring_bigops.lean) : products and sums in various structures
 * [order_bigops](order_bigops.lean) : min and max over finsets and finite sets
 * [bundled](bundled.lean) : bundled versions of the algebraic structures
+* [homomorphism](homomorphism.lean) : homomorphisms between algebraic structures
 * [category](category/category.md) : category theory (outdated, see HoTT category theory folder)

--- a/library/algebra/algebra.md
+++ b/library/algebra/algebra.md
@@ -24,5 +24,6 @@ Algebraic structures.
 * [ring_bigops](ring_bigops.lean) : products and sums in various structures
 * [order_bigops](order_bigops.lean) : min and max over finsets and finite sets
 * [bundled](bundled.lean) : bundled versions of the algebraic structures
+* [monotone](monotone.lean) : monotone maps between order structures
 * [homomorphism](homomorphism.lean) : homomorphisms between algebraic structures
 * [category](category/category.md) : category theory (outdated, see HoTT category theory folder)

--- a/library/algebra/binary.lean
+++ b/library/algebra/binary.lean
@@ -76,11 +76,11 @@ namespace binary
               ... = a*((b*c)*d) : H_assoc
   end
 
-  definition right_commutative_compose_right [reducible]
-    {A B : Type} (f : A → A → A) (g : B → A) (rcomm : right_commutative f) : right_commutative (compose_right f g) :=
+  definition right_commutative_comp_right [reducible]
+    {A B : Type} (f : A → A → A) (g : B → A) (rcomm : right_commutative f) : right_commutative (comp_right f g) :=
   λ a b₁ b₂, !rcomm
 
   definition left_commutative_compose_left [reducible]
-    {A B : Type} (f : A → A → A) (g : B → A) (lcomm : left_commutative f) : left_commutative (compose_left f g) :=
+    {A B : Type} (f : A → A → A) (g : B → A) (lcomm : left_commutative f) : left_commutative (comp_left f g) :=
   λ a b₁ b₂, !lcomm
 end binary

--- a/library/algebra/category/constructions.lean
+++ b/library/algebra/category/constructions.lean
@@ -30,7 +30,7 @@ namespace category
   --    (λ a b f, !id_right)
   --    (λ a b f, !id_left)
 
-  infixr `∘op`:60 := @compose _ (opposite _) _ _ _
+  infixr `∘op`:60 := @comp _ (opposite _) _ _ _
 
   variables {C : Category} {a b c : C}
 
@@ -47,11 +47,11 @@ namespace category
 
   definition type_category [reducible] : category Type :=
   mk (λa b, a → b)
-     (λ a b c, function.compose)
+     (λ a b c, function.comp)
      (λ a, _root_.id)
-     (λ a b c d h g f, symm (function.compose.assoc h g f))
-     (λ a b f, function.compose.left_id f)
-     (λ a b f, function.compose.right_id f)
+     (λ a b c d h g f, symm (function.comp.assoc h g f))
+     (λ a b f, function.comp.left_id f)
+     (λ a b f, function.comp.right_id f)
 
   definition Type_category [reducible] : Category := Mk type_category
 

--- a/library/algebra/complete_lattice.lean
+++ b/library/algebra/complete_lattice.lean
@@ -7,7 +7,7 @@ Complete lattices
 
 TODO: define dual complete lattice and simplify proof of dual theorems.
 -/
-import algebra.lattice data.set.basic
+import algebra.lattice data.set.basic algebra.monotone
 open set
 
 variable {A : Type}
@@ -109,7 +109,8 @@ Sup_le (take x, suppose x ∈ '{a, b},
 end complete_lattice_Inf
 
 -- Every complete_lattice_Inf is a complete_lattice_Sup
-definition complete_lattice_Inf_to_complete_lattice_Sup [C : complete_lattice_Inf A] : complete_lattice_Sup A :=
+definition complete_lattice_Inf_to_complete_lattice_Sup [C : complete_lattice_Inf A] :
+  complete_lattice_Sup A :=
 ⦃ complete_lattice_Sup, C ⦄
 
 -- Every complete_lattice_Inf is a complete_lattice
@@ -172,9 +173,9 @@ Sup_le (take x, suppose x ∈ '{a, b},
 
 end complete_lattice_Sup
 
-
 -- Every complete_lattice_Sup is a complete_lattice_Inf
-definition complete_lattice_Sup_to_complete_lattice_Inf [C : complete_lattice_Sup A] : complete_lattice_Inf A :=
+definition complete_lattice_Sup_to_complete_lattice_Inf [C : complete_lattice_Sup A] :
+  complete_lattice_Inf A :=
 ⦃ complete_lattice_Inf, C ⦄
 
 -- Every complete_lattice_Sup is a complete_lattice
@@ -189,7 +190,7 @@ variable [C : complete_lattice A]
 include C
 
 variable {f : A → A}
-premise  (mono : ∀ x y : A, x ≤ y → f x ≤ f y)
+premise  (mono : nondecreasing f)
 
 theorem knaster_tarski : ∃ a, f a = a ∧ ∀ b, f b = b → a ≤ b :=
 let a := ⨅ {u | f u ≤ u} in
@@ -198,7 +199,7 @@ have h₁ : f a = a, from
     have ∀ b, b ∈ {u | f u ≤ u} → f a ≤ b, from
       take b, suppose f b ≤ b,
       have a ≤ b,     from Inf_le this,
-      have f a ≤ f b, from !mono this,
+      have f a ≤ f b, from mono this,
       le.trans `f a ≤ f b` `f b ≤ b`,
     le_Inf this,
   have le : a ≤ f a, from
@@ -221,7 +222,7 @@ have h₁ : f a = a, from
     have ∀ b, b ∈ {u | u ≤ f u} → b ≤ f a, from
       take b, suppose b ≤ f b,
       have b ≤ a,     from le_Sup this,
-      have f b ≤ f a, from !mono this,
+      have f b ≤ f a, from mono this,
       le.trans `b ≤ f b` `f b ≤ f a`,
     Sup_le this,
   have ge : f a ≤ a, from

--- a/library/algebra/group.lean
+++ b/library/algebra/group.lean
@@ -165,6 +165,11 @@ section group
   theorem inv_inv [simp] (a : A) : (a⁻¹)⁻¹ = a :=
   inv_eq_of_mul_eq_one (mul.left_inv a)
 
+  variable (A)
+  theorem left_inverse_inv : function.left_inverse (λ a : A, a⁻¹) (λ a, a⁻¹) :=
+  take a, inv_inv a
+  variable {A}
+
   theorem inv.inj {a b : A} (H : a⁻¹ = b⁻¹) : a = b :=
   have a = a⁻¹⁻¹, by simp_nohyps,
   by inst_simp
@@ -331,6 +336,11 @@ section add_group
 
   theorem neg_neg [simp] (a : A) : -(-a) = a := neg_eq_of_add_eq_zero (add.left_inv a)
 
+  variable (A)
+  theorem left_inverse_neg : function.left_inverse (λ a : A, - a) (λ a, - a) :=
+  take a, neg_neg a
+  variable {A}
+
   theorem eq_neg_of_add_eq_zero {a b : A} (H : a + b = 0) : a = -b :=
   have -a = b, from neg_eq_of_add_eq_zero H,
   by inst_simp
@@ -414,7 +424,8 @@ section add_group
   ⦃ add_left_cancel_semigroup, s,
     add_left_cancel := @add_left_cancel A s ⦄
 
-  definition add_group.to_add_right_cancel_semigroup [trans_instance] : add_right_cancel_semigroup A :=
+  definition add_group.to_add_right_cancel_semigroup [trans_instance] :
+    add_right_cancel_semigroup A :=
   ⦃ add_right_cancel_semigroup, s,
     add_right_cancel := @add_right_cancel A s ⦄
 
@@ -513,6 +524,19 @@ section add_group
   theorem add_eq_of_eq_sub {a b c : A} (H : a = c - b) : a + b = c :=
   by simp
 
+  theorem left_inverse_sub_add_left (c : A) : function.left_inverse (λ x, x - c) (λ x, x + c) :=
+  take x, add_sub_cancel x c
+
+  theorem left_inverse_add_left_sub (c : A) : function.left_inverse (λ x, x + c) (λ x, x - c) :=
+  take x, sub_add_cancel x c
+
+  theorem left_inverse_add_right_neg_add (c : A) :
+      function.left_inverse (λ x, c + x) (λ x, - c + x) :=
+  take x, add_neg_cancel_left c x
+
+  theorem left_inverse_neg_add_add_right (c : A) :
+      function.left_inverse (λ x, - c + x) (λ x, c + x) :=
+  take x, neg_add_cancel_left c x
 end add_group
 
 structure add_comm_group [class] (A : Type) extends add_group A, add_comm_monoid A

--- a/library/algebra/group_bigops.lean
+++ b/library/algebra/group_bigops.lean
@@ -203,7 +203,7 @@ namespace finset
   variable [comm_semigroup B]
 
   theorem mulf_rcomm (f : A → B) : right_commutative (mulf f) :=
-  right_commutative_compose_right (@has_mul.mul B _) f (@mul.right_comm B _)
+  right_commutative_comp_right (@has_mul.mul B _) f (@mul.right_comm B _)
 
   namespace Prod_semigroup
   open Prodl_semigroup

--- a/library/algebra/homomorphism.lean
+++ b/library/algebra/homomorphism.lean
@@ -73,7 +73,7 @@ section add_group_A_B
     injective f :=
   take x₁ x₂,
   suppose f x₁ = f x₂,
-  have f (x₁ - x₂) = 0, using this, by rewrite [hom_sub, this, sub_self],
+  have f (x₁ - x₂) = 0, by rewrite [hom_sub, this, sub_self],
   have x₁ - x₂ = 0, from H _ this,
   eq_of_sub_eq_zero this
 
@@ -124,7 +124,7 @@ section group_A_B
     injective f :=
   take x₁ x₂,
   suppose f x₁ = f x₂,
-  have f (x₁ * x₂⁻¹) = 1, using this, by rewrite [hom_mul, hom_inv, this, mul.right_inv],
+  have f (x₁ * x₂⁻¹) = 1, by rewrite [hom_mul, hom_inv, this, mul.right_inv],
   have x₁ * x₂⁻¹ = 1, from H _ this,
   eq_of_mul_inv_eq_one this
 

--- a/library/algebra/homomorphism.lean
+++ b/library/algebra/homomorphism.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+
+Homomorphisms between structures:
+
+  is_add_hom    : structures with has_add
+  is_mul_hom    : structures with has_mul
+  is_module_hom : structures with has_add, has_smul
+  is_ring_hom   : structures with has_add, has_mul
+
+If you are working with a one particular kind of homomorphism, e.g. multiplicative, we recommend
+
+  local abbreviation is_hom := @is_mul_hom
+
+These are all tentatively declared as type classes. The theorems which infer id and compose
+as instances are *not*, however, declared as instances: the first is rarely useful and the
+second makes class inference loop.
+
+Type class inference is useful here because usually a hypothesis like  is_hom f  is in the context.
+If you need an instance that the system does not infer, simply put it in the context, e.g.
+
+  assert is_hom f, from ...,
+  ...
+-/
+import algebra.module data.set
+open function set
+
+variables {A B C : Type}
+
+/- additive structures -/
+
+definition add_ker [has_zero B] (f : A → B) : set A := {a | f a = 0}
+
+proposition add_ker_eq [has_zero B] (f : A → B) : add_ker f = f '- '{0} :=
+ext (take x, iff.intro
+  (assume H, mem_preimage (mem_singleton_of_eq H))
+  (assume H, eq_of_mem_singleton (mem_of_mem_preimage H)))
+
+structure is_add_hom [class] [has_add A] [has_add B] (f : A → B) : Prop :=
+(hom_add : ∀ a₁ a₂, f (a₁ + a₂) = f a₁ + f a₂)
+
+proposition hom_add [has_add A] [has_add B] (f : A → B) [H : is_add_hom f] (a₁ a₂ : A) :
+  f (a₁ + a₂) = f a₁ + f a₂ := is_add_hom.hom_add _ _ f a₁ a₂
+
+proposition is_add_hom_id [has_add A] : is_add_hom (@id A) :=
+is_add_hom.mk (take a₁ a₂, rfl)
+
+proposition is_add_hom_comp [has_add A] [has_add B] [has_add C]
+  {f : B → C} {g : A → B} [is_add_hom f] [is_add_hom g] : is_add_hom (f ∘ g) :=
+is_add_hom.mk (take a₁ a₂, by esimp; rewrite *hom_add)
+
+section add_group_A_B
+  variables [add_group A] [add_group B]
+
+  proposition hom_zero (f : A → B) [is_add_hom f] :
+    f (0 : A) = 0 :=
+  have f 0 + f 0 = f 0 + 0, by rewrite [-hom_add f, +add_zero],
+  eq_of_add_eq_add_left this
+
+  proposition hom_neg (f : A → B) [is_add_hom f] (a : A) :
+    f (- a) = - f a :=
+  have f (- a) + f a = 0, by rewrite [-hom_add f, add.left_inv, hom_zero],
+  eq_neg_of_add_eq_zero this
+
+  proposition hom_sub (f : A → B) [is_add_hom f] (a₁ a₂ : A) :
+    f (a₁ - a₂) = f a₁ - f a₂ :=
+  by rewrite [*sub_eq_add_neg, *hom_add, hom_neg]
+
+  proposition injective_hom_add [add_group B] {f : A → B} [is_add_hom f]
+      (H : ∀ x, f x = 0 → x = 0) :
+    injective f :=
+  take x₁ x₂,
+  suppose f x₁ = f x₂,
+  have f (x₁ - x₂) = 0, using this, by rewrite [hom_sub, this, sub_self],
+  have x₁ - x₂ = 0, from H _ this,
+  eq_of_sub_eq_zero this
+
+  proposition eq_zero_of_injective_hom [add_group B] {f : A → B} [is_add_hom f]
+      (injf : injective f) {a : A} (fa0 : f a = 0) :
+    a = 0 :=
+  have f a = f 0, by rewrite [fa0, hom_zero],
+  show a = 0, from injf this
+end add_group_A_B
+
+/- multiplicative structures -/
+
+definition mul_ker [has_one B] (f : A → B) : set A := {a | f a = 1}
+
+proposition mul_ker_eq [has_one B] (f : A → B) : mul_ker f = f '- '{1} :=
+ext (take x, iff.intro
+  (assume H, mem_preimage (mem_singleton_of_eq H))
+  (assume H, eq_of_mem_singleton (mem_of_mem_preimage H)))
+
+structure is_mul_hom [class] [has_mul A] [has_mul B] (f : A → B) : Prop :=
+(hom_mul : ∀ a₁ a₂, f (a₁ * a₂) = f a₁ * f a₂)
+
+proposition hom_mul [has_mul A] [has_mul B] (f : A → B) [H : is_mul_hom f] (a₁ a₂ : A) :
+  f (a₁ * a₂) = f a₁ * f a₂ := is_mul_hom.hom_mul _ _ f a₁ a₂
+
+proposition is_mul_hom_id [has_mul A] : is_mul_hom (@id A) :=
+is_mul_hom.mk (take a₁ a₂, rfl)
+
+proposition is_mul_hom_comp [has_mul A] [has_mul B] [has_mul C]
+  {f : B → C} {g : A → B} [is_mul_hom f] [is_mul_hom g] : is_mul_hom (f ∘ g) :=
+is_mul_hom.mk (take a₁ a₂, by esimp; rewrite *hom_mul)
+
+section group_A_B
+  variables [group A] [group B]
+
+  proposition hom_one (f : A → B) [is_mul_hom f] :
+    f (1 : A) = 1 :=
+  have f 1 * f 1 = f 1 * 1, by rewrite [-hom_mul f, *mul_one],
+  eq_of_mul_eq_mul_left' this
+
+  proposition hom_inv (f : A → B) [is_mul_hom f] (a : A) :
+    f (a⁻¹) = (f a)⁻¹ :=
+  have f (a⁻¹) * f a = 1, by rewrite [-hom_mul f, mul.left_inv, hom_one],
+  eq_inv_of_mul_eq_one this
+
+  proposition injective_hom_mul [group B] {f : A → B} [is_mul_hom f]
+      (H : ∀ x, f x = 1 → x = 1) :
+    injective f :=
+  take x₁ x₂,
+  suppose f x₁ = f x₂,
+  have f (x₁ * x₂⁻¹) = 1, using this, by rewrite [hom_mul, hom_inv, this, mul.right_inv],
+  have x₁ * x₂⁻¹ = 1, from H _ this,
+  eq_of_mul_inv_eq_one this
+
+  proposition eq_one_of_injective_hom [group B] {f : A → B} [is_mul_hom f]
+      (injf : injective f) {a : A} (fa1 : f a = 1) :
+    a = 1 :=
+  have f a = f 1, by rewrite [fa1, hom_one],
+  show a = 1, from injf this
+end group_A_B
+
+/- modules -/
+
+structure is_module_hom [class] (R : Type) {M₁ M₂ : Type}
+  [has_scalar R M₁] [has_scalar R M₂] [has_add M₁] [has_add M₂]
+  (f : M₁ → M₂) extends is_add_hom f :=
+(hom_smul : ∀ r : R, ∀ a : M₁, f (r • a) = r • f a)
+
+section module_hom
+  variables {R : Type} {M₁ M₂ M₃ : Type}
+  variables [has_scalar R M₁] [has_scalar R M₂] [has_scalar R M₃]
+  variables [has_add M₁] [has_add M₂] [has_add M₃]
+  variables (g : M₂ → M₃) (f : M₁ → M₂) [is_module_hom R g] [is_module_hom R f]
+
+  proposition hom_smul (r : R) (a : M₁) : f (r • a) = r • f a :=
+  is_module_hom.hom_smul _ _ _ _ f r a
+
+  proposition is_module_hom_id : is_module_hom R (@id M₁) :=
+  is_module_hom.mk (λ a₁ a₂, rfl) (λ r a, rfl)
+
+  proposition is_module_hom_comp : is_module_hom R (g ∘ f) :=
+  is_module_hom.mk
+    (take a₁ a₂, by esimp; rewrite *hom_add)
+    (take r a, by esimp; rewrite [hom_smul f, hom_smul g])
+
+  proposition hom_smul_add_smul (a b : R) (u v : M₁) : f (a • u + b • v) = a • f u + b • f v :=
+  by rewrite [hom_add, +hom_smul f]
+end module_hom
+
+/- rings -/
+
+structure is_ring_hom [class] {R₁ R₂ : Type} [has_mul R₁] [has_mul R₂] [has_add R₁] [has_add R₂]
+    (f : R₁ → R₂) extends is_add_hom f, is_mul_hom f
+
+section semiring
+  variables {R₁ R₂ R₃ : Type} [semiring R₁] [semiring R₂] [semiring R₃]
+  variables (g : R₂ → R₃) (f : R₁ → R₂) [is_ring_hom g] [is_ring_hom f]
+
+  proposition is_ring_hom_id : is_ring_hom (@id R₁) :=
+  is_ring_hom.mk (λ a₁ a₂, rfl) (λ a₁ a₂, rfl)
+
+  proposition is_ring_hom_comp : is_ring_hom (g ∘ f) :=
+  is_ring_hom.mk
+    (take a₁ a₂, by esimp; rewrite *hom_add)
+    (take r a, by esimp; rewrite [hom_mul f, hom_mul g])
+
+  proposition hom_mul_add_mul (a b c d : R₁) : f (a * b + c * d) = f a * f b + f c * f d :=
+  by rewrite [hom_add, +hom_mul]
+end semiring

--- a/library/algebra/module.lean
+++ b/library/algebra/module.lean
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Nathaniel Thomas, Jeremy Avigad
 
 Modules and vector spaces over a ring.
+
+(We use "left_module," which is more precise, because "module" is a keyword.)
 -/
 import algebra.field
 
@@ -64,73 +66,7 @@ section left_module
   by rewrite [sub_eq_add_neg, smul_right_distrib, neg_smul]
 end left_module
 
-/- linear maps -/
-
-structure is_linear_map [class] (R : Type) {M₁ M₂ : Type}
-  [smul₁ : has_scalar R M₁] [smul₂ : has_scalar R M₂]
-  [add₁ : has_add M₁] [add₂ : has_add M₂]
-  (T : M₁ → M₂) :=
-(additive : ∀ u v : M₁, T (u + v) = T u + T v)
-(homogeneous : ∀ a : R, ∀ u : M₁, T (a • u) = a • T u)
-
-proposition linear_map_additive (R : Type) {M₁ M₂ : Type}
-    [smul₁ : has_scalar R M₁] [smul₂ : has_scalar R M₂]
-    [add₁ : has_add M₁] [add₂ : has_add M₂]
-    (T : M₁ → M₂) [linT : is_linear_map R T] (u v : M₁) :
-  T (u + v) = T u + T v :=
-is_linear_map.additive smul₁ smul₂ _ _ T u v
-
-proposition linear_map_homogeneous {R M₁ M₂ : Type}
-    [smul₁ : has_scalar R M₁] [smul₂ : has_scalar R M₂]
-    [add₁ : has_add M₁] [add₂ : has_add M₂]
-    (T : M₁ → M₂) [linT : is_linear_map R T] (a : R) (u : M₁) :
-  T (a • u) = a • T u :=
-is_linear_map.homogeneous smul₁ smul₂ _ _ T a u
-
-proposition is_linear_map_id [instance] (R : Type) {M : Type}
-    [smulRM : has_scalar R M] [has_addM : has_add M] :
-  is_linear_map R (id : M → M) :=
-is_linear_map.mk (take u v, rfl) (take a u, rfl)
-
-section is_linear_map
-  variables {R M₁ M₂ : Type}
-  variable  [ringR : ring R]
-  variable  [moduleRM₁ : left_module R M₁]
-  variable  [moduleRM₂ : left_module R M₂]
-  include   ringR moduleRM₁ moduleRM₂
-
-  variable  T : M₁ → M₂
-  variable  [is_linear_mapT : is_linear_map R T]
-  include   is_linear_mapT
-
-  proposition linear_map_zero : T 0 = 0 :=
-  calc
-    T 0 = T ((0 : R) • 0) : zero_smul
-    ... = (0 : R) • T 0   : linear_map_homogeneous T
-    ... = 0               : zero_smul
-
-  proposition linear_map_neg (u : M₁) : T (-u) = -(T u) :=
-  by rewrite [-neg_one_smul, linear_map_homogeneous T, neg_one_smul]
-
-  proposition linear_map_smul_add_smul (a b : R) (u v : M₁) :
-    T (a • u + b • v) = a • T u + b • T v :=
-  by rewrite [linear_map_additive R T, *linear_map_homogeneous T]
-end is_linear_map
-
 /- vector spaces -/
 
 structure vector_space [class] (F V : Type) [fieldF : field F]
   extends left_module F V
-
-/- an example -/
-
-section
-  variables (F V : Type)
-  variables [field F] [vector_spaceFV : vector_space F V]
-  variable  T : V → V
-  variable  [is_linear_map F T]
-  include   vector_spaceFV
-
-  example (a b : F) (u v : V) : T (a • u + b • v) = a • T u + b • T v :=
-  !linear_map_smul_add_smul
-end

--- a/library/algebra/monotone.lean
+++ b/library/algebra/monotone.lean
@@ -372,7 +372,7 @@ section
     (nonincreasing_of_nonincreasing_comp_right H₁ (nondecreasing_of_strictly_increasing H₂))
     (nonincreasing_comp_nondec_noninc H₃)
 
-  theorem nonincreasing_comp_iff' {g : B → C} {f : A → B} {h : C → B}
+  theorem nonincreasing_comp_iff_nondecreasing_right {g : B → C} {f : A → B} {h : C → B}
       (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) :
     nonincreasing (g ∘ f) ↔ nondecreasing f :=
   have H₃ : nonincreasing g, from nonincreasing_of_left_inverse H₁ H₂,
@@ -384,7 +384,7 @@ end
 section
   variables [linear_strong_order_pair A] [linear_strong_order_pair B] [weak_order C]
 
-  theorem nondecreasing_comp_iff'' {g : B → C} {f : A → B} {h : B → A}
+  theorem nondecreasing_comp_iff_nondecreasing_left {g : B → C} {f : A → B} {h : B → A}
       (H₁ : left_inverse f h) (H₂ : strictly_increasing f) :
     nondecreasing (g ∘ f) ↔ nondecreasing g :=
   have H₃ : nondecreasing h, from nondecreasing_of_left_inverse H₁ H₂,
@@ -392,7 +392,7 @@ section
     (nondecreasing_of_nondecreasing_comp_left H₁ H₃)
     (λ H, nondecreasing_comp_nondec_nondec H (nondecreasing_of_strictly_increasing H₂))
 
-  theorem nondecreasing_comp_iff''' {g : B → C} {f : A → B} {h : B → A}
+  theorem nondecreasing_comp_iff_nonincreasing_left {g : B → C} {f : A → B} {h : B → A}
       (H₁ : left_inverse f h) (H₂ : strictly_decreasing f) :
     nondecreasing (g ∘ f) ↔ nonincreasing g :=
   have H₃ : nonincreasing h, from nonincreasing_of_left_inverse H₁ H₂,
@@ -400,7 +400,7 @@ section
     (nonincreasing_of_nondecreasing_comp_left H₁ H₃)
     (λ H, nondecreasing_comp_noninc_noninc H (nonincreasing_of_strictly_decreasing H₂))
 
-  theorem nonincreasing_comp_iff'' {g : B → C} {f : A → B} {h : B → A}
+  theorem nonincreasing_comp_iff_nondecreasing_left {g : B → C} {f : A → B} {h : B → A}
       (H₁ : left_inverse f h) (H₂ : strictly_decreasing f) :
     nonincreasing (g ∘ f) ↔ nondecreasing g :=
   have H₃ : nonincreasing h, from nonincreasing_of_left_inverse H₁ H₂,
@@ -408,7 +408,7 @@ section
     (nondecreasing_of_nonincreasing_comp_left H₁ H₃)
     (λ H, nonincreasing_comp_nondec_noninc H (nonincreasing_of_strictly_decreasing H₂))
 
-  theorem nonincreasing_comp_iff''' {g : B → C} {f : A → B} {h : B → A}
+  theorem nonincreasing_comp_iff_nonincreasing_left {g : B → C} {f : A → B} {h : B → A}
       (H₁ : left_inverse f h) (H₂ : strictly_increasing f) :
     nonincreasing (g ∘ f) ↔ nonincreasing g :=
   have H₃ : nondecreasing h, from nondecreasing_of_left_inverse H₁ H₂,

--- a/library/algebra/monotone.lean
+++ b/library/algebra/monotone.lean
@@ -1,0 +1,418 @@
+/-
+Copyright (c) 2016 Jeremy Avigad. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Jeremy Avigad
+
+Weak and strict order preserving maps.
+
+TODO: we will probably eventually want versions restricted to smaller domains,
+"nondecreasing_on" etc. Maybe we can do this with subtypes.
+-/
+import .order
+open eq eq.ops function
+
+variables {A B C : Type}
+
+section
+  variables [weak_order A] [weak_order B] [weak_order C]
+
+  definition nondecreasing (f : A → B) : Prop := ∀ ⦃a₁ a₂⦄, a₁ ≤ a₂ → f a₁ ≤ f a₂
+
+  definition nonincreasing (f : A → B) : Prop := ∀ ⦃a₁ a₂⦄, a₁ ≤ a₂ → f a₁ ≥ f a₂
+
+  theorem nondecreasing_id : nondecreasing (@id A) := take a₁ a₂, assume H, H
+
+  theorem nondecreasing_comp_nondec_nondec {g : B → C} {f : A → B}
+      (Hg : nondecreasing g) (Hf : nondecreasing f) : nondecreasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+
+  theorem nondecreasing_comp_noninc_noninc {g : B → C} {f : A → B}
+      (Hg : nonincreasing g) (Hf : nonincreasing f) : nondecreasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+
+  theorem nonincreasing_comp_noninc_nondec {g : B → C} {f : A → B}
+      (Hg : nonincreasing g) (Hf : nondecreasing f) : nonincreasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+
+  theorem nonincreasing_comp_nondec_noninc {g : B → C} {f : A → B}
+      (Hg : nondecreasing g) (Hf : nonincreasing f) : nonincreasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+end
+
+section
+  variables [strict_order A] [strict_order B] [strict_order C]
+
+  definition strictly_increasing (f : A → B) : Prop :=
+  ∀ ⦃a₁ a₂⦄, a₁ < a₂ → f a₁ < f a₂
+
+  definition strictly_decreasing (f : A → B) : Prop :=
+  ∀ ⦃a₁ a₂⦄, a₁ < a₂ → f a₁ > f a₂
+
+  theorem strictly_increasing_id : strictly_increasing (@id A) := take a₁ a₂, assume H, H
+
+  theorem strictly_increasing_comp_inc_inc {g : B → C} {f : A → B}
+      (Hg : strictly_increasing g) (Hf : strictly_increasing f) : strictly_increasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+
+  theorem strictly_increasing_comp_dec_dec {g : B → C} {f : A → B}
+      (Hg : strictly_decreasing g) (Hf : strictly_decreasing f) : strictly_increasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+
+  theorem strictly_decreasing_comp_inc_dec {g : B → C} {f : A → B}
+      (Hg : strictly_increasing g) (Hf : strictly_decreasing f) : strictly_decreasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+
+  theorem strictly_decreasing_comp_dec_inc {g : B → C} {f : A → B}
+      (Hg : strictly_decreasing g) (Hf : strictly_increasing f) : strictly_decreasing (g ∘ f) :=
+  take a₁ a₂, assume H, Hg (Hf H)
+end
+
+section
+  variables [strong_order_pair A] [strong_order_pair B]
+
+  theorem nondecreasing_of_strictly_increasing {f : A → B} (H : strictly_increasing f) :
+    nondecreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  show f a₁ ≤ f a₂, from or.elim (lt_or_eq_of_le this)
+    (suppose a₁ < a₂, le_of_lt (H this))
+    (suppose a₁ = a₂, le_of_eq (congr_arg f this))
+
+  theorem nonincreasing_of_strictly_decreasing {f : A → B} (H : strictly_decreasing f) :
+    nonincreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  show f a₁ ≥ f a₂, from or.elim (lt_or_eq_of_le this)
+    (suppose a₁ < a₂, le_of_lt (H this))
+    (suppose a₁ = a₂, le_of_eq (congr_arg f this⁻¹))
+end
+
+section
+  variables [linear_strong_order_pair A] [linear_strong_order_pair B] [linear_strong_order_pair C]
+
+  theorem lt_of_strictly_increasing {f : A → B} {a₁ a₂ : A} (H : strictly_increasing f)
+    (H' : f a₁ < f a₂) : a₁ < a₂ :=
+  lt_of_not_ge (suppose a₂ ≤ a₁,
+    have f a₂ ≤ f a₁, from nondecreasing_of_strictly_increasing H this,
+    show false, from not_le_of_gt H' this)
+
+  theorem lt_iff_of_strictly_increasing {f : A → B} (a₁ a₂ : A) (H : strictly_increasing f) :
+    f a₁ < f a₂ ↔ a₁ < a₂ :=
+  iff.intro (lt_of_strictly_increasing H) (@H a₁ a₂)
+
+  theorem le_of_strictly_increasing {f : A → B} {a₁ a₂ : A} (H : strictly_increasing f)
+    (H' : f a₁ ≤ f a₂) : a₁ ≤ a₂ :=
+  le_of_not_gt (suppose a₂ < a₁, not_le_of_gt (H this) H')
+
+  theorem le_iff_of_strictly_increasing {f : A → B} (a₁ a₂ : A) (H : strictly_increasing f) :
+    f a₁ ≤ f a₂ ↔ a₁ ≤ a₂ :=
+  iff.intro (le_of_strictly_increasing H) (λ H', nondecreasing_of_strictly_increasing H H')
+
+  theorem lt_of_strictly_decreasing {f : A → B} {a₁ a₂ : A} (H : strictly_decreasing f)
+    (H' : f a₁ > f a₂) : a₁ < a₂ :=
+  lt_of_not_ge (suppose a₂ ≤ a₁,
+    have f a₂ ≥ f a₁, from nonincreasing_of_strictly_decreasing H this,
+    show false, from not_le_of_gt H' this)
+
+  theorem gt_iff_of_strictly_decreasing {f : A → B} (a₁ a₂ : A) (H : strictly_decreasing f) :
+    f a₁ > f a₂ ↔ a₁ < a₂ :=
+  iff.intro (lt_of_strictly_decreasing H) (@H a₁ a₂)
+
+  theorem le_of_strictly_decreasing {f : A → B} {a₁ a₂ : A} (H : strictly_decreasing f)
+    (H' : f a₁ ≥ f a₂) : a₁ ≤ a₂ :=
+  le_of_not_gt (suppose a₂ < a₁, not_le_of_gt (H this) H')
+
+  theorem ge_iff_of_strictly_decreasing {f : A → B} (a₁ a₂ : A) (H : strictly_decreasing f) :
+    f a₁ ≥ f a₂ ↔ a₁ ≤ a₂ :=
+  iff.intro (le_of_strictly_decreasing H) (λ H', nonincreasing_of_strictly_decreasing H H')
+
+  theorem strictly_increasing_of_left_inverse {g : B → A} {f : A → B} (H : left_inverse g f)
+      (H' : strictly_increasing g) : strictly_increasing f :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have g (f a₁) < g (f a₂), by rewrite *H; apply this,
+  lt_of_strictly_increasing H' this
+
+  theorem strictly_decreasing_of_left_inverse {g : B → A} {f : A → B} (H : left_inverse g f)
+      (H' : strictly_decreasing g) : strictly_decreasing f :=
+  take b₁ b₂, suppose b₁ < b₂,
+  have g (f b₁) < g (f b₂), by rewrite *H; apply this,
+  lt_of_strictly_decreasing H' this
+
+  theorem nondecreasing_of_left_inverse {g : B → A} {f : A → B} (H : left_inverse g f)
+      (H' : strictly_increasing g) : nondecreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have g (f a₁) ≤ g (f a₂), by rewrite *H; apply this,
+  le_of_strictly_increasing H' this
+
+  theorem nonincreasing_of_left_inverse {g : B → A} {f : A → B} (H : left_inverse g f)
+      (H' : strictly_decreasing g) : nonincreasing f :=
+  take b₁ b₂, suppose b₁ ≤ b₂,
+  have g (f b₁) ≤ g (f b₂), by rewrite *H; apply this,
+  le_of_strictly_decreasing H' this
+end
+
+/- composition rules for strict orders -/
+
+section
+  variables [strict_order A] [strict_order B] [strict_order C]
+
+  theorem strictly_increasing_of_strictly_increasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_increasing h) (H₃ : strictly_increasing (g ∘ f)) :
+    strictly_increasing f :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have h (g (f a₁)) < h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ < f a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_decreasing_of_strictly_increasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) (H₃ : strictly_increasing (g ∘ f)) :
+    strictly_decreasing f :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have h (g (f a₁)) > h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ > f a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_decreasing_of_strictly_decreasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_increasing h) (H₃ : strictly_decreasing (g ∘ f)) :
+    strictly_decreasing f :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have h (g (f a₁)) > h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ > f a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_increasing_of_strictly_decreasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) (H₃ : strictly_decreasing (g ∘ f)) :
+    strictly_increasing f :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have h (g (f a₁)) < h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ < f a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_increasing_of_strictly_decreasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_decreasing h) (H₃ : strictly_decreasing (g ∘ f)) :
+    strictly_increasing g :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have g (f (h a₁)) < g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ < g a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_decreasing_of_strictly_decreasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_increasing h) (H₃ : strictly_decreasing (g ∘ f)) :
+    strictly_decreasing g :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have g (f (h a₁)) > g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ > g a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_increasing_of_strictly_increasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_increasing h) (H₃ : strictly_increasing (g ∘ f)) :
+    strictly_increasing g :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have g (f (h a₁)) < g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ < g a₂, by rewrite *H₁ at this; apply this
+
+  theorem strictly_decreasing_of_strictly_increasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_decreasing h) (H₃ : strictly_increasing (g ∘ f)) :
+    strictly_decreasing g :=
+  take a₁ a₂, suppose a₁ < a₂,
+  have g (f (h a₁)) > g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ > g a₂, by rewrite *H₁ at this; apply this
+end
+
+section
+  variables [strict_order A] [linear_strong_order_pair B] [linear_strong_order_pair C]
+
+  theorem strictly_increasing_comp_iff_strictly_increasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_increasing h) :
+    strictly_increasing (g ∘ f) ↔ strictly_increasing f :=
+  have H₃ : strictly_increasing g, from strictly_increasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_increasing_of_strictly_increasing_comp_right H₁ H₂)
+    (strictly_increasing_comp_inc_inc H₃)
+
+  theorem strictly_increasing_comp_iff_strictly_decreasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) :
+    strictly_increasing (g ∘ f) ↔ strictly_decreasing f :=
+  have H₃ : strictly_decreasing g, from strictly_decreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_decreasing_of_strictly_increasing_comp_right H₁ H₂)
+    (strictly_increasing_comp_dec_dec H₃)
+
+  theorem strictly_decreasing_comp_iff_strictly_decreasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_increasing h) :
+    strictly_decreasing (g ∘ f) ↔ strictly_decreasing f :=
+  have H₃ : strictly_increasing g, from strictly_increasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_decreasing_of_strictly_decreasing_comp_right H₁ H₂)
+    (strictly_decreasing_comp_inc_dec H₃)
+
+  theorem strictly_decreasing_comp_iff_strictly_increasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) :
+    strictly_decreasing (g ∘ f) ↔ strictly_increasing f :=
+  have H₃ : strictly_decreasing g, from strictly_decreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_increasing_of_strictly_decreasing_comp_right H₁ H₂)
+    (strictly_decreasing_comp_dec_inc H₃)
+end
+
+section
+  variables [linear_strong_order_pair A] [linear_strong_order_pair B] [strict_order C]
+
+  theorem strictly_increasing_comp_iff_strinctly_increasing_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_increasing f) :
+    strictly_increasing (g ∘ f) ↔ strictly_increasing g :=
+  have H₃ : strictly_increasing h, from strictly_increasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_increasing_of_strictly_increasing_comp_left H₁ H₃)
+    (λ H, strictly_increasing_comp_inc_inc H H₂)
+
+  theorem strictly_increasing_comp_iff_strictly_decreasing_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_decreasing f) :
+    strictly_increasing (g ∘ f) ↔ strictly_decreasing g :=
+  have H₃ : strictly_decreasing h, from strictly_decreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_decreasing_of_strictly_increasing_comp_left H₁ H₃)
+    (λ H, strictly_increasing_comp_dec_dec H H₂)
+
+  theorem strictly_decreasing_comp_iff_strictly_increasing_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_decreasing f) :
+    strictly_decreasing (g ∘ f) ↔ strictly_increasing g :=
+  have H₃ : strictly_decreasing h, from strictly_decreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_increasing_of_strictly_decreasing_comp_left H₁ H₃)
+    (λ H, strictly_decreasing_comp_inc_dec H H₂)
+
+  theorem strictly_decreasing_comp_iff_strictly_decreasing_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_increasing f) :
+    strictly_decreasing (g ∘ f) ↔ strictly_decreasing g :=
+  have H₃ : strictly_increasing h, from strictly_increasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (strictly_decreasing_of_strictly_decreasing_comp_left H₁ H₃)
+    (λ H, strictly_decreasing_comp_dec_inc H H₂)
+end
+
+/- composition rules for weak orders -/
+
+section
+  variables [weak_order A] [weak_order B] [weak_order C]
+
+  theorem nondecreasing_of_nondecreasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : nondecreasing h) (H₃ : nondecreasing (g ∘ f)) :
+    nondecreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have h (g (f a₁)) ≤ h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ ≤ f a₂, by rewrite *H₁ at this; apply this
+
+  theorem nonincreasing_of_nondecreasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : nonincreasing h) (H₃ : nondecreasing (g ∘ f)) :
+    nonincreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have h (g (f a₁)) ≥ h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ ≥ f a₂, by rewrite *H₁ at this; apply this
+
+  theorem nonincreasing_of_nonincreasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : nondecreasing h) (H₃ : nonincreasing (g ∘ f)) :
+    nonincreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have h (g (f a₁)) ≥ h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ ≥ f a₂, by rewrite *H₁ at this; apply this
+
+  theorem nondecreasing_of_nonincreasing_comp_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : nonincreasing h) (H₃ : nonincreasing (g ∘ f)) :
+    nondecreasing f :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have h (g (f a₁)) ≤ h (g (f a₂)), from H₂ (H₃ this),
+  show f a₁ ≤ f a₂, by rewrite *H₁ at this; apply this
+
+  theorem nondecreasing_of_nondecreasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : nondecreasing h) (H₃ : nondecreasing (g ∘ f)) :
+    nondecreasing g :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have g (f (h a₁)) ≤ g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ ≤ g a₂, by rewrite *H₁ at this; apply this
+
+  theorem nonincreasing_of_nondecreasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : nonincreasing h) (H₃ : nondecreasing (g ∘ f)) :
+    nonincreasing g :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have g (f (h a₁)) ≥ g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ ≥ g a₂, by rewrite *H₁ at this; apply this
+
+  theorem nondecreasing_of_nonincreasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : nonincreasing h) (H₃ : nonincreasing (g ∘ f)) :
+    nondecreasing g :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have g (f (h a₁)) ≤ g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ ≤ g a₂, by rewrite *H₁ at this; apply this
+
+  theorem nonincreasing_of_nonincreasing_comp_left {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : nondecreasing h) (H₃ : nonincreasing (g ∘ f)) :
+    nonincreasing g :=
+  take a₁ a₂, suppose a₁ ≤ a₂,
+  have g (f (h a₁)) ≥ g (f (h a₂)), from H₃ (H₂ this),
+  show g a₁ ≥ g a₂, by rewrite *H₁ at this; apply this
+end
+
+section
+  variables [weak_order A] [linear_strong_order_pair B] [linear_strong_order_pair C]
+
+  theorem nondecreasing_comp_iff_nondecreasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_increasing h) :
+    nondecreasing (g ∘ f) ↔ nondecreasing f :=
+  have H₃ : nondecreasing g, from nondecreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nondecreasing_of_nondecreasing_comp_right H₁ (nondecreasing_of_strictly_increasing H₂))
+    (nondecreasing_comp_nondec_nondec H₃)
+
+  theorem nondecreasing_comp_iff_nonincreasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) :
+    nondecreasing (g ∘ f) ↔ nonincreasing f :=
+  have H₃ : nonincreasing g, from nonincreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nonincreasing_of_nondecreasing_comp_right H₁ (nonincreasing_of_strictly_decreasing H₂))
+    (nondecreasing_comp_noninc_noninc H₃)
+
+  theorem nonincreasing_comp_iff_nonincreasing_right {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_increasing h) :
+    nonincreasing (g ∘ f) ↔ nonincreasing f :=
+  have H₃ : nondecreasing g, from nondecreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nonincreasing_of_nonincreasing_comp_right H₁ (nondecreasing_of_strictly_increasing H₂))
+    (nonincreasing_comp_nondec_noninc H₃)
+
+  theorem nonincreasing_comp_iff' {g : B → C} {f : A → B} {h : C → B}
+      (H₁ : left_inverse h g) (H₂ : strictly_decreasing h) :
+    nonincreasing (g ∘ f) ↔ nondecreasing f :=
+  have H₃ : nonincreasing g, from nonincreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nondecreasing_of_nonincreasing_comp_right H₁ (nonincreasing_of_strictly_decreasing H₂))
+    (nonincreasing_comp_noninc_nondec H₃)
+end
+
+section
+  variables [linear_strong_order_pair A] [linear_strong_order_pair B] [weak_order C]
+
+  theorem nondecreasing_comp_iff'' {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_increasing f) :
+    nondecreasing (g ∘ f) ↔ nondecreasing g :=
+  have H₃ : nondecreasing h, from nondecreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nondecreasing_of_nondecreasing_comp_left H₁ H₃)
+    (λ H, nondecreasing_comp_nondec_nondec H (nondecreasing_of_strictly_increasing H₂))
+
+  theorem nondecreasing_comp_iff''' {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_decreasing f) :
+    nondecreasing (g ∘ f) ↔ nonincreasing g :=
+  have H₃ : nonincreasing h, from nonincreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nonincreasing_of_nondecreasing_comp_left H₁ H₃)
+    (λ H, nondecreasing_comp_noninc_noninc H (nonincreasing_of_strictly_decreasing H₂))
+
+  theorem nonincreasing_comp_iff'' {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_decreasing f) :
+    nonincreasing (g ∘ f) ↔ nondecreasing g :=
+  have H₃ : nonincreasing h, from nonincreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nondecreasing_of_nonincreasing_comp_left H₁ H₃)
+    (λ H, nonincreasing_comp_nondec_noninc H (nonincreasing_of_strictly_decreasing H₂))
+
+  theorem nonincreasing_comp_iff''' {g : B → C} {f : A → B} {h : B → A}
+      (H₁ : left_inverse f h) (H₂ : strictly_increasing f) :
+    nonincreasing (g ∘ f) ↔ nonincreasing g :=
+  have H₃ : nondecreasing h, from nondecreasing_of_left_inverse H₁ H₂,
+  iff.intro
+    (nonincreasing_of_nonincreasing_comp_left H₁ H₃)
+    (λ H, nonincreasing_comp_noninc_nondec H (nondecreasing_of_strictly_increasing H₂))
+end

--- a/library/data/equiv.lean
+++ b/library/data/equiv.lean
@@ -63,7 +63,7 @@ open equiv.ops
 lemma id_apply {A : Type} (x : A) : id ∙ x = x :=
 rfl
 
-lemma compose_apply {A B C : Type} (g : B ≃ C) (f : A ≃ B) (x : A) : (g ∘ f) ∙ x = g ∙ f ∙ x :=
+lemma comp_apply {A B C : Type} (g : B ≃ C) (f : A ≃ B) (x : A) : (g ∘ f) ∙ x = g ∙ f ∙ x :=
 begin cases g, cases f, esimp end
 
 lemma inverse_apply_apply {A B : Type} : ∀ (e : A ≃ B) (x : A), e⁻¹ ∙ e ∙ x = x
@@ -379,7 +379,7 @@ assume h₁ h₂, by rewrite [swap_apply_def, if_neg h₁, if_neg h₂]
 lemma swap_swap (a b : A) : swap a b ∘ swap a b = id :=
 eq_of_to_fun_eq (funext (λ x, begin unfold [swap, fn, equiv.trans, equiv.refl], rewrite swap_core_swap_core end))
 
-lemma swap_compose_apply (a b : A) (π : perm A) (x : A) : (swap a b ∘ π) ∙ x = if π ∙ x = a then b else if π ∙ x = b then a else π ∙ x :=
+lemma swap_comp_apply (a b : A) (π : perm A) (x : A) : (swap a b ∘ π) ∙ x = if π ∙ x = a then b else if π ∙ x = b then a else π ∙ x :=
 begin cases π, reflexivity end
 
 end swap

--- a/library/data/hf.lean
+++ b/library/data/hf.lean
@@ -455,7 +455,7 @@ theorem powerset_insert {a : hf} {s : hf} : a ∉ s → 𝒫 (insert a s) = 𝒫
 begin unfold [mem, powerset, insert, union, image], rewrite [*to_finset_of_finset], intro h,
       have (λ (x : finset hf), of_finset (finset.insert a x)) = (λ (x : finset hf), of_finset (finset.insert a (to_finset (of_finset x)))), from
         funext (λ x, by rewrite to_finset_of_finset),
-      rewrite [finset.powerset_insert h, finset.image_union, -*finset.image_comp, ↑compose, this]
+      rewrite [finset.powerset_insert h, finset.image_union, -*finset.image_comp, ↑comp, this]
 end
 
 theorem mem_powerset_iff_subset (s : hf) : ∀ x : hf, x ∈ 𝒫 s ↔ x ⊆ s :=

--- a/library/data/nat/order.lean
+++ b/library/data/nat/order.lean
@@ -228,6 +228,52 @@ lt.base n
 lemma lt_succ_of_lt {i j : nat} : i < j → i < succ j :=
 assume Plt, lt.trans Plt (self_lt_succ j)
 
+/- increasing and decreasing functions -/
+
+section
+  variables {A : Type} [strict_order A] {f : ℕ → A}
+
+  theorem strictly_increasing_of_forall_lt_succ (H : ∀ i, f i < f (succ i)) : strictly_increasing f :=
+  take i j,
+  nat.induction_on j
+    (suppose i < 0, absurd this !not_lt_zero)
+    (take j', assume ih, suppose i < succ j',
+       or.elim (lt_or_eq_of_le (le_of_lt_succ this))
+         (suppose i < j', lt.trans (ih this) (H j'))
+         (suppose i = j', by rewrite this; apply H))
+
+  theorem strictly_decreasing_of_forall_gt_succ (H : ∀ i, f i > f (succ i)) : strictly_decreasing f :=
+  take i j,
+  nat.induction_on j
+    (suppose i < 0, absurd this !not_lt_zero)
+    (take j', assume ih, suppose i < succ j',
+       or.elim (lt_or_eq_of_le (le_of_lt_succ this))
+         (suppose i < j', lt.trans (H j') (ih this))
+         (suppose i = j', by rewrite this; apply H))
+end
+
+section
+  variables {A : Type} [weak_order A] {f : ℕ → A}
+
+  theorem nondecreasing_of_forall_le_succ (H : ∀ i, f i ≤ f (succ i)) : nondecreasing f :=
+  take i j,
+  nat.induction_on j
+    (suppose i ≤ 0, have i = 0, from eq_zero_of_le_zero this, by rewrite this; apply le.refl)
+    (take j', assume ih, suppose i ≤ succ j',
+       or.elim (le_or_eq_succ_of_le_succ this)
+         (suppose i ≤ j', le.trans (ih this) (H j'))
+         (suppose i = succ j', by rewrite this; apply le.refl))
+
+  theorem nonincreasing_of_forall_ge_succ (H : ∀ i, f i ≥ f (succ i)) : nonincreasing f :=
+  take i j,
+  nat.induction_on j
+    (suppose i ≤ 0, have i = 0, from eq_zero_of_le_zero this, by rewrite this; apply le.refl)
+    (take j', assume ih, suppose i ≤ succ j',
+       or.elim (le_or_eq_succ_of_le_succ this)
+         (suppose i ≤ j', le.trans (H j') (ih this))
+         (suppose i = succ j', by rewrite this; apply le.refl))
+end
+
 /- other forms of induction -/
 
 protected definition strong_rec_on {P : nat → Type} (n : ℕ) (H : ∀n, (∀m, m < n → P m) → P n) : P n :=
@@ -458,7 +504,6 @@ section least_and_greatest
       rewrite Heq at Hi,
       apply absurd (least_of_bound P Hi) Pnsm
     end
-
   theorem least_lt {n i : ℕ} (ltin : i < n) (Hi : P i) : least P n < n :=
     lt_of_le_of_lt (ge_least_of_lt P ltin Hi) ltin
 

--- a/library/data/set/basic.lean
+++ b/library/data/set/basic.lean
@@ -53,18 +53,18 @@ assume h, absurd rfl (and.elim_right h)
 /- bounded quantification -/
 
 abbreviation bounded_forall (a : set X) (P : X → Prop) := ∀⦃x⦄, x ∈ a → P x
-notation `forallb` binders `∈` a `, ` r:(scoped:1 P, P) := bounded_forall a r
-notation `∀₀` binders `∈` a `, ` r:(scoped:1 P, P) := bounded_forall a r
+notation `forallb` binders ` ∈ ` a `, ` r:(scoped:1 P, P) := bounded_forall a r
+notation `∀₀` binders ` ∈ ` a `, ` r:(scoped:1 P, P) := bounded_forall a r
 
 abbreviation bounded_exists (a : set X) (P : X → Prop) := ∃⦃x⦄, x ∈ a ∧ P x
-notation `existsb` binders `∈` a `, ` r:(scoped:1 P, P) := bounded_exists a r
-notation `∃₀` binders `∈` a `, ` r:(scoped:1 P, P) := bounded_exists a r
+notation `existsb` binders ` ∈ ` a `, ` r:(scoped:1 P, P) := bounded_exists a r
+notation `∃₀` binders ` ∈ ` a `, ` r:(scoped:1 P, P) := bounded_exists a r
 
 theorem bounded_exists.intro {P : X → Prop} {s : set X} {x : X} (xs : x ∈ s) (Px : P x) :
   ∃₀ x ∈ s, P x :=
 exists.intro x (and.intro xs Px)
 
-lemma bounded_forall_congr {A : Type} {S : set A} {P Q : A → Prop} (H : ∀₀ x∈S, P x ↔ Q x) :
+lemma bounded_forall_congr {A : Type} {S : set A} {P Q : A → Prop} (H : ∀₀ x ∈ S, P x ↔ Q x) :
   (∀₀ x ∈ S, P x) = (∀₀ x ∈ S, Q x) :=
 begin
   apply propext,
@@ -74,7 +74,7 @@ begin
   apply H
 end
 
-lemma bounded_exists_congr {A : Type} {S : set A} {P Q : A → Prop} (H : ∀₀ x∈S, P x ↔ Q x) :
+lemma bounded_exists_congr {A : Type} {S : set A} {P Q : A → Prop} (H : ∀₀ x ∈ S, P x ↔ Q x) :
   (∃₀ x ∈ S, P x) = (∃₀ x ∈ S, Q x) :=
 begin
   apply propext,

--- a/library/data/set/function.lean
+++ b/library/data/set/function.lean
@@ -118,7 +118,7 @@ assume xa : x ∈ a,
 have H : f1 x ∈ b, from maps_to_f1 xa,
 show f2 x ∈ b, from eq_on_a xa ▸ H
 
-theorem maps_to_compose {g : Y → Z} {f : X → Y} {a : set X} {b : set Y} {c : set Z}
+theorem maps_to_comp {g : Y → Z} {f : X → Y} {a : set X} {b : set Y} {c : set Z}
    (H1 : maps_to g b c) (H2 : maps_to f a b) : maps_to (g ∘ f) a c :=
 take x, assume H : x ∈ a, H1 (H2 H)
 
@@ -157,7 +157,7 @@ assume H : f2 x1 = f2 x2,
 have H' : f1 x1 = f1 x2, from eq_f1_f2 ax1 ⬝ H ⬝ (eq_f1_f2 ax2)⁻¹,
 show x1 = x2, from inj_f1 ax1 ax2 H'
 
-theorem inj_on_compose {g : Y → Z} {f : X → Y} {a : set X} {b : set Y}
+theorem inj_on_comp {g : Y → Z} {f : X → Y} {a : set X} {b : set Y}
     (fab : maps_to f a b) (Hg : inj_on g b) (Hf: inj_on f a) :
   inj_on (g ∘ f) a :=
 take x1 x2 : X,
@@ -195,7 +195,7 @@ have H2 : x ∈ a, from and.left H1,
 have H3 : f2 x = y, from (eq_f1_f2 H2)⁻¹ ⬝ and.right H1,
 exists.intro x (and.intro H2 H3)
 
-theorem surj_on_compose {g : Y → Z} {f : X → Y} {a : set X} {b : set Y} {c : set Z}
+theorem surj_on_comp {g : Y → Z} {f : X → Y} {a : set X} {b : set Y} {c : set Z}
   (Hg : surj_on g b c) (Hf: surj_on f a b) :
   surj_on (g ∘ f) a c :=
 take z,
@@ -260,16 +260,16 @@ lemma image_eq_of_bij_on {f : X → Y} {a : set X} {b : set Y} (bfab : bij_on f 
   f ' a = b :=
 image_eq_of_maps_to_of_surj_on (and.left bfab) (and.right (and.right bfab))
 
-theorem bij_on_compose {g : Y → Z} {f : X → Y} {a : set X} {b : set Y} {c : set Z}
+theorem bij_on_comp {g : Y → Z} {f : X → Y} {a : set X} {b : set Y} {c : set Z}
   (Hg : bij_on g b c) (Hf: bij_on f a b) :
   bij_on (g ∘ f) a c :=
 match Hg with and.intro Hgmap (and.intro Hginj Hgsurj) :=
   match Hf with and.intro Hfmap (and.intro Hfinj Hfsurj) :=
     and.intro
-      (maps_to_compose Hgmap Hfmap)
+      (maps_to_comp Hgmap Hfmap)
       (and.intro
-        (inj_on_compose Hfmap Hginj Hfinj)
-        (surj_on_compose Hgsurj Hfsurj))
+        (inj_on_comp Hfmap Hginj Hfinj)
+        (surj_on_comp Hgsurj Hfsurj))
   end
 end
 
@@ -320,7 +320,7 @@ calc
      ... = g (f x2) : H1
      ... = x2       : H x2a
 
-theorem left_inv_on_compose {f' : Y → X} {g' : Z → Y} {g : Y → Z} {f : X → Y}
+theorem left_inv_on_comp {f' : Y → X} {g' : Z → Y} {g : Y → Z} {f : X → Y}
    {a : set X} {b : set Y} (fab : maps_to f a b)
     (Hf : left_inv_on f' f a) (Hg : left_inv_on g' g b) : left_inv_on (f' ∘ g') (g ∘ f) a :=
 take x : X,
@@ -353,10 +353,10 @@ have gya : g y ∈ a, from gba yb,
 have H1 : f (g y) = y, from H yb,
 exists.intro (g y) (and.intro gya H1)
 
-theorem right_inv_on_compose {f' : Y → X} {g' : Z → Y} {g : Y → Z} {f : X → Y}
+theorem right_inv_on_comp {f' : Y → X} {g' : Z → Y} {g : Y → Z} {f : X → Y}
    {c : set Z} {b : set Y} (g'cb : maps_to g' c b)
     (Hf : right_inv_on f' f b) (Hg : right_inv_on g' g c) : right_inv_on (f' ∘ g') (g ∘ f) c :=
-left_inv_on_compose g'cb Hg Hf
+left_inv_on_comp g'cb Hg Hf
 
 theorem right_inv_on_of_inj_on_of_left_inv_on {f : X → Y} {g : Y → X} {a : set X} {b : set Y}
     (fab : maps_to f a b) (gba : maps_to g b a) (injf : inj_on f a) (lfg : left_inv_on f g b) :

--- a/library/data/set/map.lean
+++ b/library/data/set/map.lean
@@ -44,10 +44,10 @@ mk_equivalence (@map.equiv X Y a b) (@equiv.refl X Y a b) (@equiv.symm X Y a b)
 
 /- compose -/
 
-protected definition compose (g : map b c) (f : map a b) : map a c :=
-map.mk (#function g ∘ f) (maps_to_compose (mapsto g) (mapsto f))
+protected definition comp (g : map b c) (f : map a b) : map a c :=
+map.mk (#function g ∘ f) (maps_to_comp (mapsto g) (mapsto f))
 
-notation g ∘ f := map.compose g f
+notation g ∘ f := map.comp g f
 
 /- range -/
 
@@ -64,9 +64,9 @@ theorem injective_of_equiv {f1 f2 : map a b} (H1 : f1 ~ f2) (H2 : map.injective 
   map.injective f2 :=
 inj_on_of_eq_on H1 H2
 
-theorem injective_compose {g : map b c} {f : map a b} (Hg : map.injective g) (Hf: map.injective f) :
+theorem injective_comp {g : map b c} {f : map a b} (Hg : map.injective g) (Hf: map.injective f) :
   map.injective (g ∘ f) :=
-inj_on_compose (mapsto f) Hg Hf
+inj_on_comp (mapsto f) Hg Hf
 
 /- surjective -/
 
@@ -76,10 +76,10 @@ theorem surjective_of_equiv {f1 f2 : map a b} (H1 : f1 ~ f2) (H2 : map.surjectiv
   map.surjective f2 :=
 surj_on_of_eq_on H1 H2
 
-theorem surjective_compose {g : map b c} {f : map a b} (Hg : map.surjective g)
+theorem surjective_comp {g : map b c} {f : map a b} (Hg : map.surjective g)
     (Hf: map.surjective f) :
   map.surjective (g ∘ f) :=
-surj_on_compose Hg Hf
+surj_on_comp Hg Hf
 
 theorem image_eq_of_surjective {f : map a b} (H : map.surjective f) : f ' a = b :=
 image_eq_of_maps_to_of_surj_on (map.mapsto f) H
@@ -92,11 +92,11 @@ theorem bijective_of_equiv {f1 f2 : map a b} (H1 : f1 ~ f2) (H2 : map.bijective 
   map.bijective f2 :=
 and.intro (injective_of_equiv H1 (and.left H2)) (surjective_of_equiv H1 (and.right H2))
 
-theorem bijective_compose {g : map b c} {f : map a b} (Hg : map.bijective g) (Hf: map.bijective f) :
+theorem bijective_comp {g : map b c} {f : map a b} (Hg : map.bijective g) (Hf: map.bijective f) :
   map.bijective (g ∘ f) :=
 obtain Hg₁ Hg₂, from Hg,
 obtain Hf₁ Hf₂, from Hf,
-and.intro (injective_compose Hg₁ Hf₁) (surjective_compose Hg₂ Hf₂)
+and.intro (injective_comp Hg₁ Hf₁) (surjective_comp Hg₂ Hf₂)
 
 theorem image_eq_of_bijective {f : map a b} (H : map.bijective f) : f ' a = b :=
 image_eq_of_surjective (proof and.right H qed)
@@ -118,10 +118,10 @@ theorem injective_of_left_inverse {g : map b a} {f : map a b} (H : map.left_inve
   map.injective f :=
 inj_on_of_left_inv_on H
 
-theorem left_inverse_compose {f' : map b a} {g' : map c b} {g : map b c} {f : map a b}
+theorem left_inverse_comp {f' : map b a} {g' : map c b} {g : map b c} {f : map a b}
     (Hf : map.left_inverse f' f) (Hg : map.left_inverse g' g) :
   map.left_inverse (f' ∘ g') (g ∘ f) :=
-left_inv_on_compose (mapsto f) Hf Hg
+left_inv_on_comp (mapsto f) Hf Hg
 
 /- right inverse -/
 
@@ -150,10 +150,10 @@ theorem left_inverse_of_surjective_of_right_inverse {f : map a b} {g : map b a}
   map.left_inverse f g :=
 left_inv_on_of_surj_on_right_inv_on surjf rfg
 
-theorem right_inverse_compose {f' : map b a} {g' : map c b} {g : map b c} {f : map a b}
+theorem right_inverse_comp {f' : map b a} {g' : map c b} {g : map b c} {f : map a b}
     (Hf : map.right_inverse f' f) (Hg : map.right_inverse g' g) :
   map.right_inverse (f' ∘ g') (g ∘ f) :=
-map.left_inverse_compose Hg Hf
+map.left_inverse_comp Hg Hf
 
 theorem equiv_of_map.left_inverse_of_right_inverse {g1 g2 : map b a} {f : map a b}
   (H1 : map.left_inverse g1 f) (H2 : map.right_inverse g2 f) : g1 ~ g2 :=

--- a/library/data/stream.lean
+++ b/library/data/stream.lean
@@ -595,7 +595,7 @@ infix `⊛`:75 := apply  -- input as \o*
 
 theorem identity (s : stream A) : pure id ⊛ s = s :=
 rfl
-theorem composition (g : stream (B → C)) (f : stream (A → B)) (s : stream A) : pure compose ⊛ g ⊛ f ⊛ s = g ⊛ (f ⊛ s) :=
+theorem composition (g : stream (B → C)) (f : stream (A → B)) (s : stream A) : pure comp ⊛ g ⊛ f ⊛ s = g ⊛ (f ⊛ s) :=
 rfl
 theorem homomorphism (f : A → B) (a : A) : pure f ⊛ pure a = pure (f a) :=
 rfl

--- a/library/init/function.lean
+++ b/library/init/function.lean
@@ -12,13 +12,13 @@ namespace function
 
 variables {A : Type} {B : Type} {C : Type} {D : Type} {E : Type}
 
-definition compose [reducible] [unfold_full] (f : B → C) (g : A → B) : A → C :=
+definition comp [reducible] [unfold_full] (f : B → C) (g : A → B) : A → C :=
 λx, f (g x)
 
-definition compose_right [reducible] [unfold_full] (f : B → B → B) (g : A → B) : B → A → B :=
+definition comp_right [reducible] [unfold_full] (f : B → B → B) (g : A → B) : B → A → B :=
 λ b a, f b (g a)
 
-definition compose_left [reducible] [unfold_full] (f : B → B → B) (g : A → B) : A → B → B :=
+definition comp_left [reducible] [unfold_full] (f : B → B → B) (g : A → B) : A → B → B :=
 λ a b, f (g a) b
 
 definition on_fun [reducible] [unfold_full] (f : B → B → C) (g : A → B) : A → A → C :=
@@ -31,7 +31,7 @@ definition combine [reducible] [unfold_full] (f : A → B → C) (op : C → D �
 definition const [reducible] [unfold_full] (B : Type) (a : A) : B → A :=
 λx, a
 
-definition dcompose [reducible] [unfold_full] {B : A → Type} {C : Π {x : A}, B x → Type}
+definition dcomp [reducible] [unfold_full] {B : A → Type} {C : Π {x : A}, B x → Type}
   (f : Π {x : A} (y : B x), C y) (g : Πx, B x) : Πx, C (g x) :=
 λx, f (g x)
 
@@ -53,8 +53,8 @@ rfl
 theorem uncurry_curry (f : A × B → C) : uncurry (curry f) = f :=
 funext (λ p, match p with (a, b) := rfl end)
 
-infixr  ` ∘ `            := compose
-infixr  ` ∘' `:60        := dcompose
+infixr  ` ∘ `            := comp
+infixr  ` ∘' `:60        := dcomp
 infixl  ` on `:1         := on_fun
 infixr  ` $ `:1          := app
 notation f ` -[` op `]- ` g  := combine f op g
@@ -63,23 +63,23 @@ lemma left_id (f : A → B) : id ∘ f = f := rfl
 
 lemma right_id (f : A → B) : f ∘ id = f := rfl
 
-theorem compose.assoc (f : C → D) (g : B → C) (h : A → B) : (f ∘ g) ∘ h = f ∘ (g ∘ h) := rfl
+theorem comp.assoc (f : C → D) (g : B → C) (h : A → B) : (f ∘ g) ∘ h = f ∘ (g ∘ h) := rfl
 
-theorem compose.left_id (f : A → B) : id ∘ f = f := rfl
+theorem comp.left_id (f : A → B) : id ∘ f = f := rfl
 
-theorem compose.right_id (f : A → B) : f ∘ id = f := rfl
+theorem comp.right_id (f : A → B) : f ∘ id = f := rfl
 
-theorem compose_const_right (f : B → C) (b : B) : f ∘ (const A b) = const A (f b) := rfl
+theorem comp_const_right (f : B → C) (b : B) : f ∘ (const A b) = const A (f b) := rfl
 
 definition injective [reducible] (f : A → B) : Prop := ∀ ⦃a₁ a₂⦄, f a₁ = f a₂ → a₁ = a₂
 
-theorem injective_compose {g : B → C} {f : A → B} (Hg : injective g) (Hf : injective f) :
+theorem injective_comp {g : B → C} {f : A → B} (Hg : injective g) (Hf : injective f) :
   injective (g ∘ f) :=
 take a₁ a₂, assume Heq, Hf (Hg Heq)
 
 definition surjective [reducible] (f : A → B) : Prop := ∀ b, ∃ a, f a = b
 
-theorem surjective_compose {g : B → C} {f : A → B} (Hg : surjective g) (Hf : surjective f) :
+theorem surjective_comp {g : B → C} {f : A → B} (Hg : surjective g) (Hf : surjective f) :
   surjective (g ∘ f) :=
 take c,
   obtain b (Hb : g b = c), from Hg c,
@@ -88,11 +88,11 @@ take c,
 
 definition bijective (f : A → B) := injective f ∧ surjective f
 
-theorem bijective_compose {g : B → C} {f : A → B} (Hg : bijective g) (Hf : bijective f) :
+theorem bijective_comp {g : B → C} {f : A → B} (Hg : bijective g) (Hf : bijective f) :
   bijective (g ∘ f) :=
 obtain Hginj Hgsurj, from Hg,
 obtain Hfinj Hfsurj, from Hf,
-and.intro (injective_compose Hginj Hfinj) (surjective_compose Hgsurj Hfsurj)
+and.intro (injective_comp Hginj Hfinj) (surjective_comp Hgsurj Hfsurj)
 
 -- g is a left inverse to f
 definition left_inverse (g : B → A) (f : A → B) : Prop := ∀x, g (f x) = x

--- a/library/logic/cast.lean
+++ b/library/logic/cast.lean
@@ -67,7 +67,7 @@ section
   theorem hproof_irrel {a b : Prop} (H : a = b) (H₁ : a) (H₂ : b) : H₁ == H₂ :=
   eq_rec_to_heq (proof_irrel (cast H H₁) H₂)
 
-  --TODO: generalize to eq.rec. This is a special case of rec_on_compose in eq.lean
+  --TODO: generalize to eq.rec. This is a special case of rec_on_comp in eq.lean
   theorem cast_trans (Hab : A = B) (Hbc : B = C) (a : A) :
     cast Hbc (cast Hab a) = cast (Hab ⬝ Hbc) a :=
   by subst Hab

--- a/library/logic/eq.lean
+++ b/library/logic/eq.lean
@@ -34,7 +34,7 @@ namespace eq
       eq.drec_on H b = eq.drec_on H' b :=
   proof_irrel H H' ▸ rfl
 
-  theorem rec_on_compose {a b c : A} {P : A → Type} (H₁ : a = b) (H₂ : b = c)
+  theorem rec_on_comp {a b c : A} {P : A → Type} (H₁ : a = b) (H₂ : b = c)
           (u : P a) : eq.rec_on H₂ (eq.rec_on H₁ u) = eq.rec_on (trans H₁ H₂) u :=
     (show ∀ H₂ : b = c, eq.rec_on H₂ (eq.rec_on H₁ u) = eq.rec_on (trans H₁ H₂) u,
       from eq.drec_on H₂ (take (H₂ : b = b), rec_on_id H₂ _))

--- a/library/logic/examples/leftinv_of_inj.lean
+++ b/library/logic/examples/leftinv_of_inj.lean
@@ -23,7 +23,7 @@ have linv : left_inverse finv f, from
     have ex : ∃ a₁ : A, f a₁ = f a, from exists.intro a rfl,
     have h₁ : f (some ex) = f a,    from !some_spec,
     begin
-      esimp [mk_left_inv, compose, id],
+      esimp [mk_left_inv, comp, id],
       rewrite [dif_pos ex],
       exact (!inj h₁)
     end,

--- a/library/theories/analysis/real_limit.lean
+++ b/library/theories/analysis/real_limit.lean
@@ -420,17 +420,6 @@ section monotone_sequences
 open real set
 variable {X : ℕ → ℝ}
 
-definition nondecreasing (X : ℕ → ℝ) : Prop := ∀ ⦃i j⦄, i ≤ j → X i ≤ X j
-
-proposition nondecreasing_of_forall_le_succ (H : ∀ i, X i ≤ X (succ i)) : nondecreasing X :=
-take i j, suppose i ≤ j,
-have ∀ n, X i ≤ X (i + n), from
-  take n, nat.induction_on n
-    (by rewrite nat.add_zero; apply le.refl)
-    (take n, assume ih, le.trans ih (H (i + n))),
-have X i ≤ X (i + (j - i)), from !this,
-by rewrite [add_sub_of_le `i ≤ j` at this]; exact this
-
 proposition converges_to_seq_sup_of_nondecreasing (nondecX : nondecreasing X) {b : ℝ}
     (Hb : ∀ i, X i ≤ b) : X ⟶ sup (X ' univ) in ℕ :=
 let sX := sup (X ' univ) in
@@ -458,41 +447,6 @@ exists.intro i
     have sX < X j + ε, from lt_add_of_sub_lt_right this,
     have sX - X j < ε, from sub_lt_left_of_lt_add this,
     show (abs (X j - sX)) < ε, by rewrite eq₁; exact this)
-
-definition nonincreasing (X : ℕ → ℝ) : Prop := ∀ ⦃i j⦄, i ≤ j → X i ≥ X j
-
-proposition nodecreasing_of_nonincreasing_neg (nonincX : nonincreasing (λ n, - X n)) :
-  nondecreasing (λ n, X n) :=
-take i j, suppose i ≤ j,
-show X i ≤ X j, from le_of_neg_le_neg (nonincX this)
-
-proposition noincreasing_neg_of_nondecreasing (nondecX : nondecreasing X) :
-  nonincreasing (λ n, - X n) :=
-take i j, suppose i ≤ j,
-show - X i ≥ - X j, from neg_le_neg (nondecX this)
-
-proposition nonincreasing_neg_iff (X : ℕ → ℝ) : nonincreasing (λ n, - X n) ↔ nondecreasing X :=
-iff.intro nodecreasing_of_nonincreasing_neg noincreasing_neg_of_nondecreasing
-
-proposition nonincreasing_of_nondecreasing_neg (nondecX : nondecreasing (λ n, - X n)) :
-  nonincreasing (λ n, X n) :=
-take i j, suppose i ≤ j,
-show X i ≥ X j, from le_of_neg_le_neg (nondecX this)
-
-proposition nodecreasing_neg_of_nonincreasing (nonincX : nonincreasing X) :
-  nondecreasing (λ n, - X n) :=
-take i j, suppose i ≤ j,
-show - X i ≤ - X j, from neg_le_neg (nonincX this)
-
-proposition nondecreasing_neg_iff (X : ℕ → ℝ) : nondecreasing (λ n, - X n) ↔ nonincreasing X :=
-iff.intro nonincreasing_of_nondecreasing_neg nodecreasing_neg_of_nonincreasing
-
-proposition nonincreasing_of_forall_succ_le (H : ∀ i, X (succ i) ≤ X i) : nonincreasing X :=
-begin
-  rewrite -nondecreasing_neg_iff,
-  show nondecreasing (λ n : ℕ, - X n), from
-    nondecreasing_of_forall_le_succ (take i, neg_le_neg (H i))
-end
 
 proposition converges_to_seq_inf_of_nonincreasing (nonincX : nonincreasing X) {b : ℝ}
     (Hb : ∀ i, b ≤ X i) : X ⟶ inf (X ' univ) in ℕ :=
@@ -527,7 +481,7 @@ let  aX := (λ n, (abs x)^n),
     iaX := real.inf (aX ' univ),
     asX := (λ n, (abs x)^(succ n)) in
 have noninc_aX : nonincreasing aX, from
-  nonincreasing_of_forall_succ_le
+  nonincreasing_of_forall_ge_succ
     (take i,
       have (abs x) * (abs x)^i ≤ 1 * (abs x)^i,
         from mul_le_mul_of_nonneg_right (le_of_lt H) (!pow_nonneg_of_nonneg !abs_nonneg),

--- a/library/theories/group_theory/action.lean
+++ b/library/theories/group_theory/action.lean
@@ -114,7 +114,7 @@ assume Pgstab,
 have hom g a = a, from of_mem_sep Pgstab, calc
   hom (f*g) a = perm.f ((hom f) * (hom g)) a : is_hom hom
           ... = ((hom f) ∘ (hom g)) a        : by rewrite perm_f_mul
-          ... = (hom f) a                    : by unfold compose; rewrite this
+          ... = (hom f) a                    : by unfold comp; rewrite this
 
 lemma stab_subset : stab hom H a ⊆ H :=
       begin
@@ -126,7 +126,7 @@ assume Pg,
 have hom g a = hom h a, from of_mem_sep Pg, calc
   hom (h⁻¹*g) a = perm.f ((hom h⁻¹) * (hom g)) a : by rewrite (is_hom hom)
   ... = ((hom h⁻¹) ∘ hom g) a                    : by rewrite perm_f_mul
-  ... = perm.f ((hom h)⁻¹ * hom h) a             : by unfold compose; rewrite [this, perm_f_mul, hom_map_inv hom h]
+  ... = perm.f ((hom h)⁻¹ * hom h) a             : by unfold comp; rewrite [this, perm_f_mul, hom_map_inv hom h]
   ... = perm.f (1 : perm S) a                    : by rewrite (mul.left_inv (hom h))
   ... = a                                        : by esimp
 
@@ -486,7 +486,7 @@ definition lower_perm (p : perm (fin (succ n))) (P : p maxi = maxi) : perm (fin 
 perm.mk (lower_inj p (perm.inj p) P)
   (take i j, begin
   rewrite [-eq_iff_veq, *lower_inj_apply, eq_iff_veq],
-  apply injective_compose (perm.inj p) lift_succ_inj
+  apply injective_comp (perm.inj p) lift_succ_inj
   end)
 
 lemma lift_lower_eq : ∀ {p : perm (fin (succ n))} (P : p maxi = maxi),

--- a/library/theories/group_theory/cyclic.lean
+++ b/library/theories/group_theory/cyclic.lean
@@ -292,7 +292,7 @@ lemma rotl_rotr : ∀ {n : nat} (m : nat), (@rotl n m) ∘ (rotr m) = id
 | (nat.succ n) := take m, funext take i, calc (mk_mod n (n*m)) + (-(mk_mod n (n*m)) + i) = i : add_neg_cancel_left
 
 lemma rotl_succ {n : nat} : (rotl 1) ∘ (@succ n) = lift_succ :=
-funext (take i, eq_of_veq (begin rewrite [↑compose, ↑rotl, ↑madd, mul_one n, ↑mk_mod, mod_add_mod, ↑lift_succ, val_succ, -succ_add_eq_succ_add, add_mod_self_left, mod_eq_of_lt (lt.trans (is_lt i) !lt_succ_self), -val_lift] end))
+funext (take i, eq_of_veq (begin rewrite [↑comp, ↑rotl, ↑madd, mul_one n, ↑mk_mod, mod_add_mod, ↑lift_succ, val_succ, -succ_add_eq_succ_add, add_mod_self_left, mod_eq_of_lt (lt.trans (is_lt i) !lt_succ_self), -val_lift] end))
 
 definition list.rotl {A : Type} : ∀ l : list A, list A
 | []     := []
@@ -336,7 +336,7 @@ lemma rotl_seq_ne_id : ∀ {n : nat}, (∃ a b : A, a ≠ b) → ∀ i, i < n �
   assume Peq, absurd (congr_fun Peq f) P
 
 lemma rotr_rotl_fun {n : nat} (m : nat) (f : seq A n) : rotr_fun m (rotl_fun m f) = f :=
-calc f ∘ (rotl m) ∘ (rotr m) = f ∘ ((rotl m) ∘ (rotr m)) : by rewrite -compose.assoc
+calc f ∘ (rotl m) ∘ (rotr m) = f ∘ ((rotl m) ∘ (rotr m)) : by rewrite -comp.assoc
                          ... = f ∘ id                    : by rewrite (rotl_rotr m)
 
 lemma rotl_fun_inj {n : nat} {m : nat} : @injective (seq A n) (seq A n) (rotl_fun m) :=
@@ -365,7 +365,7 @@ include finA deceqA
 
 lemma rotl_perm_mul {i j : nat} : (rotl_perm A n i) * (rotl_perm A n j) = rotl_perm A n (j+i) :=
 eq_of_feq (funext take f, calc
-  f ∘ (rotl j) ∘ (rotl i) = f ∘ ((rotl j) ∘ (rotl i)) : by rewrite -compose.assoc
+  f ∘ (rotl j) ∘ (rotl i) = f ∘ ((rotl j) ∘ (rotl i)) : by rewrite -comp.assoc
                       ... = f ∘ (rotl (j+i))          : by rewrite rotl_compose)
 
 lemma rotl_perm_pow_eq : ∀ {i : nat}, (rotl_perm A n 1) ^ i = rotl_perm A n i

--- a/library/theories/group_theory/finsubg.lean
+++ b/library/theories/group_theory/finsubg.lean
@@ -137,7 +137,7 @@ begin
   esimp [fin_inv, fin_lcoset, fin_rcoset],
   rewrite [-image_comp],
   apply ext, intro b,
-  rewrite [*mem_image_iff, ↑compose, ↑lmul_by, ↑rmul_by],
+  rewrite [*mem_image_iff, ↑comp, ↑lmul_by, ↑rmul_by],
   apply iff.intro,
     intro Pl, cases Pl with h Ph, cases Ph with Pin Peq,
     existsi h⁻¹, apply and.intro,

--- a/library/theories/group_theory/perm.lean
+++ b/library/theories/group_theory/perm.lean
@@ -83,7 +83,7 @@ definition perm_is_fintype [instance] : fintype (perm A) :=
            fintype.mk all_perms nodup_all_perms all_perms_complete
 
 definition perm.mul (f g : perm A) :=
-           perm.mk (f∘g) (injective_compose (perm.inj f) (perm.inj g))
+           perm.mk (f∘g) (injective_comp (perm.inj f) (perm.inj g))
 definition perm.one [reducible] : perm A := perm.mk id injective_id
 definition perm.inv (f : perm A) := let inj := perm.inj f in
            perm.mk (perm_inv inj) (perm_inv_inj inj)

--- a/library/theories/group_theory/pgroup.lean
+++ b/library/theories/group_theory/pgroup.lean
@@ -200,7 +200,7 @@ lemma rotl_perm_peo_of_peo {n : nat} : ∀ {m} {s : seq A n}, peo s → peo (rot
 | (succ m) := take s,
   have Pmul : rotl_perm A n (m + 1) s = rotl_fun 1 (rotl_perm A n m s), from
     calc s ∘ (rotl (m + 1)) = s ∘ ((rotl m) ∘ (rotl 1)) : rotl_compose
-                        ... = s ∘ (rotl m) ∘ (rotl 1) : compose.assoc,
+                        ... = s ∘ (rotl m) ∘ (rotl 1) : comp.assoc,
   begin
   rewrite [-add_one, Pmul], intro P,
   exact rotl1_peo_of_peo (rotl_perm_peo_of_peo P)
@@ -257,7 +257,7 @@ funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, -rotl_perm_pow_eq, rot
 
 lemma rotl_peo_seq_compose {n i j : nat} :
   (rotl_peo_seq A n i) ∘ (rotl_peo_seq A n j) = rotl_peo_seq A n (j + i) :=
-funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, ↑rotl_perm, ↑rotl_fun, compose.assoc, rotl_compose] end
+funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, ↑rotl_perm, ↑rotl_fun, comp.assoc, rotl_compose] end
 
 lemma rotl_peo_seq_mod {n i : nat} : rotl_peo_seq A n i = rotl_peo_seq A n (i % succ n) :=
 funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, rotl_perm_mod] end

--- a/library/theories/group_theory/subgroup.lean
+++ b/library/theories/group_theory/subgroup.lean
@@ -22,11 +22,11 @@ definition r a (S : set A) := (rmul a) ' S
 lemma lmul_compose : ∀ (a b : A), (lmul a) ∘ (lmul b) = lmul (a*b) :=
       take a, take b,
       funext (assume x, by
-        rewrite [↑function.compose, ↑lmul, mul.assoc])
+        rewrite [↑function.comp, ↑lmul, mul.assoc])
 lemma rmul_compose : ∀ (a b : A), (rmul a) ∘ (rmul b) = rmul (b*a) :=
       take a, take b,
       funext (assume x, by
-        rewrite [↑function.compose, ↑rmul, mul.assoc])
+        rewrite [↑function.comp, ↑rmul, mul.assoc])
 lemma lcompose a b (S : set A) : l a (l b S) = l (a*b) S :=
       calc (lmul a) ' ((lmul b) ' S) = ((lmul a) ∘ (lmul b)) ' S : image_comp
       ... = lmul (a*b) ' S : lmul_compose

--- a/tests/lean/550.lean
+++ b/tests/lean/550.lean
@@ -12,19 +12,19 @@ attribute bijection.func [coercion]
 namespace bijection
   variable {A : Type}
 
-  definition compose (f g : bijection A) : bijection A :=
+  definition comp (f g : bijection A) : bijection A :=
   bijection.mk
     (f ∘ g)
     (finv g ∘ finv f)
-    (by rewrite [compose.assoc, -{finv f ∘ _}compose.assoc, linv f, compose.left_id, linv g])
-    (by rewrite [-compose.assoc, {_ ∘ finv g}compose.assoc, rinv g, compose.right_id, rinv f])
+    (by rewrite [comp.assoc, -{finv f ∘ _}comp.assoc, linv f, comp.left_id, linv g])
+    (by rewrite [-comp.assoc, {_ ∘ finv g}comp.assoc, rinv g, comp.right_id, rinv f])
 
-  infixr ` ∘b `:100 := compose
+  infixr ` ∘b `:100 := comp
 
   lemma compose.assoc (f g h : bijection A) : (f ∘b g) ∘b h = f ∘b (g ∘b h) := rfl
 
   definition id : bijection A :=
-  bijection.mk id id (compose.left_id id) (compose.left_id id)
+  bijection.mk id id (comp.left_id id) (comp.left_id id)
 
   lemma id.left_id (f : bijection A) : id ∘b f = f :=
   bijection.rec_on f (λx x x x, rfl)
@@ -40,5 +40,5 @@ namespace bijection
     (linv f)
 
   lemma inv.linv (f : bijection A) : inv f ∘b f = id :=
-  bijection.rec_on f (λfunc finv linv rinv, by rewrite [↑inv, ↑compose, linv])
+  bijection.rec_on f (λfunc finv linv rinv, by rewrite [↑inv, ↑comp, linv])
 end bijection

--- a/tests/lean/550.lean.expected.out
+++ b/tests/lean/550.lean.expected.out
@@ -1,4 +1,4 @@
-550.lean:43:72: error:invalid 'rewrite' tactic, step produced type incorrect term, details: type mismatch at application
+550.lean:43:69: error:invalid 'rewrite' tactic, step produced type incorrect term, details: type mismatch at application
   eq.symm linv
 term
   linv
@@ -16,13 +16,13 @@ linv : finv ∘ func = id,
 rinv : func ∘ finv = id
 ⊢ mk (finv ∘ func) (finv ∘ func)
     (eq.rec
-       (eq.rec (eq.rec (eq.rec (eq.rec (eq.refl id) (eq.symm linv)) (eq.symm (compose.left_id func))) (eq.symm rinv))
-          (function.compose.assoc func finv func))
-       (eq.symm (function.compose.assoc finv func (finv ∘ func))))
+       (eq.rec (eq.rec (eq.rec (eq.rec (eq.refl id) (eq.symm linv)) (eq.symm (comp.left_id func))) (eq.symm rinv))
+          (comp.assoc func finv func))
+       (eq.symm (comp.assoc finv func (finv ∘ func))))
     (eq.rec
-       (eq.rec (eq.rec (eq.rec (eq.rec (eq.refl id) (eq.symm linv)) (eq.symm (compose.right_id finv))) (eq.symm rinv))
-          (eq.symm (function.compose.assoc finv func finv)))
-       (function.compose.assoc (finv ∘ func) finv func)) = id
+       (eq.rec (eq.rec (eq.rec (eq.rec (eq.refl id) (eq.symm linv)) (eq.symm (comp.right_id finv))) (eq.symm rinv))
+          (eq.symm (comp.assoc finv func finv)))
+       (comp.assoc (finv ∘ func) finv func)) = id
 550.lean:43:44: error: don't know how to synthesize placeholder
 A : Type,
 f : bijection A,

--- a/tests/lean/run/blast_tuple2.lean
+++ b/tests/lean/run/blast_tuple2.lean
@@ -44,15 +44,15 @@ example : m = n → xs == ys → nil ++ xs == ys := by inst_simp
 example : (xs ++ ys) ++ zs == xs ++ (ys ++ zs) := by inst_simp
 example : p = m + n → zs == xs ++ ys → zs ++ ws == (xs ++ ys) ++ ws := by inst_simp
 example : m + n = p → xs ++ ys == zs → zs ++ ws == xs ++ (ys ++ ws) := by inst_simp
-        
+
 example : m = n → p = q → m + n = p → xs == ys → zs == ws → xs ++ ys == zs → ws ++ ws == (ys ++ xs) ++ (xs ++ ys) := by inst_simp
 
 example : m = n → n = p → xs == reverse ys → ys == reverse zs → xs == zs := by inst_simp
 
-example : m = n → xs == ys → f = g → a = b → map f (cons a xs) == cons (g b) (map g ys) := by 
+example : m = n → xs == ys → f = g → a = b → map f (cons a xs) == cons (g b) (map g ys) := by
 inst_simp
 
-attribute function.compose [semireducible]
+attribute function.comp [semireducible]
 example : m = n → xs == ys → h1 = h2 → k1 = k2 → map k1 (map h1 xs) == map (k2 ∘ h2) ys := by inst_simp
 
 example : ∀ (xs : tuple A (nat.succ m)) (ys : tuple A (nat.succ n))

--- a/tests/lean/run/new_obtain4.lean
+++ b/tests/lean/run/new_obtain4.lean
@@ -3,7 +3,7 @@ open set function eq.ops
 
 variables {X Y Z : Type}
 
-lemma image_compose (f : Y → X) (g : X → Y) (a : set X) : (f ∘ g) ' a = f ' (g ' a) :=
+lemma image_comp (f : Y → X) (g : X → Y) (a : set X) : (f ∘ g) ' a = f ' (g ' a) :=
 ext (take z,
   iff.intro
     (assume Hz,
@@ -11,4 +11,4 @@ ext (take z,
       by repeat (apply mem_image | assumption | reflexivity))
     (assume Hz,
       obtain y [x Hz₁ Hz₂] Hy₂, from Hz,
-      by repeat (apply mem_image | assumption | esimp [compose] | rewrite Hz₂)))
+      by repeat (apply mem_image | assumption | esimp [comp] | rewrite Hz₂)))


### PR DESCRIPTION
In this pull request:
- uniform treatment of homomorphisms for structures
- uniform treatment of monotone functions
- rename compose to comp

The combinatorial explosion of variants in monotone.lean was a nightmare. Here, for example, are all the variants for negation: 

https://github.com/avigad/lean/blob/master/library/algebra/ordered_group.lean#L629-L736

We could have all the same variants for _each_ of the following: addition on the left, addition on the right, subtraction, multiplication by a positive number on the left, multiplication by a positive number on the right, division by a positive number, multiplication by a negative number on the left, multiplication by a negative number on the right, and division by a negative number.

Or maybe we don't need any of these, because blast or polya or something else will prove whatever we need on the fly. Anyhow, the infrastructure is there if we need it, and we can delete it if not.

Things I am too tired to do now: 
- using a dot instead of a bullet for scalar multiplication
- proving that rings and additive groups are instances of modules
  They can wait until after the elaborator refactoring.
