### PR TITLE
Structure check

### DIFF
--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -262,6 +262,13 @@ struct structure_cmd_fn {
             } else {
                 if (has_placeholder(m_type))
                     throw_explicit_universe(pos);
+                // Note that if we do infer the result universe, `mk_result_level` will ensure that the
+                // result type cannot be zero when the structure might otherwise eliminate only to zero.
+                if (m_env.impredicative() && !is_zero(sort_level(m_type)) && !is_not_zero(sort_level(m_type)))
+                    throw parser_error("invalid universe polymorphic structure declaration, "
+                                       "the resultant universe is not Prop (i.e., 0), "
+                                       "but it may be Prop for some parameter values "
+                                       "(solution: use 'l+1' or 'max 1 l')", m_p.pos());
             }
         } else {
             if (!m_infer_result_universe)

--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -249,10 +249,9 @@ struct structure_cmd_fn {
             m_type = m_p.parse_expr();
             while (is_annotation(m_type))
                 m_type = get_annotation_arg(m_type);
-            m_inductive_predicate = m_env.impredicative() && is_zero(sort_level(m_type));
             if (!is_sort(m_type))
                 throw parser_error("invalid 'structure', 'Type' expected", pos);
-
+            m_inductive_predicate = m_env.impredicative() && is_zero(sort_level(m_type));
             if (m_inductive_predicate)
                 m_infer_result_universe = false;
 

--- a/tests/lean/bad_structures.lean.expected.out
+++ b/tests/lean/bad_structures.lean.expected.out
@@ -1,2 +1,3 @@
 bad_structures.lean:1:71: error: invalid 'structure', the resultant universe must be provided when explicit universe levels are being used
 bad_structures.lean:4:49: error: invalid 'structure', the resultant universe must be provided when explicit universe levels are being used
+bad_structures.lean:7:60: error: invalid universe polymorphic structure declaration, the resultant universe is not Prop (i.e., 0), but it may be Prop for some parameter values (solution: use 'l+1' or 'max 1 l')

--- a/tests/lean/structure_result_type_may_be_zero.lean
+++ b/tests/lean/structure_result_type_may_be_zero.lean
@@ -1,0 +1,1 @@
+record Fun.{uA uB} (A : Type.{uA}) (B : Type.{uB}) : Type.{imax uA uB} := (item : Π(a : A), B)

--- a/tests/lean/structure_result_type_may_be_zero.lean.expected.out
+++ b/tests/lean/structure_result_type_may_be_zero.lean.expected.out
@@ -1,0 +1,1 @@
+structure_result_type_may_be_zero.lean:1:71: error: invalid universe polymorphic structure declaration, the resultant universe is not Prop (i.e., 0), but it may be Prop for some parameter values (solution: use 'l+1' or 'max 1 l')

--- a/tests/lean/structure_with_index_error.lean
+++ b/tests/lean/structure_with_index_error.lean
@@ -1,0 +1,1 @@
+structure foo : true → Type := (bar : true)

--- a/tests/lean/structure_with_index_error.lean.expected.out
+++ b/tests/lean/structure_with_index_error.lean.expected.out
@@ -1,0 +1,1 @@
+structure_with_index_error.lean:1:14: error: invalid 'structure', 'Type' expected


### PR DESCRIPTION
Note that this pull request simply disallows structures whose result universe is not definitely zero but might be zero, when the environment is impredicative. The check for inductive types that satisfy this property is conservative and rejects if there is a single intro-rule and it takes a (non-parameter) argument. Since the unique intro rule of structures must take at least one argument, the policy in this pull request is not any more conservative than the one for general inductive types.
