### PR TITLE
Compute correct flycheck message width

### DIFF
--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -108,4 +108,15 @@
      ;; In worst case, just use the same width of current window
      (t body-width))))
 
+(defun lean-flycheck-error-list-message-width ()
+  "Return the width of error messages in the flycheck-error list buffer"
+  (let (;; assume 'Message' is last column and has size 0 (true for default config)
+        (other-columns-width (apply '+ (mapcar (apply-partially 'nth 1) flycheck-error-list-format)))
+        (margin (length flycheck-error-list-format)))
+    (cond
+     ;; If lean-flycheck-msg-width is set, use it
+     (lean-flycheck-msg-width
+      lean-flycheck-msg-width)
+     (t (- (lean-flycheck-error-list-buffer-width) other-columns-width margin)))))
+
 (provide 'lean-flycheck)

--- a/src/emacs/lean-option.el
+++ b/src/emacs/lean-option.el
@@ -35,7 +35,7 @@
            (setq option-alist
                  (lean-update-option-alist option-alist
                                            "pp.width"
-                                           (lean-flycheck-error-list-buffer-width))))
+                                           (lean-flycheck-error-list-message-width))))
           ((not pp-width-entry)
            (setq option-alist
                  (lean-update-option-alist option-alist


### PR DESCRIPTION
Subtracts the widths of all other columns from the buffer width. Somewhat relatedly, we might want to hide that unused 'ID' column.

I begin to regret never having learned Lisp.
