### PR TITLE
Freudenthal Suspension Theorem

### DIFF
--- a/hott/algebra/homotopy_group.hlean
+++ b/hott/algebra/homotopy_group.hlean
@@ -47,15 +47,13 @@ namespace eq
 
   definition phomotopy_group_pequiv [constructor] (n : ℕ) {A B : Type*} (H : A ≃* B)
     : π*[n] A ≃* π*[n] B :=
-  ptrunc_pequiv 0 (iterated_loop_space_pequiv n H)
+  ptrunc_pequiv_ptrunc 0 (iterated_loop_space_pequiv n H)
 
-  set_option pp.coercions true
-  set_option pp.numerals false
   definition phomotopy_group_pequiv_loop_ptrunc [constructor] (k : ℕ) (A : Type*) :
     π*[k] A ≃* Ω[k] (ptrunc k A) :=
   begin
     refine !iterated_loop_ptrunc_pequiv⁻¹ᵉ* ⬝e* _,
-    rewrite [trunc_index.zero_add]
+    exact loopn_pequiv_loopn k (pequiv_of_eq begin rewrite [trunc_index.zero_add] end)
   end
 
   open equiv unit
@@ -112,6 +110,9 @@ namespace eq
 
   definition tinverse [constructor] {X : Type*} : π*[1] X →* π*[1] X :=
   ptrunc_functor 0 pinverse
+
+  definition is_equiv_tinverse [constructor] (A : Type*) : is_equiv (@tinverse A) :=
+  by apply @is_equiv_trunc_functor; apply is_equiv_eq_inverse
 
   definition ptrunc_functor_pinverse [constructor] {X : Type*}
     : ptrunc_functor 0 (@pinverse X) ~* @tinverse X :=

--- a/hott/algebra/trunc_group.hlean
+++ b/hott/algebra/trunc_group.hlean
@@ -13,27 +13,29 @@ open eq is_trunc trunc
 namespace algebra
 
   section
-  parameters (A : Type) (mul : A → A → A) (inv : A → A) (one : A)
-    {mul_assoc : ∀a b c, mul (mul a b) c = mul a (mul b c)}
-    {one_mul : ∀a, mul one a = a} {mul_one : ∀a, mul a one = a}
-    {mul_left_inv : ∀a, mul (inv a) a = one}
+  parameters (n : trunc_index) {A : Type} (mul : A → A → A) (inv : A → A) (one : A)
+    (mul_assoc : ∀a b c, mul (mul a b) c = mul a (mul b c))
+    (one_mul : ∀a, mul one a = a) (mul_one : ∀a, mul a one = a)
+    (mul_left_inv : ∀a, mul (inv a) a = one)
 
-  local abbreviation G := trunc 0 A
+  local abbreviation G := trunc n A
 
-  include mul_assoc one_mul mul_one mul_left_inv
+  include mul
   definition trunc_mul [unfold 9 10] (g h : G) : G :=
   begin
-    apply trunc.rec_on g, intro p,
-    apply trunc.rec_on h, intro q,
+    induction g with p,
+    induction h with q,
     exact tr (mul p q)
   end
 
+  omit mul include inv
   definition trunc_inv [unfold 9] (g : G) : G :=
   begin
-    apply trunc.rec_on g, intro p,
+    induction g with p,
     exact tr (inv p)
   end
 
+  omit inv include one
   definition trunc_one [constructor] : G :=
   tr one
 
@@ -41,56 +43,62 @@ namespace algebra
   local postfix ⁻¹ := trunc_inv
   local infix * := trunc_mul
 
+  parameters {mul} {inv} {one}
+  omit one include mul_assoc
   theorem trunc_mul_assoc (g₁ g₂ g₃ : G) : g₁ * g₂ * g₃ = g₁ * (g₂ * g₃) :=
   begin
-    apply trunc.rec_on g₁, intro p₁,
-    apply trunc.rec_on g₂, intro p₂,
-    apply trunc.rec_on g₃, intro p₃,
+    induction g₁ with p₁,
+    induction g₂ with p₂,
+    induction g₃ with p₃,
     exact ap tr !mul_assoc,
   end
 
