### PR TITLE
[WIP] Automatically add [unfold] hints to equations definitions

### DIFF
--- a/hott/homotopy/LES_of_homotopy_groups.hlean
+++ b/hott/homotopy/LES_of_homotopy_groups.hlean
@@ -515,7 +515,7 @@ namespace chain_complex
   definition str_of_nat {n : ℕ} : ℕ → ℕ × fin (succ n) :=
   λm, (m / (succ n), mk_mod n m)
 
-  definition nat_of_str_3S [unfold 2] [reducible]
+  definition nat_of_str_3S [reducible]
     : Π(x : stratified +ℕ 2), nat_of_str x + 1 = nat_of_str (@S (stratified +ℕ 2) x)
   | (n, fin.mk 0 H) := by reflexivity
   | (n, fin.mk 1 H) := by reflexivity

--- a/hott/types/fin.hlean
+++ b/hott/types/fin.hlean
@@ -315,7 +315,7 @@ end
 definition mk_pred (i : nat) (h : succ i < succ n) : fin n :=
 mk i (lt_of_succ_lt_succ h)
 
-definition succ : fin n → fin (succ n)
+definition succ [unfold] : fin n → fin (succ n)
 | (mk v h) := mk (nat.succ v) (succ_lt_succ h)
 
 lemma val_succ : Π (i : fin n), val (succ i) = nat.succ (val i)

--- a/hott/types/lift.hlean
+++ b/hott/types/lift.hlean
@@ -17,10 +17,10 @@ namespace lift
   protected definition eta : up (down z) = z :=
   by induction z; reflexivity
 
