### PR TITLE
Fix emacs info commands in project subdirs

### DIFF
--- a/src/emacs/lean-company.el
+++ b/src/emacs/lean-company.el
@@ -84,8 +84,6 @@
 (defun company-lean--import-candidates (prefix)
   (let* ((cur-dir (f-dirname (buffer-file-name)))
          (parent-dir (f-parent cur-dir))
-         (project-dir (f--traverse-upwards (f-exists? (f-expand ".project" it))
-                                           (f-dirname (buffer-file-name))))
          (candidates
           (cond
            ;; prefix = ".."

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -150,6 +150,7 @@ will be flushed everytime it's executed."
           (pcase (lean-choose-minor-mode-based-on-extension)
             (`standard "--lean")
             (`hott     "--hlean")))
+         (default-directory (or (lean-project-find-root) default-directory))
          (process-args (append `(,process-name
                                  ,process-buffer-name
                                  ,(lean-get-executable lean-executable-name)

--- a/src/emacs/lean-project.el
+++ b/src/emacs/lean-project.el
@@ -11,7 +11,10 @@
   "Project file name")
 
 (defun lean-project-find-root ()
-  (lean-find-file-upward lean-project-file-name))
+  (let ((p (f--traverse-upwards (f-exists? (f-expand lean-project-file-name it))
+                                (f-dirname (buffer-file-name)))))
+    (if p (file-name-as-directory p)
+          nil)))
 
 (defun lean-project-inside-p ()
   (if (lean-project-find-root) t nil))

--- a/src/emacs/lean-server.el
+++ b/src/emacs/lean-server.el
@@ -12,6 +12,7 @@
 (require 'lean-variable)
 (require 'lean-cmd)
 (require 'lean-info)
+(require 'lean-project)
 (require 'lean-util)
 
 ;; Parameters
@@ -175,6 +176,7 @@
   ;; (message "lean-server-create-process")
   (let* ((type (or type (lean-choose-minor-mode-based-on-extension)))
          (process-connection-type nil)
+         (default-directory (or (lean-project-find-root) default-directory))
          (p (apply 'start-process
                    (append (list (lean-server-process-name type)
                                  (lean-server-buffer-name type)

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -127,13 +127,13 @@ static void display_help(std::ostream & out) {
     std::cout << "  --debug=tag       enable assertions with the given tag\n";
         )
     std::cout << "  -D name=value     set a configuration option (see set_option command)\n";
-    std::cout << "  --dir=directory   display information about identifier or token in the given posivition\n";
+    std::cout << "  --dir=directory   base directory for relative imports\n";
     std::cout << "Frontend query interface:\n";
     std::cout << "  --line=value      line number for query\n";
     std::cout << "  --col=value       column number for query\n";
     std::cout << "  --goal            display goal at close to given position\n";
-    std::cout << "  --hole            display type of the \"hole\" in the given posivition\n";
-    std::cout << "  --info            display information about identifier or token in the given posivition\n";
+    std::cout << "  --hole            display type of the \"hole\" in the given position\n";
+    std::cout << "  --info            display information about identifier or token in the given position\n";
     std::cout << "Exporting data:\n";
     std::cout << "  --export=file -E  export final environment as textual low-level file\n";
     std::cout << "  --export-all=file -A  export final environment (and all dependencies) as textual low-level file\n";


### PR DESCRIPTION
The `lean-show-*` commands did not respect the current project for the value of `--dir`, which resulted in empty output.