+  omit mul_assoc include one_mul
   theorem trunc_one_mul (g : G) : 1 * g = g :=
   begin
-    apply trunc.rec_on g, intro p,
+    induction g with p,
     exact ap tr !one_mul
   end
 
+  omit one_mul include mul_one
   theorem trunc_mul_one (g : G) : g * 1 = g :=
   begin
-    apply trunc.rec_on g, intro p,
+    induction g with p,
     exact ap tr !mul_one
   end
 
+  omit mul_one include mul_left_inv
   theorem trunc_mul_left_inv (g : G) : g⁻¹ * g = 1 :=
   begin
-    apply trunc.rec_on g, intro p,
+    induction g with p,
     exact ap tr !mul_left_inv
   end
 
+  omit mul_left_inv
   theorem trunc_mul_comm (mul_comm : ∀a b, mul a b = mul b a) (g h : G)
     : g * h = h * g :=
   begin
-    apply trunc.rec_on g, intro p,
-    apply trunc.rec_on h, intro q,
+    induction g with p,
+    induction h with q,
     exact ap tr !mul_comm
   end
 
-  parameters (mul_assoc) (one_mul) (mul_one) (mul_left_inv) {A}
+  parameters (mul) (inv) (one)
 
-  definition trunc_group [constructor] : group G :=
+  definition trunc_group [constructor] : group (trunc 0 A) :=
   ⦃group,
-    mul          := trunc_mul,
-    mul_assoc    := trunc_mul_assoc,
-    one          := trunc_one,
-    one_mul      := trunc_one_mul,
-    mul_one      := trunc_mul_one,
-    inv          := trunc_inv,
-    mul_left_inv := trunc_mul_left_inv,
+    mul          := algebra.trunc_mul          0 mul,
+    mul_assoc    := algebra.trunc_mul_assoc    0 mul_assoc,
+    one          := algebra.trunc_one          0 one,
+    one_mul      := algebra.trunc_one_mul      0 one_mul,
+    mul_one      := algebra.trunc_mul_one      0 mul_one,
+    inv          := algebra.trunc_inv          0 inv,
+    mul_left_inv := algebra.trunc_mul_left_inv 0 mul_left_inv,
    is_set_carrier := _⦄
 
-
-  definition trunc_comm_group [constructor] (mul_comm : ∀a b, mul a b = mul b a) : comm_group G :=
-  ⦃comm_group, trunc_group, mul_comm := trunc_mul_comm mul_comm⦄
+  definition trunc_comm_group [constructor] (mul_comm : ∀a b, mul a b = mul b a)
+    : comm_group (trunc 0 A) :=
+  ⦃comm_group, trunc_group, mul_comm := algebra.trunc_mul_comm 0 mul_comm⦄
 
   end
 end algebra

--- a/hott/book.md
+++ b/hott/book.md
@@ -18,7 +18,7 @@ The rows indicate the chapters, the columns the sections.
 | Ch 1  | . | . | . | . | + | + | + | + | + | .  | +  | +  |    |    |    |
 | Ch 2  | + | + | + | + | . | + | + | + | + | +  | +  | +  | +  | +  | +  |
 | Ch 3  | + | + | + | + | ½ | + | + | + | + | .  | +  |    |    |    |    |
-| Ch 4  | - | + | + | + | . | + | ½ | + | + |    |    |    |    |    |    |
+| Ch 4  | - | + | + | + | . | + | + | + | + |    |    |    |    |    |    |
 | Ch 5  | - | . | ½ | - | - | . | . | ½ |   |    |    |    |    |    |    |
 | Ch 6  | . | + | + | + | + | ½ | ½ | + | ¾ | ¼  | ¾  | +  | .  |    |    |
 | Ch 7  | + | + | + | - | ¾ | - | - |   |   |    |    |    |    |    |    |