-  protected definition code [unfold 2 3] : lift A → lift A → Type
+  protected definition code : lift A → lift A → Type
   | code (up a) (up a') := a = a'
 
-  protected definition decode [unfold 2 3] : Π(z z' : lift A), lift.code z z' → z = z'
+  protected definition decode : Π(z z' : lift A), lift.code z z' → z = z'
   | decode (up a) (up a') := λc, ap up c
 
   variables {z z'}
@@ -51,7 +51,7 @@ namespace lift
   end
 
   variables {A' : Type} (f : A → A') (g : lift A → lift A')
-  definition lift_functor [unfold 4] : lift A → lift A'
+  definition lift_functor : lift A → lift A'
   | lift_functor (up a) := up (f a)
 
   definition is_equiv_lift_functor [constructor] [Hf : is_equiv f] : is_equiv (lift_functor f) :=

--- a/hott/types/list.hlean
+++ b/hott/types/list.hlean
@@ -193,7 +193,7 @@ calc
 
 theorem length_reverse : ∀ (l : list T), length (reverse l) = length l
 | []      := rfl
-| (x::xs) := begin unfold reverse, rewrite [length_concat, length_cons, length_reverse] end
+| (x::xs) := begin unfold reverse, rewrite [length_concat, length_reverse] end
 
 /- head and tail -/
 

--- a/hott/types/nat/hott.hlean
+++ b/hott/types/nat/hott.hlean
@@ -82,13 +82,13 @@ namespace nat
       { exfalso, apply lt.irrefl, apply lt_of_le_of_lt H H'}}
   end
 
-  protected definition code [reducible] [unfold 1 2] : ℕ → ℕ → Type₀
+  protected definition code [reducible] : ℕ → ℕ → Type₀
   | code 0        0        := unit
   | code 0        (succ m) := empty
   | code (succ n) 0        := empty
   | code (succ n) (succ m) := code n m
 
-  protected definition refl : Πn, nat.code n n
+  protected definition refl [unfold] : Πn, nat.code n n
   | refl 0        := star
   | refl (succ n) := refl n
 

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -20,7 +20,7 @@ namespace sigma
 
   /- Paths in a sigma-type -/
 
-  protected definition eta [unfold 3] : Π (u : Σa, B a), ⟨u.1 , u.2⟩ = u
+  protected definition eta : Π (u : Σa, B a), ⟨u.1 , u.2⟩ = u
   | eta ⟨u₁, u₂⟩ := idp
 
   definition eta2 : Π (u : Σa b, C a b), ⟨u.1, u.2.1, u.2.2⟩ = u
@@ -73,7 +73,7 @@ namespace sigma
 
   /- the uncurried version of sigma_eq. We will prove that this is an equivalence -/
 
-  definition sigma_eq_unc [unfold 5] : Π (pq : Σ(p : u.1 = v.1), u.2 =[p] v.2), u = v
+  definition sigma_eq_unc : Π (pq : Σ(p : u.1 = v.1), u.2 =[p] v.2), u = v
   | sigma_eq_unc ⟨pq₁, pq₂⟩ := sigma_eq pq₁ pq₂
 
   definition dpair_sigma_eq_unc : Π (pq : Σ(p : u.1 = v.1), u.2 =[p] v.2),

--- a/hott/types/sum.hlean
+++ b/hott/types/sum.hlean
@@ -17,12 +17,12 @@ namespace sum
   protected definition eta : sum.rec inl inr z = z :=
   by induction z; all_goals reflexivity
 
-  protected definition code [unfold 3 4] : A + B → A + B → Type.{max u v}
+  protected definition code : A + B → A + B → Type.{max u v}
   | code (inl a) (inl a') := lift (a = a')
   | code (inr b) (inr b') := lift (b = b')
   | code _       _        := lift empty
 
-  protected definition decode [unfold 3 4] : Π(z z' : A + B), sum.code z z' → z = z'
+  protected definition decode : Π(z z' : A + B), sum.code z z' → z = z'
   | decode (inl a) (inl a') := λc, ap inl (down c)
   | decode (inl a) (inr b') := λc, empty.elim (down c) _
   | decode (inr b) (inl a') := λc, empty.elim (down c) _
@@ -110,7 +110,7 @@ namespace sum
   /- Functorial action -/
 
   variables {A' B' : Type} (f : A → A') (g : B → B')
-  definition sum_functor [unfold 7] : A + B → A' + B'
+  definition sum_functor : A + B → A' + B'
   | sum_functor (inl a) := inl (f a)
   | sum_functor (inr b) := inr (g b)
 
@@ -142,7 +142,7 @@ namespace sum
   definition sum_equiv_sum_right [constructor] (f : A ≃ A') : A + B ≃ A' + B :=
   sum_equiv_sum f equiv.rfl
 
-  definition flip [unfold 3] : A + B → B + A
+  definition flip : A + B → B + A
   | flip (inl a) := inr a
   | flip (inr b) := inl b
 

--- a/library/data/bag.lean
+++ b/library/data/bag.lean
@@ -267,7 +267,7 @@ private definition max_count (l₁ l₂ : list A) : list A → list A
 | []     := []
 | (a::l) := if list.count a l₁ ≥ list.count a l₂ then gen (list.count a l₁) a ++ max_count l else gen (list.count a l₂) a ++ max_count l
 
-private definition min_count (l₁ l₂ : list A) : list A → list A
+private definition min_count [unfold] (l₁ l₂ : list A) : list A → list A
 | []     := []
 | (a::l) := if list.count a l₁ ≤ list.count a l₂ then gen (list.count a l₁) a ++ min_count l else gen (list.count a l₂) a ++ min_count l
 
@@ -391,14 +391,14 @@ perm.induction_on h
   (λ x y l l₁ l₂, by_cases
     (suppose i₁ : list.count x l₁ ≥ list.count x l₂, by_cases
       (suppose i₂ : list.count y l₁ ≥ list.count y l₂,
-        begin unfold max_count, unfold max_count, rewrite [*if_pos i₁, *if_pos i₂], apply perm_app_left_comm end)
+        begin unfold max_count, rewrite [*if_pos i₁, *if_pos i₂], apply perm_app_left_comm end)
       (suppose i₂ : ¬ list.count y l₁ ≥ list.count y l₂,
-        begin unfold max_count, unfold max_count, rewrite [*if_pos i₁, *if_neg i₂], apply perm_app_left_comm end))
+        begin unfold max_count, rewrite [*if_pos i₁, *if_neg i₂], apply perm_app_left_comm end))
     (suppose i₁ : ¬ list.count x l₁ ≥ list.count x l₂, by_cases
       (suppose i₂ : list.count y l₁ ≥ list.count y l₂,
-        begin unfold max_count, unfold max_count, rewrite [*if_neg i₁, *if_pos i₂], apply perm_app_left_comm end)
+        begin unfold max_count, rewrite [*if_neg i₁, *if_pos i₂], apply perm_app_left_comm end)
       (suppose i₂ : ¬ list.count y l₁ ≥ list.count y l₂,
-        begin unfold max_count, unfold max_count, rewrite [*if_neg i₁, *if_neg i₂], apply perm_app_left_comm end)))
+        begin unfold max_count, rewrite [*if_neg i₁, *if_neg i₂], apply perm_app_left_comm end)))
   (λ s₁ s₂ s₃ p₁ p₂ ih₁ ih₂ l₁ l₂, perm.trans (ih₁ l₁ l₂) (ih₂ l₁ l₂))
 
 private lemma perm_max_count {l₁ l₂ l₃ r₁ r₂ r₃ : list A} (p₁ : l₁ ~ r₁) (p₂ : l₂ ~ r₂) (p₃ : l₃ ~ r₃) : max_count l₁ l₂ l₃ ~ max_count r₁ r₂ r₃ :=

--- a/library/data/finset/comb.lean
+++ b/library/data/finset/comb.lean
@@ -414,7 +414,7 @@ theorem list_powerset_eq_list_powerset_of_perm {l₁ l₂ : list A} (p : l₁ ~ 
 perm.induction_on p
   rfl
   (λ x l₁ l₂ p ih, by rewrite [↑list_powerset, ih])
-  (λ x y l, by rewrite [↑list_powerset, ↑list_powerset, *image_union, image_insert_comm,
+  (λ x y l, by rewrite [↑list_powerset, *image_union, image_insert_comm,
                         *union_assoc, union_left_comm (finset.image (finset.insert x) _)])
   (λ l₁ l₂ l₃ p₁ p₂ r₁ r₂, eq.trans r₁ r₂)
 

--- a/library/data/list/set.lean
+++ b/library/data/list/set.lean
@@ -450,7 +450,7 @@ lemma dmap_nodup_of_dinj {p : A → Prop} [h : decidable_pred p] {f : Π a, p a 
 end nodup
 
 /- upto -/
-definition upto : nat → list nat
+definition upto [unfold] : nat → list nat
 | 0     := []
 | (n+1) := n :: upto n
 

--- a/library/data/nat/examples/fib.lean
+++ b/library/data/nat/examples/fib.lean
@@ -11,7 +11,7 @@ definition fib : nat → nat
 | 1     := 1
 | (n+2) := fib (n+1) + fib n
 
-private definition fib_fast_aux : nat → (nat × nat)
+private definition fib_fast_aux [unfold] : nat → (nat × nat)
 | 0     := (0, 1)
 | 1     := (1, 1)
 | (n+2) :=

--- a/library/theories/finite_group_theory/cyclic.lean
+++ b/library/theories/finite_group_theory/cyclic.lean
@@ -292,7 +292,7 @@ lemma rotl_rotr : ∀ {n : nat} (m : nat), (@rotl n m) ∘ (rotr m) = id
 | (nat.succ n) := take m, funext take i, calc (mk_mod n (n*m)) + (-(mk_mod n (n*m)) + i) = i : add_neg_cancel_left
 
 lemma rotl_succ {n : nat} : (rotl 1) ∘ (@succ n) = lift_succ :=
-funext (take i, eq_of_veq (begin rewrite [↑comp, ↑rotl, ↑madd, mul_one n, ↑mk_mod, mod_add_mod, ↑lift_succ, val_succ, -succ_add_eq_succ_add, add_mod_self_left, mod_eq_of_lt (lt.trans (is_lt i) !lt_succ_self), -val_lift] end))
+funext (take i, eq_of_veq (begin rewrite [↑comp, ↑madd, mul_one n, ↑mk_mod, mod_add_mod, ↑lift_succ, val_succ, -succ_add_eq_succ_add, add_mod_self_left, mod_eq_of_lt (lt.trans (is_lt i) !lt_succ_self), -val_lift] end))
 
 definition list.rotl {A : Type} : ∀ l : list A, list A
 | []     := []

--- a/library/theories/finite_group_theory/pgroup.lean
+++ b/library/theories/finite_group_theory/pgroup.lean
@@ -255,6 +255,8 @@ funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, ↑rotl_perm, rotl_seq
 lemma rotl_peo_seq_id {n : nat} : rotl_peo_seq A n (succ n) = id :=
 funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, -rotl_perm_pow_eq, rotl_perm_pow_eq_one] end
 
+local attribute rotl [unfold]
+
 lemma rotl_peo_seq_compose {n i j : nat} :
   (rotl_peo_seq A n i) ∘ (rotl_peo_seq A n j) = rotl_peo_seq A n (j + i) :=
 funext take s, subtype.eq begin rewrite [↑rotl_peo_seq, ↑rotl_perm, ↑rotl_fun, comp.assoc, rotl_compose] end

--- a/library/theories/measure_theory/extended_real.lean
+++ b/library/theories/measure_theory/extended_real.lean
@@ -175,7 +175,7 @@ theorem neg_mul_infty {x : real} (H : x < 0) : x * ∞ = -∞ :=
 by rewrite [ereal.mul_comm, infty_mul_neg H]
 
 private theorem infty_mul_zero : ∞ * 0 = 0 :=
-by rewrite [*ereal.mul_def, ↑ereal.mul, ereal.zero_def, ↑blow_up, if_pos rfl]
+by rewrite [*ereal.mul_def, ↑ereal.mul, ereal.zero_def, if_pos rfl]
 
 private theorem zero_mul_infty : 0 * ∞ = 0 :=
 by rewrite [ereal.mul_comm, infty_mul_zero]
@@ -225,11 +225,11 @@ by rewrite [ereal.mul_comm, ereal.mul_zero]
 private theorem aux3 : ∀ u, ∞ * (∞ * u) = ∞ * u
 | ∞           := rfl
 | (of_real x) := if H : x = 0 then
-                   by rewrite [*ereal.mul_def, ↑ereal.mul, ↑blow_up, *H, *if_pos rfl]
+                   by rewrite [*ereal.mul_def, ↑ereal.mul, *H, *if_pos rfl]
                  else if H1 : x > 0 then
-                   by rewrite [*ereal.mul_def, ↑ereal.mul, ↑blow_up, if_neg H, if_pos H1]
+                   by rewrite [*ereal.mul_def, ↑ereal.mul, if_neg H, if_pos H1]
                  else
-                   by rewrite [*ereal.mul_def, ↑ereal.mul, ↑blow_up, if_neg H, if_neg H1]
+                   by rewrite [*ereal.mul_def, ↑ereal.mul, if_neg H, if_neg H1]
 | -∞          := rfl
 
 private theorem aux4 (x y : real) : ∞ * x * y = ∞ * (x * y) :=

--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -82,13 +82,11 @@ void decl_attributes::parse(parser & p) {
                         break;
                     case attribute_kind::MultiParametric: {
                         buffer<unsigned> vs;
-                        while (true) {
+                        while (!p.curr_is_token(get_rbracket_tk())) {
                             unsigned v = p.parse_small_nat();
                             if (v == 0)
                                 throw parser_error("invalid attribute parameter, value must be positive", pos);
                             vs.push_back(v-1);
-                            if (p.curr_is_token(get_rbracket_tk()))
-                                break;
                         }
                         p.next();
                         m_entries = cons(entry(attr, to_list(vs)), m_entries);

--- a/src/library/normalize.cpp
+++ b/src/library/normalize.cpp
@@ -112,14 +112,6 @@ struct unfold_hint_config {
 template class scoped_ext<unfold_hint_config>;
 typedef scoped_ext<unfold_hint_config> unfold_hint_ext;
 
-environment add_unfold_hint(environment const & env, name const & n, list<unsigned> const & idxs, name const & ns, bool persistent) {
-    lean_assert(idxs);
-    declaration const & d = env.get(n);
-    if (!d.is_definition())
-        throw exception("invalid [unfold] hint, declaration must be a non-opaque definition");
-    return unfold_hint_ext::add_entry(env, get_dummy_ios(), mk_add_unfold_entry(n, idxs), ns, persistent);
-}
-
 list<unsigned> has_unfold_hint(environment const & env, name const & d) {
     unfold_hint_state const & s = unfold_hint_ext::get_state(env);
     if (auto it = s.m_unfold.find(d))
@@ -130,6 +122,15 @@ list<unsigned> has_unfold_hint(environment const & env, name const & d) {
 
 environment erase_unfold_hint(environment const & env, name const & n, name const & ns, bool persistent) {
     return unfold_hint_ext::add_entry(env, get_dummy_ios(), mk_erase_unfold_entry(n), ns, persistent);
+}
+
+environment add_unfold_hint(environment const & env, name const & n, list<unsigned> const & idxs, name const & ns, bool persistent) {
+    if (!idxs)
+        return erase_unfold_hint(env, n, ns, persistent);
+    declaration const & d = env.get(n);
+    if (!d.is_definition())
+        throw exception("invalid [unfold] hint, declaration must be a non-opaque definition");
+    return unfold_hint_ext::add_entry(env, get_dummy_ios(), mk_add_unfold_entry(n, idxs), ns, persistent);
 }
 
 environment add_unfold_full_hint(environment const & env, name const & n, name const & ns, bool persistent) {


### PR DESCRIPTION
This is a preliminary implementation of https://github.com/leanprover/lean/issues/694#issuecomment-220469553. It applies `[unfold ...]` to any definition that is non-mutually defined by pattern matching. It can handle implicit arguments in the pattern and section variables.

Some observations:
- The attribute is applied to 187 definitions in the stdlib.
- I was able to remove 11 manual applications of the attribute (all in `hott/`, I guess the attribute isn't used widely yet) and some explicit unfold steps in proofs.
- There were 2 'false positives' where the attribute complicated proofs. I modified the parser so that `[unfold]` without arguments would be accepted and remove the unfold hint (which may not be the most readable solution).
- I applied the parameter-less `[unfold]` to 4 more recursive definitions because, unlike with an explicit unfold step, the recursive occurences weren't folded back. @leodemoura might this be something easy to change?
