### PR TITLE
Uniform handling of declaration compound names

### DIFF
--- a/src/frontends/lean/builtin_cmds.cpp
+++ b/src/frontends/lean/builtin_cmds.cpp
@@ -54,10 +54,7 @@ environment section_cmd(parser & p) {
 }
 
 environment namespace_cmd(parser & p) {
-    auto pos = p.pos();
-    name n = p.check_atomic_id_next("invalid namespace declaration, atomic identifier expected");
-    if (is_root_namespace(n))
-        throw parser_error(sstream() << "invalid namespace name, '" << n << "' is reserved", pos);
+    name n = p.check_decl_id_next("invalid namespace declaration, identifier expected");
     p.push_local_scope();
     return push_scope(p.env(), p.ios(), scope_kind::Namespace, n);
 }
@@ -105,7 +102,7 @@ environment end_scoped_cmd(parser & p) {
     list<pair<name, expr>> entries        = p.get_local_entries();
     p.pop_local_scope();
     if (p.curr_is_identifier()) {
-        name n = p.check_atomic_id_next("invalid end of scope, atomic identifier expected");
+        name n = p.check_id_next("invalid end of scope, identifier expected");
         environment env = pop_scope(p.env(), p.ios(), n);
         return redeclare_aliases(env, p, level_entries, entries);
     } else {

--- a/src/frontends/lean/builtin_exprs.cpp
+++ b/src/frontends/lean/builtin_exprs.cpp
@@ -93,7 +93,7 @@ static expr parse_let(parser & p, pos_info const & pos) {
         return parse_let_body(p, pos);
     } else {
         auto id_pos     = p.pos();
-        name id         = p.check_atomic_id_next("invalid let declaration, identifier expected");
+        name id         = p.check_atomic_id_next("invalid let declaration, atomic identifier expected");
         optional<expr> type;
         expr value;
         if (p.curr_is_token(get_assign_tk())) {

--- a/src/frontends/lean/builtin_tactics.cpp
+++ b/src/frontends/lean/builtin_tactics.cpp
@@ -46,7 +46,7 @@ static expr parse_rparen(parser &, unsigned, expr const * args, pos_info const &
 
 static expr parse_let_tactic(parser & p, unsigned, expr const *, pos_info const & pos) {
     auto id_pos     = p.pos();
-    name id    = p.check_atomic_id_next("invalid 'let' tactic, identifier expected");
+    name id    = p.check_atomic_id_next("invalid 'let' tactic, atomic identifier expected");
     p.check_token_next(get_assign_tk(), "invalid 'let' tactic, ':=' expected");
     expr value = p.parse_tactic_expr_arg();
     // Register value as expandable local expr. Identical to let term parsing, but without surrounding mk_let.
@@ -57,7 +57,7 @@ static expr parse_let_tactic(parser & p, unsigned, expr const *, pos_info const 
 }
 
 static expr parse_note_tactic(parser & p, unsigned, expr const *, pos_info const & pos) {
-    name id    = p.check_atomic_id_next("invalid 'note' tactic, identifier expected");
+    name id    = p.check_atomic_id_next("invalid 'note' tactic, atomic identifier expected");
     p.check_token_next(get_assign_tk(), "invalid 'note' tactic, ':=' expected");
     expr value = p.parse_tactic_expr_arg();
     return p.save_pos(mk_note_tactic_expr(id, value), pos);
@@ -76,7 +76,7 @@ static expr parse_generalize_tactic(parser & p, unsigned, expr const *, pos_info
     name id;
     if (p.curr_is_token(get_as_tk())) {
         p.next();
-        id = p.check_atomic_id_next("invalid 'generalize' tactic, identifier expected");
+        id = p.check_atomic_id_next("invalid 'generalize' tactic, atomic identifier expected");
     } else {
         if (is_constant(e))
             id = const_name(e);

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -544,7 +544,7 @@ static void parse_equations_core(parser & p, buffer<expr> const & fns, buffer<ex
         unsigned prev_num_undef_ids = p.get_num_undef_ids();
         buffer<expr> locals;
         {
-            parser::undef_id_to_local_scope scope2(p);
+            parser::local_and_undef_id_to_local_scope scope2(p);
             buffer<expr> lhs_args;
             auto lhs_pos = p.pos();
             if (p.curr_is_token(get_explicit_tk())) {
@@ -677,7 +677,7 @@ expr parse_match(parser & p, unsigned, expr const *, pos_info const & pos) {
             unsigned prev_num_undef_ids = p.get_num_undef_ids();
             buffer<expr> locals;
             {
-                parser::undef_id_to_local_scope scope2(p);
+                parser::local_and_undef_id_to_local_scope scope2(p);
                 auto lhs_pos = p.pos();
                 lhs = p.parse_expr();
                 lhs = p.mk_app(fn, lhs, lhs_pos);

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -83,7 +83,7 @@ typedef std::vector<snapshot> snapshot_vector;
 
 enum class keep_theorem_mode { All, DiscardImported, DiscardAll };
 
-enum class undef_id_behavior { Error, AssumeConstant, AssumeLocal };
+enum class undef_id_behavior { Error, AssumeConstant, AssumeLocal, AssumeLocalAndAlsoDefinedLocals };
 
 class parser {
     environment             m_env;
@@ -491,6 +491,7 @@ public:
     */
     struct undef_id_to_const_scope : public flet<undef_id_behavior> { undef_id_to_const_scope(parser & p); };
     struct undef_id_to_local_scope : public flet<undef_id_behavior> { undef_id_to_local_scope(parser &); };
+    struct local_and_undef_id_to_local_scope : public flet<undef_id_behavior> { local_and_undef_id_to_local_scope(parser &); };
 
     /** \brief Return the size of the stack of undefined local constants */
     unsigned get_num_undef_ids() const { return m_undef_ids.size(); }

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -292,6 +292,7 @@ void pretty_fn::set_options_core(options const & _o) {
     m_numerals        = get_pp_numerals(o);
     m_abbreviations   = get_pp_abbreviations(o);
     m_preterm         = get_pp_preterm(o);
+    m_binder_types    = get_pp_binder_types(o);
     m_hide_full_terms = get_formatter_hide_full_terms(o);
     m_num_nat_coe     = m_numerals && !m_coercion;
 }
@@ -669,8 +670,10 @@ format pretty_fn::pp_binder(expr const & local) {
     if (bi != binder_info())
         r += format(open_binder_string(bi, m_unicode));
     r += format(local_pp_name(local));
-    r += space();
-    r += compose(colon(), nest(m_indent, compose(line(), pp_child(mlocal_type(local), 0).fmt())));
+    if (m_binder_types) {
+        r += space();
+        r += compose(colon(), nest(m_indent, compose(line(), pp_child(mlocal_type(local), 0).fmt())));
+    }
     if (bi != binder_info())
         r += format(close_binder_string(bi, m_unicode));
     return r;
@@ -678,13 +681,17 @@ format pretty_fn::pp_binder(expr const & local) {
 
 format pretty_fn::pp_binder_block(buffer<name> const & names, expr const & type, binder_info const & bi) {
     format r;
-    r += format(open_binder_string(bi, m_unicode));
+    if (m_binder_types || bi != binder_info())
+        r += format(open_binder_string(bi, m_unicode));
     for (name const & n : names) {
         r += format(n);
-        r += space();
     }
-    r += compose(colon(), nest(m_indent, compose(line(), pp_child(type, 0).fmt())));
-    r += format(close_binder_string(bi, m_unicode));
+    if (m_binder_types) {
+        r += space();
+        r += compose(colon(), nest(m_indent, compose(line(), pp_child(type, 0).fmt())));
+    }
+    if (m_binder_types || bi != binder_info())
+        r += format(close_binder_string(bi, m_unicode));
     return group(r);
 }
 

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -70,6 +70,7 @@ private:
     bool                    m_abbreviations;
     bool                    m_hide_full_terms;
     bool                    m_preterm;
+    bool                    m_binder_types;
 
     name mk_metavar_name(name const & m);
     name mk_local_name(name const & n, name const & suggested);

--- a/src/frontends/lean/print_cmd.cpp
+++ b/src/frontends/lean/print_cmd.cpp
@@ -387,7 +387,7 @@ static bool print_constant(parser const & p, char const * kind, declaration cons
         out << "protected ";
     out << kind << " " << to_user_name(p.env(), d.get_name());
     print_attributes(p, d.get_name());
-    out << " : " << d.get_type();
+    out.update_options(out.get_options().update((name {"pp", "binder_types"}), true)) << " : " << d.get_type();
     if (is_def)
         out << " :=";
     out << "\n";

--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -129,7 +129,7 @@ struct structure_cmd_fn {
     /** \brief Parse structure name and (optional) universe parameters */
     void parse_decl_name() {
         m_name_pos = m_p.pos();
-        m_name = m_p.check_atomic_decl_id_next("invalid 'structure', identifier expected");
+        m_name = m_p.check_decl_id_next("invalid 'structure', identifier expected");
         m_name = m_namespace + m_name;
         buffer<name> ls_buffer;
         if (parse_univ_params(m_p, ls_buffer)) {
@@ -937,7 +937,7 @@ struct structure_cmd_fn {
                 m_mk_short = LEAN_DEFAULT_STRUCTURE_INTRO;
                 m_mk_infer = implicit_infer_kind::Implicit;
             } else {
-                m_mk_short = m_p.check_atomic_id_next("invalid 'structure', identifier expected");
+                m_mk_short = m_p.check_atomic_id_next("invalid 'structure', atomic identifier expected");
                 m_mk_infer = parse_implicit_infer_modifier(m_p);
                 if (!m_p.curr_is_command_like())
                     m_p.check_token_next(get_dcolon_tk(), "invalid 'structure', '::' expected");

--- a/src/library/definitional/equations.cpp
+++ b/src/library/definitional/equations.cpp
@@ -353,7 +353,6 @@ class equation_compiler_fn {
     [[ noreturn ]] static void throw_error(sstream const & ss, expr const & src) { throw_generic_exception(ss, src); }
     [[ noreturn ]] static void throw_error(expr const & src, pp_fn const & fn) { throw_generic_exception(src, fn); }
     [[ noreturn ]] void throw_error(sstream const & ss) const { throw_generic_exception(ss, m_meta); }
-    [[ noreturn ]] void throw_error(expr const & src, sstream const & ss) const { throw_generic_exception(ss, src); }
 
     void check_limitations(expr const & eqns) const {
         if (is_wf_equations(eqns) && equations_num_fns(eqns) != 1)
@@ -569,27 +568,19 @@ class equation_compiler_fn {
         validate_exception(expr const & e):m_expr(e) {}
     };
 
-    void check_in_local_ctx(expr const & e, buffer<expr> const & local_ctx) {
-        if (!contains_local(e, local_ctx))
-            throw_error(e, sstream() << "invalid recursive equation, variable '" << e
-                        << "' has the same name of a variable in an outer-scope (solution: rename this variable)");
-    }
-
     // Validate/normalize the given pattern.
     // It stores in reachable_vars any variable that does not occur
     // in inaccessible terms.
-    expr validate_pattern(expr pat, buffer<expr> const & local_ctx, name_set & reachable_vars) {
+    expr validate_pattern(expr pat, name_set & reachable_vars) {
         if (is_inaccessible(pat))
             return pat;
         if (is_local(pat)) {
             reachable_vars.insert(mlocal_name(pat));
-            check_in_local_ctx(pat, local_ctx);
             return pat;
         }
         expr new_pat = whnf(pat);
         if (is_local(new_pat)) {
             reachable_vars.insert(mlocal_name(new_pat));
-            check_in_local_ctx(new_pat, local_ctx);
             return new_pat;
         }
         buffer<expr> pat_args;
@@ -597,7 +588,7 @@ class equation_compiler_fn {
         if (auto in = is_constructor(fn)) {
             unsigned num_params = *inductive::get_num_params(env(), *in);
             for (unsigned i = num_params; i < pat_args.size(); i++)
-                pat_args[i] = validate_pattern(pat_args[i], local_ctx, reachable_vars);
+                pat_args[i] = validate_pattern(pat_args[i], reachable_vars);
             return mk_app(fn, pat_args, pat.get_tag());
         } else {
             throw validate_exception(pat);
@@ -608,10 +599,10 @@ class equation_compiler_fn {
     // The lhs is only used to report errors.
     // It stores in reachable_vars any variable that does not occur
     // in inaccessible terms.
-    void validate_patterns(expr const & lhs, buffer<expr> const & local_ctx, buffer<expr> & patterns, name_set & reachable_vars) {
+    void validate_patterns(expr const & lhs, buffer<expr> & patterns, name_set & reachable_vars) {
         for (expr & pat : patterns) {
             try {
-                pat = validate_pattern(pat, local_ctx, reachable_vars);
+                pat = validate_pattern(pat, reachable_vars);
             } catch (validate_exception & ex) {
                 expr problem_expr = ex.m_expr;
                 throw_error(lhs, [=](formatter const & fmt) {
@@ -649,7 +640,7 @@ class equation_compiler_fn {
             buffer<expr> patterns;
             expr const & fn  = get_app_args(lhs, patterns);
             name_set reachable_vars;
-            validate_patterns(lhs, local_ctx, patterns, reachable_vars);
+            validate_patterns(lhs, patterns, reachable_vars);
             for (expr const & v : local_ctx) {
                 // every variable in the local_ctx must be "reachable".
                 if (!reachable_vars.contains(mlocal_name(v))) {

--- a/src/library/pp_options.cpp
+++ b/src/library/pp_options.cpp
@@ -97,6 +97,7 @@ static name * g_pp_abbreviations   = nullptr;
 static name * g_pp_preterm         = nullptr;
 static name * g_pp_goal_compact    = nullptr;
 static name * g_pp_goal_max_hyps   = nullptr;
+name * g_pp_binder_types    = new name {"pp", "binder_types"};
 static name * g_pp_all             = nullptr;
 static list<options> * g_distinguishing_pp_options = nullptr;
 
@@ -156,6 +157,8 @@ void initialize_pp_options() {
                          "(pretty printer) try to display goal in a single line when possible");
     register_unsigned_option(*g_pp_goal_max_hyps, LEAN_DEFAULT_PP_GOAL_MAX_HYPS,
                              "(pretty printer) maximum number of hypotheses to be displayed");
+    register_bool_option(*g_pp_binder_types, false,
+                         "(pretty printer) display types of lambda and Pi parameters");
     register_bool_option(*g_pp_all, LEAN_DEFAULT_PP_ALL,
                          "(pretty printer) display coercions, implicit parameters, fully qualified names, universes, "
                          "and disable abbreviations, beta reduction and notation during pretty printing");
@@ -223,6 +226,7 @@ bool     get_pp_abbreviations(options const & opts)   { return opts.get_bool(*g_
 bool     get_pp_preterm(options const & opts)         { return opts.get_bool(*g_pp_preterm, LEAN_DEFAULT_PP_PRETERM); }
 bool     get_pp_goal_compact(options const & opts)    { return opts.get_bool(*g_pp_goal_compact, LEAN_DEFAULT_PP_GOAL_COMPACT); }
 unsigned get_pp_goal_max_hyps(options const & opts)   { return opts.get_unsigned(*g_pp_goal_max_hyps, LEAN_DEFAULT_PP_GOAL_MAX_HYPS); }
+bool     get_pp_binder_types(options const & opts)    { return opts.get_bool(*g_pp_binder_types, false); }
 bool     get_pp_all(options const & opts)             { return opts.get_bool(*g_pp_all, LEAN_DEFAULT_PP_ALL); }
 
 list<options> const & get_distinguishing_pp_options() { return *g_distinguishing_pp_options; }

--- a/src/library/pp_options.h
+++ b/src/library/pp_options.h
@@ -37,6 +37,7 @@ bool     get_pp_abbreviations(options const & opts);
 bool     get_pp_preterm(options const & opts);
 bool     get_pp_goal_compact(options const & opts);
 unsigned get_pp_goal_max_hyps(options const & opts);
+bool     get_pp_binder_types(options const & opts);
 bool     get_pp_all(options const & opts);
 list<options> const & get_distinguishing_pp_options();
 

--- a/src/util/memory.cpp
+++ b/src/util/memory.cpp
@@ -193,4 +193,8 @@ void* operator new[](std::size_t sz) throw(std::bad_alloc) { return lean::malloc
 void  operator delete[](void * ptr) throw() { return lean::free(ptr); }
 void* operator new(std::size_t sz, std::nothrow_t const &) noexcept { return lean::malloc(sz, false); }
 void* operator new[](std::size_t sz, std::nothrow_t const &) noexcept { return lean::malloc(sz, false); }
+
+#pragma GCC diagnostic ignored "-Wc++14-compat"
+void operator delete(void * ptr, size_t _size) throw() { return lean::free(ptr); }
+void operator delete[](void * ptr, size_t _size) throw() { return lean::free(ptr); }
 #endif

--- a/tests/lean/bad_namespace.lean
+++ b/tests/lean/bad_namespace.lean
@@ -1,1 +1,0 @@
-namespace _root_

--- a/tests/lean/bad_namespace.lean.expected.out
+++ b/tests/lean/bad_namespace.lean.expected.out
@@ -1,1 +1,0 @@
-bad_namespace.lean:1:10: error: invalid namespace name, '_root_' is reserved

--- a/tests/lean/internal_names.lean
+++ b/tests/lean/internal_names.lean
@@ -3,3 +3,5 @@ definition _foo : nat := 0 -- error
 structure _bla := (a b : nat)
 
 inductive _empty : Type.
+
+namespace _no

--- a/tests/lean/internal_names.lean.expected.out
+++ b/tests/lean/internal_names.lean.expected.out
@@ -1,3 +1,4 @@
 internal_names.lean:1:11: error: invalid declaration name '_foo', identifiers starting with '_' are reserved to the system
 internal_names.lean:3:10: error: invalid declaration name '_bla', identifiers starting with '_' are reserved to the system
 internal_names.lean:5:10: error: invalid declaration name '_empty', identifiers starting with '_' are reserved to the system
+internal_names.lean:7:10: error: invalid declaration name '_no', identifiers starting with '_' are reserved to the system

--- a/tests/lean/run/ns2.lean
+++ b/tests/lean/run/ns2.lean
@@ -27,3 +27,8 @@ namespace vvv
 end vvv
 end bla
 check bla.vvv.my.empty
+
+namespace foo.bla
+  structure vvv.xyz := mk
+end foo.bla
+check foo.bla.vvv.xyz.mk

--- a/tests/lean/shadow.lean
+++ b/tests/lean/shadow.lean
@@ -1,8 +1,0 @@
-open nat
-
-variable a : nat
-
--- The variable 'a' in the following definition is not the variable 'a' above
-definition tadd : nat → nat → nat
-| tadd zero     b := b
-| tadd (succ a) b := succ (tadd a b)

--- a/tests/lean/shadow.lean.expected.out
+++ b/tests/lean/shadow.lean.expected.out
@@ -1,1 +1,0 @@
-shadow.lean:8:13: error: invalid recursive equation, variable 'a' has the same name of a variable in an outer-scope (solution: rename this variable)

--- a/tests/lean/t3.lean
+++ b/tests/lean/t3.lean
@@ -23,8 +23,6 @@ namespace tst
   end foo
 end tst
 print raw Type.{tst.foo.U}
-namespace tst.foo    -- Error: we cannot use qualified names in declarations
-universe full.name.U -- Error: we cannot use qualified names in declarations
 namespace tst
   namespace foo
     print raw Type.{v}  -- Remark: alias 'v' for 'tst.v' is available again

--- a/tests/lean/t3.lean.expected.out
+++ b/tests/lean/t3.lean.expected.out
@@ -9,8 +9,7 @@ t3.lean:16:2: error: invalid namespace declaration, a namespace cannot be declar
 Type
 Type
 Type
-t3.lean:26:10: error: invalid namespace declaration, atomic identifier expected
 Type
 Type
-t3.lean:35:2: error: universe level alias 'u' shadows existing global universe level
-t3.lean:37:16: error: unknown universe 'bla.u'
+t3.lean:33:2: error: universe level alias 'u' shadows existing global universe level
+t3.lean:35:16: error: unknown universe 'bla.u'


### PR DESCRIPTION
- allow compound names in `namespace` and `structure`
- adjust error messages

---

It seems that `inductive` can have a compound name, while `structure`s can't, which complicates auto-generating them. As far as I can see, there is no technical reason for this restriction, so now all declarations allow compound names (except for nested declarations like fields).

A quick grep over the libraries only found two instances in the old group theory library where nested namespace declarations could be merged.