@@ -75,7 +75,7 @@ Chapter 3: Sets and logic
 - 3.2 (Propositions as types?): [types.univ](types/univ.hlean)
 - 3.3 (Mere propositions): [init.trunc](init/trunc.hlean) and [prop_trunc](prop_trunc.hlean) (Lemma 3.3.5).
 - 3.4 (Classical vs. intuitionistic logic): decidable is defined in [init.logic](init/logic.hlean)
-- 3.5 (Subsets and propositional resizing): Lemma 3.5.1 is subtype_eq in [types.sigma](types/sigma.hlean), we don't have propositional resizing as axiom yet.
+- 3.5 (Subsets and propositional resizing): Lemma 3.5.1 is subtype_eq in [types.sigma](types/sigma.hlean). We have not declared propositional resizing as an axiom.
 - 3.6 (The logic of mere propositions): in the corresponding file in the [types](types/types.md) folder. (is_trunc_prod is defined in [types.sigma](types/sigma.hlean))
 - 3.7 (Propositional truncation): [init.hit](init/hit.hlean) and [hit.trunc](hit/trunc.hlean)
 - 3.8 (The axiom of choice): [choice](choice.hlean)
@@ -92,7 +92,7 @@ Chapter 4: Equivalences
 - 4.4 (Contractible fibers): [types.equiv](types/equiv.hlean)
 - 4.5 (On the definition of equivalences): no formalizable content
 - 4.6 (Surjections and embeddings): [function](function.hlean)
-- 4.7 (Closure properties of equivalences): 4.7.1 in [init.equiv](init/equiv.hlean); 4.7.2 in [function](function.hlean); 4.7.5 and 4.7.7 in [types.sigma](types/sigma.hlean) (sigma_functor is a generalization of total(f)); and 4.7.6 in 4.7.6 in [types.fiber](types/fiber.hlean).
+- 4.7 (Closure properties of equivalences): 4.7.1 in [init.equiv](init/equiv.hlean); 4.7.2 in [function](function.hlean); 4.7.3 and 4.7.4 in [types.arrow_2](types/arrow_2.hlean) 4.7.5 in [types.sigma](types/sigma.hlean) (sigma_functor is a generalization of total(f)); 4.7.6 in [types.fiber](types/fiber.hlean) and 4.7.7 in [types.equiv](types/equiv.hlean).
 - 4.8 (The object classifier): 4.8.1 and 4.8.2 in [types.fiber](types/fiber.hlean); 4.8.3 and 4.8.4 in [types.univ](types/univ.hlean)
 - 4.9 (Univalence implies function extensionality): [init.funext](init/funext.hlean)
 
@@ -132,7 +132,7 @@ Chapter 7: Homotopy n-types
 - 7.2 (Uniqueness of identity proofs and Hedberg’s theorem): [init.hedberg](init/hedberg.hlean) and [types.trunc](types/trunc.hlean)
 - 7.3 (Truncations): [init.hit](init/hit.hlean), [hit.trunc](hit/trunc.hlean) and [types.trunc](types/trunc.hlean)
 - 7.4 (Colimits of n-types): not formalized
-- 7.5 (Connectedness): [homotopy.connectedness](homotopy/connectedness.hlean) (the main "induction principle" Lemma 7.5.7)
+- 7.5 (Connectedness): [homotopy.connectedness](homotopy/connectedness.hlean) (missing theorems: 6, 8, 9, 10, 12, 13)
 - 7.6 (Orthogonal factorization): not formalized
 - 7.7 (Modalities): not formalized, and may be unformalizable in general because it's unclear how to define modalities
 
@@ -142,7 +142,7 @@ Chapter 8: Homotopy theory
 Unless otherwise noted, the files are in the folder [homotopy](homotopy/homotopy.md)
 
 - 8.1 (π_1(S^1)): [homotopy.circle](homotopy/circle.hlean) (only the encode-decode proof)
