### PR TITLE
fix(frontends/lean/inductive_cmd): remove universe placeholder from p…

### DIFF
--- a/src/frontends/lean/inductive_cmd.cpp
+++ b/src/frontends/lean/inductive_cmd.cpp
@@ -702,11 +702,11 @@ struct inductive_cmd_fn {
         unsigned i       = nparams;
         for (inductive_decl & decl : decls) {
             expr type = mlocal_type(to_elab[i]);
-            if (m_infer_result_universe)
-                type = update_result_sort(type, resultant_level);
             bool use_cache = false;
             type = Pi(nparams, to_elab.data(), type, use_cache);
             type = Pi(locals, type, use_cache);
+            if (m_infer_result_universe)
+                type = replace_u(type, resultant_level);
             decl = update_inductive_decl(decl, type);
             i++;
         }

--- a/tests/lean/inductive_cmd_leftover_placeholder_universe.lean
+++ b/tests/lean/inductive_cmd_leftover_placeholder_universe.lean
@@ -1,0 +1,3 @@
+inductive ValueEffect (V : Type) (R : Type → Type) : Type :=
+| Value : V → ValueEffect V R
+| Effect : R (ValueEffect V R) → ValueEffect V R

--- a/tests/lean/inductive_cmd_leftover_placeholder_universe.lean.expected.out
+++ b/tests/lean/inductive_cmd_leftover_placeholder_universe.lean.expected.out
@@ -1,0 +1,1 @@
+inductive_cmd_leftover_placeholder_universe.lean:1:0: error: arg #3 of 'ValueEffect.Effect' contains a non valid occurrence of the datatypes being declared


### PR DESCRIPTION
…arameters

Note that the following less helpful error is triggered for the test file on master:

```
error: invalid reference to undefined global universe level '14.u'
```

The issue is that even though the global universe placeholder starts out only as the resultant level, it may appear elsewhere after unification.
