### PR TITLE
fix(builtin_cmds): metavar_args should be false by default

### DIFF
--- a/src/frontends/lean/builtin_cmds.cpp
+++ b/src/frontends/lean/builtin_cmds.cpp
@@ -118,7 +118,7 @@ environment check_cmd(parser & p) {
     auto tc = mk_type_checker(p.env());
     expr type = tc->check(e, ls).first;
     options opts          = p.ios().get_options();
-    opts                  = opts.update_if_undef(get_pp_metavar_args_name(), true);
+    opts                  = opts.update_if_undef(get_pp_metavar_args_name(), false);
     io_state new_ios(p.ios(), opts);
     auto out              = regular(p.env(), new_ios, tc->get_type_context());
     formatter fmt         = out.get_formatter();

--- a/tests/lean/check.lean
+++ b/tests/lean/check.lean
@@ -1,5 +1,5 @@
 import logic
-
+set_option pp.metavar_args true
 check and.intro
 check or.elim
 check eq

--- a/tests/lean/check2.lean
+++ b/tests/lean/check2.lean
@@ -1,3 +1,3 @@
 import logic
-
+set_option pp.metavar_args true
 check eq.rec_on

--- a/tests/lean/ppbug.lean
+++ b/tests/lean/ppbug.lean
@@ -1,1 +1,2 @@
+set_option pp.metavar_args true
 check char.rec_on

--- a/tests/lean/protected_test.lean
+++ b/tests/lean/protected_test.lean
@@ -1,3 +1,4 @@
+set_option pp.metavar_args true
 namespace nat
   check induction_on      -- ERROR
   check rec_on            -- ERROR

--- a/tests/lean/protected_test.lean.expected.out
+++ b/tests/lean/protected_test.lean.expected.out
@@ -1,7 +1,7 @@
-protected_test.lean:2:8: error: unknown identifier 'induction_on'
-protected_test.lean:3:8: error: unknown identifier 'rec_on'
+protected_test.lean:3:8: error: unknown identifier 'induction_on'
+protected_test.lean:4:8: error: unknown identifier 'rec_on'
 nat.induction_on : ∀ n, ?C 0 → (∀ a, ?C a → ?C (succ a)) → ?C n
 le.rec_on : le ?a ?a_1 → ?C ?a → (∀ {b}, le ?a b → ?C b → ?C (succ b)) → ?C ?a_1
 le.rec_on : le ?a ?a_1 → ?C ?a → (∀ {b}, le ?a b → ?C b → ?C (succ b)) → ?C ?a_1
-protected_test.lean:8:10: error: unknown identifier 'rec_on'
+protected_test.lean:9:10: error: unknown identifier 'rec_on'
 le.rec_on : le ?a ?a_1 → ?C ?a → (∀ {b}, le ?a b → ?C b → ?C (succ b)) → ?C ?a_1

--- a/tests/lean/sec_param_pp2.lean.expected.out
+++ b/tests/lean/sec_param_pp2.lean.expected.out
@@ -1,4 +1,4 @@
 id2 : (A → B → A) → A
 id2 : (A → B → A) → A
-id2 : ?B a → (A → ?B a → A) → A
+id2 : ?B → (A → ?B → A) → A
 id2 : ?A → (Π {B}, B → (?A → B → ?A) → ?A)


### PR DESCRIPTION
fixes #1067.

When fixing the tests, I noticed one behaviour which was different than I expected. When the option `pp.metavar_args` is `false` _all_ arguments of metavariables are hidden, even the ones I expect to see (if the metavariable is a function applied to some argument). Example:

``` lean
variable (toto : Type)
set_option pp.metavar_args true
check nat.induction_on
set_option pp.metavar_args false
check nat.induction_on
```

Produced output:

``` lean
nat.induction_on : ∀ n, ?C toto 0 → (∀ a, ?C toto a → ?C toto (nat.succ a)) → ?C toto n
nat.induction_on : ∀ n, ?C → (∀ a, ?C → ?C) → ?C
```

Expected output

``` lean
nat.induction_on : ∀ n, ?C toto 0 → (∀ a, ?C toto a → ?C toto (nat.succ a)) → ?C toto n
nat.induction_on : ∀ n, ?C 0 → (∀ a, ?C a → ?C (nat.succ a)) → ?C n
```

(the full type of `nat.induction_on` is `∀ {C : ℕ → Prop} (n : ℕ), C 0 → (∀ (a : ℕ), C a → C (nat.succ a)) → C n`)