-- 8.2 (Connectedness of suspensions): [homotopy.connectedness](homotopy/connectedness.hlean) (different proof)
+- 8.2 (Connectedness of suspensions): [homotopy.connectedness](homotopy/connectedness.hlean) (different proof of Theorem 8.2.1)
 - 8.3 (πk≤n of an n-connected space and π_{k<n}(S^n)): [homotopy.homotopy_group](homotopy/homotopy_group.hlean)
 - 8.4 (Fiber sequences and the long exact sequence): not formalized
 - 8.5 (The Hopf fibration): [homotopy.circle](homotopy/circle.hlean) (H-space structure on the circle, Lemma 8.5.8), [homotopy.join](homotopy/join.hlean) (join is associative, Lemma 8.5.9), the rest is not formalized

--- a/hott/cubical/square.hlean
+++ b/hott/cubical/square.hlean
@@ -302,10 +302,38 @@ namespace eq
     (s : square q r (ap f p) (ap g p)) : q =[p] r :=
   by induction p;apply pathover_idp_of_eq;exact eq_of_vdeg_square s
 
+  definition eq_pathover_constant_left {g : A → B} {p : a = a'} {b : B} {q : b = g a} {r : b = g a'}
+    (s : square q r idp (ap g p)) : q =[p] r :=
+  eq_pathover (ap_constant p b ⬝ph s)
+
+  definition eq_pathover_id_left {g : A → A} {p : a = a'} {q : a = g a} {r : a' = g a'}
+    (s : square q r p (ap g p)) : q =[p] r :=
+  eq_pathover (ap_id p ⬝ph s)
+
+  definition eq_pathover_constant_right {f : A → B} {p : a = a'} {b : B} {q : f a = b} {r : f a' = b}
+    (s : square q r (ap f p) idp) : q =[p] r :=
+  eq_pathover (s ⬝hp (ap_constant p b)⁻¹)
+
+  definition eq_pathover_id_right {f : A → A} {p : a = a'} {q : f a = a} {r : f a' = a'}
+    (s : square q r (ap f p) p) : q =[p] r :=
+  eq_pathover (s ⬝hp (ap_id p)⁻¹)
+
   definition square_of_pathover [unfold 7]
     {f g : A → B} {p : a = a'} {q : f a = g a} {r : f a' = g a'}
     (s : q =[p] r) : square q r (ap f p) (ap g p) :=
   by induction p;apply vdeg_square;exact eq_of_pathover_idp s
+
+  definition eq_pathover_constant_left_id_right {p : a = a'} {a₀ : A} {q : a₀ = a} {r : a₀ = a'}
+    (s : square q r idp p) : q =[p] r :=
+  eq_pathover (ap_constant p a₀ ⬝ph s ⬝hp (ap_id p)⁻¹)
+
+  definition eq_pathover_id_left_constant_right {p : a = a'} {a₀ : A} {q : a = a₀} {r : a' = a₀}
+    (s : square q r p idp) : q =[p] r :=
+  eq_pathover (ap_id p ⬝ph s ⬝hp (ap_constant p a₀)⁻¹)
+
+  definition loop_pathover {p : a = a'} {b : B} {q : a = a} {r : a' = a'}
+    (s : square q r p p) : q =[p] r :=
+  eq_pathover (ap_id p ⬝ph s ⬝hp (ap_id p)⁻¹)
 
   /- interaction of equivalences with operations on squares -/
 

--- a/hott/function.hlean
+++ b/hott/function.hlean
@@ -116,6 +116,14 @@ namespace function
   definition is_prop_is_surjective [instance] : is_prop (is_surjective f) :=
   by unfold is_surjective; exact _
 
+  definition is_surjective_cancel_right {A B C : Type} (g : B → C) (f : A → B)
+    [H : is_surjective (g ∘ f)] : is_surjective g :=
+  begin
+    intro c,
+    induction H c with v, induction v with a p,
+    exact tr (fiber.mk (f a) p)
+  end
+
   definition is_weakly_constant_ap [instance] [H : is_weakly_constant f] (a a' : A) :
     is_weakly_constant (ap f : a = a' → f a = f a') :=
   take p q : a = a',
@@ -222,7 +230,7 @@ namespace function
     (λb,
       ((trunc_functor_compose n (sect r) r) b)⁻¹
       ⬝ trunc_homotopy n (right_inverse r) b
-      ⬝ trunc_functor_id B n b)
+      ⬝ trunc_functor_id n B b)
 
   -- Lemma 3.11.7
   definition is_contr_retract (r : A → B) [H : is_retraction r] : is_contr A → is_contr B :=

--- a/hott/hit/trunc.hlean
+++ b/hott/hit/trunc.hlean
@@ -32,7 +32,7 @@ attribute trunc.elim [recursor 6] [unfold 6]
 
 namespace trunc
 
-  variables {X Y Z : Type} {P : X → Type} (A B : Type) (n : trunc_index)
+  variables {X Y Z : Type} {P : X → Type} (n : trunc_index) (A B : Type)
 
   local attribute is_trunc_eq [instance]
 

--- a/hott/homotopy/circle.hlean
+++ b/hott/homotopy/circle.hlean
@@ -238,12 +238,12 @@ namespace circle
   open algebra trunc
 
   definition fg_carrier_equiv_int : π[1](S¹.) ≃ ℤ :=
-  trunc_equiv_trunc 0 base_eq_base_equiv ⬝e @(trunc_equiv ℤ _) proof _ qed
+  trunc_equiv_trunc 0 base_eq_base_equiv ⬝e @(trunc_equiv 0 ℤ) proof _ qed
 
   definition con_comm_base (p q : base = base) : p ⬝ q = q ⬝ p :=
   eq_of_fn_eq_fn base_eq_base_equiv (by esimp;rewrite [+encode_con,add.comm])
 
-  definition fundamental_group_of_circle : π₁(S¹.) = group_integers :=
+  definition fundamental_group_of_circle : π₁(S¹.) = gℤ :=
   begin
     apply (Group_eq fg_carrier_equiv_int),
     intros g h,

--- a/hott/homotopy/homotopy_group.hlean
+++ b/hott/homotopy/homotopy_group.hlean
@@ -7,7 +7,7 @@ Authors: Floris van Doorn, Clive Newstead
 
 import algebra.homotopy_group .connectedness
 
-open eq is_trunc trunc_index pointed algebra trunc nat homotopy
+open eq is_trunc trunc_index pointed algebra trunc nat homotopy fiber pointed
 
 namespace is_trunc
   -- Lemma 8.3.1
@@ -25,19 +25,14 @@ namespace is_trunc
   theorem trivial_homotopy_group_of_is_conn (A : Type*) {k n : ℕ} (H : k ≤ n) [is_conn n A]
     : is_contr (π[k] A) :=
   begin
-      have H2 : of_nat k ≤ of_nat n, from of_nat_le_of_nat H,
-      have H3 : is_contr (ptrunc k A),
-      begin
-        fapply is_contr_equiv_closed,
-        { apply trunc_trunc_equiv_left _ k n H2}
-      end,
-      have H4 : is_contr (Ω[k](ptrunc k A)),
-        from !is_trunc_loop_of_is_trunc,
+      have H3 : is_contr (ptrunc k A), from is_conn_of_le A (of_nat_le_of_nat H),
+      have H4 : is_contr (Ω[k](ptrunc k A)), from !is_trunc_loop_of_is_trunc,
       apply is_trunc_equiv_closed_rev,
       { apply equiv_of_pequiv (phomotopy_group_pequiv_loop_ptrunc k A)}
   end
 
   -- Corollary 8.3.3
+  section
   open sphere.ops sphere_index
   theorem homotopy_group_sphere_le (n k : ℕ) (H : k < n) : is_contr (π[k] (S. n)) :=
   begin
@@ -47,5 +42,11 @@ namespace is_trunc
       apply @(trivial_homotopy_group_of_is_conn _ H2),
       rewrite [-trunc_index.of_sphere_index_of_nat, -trunc_index.succ_sub_one], apply is_conn_sphere}
   end
+  end
+
+  theorem is_contr_HG_fiber_of_is_connected {A B : Type*} (k n : ℕ) (f : A →* B)
+    [H : is_conn_map n f] (H2 : k ≤ n) : is_contr (π[k] (pfiber f)) :=
+  @(trivial_homotopy_group_of_is_conn (pfiber f) H2) (H pt)
+
 
 end is_trunc

--- a/hott/homotopy/homotopy_group.hlean
+++ b/hott/homotopy/homotopy_group.hlean
@@ -39,13 +39,12 @@ namespace is_trunc
     cases n with n,
     { exfalso, apply not_lt_zero, exact H},
     { have H2 : k ≤ n, from le_of_lt_succ H,
-      apply @(trivial_homotopy_group_of_is_conn _ H2),
-      rewrite [-trunc_index.of_sphere_index_of_nat, -trunc_index.succ_sub_one], apply is_conn_sphere}
+      apply @(trivial_homotopy_group_of_is_conn _ H2)}
   end
   end
 
   theorem is_contr_HG_fiber_of_is_connected {A B : Type*} (k n : ℕ) (f : A →* B)
-    [H : is_conn_map n f] (H2 : k ≤ n) : is_contr (π[k] (pfiber f)) :=
+    [H : is_conn_fun n f] (H2 : k ≤ n) : is_contr (π[k] (pfiber f)) :=
   @(trivial_homotopy_group_of_is_conn (pfiber f) H2) (H pt)
 
 

--- a/hott/homotopy/sphere.hlean
+++ b/hott/homotopy/sphere.hlean
@@ -153,7 +153,27 @@ weak_order.mk le sphere_index.le.sp_refl @sphere_index.le_trans @sphere_index.le
 
 namespace trunc_index
   definition sub_two_eq_sub_one_sub_one (n : ℕ) : n.-2 = n..-1..-1 :=
-  nat.rec_on n idp (λn p, ap trunc_index.succ p)
+  begin
+    induction n with n IH,
+    { reflexivity},
+    { exact ap trunc_index.succ IH}
+  end
+
+  definition of_nat_sub_one (n : ℕ)
+    : (sphere_index.of_nat n)..-1 = (trunc_index.sub_two n).+1 :=
+  begin
+    induction n with n IH,
+    { reflexivity},
+    { exact ap trunc_index.succ IH}
+  end
+
+  definition sub_one_of_sphere_index (n : ℕ)
+    : of_sphere_index n..-1 = (trunc_index.sub_two n).+1 :=
+  begin
+    induction n with n IH,
+    { reflexivity},
+    { exact ap trunc_index.succ IH}
+  end
 
   definition succ_sub_one (n : ℕ₋₁) : n.+1..-1 = n :> ℕ₋₂ :=
   idp
@@ -180,7 +200,7 @@ definition sphere : ℕ₋₁ → Type₀
 
 namespace sphere
 
-  export [notation] [coercion] sphere_index
+  export [notation] sphere_index
 
   definition base {n : ℕ} : sphere n := north
   definition pointed_sphere [instance] [constructor] (n : ℕ) : pointed (sphere n) :=

--- a/hott/init/funext.hlean
+++ b/hott/init/funext.hlean
@@ -221,15 +221,22 @@ theorem weak_funext_of_ua : weak_funext :=
     from p⁻¹ ▸ tU,
   tlast)
 
--- In the following we will proof function extensionality using the univalence axiom
+-- we have proven function extensionality from the univalence axiom
 definition funext_of_ua : funext :=
   funext_of_weak_funext (@weak_funext_of_ua)
+
+/-
+  We still take funext as an axiom, so that when you write "print axioms foo", you can see whether
+  it uses only function extensionality, and not also univalence.
+-/
+
+axiom function_extensionality : funext
 
 variables {A : Type} {P : A → Type} {f g : Π x, P x}
 
 namespace funext
   theorem is_equiv_apd [instance] (f g : Π x, P x) : is_equiv (@apd10 A P f g) :=
-  funext_of_ua f g
+  function_extensionality f g
 end funext
 
 open funext

--- a/hott/init/path.hlean
+++ b/hott/init/path.hlean
@@ -185,6 +185,18 @@ namespace eq
   definition idp_eq_con {p : x = y} {q : y = x} (r : p⁻¹ = q) : idp = q ⬝ p :=
   by cases p; exact r
 
+  definition eq_idp_of_con_right {p : x = x} {q : x = y} (r : p ⬝ q = q) : p = idp :=
+  by cases q; exact r
+
+  definition eq_idp_of_con_left {p : x = x} {q : y = x} (r : q ⬝ p = q) : p = idp :=
+  by cases q; exact (idp_con p)⁻¹ ⬝ r
+
+  definition idp_eq_of_con_right {p : x = x} {q : x = y} (r : q = p ⬝ q) : idp = p :=
+  by cases q; exact r
+
+  definition idp_eq_of_con_left {p : x = x} {q : y = x} (r : q = q ⬝ p) : idp = p :=
+  by cases q; exact r ⬝ idp_con p
+
   /- Transport -/
 
   definition transport [subst] [reducible] [unfold 5] (P : A → Type) {x y : A} (p : x = y)

--- a/hott/init/ua.hlean
+++ b/hott/init/ua.hlean
@@ -48,6 +48,12 @@ ap to_fun (equiv_of_eq_ua f)
 definition cast_ua {A B : Type} (f : A ≃ B) (a : A) : cast (ua f) a = f a :=
 ap10 (cast_ua_fn f) a
 
+definition cast_ua_inv_fn {A B : Type} (f : A ≃ B) : cast (ua f)⁻¹ = to_inv f :=
+ap to_inv (equiv_of_eq_ua f)
+
+definition cast_ua_inv {A B : Type} (f : A ≃ B) (b : B) : cast (ua f)⁻¹ b = to_inv f b :=
+ap10 (cast_ua_inv_fn f) b
+
 definition ua_equiv_of_eq [reducible] {A B : Type} (p : A = B) : ua (equiv_of_eq p) = p :=
 left_inv equiv_of_eq p
 

--- a/hott/types/eq.hlean
+++ b/hott/types/eq.hlean
@@ -472,9 +472,10 @@ namespace eq
       { exact decode},
       { intro c,
         unfold [encode, decode, decode'],
-        induction p, esimp, rewrite [is_prop_elim_self,▸*,+idp_con], apply tr_eq_of_pathover,
+        induction p, esimp, rewrite [is_prop_elim_self,▸*,+idp_con],
+        apply tr_eq_of_pathover,
         eapply @sigma.rec_on _ _ (λx, x.2 =[(is_prop.elim ⟨x.1, x.2⟩ ⟨a, c⟩)..1] c)
-          (center (sigma code)), -- BUG(?): induction fails
+          (center (sigma code)),
         intro a c, apply eq_pr2},
       { intro q, induction q, esimp, apply con.left_inv, },
     end

--- a/hott/types/int/hott.hlean
+++ b/hott/types/int/hott.hlean
@@ -16,6 +16,8 @@ namespace int
   open algebra
   definition group_integers : Group :=
   Group.mk ℤ (group_of_add_group _)
+
+  notation `gℤ` := group_integers
   end
 
   definition is_equiv_succ [instance] : is_equiv succ :=

--- a/hott/types/pointed.hlean
+++ b/hott/types/pointed.hlean
@@ -31,8 +31,8 @@ namespace pointed
   attribute pType.carrier [coercion]
   variables {A B : Type}
 
-  definition pt [unfold 2] [H : pointed A] := point A
-  definition Point [unfold 1] (A : Type*) := pType.Point A
+  definition pt [reducible] [unfold 2] [H : pointed A] := point A
+  definition Point [reducible] [unfold 1] (A : Type*) := pType.Point A
   abbreviation carrier [unfold 1] (A : Type*) := pType.carrier A
   protected definition Mk [constructor] {A : Type} (a : A) := pType.mk A a
   protected definition MK [constructor] (A : Type) (a : A) := pType.mk A a
@@ -90,12 +90,15 @@ namespace pointed
   definition iterated_ploop_space_succ [unfold_full] (k : ℕ) (A : Type*)
     : Ω[succ k] A = Ω Ω[k] A := rfl
 
-  definition rfln  [constructor] [reducible] {A : Type*} {n : ℕ} : Ω[n] A := pt
-  definition refln [constructor] [reducible] (A : Type*) (n : ℕ) : Ω[n] A := pt
+  definition rfln  [constructor] [reducible] {n : ℕ} {A : Type*} : Ω[n] A := pt
+  definition refln [constructor] [reducible] (n : ℕ) (A : Type*) : Ω[n] A := pt
   definition refln_eq_refl (A : Type*) (n : ℕ) : rfln = rfl :> Ω[succ n] A := rfl
 
   definition iterated_loop_space [unfold 3] (A : Type) [H : pointed A] (n : ℕ) : Type :=
   Ω[n] (pointed.mk' A)
+
+  definition loop_mul {k : ℕ} {A : Type*} (mul : A → A → A) : Ω[k] A → Ω[k] A → Ω[k] A :=
+  begin cases k with k, exact mul, exact concat end
 
   definition pType_eq {A B : Type*} (f : A ≃ B) (p : f pt = pt) : A = B :=
   begin

--- a/hott/types/pointed2.hlean
+++ b/hott/types/pointed2.hlean
@@ -217,6 +217,11 @@ namespace pointed
     { exact loop_pequiv_loop IH}
   end
 
+  definition loopn_pequiv_loopn_con (n : ℕ) (f : A ≃* B) (p q : Ω[n+1] A)
+    : loopn_pequiv_loopn (n+1) f (p ⬝ q) =
+    loopn_pequiv_loopn (n+1) f p ⬝ loopn_pequiv_loopn (n+1) f q :=
+  ap1_con (loopn_pequiv_loopn n f) p q
+
   definition pmap_functor [constructor] {A A' B B' : Type*} (f : A' →* A) (g : B →* B') :
     ppmap A B →* ppmap A' B' :=
   pmap.mk (λh, g ∘* h ∘* f)

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -209,9 +209,8 @@ namespace sigma
   definition sigma_functor [unfold 7] (u : Σa, B a) : Σa', B' a' :=
   ⟨f u.1, g u.1 u.2⟩
 
-  definition total [reducible] [unfold 5] {B' : A → Type} (g : Πa, B a → B' a) (u : Σa, B a)
-    : Σa', B' a' :=
-  sigma_functor id g u
+  definition total [reducible] [unfold 5] {B' : A → Type} (g : Πa, B a → B' a) : (Σa, B a) → (Σa, B' a) :=
+  sigma_functor id g
 
   /- Equivalences -/
   definition is_equiv_sigma_functor [constructor] [H1 : is_equiv f] [H2 : Π a, is_equiv (g a)]

--- a/tests/lean/hott/len_eq.hlean
+++ b/tests/lean/hott/len_eq.hlean
@@ -69,8 +69,8 @@ theorem lem_eq_iff_vector_inj (A : Type) [inh : inhabited A] : lem_eq A ↔ vect
 iff.intro
   (assume Hl : lem_eq A,
    assume n m he,
-   assert a : A, from default A,
-   assert v : vector A n, from const n a,
+   have a : A, from default A,
+   have v : vector A n, from const n a,
    have e₁  : v == cast he v, from heq.symm (cast_heq he v),
    Hl n m v (cast he v) e₁)
   (assume Hr : vector_inj A,


### PR DESCRIPTION
Changes in the library to prove the Freudenthal Suspension Theorem. Currently, the proof is [here](https://github.com/cmu-phil/Spectral/blob/bb5f719cd92b13e16eaf8f3569fbeac0e0977020/homotopy/sec86.hlean#L229-L230).
I will move it to the HoTT library once I finish the stability of the homotopy groups of spheres (currently I have that the homotopy groups are stable as pointed types, but not yet as groups).
