### PR TITLE
Allow shadowing variables in patterns

### DIFF
--- a/library/theories/finite_group_theory/cyclic.lean
+++ b/library/theories/finite_group_theory/cyclic.lean
@@ -258,8 +258,8 @@ definition rotl : ∀ {n : nat} m : nat, fin n → fin n
 | (succ n) := take m, madd (mk_mod n (n*m))
 
 definition rotr : ∀ {n : nat} m : nat, fin n → fin n
-| (0:nat)      := take m i, elim0 i
-| (nat.succ n) := take m, madd (-(mk_mod n (n*m)))
+| 0        := take m i, elim0 i
+| (succ n) := take m, madd (-(mk_mod n (n*m)))
 
 lemma rotl_succ' {n m : nat} : rotl m = madd (mk_mod n (n*m)) := rfl
 

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -441,13 +441,8 @@ static bool is_curr_with_or_comma_or_bar(parser & p) {
 }
 
 /**
-   For convenience, the left-hand-side of a recursive equation may contain
-   undeclared variables.
-   We use parser::undef_id_to_local_scope to force the parser to create a local constant for
-   each undefined identifier.
-
-   This method validates occurrences of these variables. They can only occur as an application
-   or macro argument.
+   This method validates occurrences of local variables (i.e., variables bound in the pattern).
+   They can only occur as an application or macro argument.
 */
 static void validate_equation_lhs(parser const & p, expr const & lhs, buffer<expr> const & locals) {
     if (is_app(lhs)) {

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -542,42 +542,45 @@ static void parse_equations_core(parser & p, buffer<expr> const & fns, buffer<ex
     while (true) {
         expr lhs;
         unsigned prev_num_undef_ids = p.get_num_undef_ids();
-        buffer<expr> locals;
-        {
-            parser::undef_id_to_local_scope scope2(p);
-            buffer<expr> lhs_args;
-            auto lhs_pos = p.pos();
-            if (p.curr_is_token(get_explicit_tk())) {
-                p.next();
-                name fn_name = p.check_decl_id_next("invalid recursive equation, identifier expected");
-                lhs_args.push_back(p.save_pos(mk_explicit(get_equation_fn(fns, fn_name, lhs_pos)), lhs_pos));
-            } else {
-                expr first = p.parse_expr(get_max_prec());
-                expr fn    = first;
-                if (is_explicit(fn))
-                    fn = get_explicit_arg(fn);
-                if (is_local(fn) && is_equation_fn(fns, local_pp_name(fn))) {
-                    lhs_args.push_back(first);
-                } else if (fns.size() == 1) {
-                    lhs_args.push_back(p.save_pos(mk_explicit(fns[0]), lhs_pos));
-                    lhs_args.push_back(first);
-                } else {
-                    throw parser_error("invalid recursive equation, head symbol in left-hand-side is not a constant",
-                                       lhs_pos);
-                }
-            }
-            while (!p.curr_is_token(get_assign_tk()))
-                lhs_args.push_back(p.parse_expr(get_max_prec()));
-            lean_assert(lhs_args.size() > 0);
-            lhs = lhs_args[0];
-            for (unsigned i = 1; i < lhs_args.size(); i++)
-                lhs = copy_tag(lhs_args[i], mk_app(lhs, lhs_args[i]));
+        buffer<expr> lhs_args;
 
-            unsigned num_undef_ids = p.get_num_undef_ids();
-            for (unsigned i = prev_num_undef_ids; i < num_undef_ids; i++) {
-                locals.push_back(p.get_undef_id(i));
+        // check if lhs starts with an (explicit) equation function symbol (which is optional for fns.size() == 1)
+        optional<expr> fn;
+        auto lhs_pos = p.pos();
+        if (p.curr_is_token(get_explicit_tk())) {
+            p.next();
+            name fn_name = p.check_decl_id_next("invalid recursive equation, identifier expected");
+            lhs_args.push_back(p.save_pos(mk_explicit(get_equation_fn(fns, fn_name, lhs_pos)), lhs_pos));
+        } else if (p.curr_is_identifier() && (fn = is_equation_fn(fns, p.get_name_val()))) {
+            p.next();
+            lhs_args.push_back(p.save_pos(*fn, lhs_pos));
+        } else {
+            if (fns.size() == 1) {
+                lhs_args.push_back(p.save_pos(mk_explicit(fns[0]), lhs_pos));
+            } else {
+                throw parser_error("invalid recursive equation, head symbol in left-hand-side is not an equation function",
+                                   lhs_pos);
             }
         }
+
+        // parse the remaining left-hand side
+        {
+            parser::local_and_undef_id_to_local_scope scope2(p);
+            while (!p.curr_is_token(get_assign_tk()))
+                lhs_args.push_back(p.parse_expr(get_max_prec()));
+        }
+
+        lean_assert(lhs_args.size() > 0);
+        lhs = lhs_args[0];
+        for (unsigned i = 1; i < lhs_args.size(); i++)
+            lhs = copy_tag(lhs_args[i], mk_app(lhs, lhs_args[i]));
+
+        buffer<expr> locals;
+        unsigned num_undef_ids = p.get_num_undef_ids();
+        for (unsigned i = prev_num_undef_ids; i < num_undef_ids; i++) {
+            locals.push_back(p.get_undef_id(i));
+        }
+
         validate_equation_lhs(p, lhs, locals);
         lhs = merge_equation_lhs_vars(lhs, locals);
         auto assign_pos = p.pos();
@@ -677,7 +680,7 @@ expr parse_match(parser & p, unsigned, expr const *, pos_info const & pos) {
             unsigned prev_num_undef_ids = p.get_num_undef_ids();
             buffer<expr> locals;
             {
-                parser::undef_id_to_local_scope scope2(p);
+                parser::local_and_undef_id_to_local_scope scope2(p);
                 auto lhs_pos = p.pos();
                 lhs = p.parse_expr();
                 lhs = p.mk_app(fn, lhs, lhs_pos);

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -18,6 +18,7 @@ Author: Leonardo de Moura
 #include "kernel/replace_fn.h"
 #include "kernel/abstract.h"
 #include "kernel/instantiate.h"
+#include "kernel/inductive/inductive.h"
 #include "kernel/error_msgs.h"
 #include "library/trace.h"
 #include "library/parser_nested_exception.h"
@@ -108,7 +109,7 @@ parser::undef_id_to_const_scope::undef_id_to_const_scope(parser & p):
 parser::undef_id_to_local_scope::undef_id_to_local_scope(parser & p):
     flet<undef_id_behavior>(p.m_undef_id_behavior, undef_id_behavior::AssumeLocal) {}
 parser::local_and_undef_id_to_local_scope::local_and_undef_id_to_local_scope(parser & p):
-    flet<undef_id_behavior>(p.m_undef_id_behavior, undef_id_behavior::AssumeLocalAndAlsoDefinedLocals) {}
+    flet<undef_id_behavior>(p.m_undef_id_behavior, undef_id_behavior::AssumeLocalAndAlsoDefinedNonConstructors) {}
 
 static name * g_tmp_prefix = nullptr;
 
@@ -1459,6 +1460,13 @@ expr parser::parse_led_notation(expr left) {
     }
 }
 
+expr parser::mk_placeholder_local(name const & id, pos_info const & p) {
+    expr local = mk_local(id, mk_expr_placeholder());
+    m_undef_ids.push_back(local);
+    save_identifier_info(p, local_pp_name(local));
+    return save_pos(local, p);
+}
+
 expr parser::id_to_expr(name const & id, pos_info const & p) {
     buffer<level> lvl_buffer;
     levels ls;
@@ -1476,11 +1484,8 @@ expr parser::id_to_expr(name const & id, pos_info const & p) {
         if (ls && m_undef_id_behavior != undef_id_behavior::AssumeConstant)
             throw parser_error("invalid use of explicit universe parameter, identifier is a variable, "
                                "parameter or a constant bound to parameters in a section", p);
-        if (m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedLocals) {
-            expr local = mk_local(id, mk_expr_placeholder());
-            m_undef_ids.push_back(local);
-            return save_pos(local, p);
-        }
+        if (m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedNonConstructors)
+            return mk_placeholder_local(id, p);
         auto r = copy_with_new_pos(*it1, p);
         save_type_info(r);
         save_identifier_info(p, id);
@@ -1491,6 +1496,10 @@ expr parser::id_to_expr(name const & id, pos_info const & p) {
         auto new_id = ns + id;
         if (!ns.is_anonymous() && m_env.find(new_id) &&
             (!id.is_atomic() || !is_protected(m_env, new_id))) {
+            if (m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedNonConstructors &&
+                    id.is_atomic() && !inductive::is_intro_rule(m_env, new_id)) {
+                return mk_placeholder_local(id, p);
+            }
             auto r = save_pos(mk_constant(new_id, ls), p);
             save_type_info(r);
             add_ref_index(new_id, p);
@@ -1513,16 +1522,32 @@ expr parser::id_to_expr(name const & id, pos_info const & p) {
 
     optional<expr> r;
     // globals
-    if (m_env.find(id))
+    if (m_env.find(id)) {
+        if (m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedNonConstructors && id.is_atomic()) {
+            bool has_constructor = false;
+            for (auto & c : to_constants(id, "", p)) {
+                if (inductive::is_intro_rule(m_env, c))
+                    has_constructor = true;
+            }
+            if (!has_constructor)
+                return mk_placeholder_local(id, p);
+        }
         r = save_pos(mk_constant(id, ls), p);
+    }
     // aliases
     auto as = get_expr_aliases(m_env, id);
     if (!is_nil(as)) {
         buffer<expr> new_as;
         if (r)
             new_as.push_back(*r);
+        bool has_constructor = false;
         for (auto const & e : as) {
+            has_constructor |= (bool)inductive::is_intro_rule(m_env, e);
             new_as.push_back(copy_with_new_pos(mk_constant(e, ls), p));
+        }
+        if (m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedNonConstructors &&
+            id.is_atomic() && !has_constructor) {
+            return mk_placeholder_local(id, p);
         }
         r = save_pos(mk_choice(new_as.size(), new_as.data()), p);
         save_overload(*r);
@@ -1530,10 +1555,9 @@ expr parser::id_to_expr(name const & id, pos_info const & p) {
     if (!r) {
         if (m_undef_id_behavior == undef_id_behavior::AssumeConstant) {
             r = save_pos(mk_constant(get_namespace(m_env) + id, ls), p);
-        } else if (m_undef_id_behavior == undef_id_behavior::AssumeLocal || m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedLocals) {
-            expr local = mk_local(id, mk_expr_placeholder());
-            m_undef_ids.push_back(local);
-            r = save_pos(local, p);
+        } else if (m_undef_id_behavior == undef_id_behavior::AssumeLocal ||
+                   m_undef_id_behavior == undef_id_behavior::AssumeLocalAndAlsoDefinedNonConstructors) {
+            return mk_placeholder_local(id, p);
         }
     }
     if (!r)
@@ -1542,8 +1566,6 @@ expr parser::id_to_expr(name const & id, pos_info const & p) {
     if (is_constant(*r)) {
         add_ref_index(const_name(*r), p);
         save_identifier_info(p, const_name(*r));
-    } else if (is_local(*r)) {
-        save_identifier_info(p, local_pp_name(*r));
     }
     return *r;
 }

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -83,7 +83,7 @@ typedef std::vector<snapshot> snapshot_vector;
 
 enum class keep_theorem_mode { All, DiscardImported, DiscardAll };
 
-enum class undef_id_behavior { Error, AssumeConstant, AssumeLocal };
+enum class undef_id_behavior { Error, AssumeConstant, AssumeLocal, AssumeLocalAndAlsoDefinedLocals };
 
 class parser {
     environment             m_env;
@@ -491,6 +491,7 @@ public:
     */
     struct undef_id_to_const_scope : public flet<undef_id_behavior> { undef_id_to_const_scope(parser & p); };
     struct undef_id_to_local_scope : public flet<undef_id_behavior> { undef_id_to_local_scope(parser &); };
+    struct local_and_undef_id_to_local_scope : public flet<undef_id_behavior> { local_and_undef_id_to_local_scope(parser &); };
 
     /** \brief Return the size of the stack of undefined local constants */
     unsigned get_num_undef_ids() const { return m_undef_ids.size(); }

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -83,7 +83,7 @@ typedef std::vector<snapshot> snapshot_vector;
 
 enum class keep_theorem_mode { All, DiscardImported, DiscardAll };
 
-enum class undef_id_behavior { Error, AssumeConstant, AssumeLocal, AssumeLocalAndAlsoDefinedLocals };
+enum class undef_id_behavior { Error, AssumeConstant, AssumeLocal, AssumeLocalAndAlsoDefinedNonConstructors };
 
 class parser {
     environment             m_env;
@@ -533,6 +533,8 @@ public:
     public:
         in_notation_ctx(parser & p):m_ctx(p.m_scanner) {}
     };
+
+    expr mk_placeholder_local(const name &id, const pos_info &p);
 };
 
 bool parse_commands(environment & env, io_state & ios, std::istream & in, char const * strm_name, optional<std::string> const & base_dir,

--- a/src/library/definitional/equations.cpp
+++ b/src/library/definitional/equations.cpp
@@ -353,7 +353,6 @@ class equation_compiler_fn {
     [[ noreturn ]] static void throw_error(sstream const & ss, expr const & src) { throw_generic_exception(ss, src); }
     [[ noreturn ]] static void throw_error(expr const & src, pp_fn const & fn) { throw_generic_exception(src, fn); }
     [[ noreturn ]] void throw_error(sstream const & ss) const { throw_generic_exception(ss, m_meta); }
-    [[ noreturn ]] void throw_error(expr const & src, sstream const & ss) const { throw_generic_exception(ss, src); }
 
     void check_limitations(expr const & eqns) const {
         if (is_wf_equations(eqns) && equations_num_fns(eqns) != 1)
@@ -569,27 +568,19 @@ class equation_compiler_fn {
         validate_exception(expr const & e):m_expr(e) {}
     };
 
-    void check_in_local_ctx(expr const & e, buffer<expr> const & local_ctx) {
-        if (!contains_local(e, local_ctx))
-            throw_error(e, sstream() << "invalid recursive equation, variable '" << e
-                        << "' has the same name of a variable in an outer-scope (solution: rename this variable)");
-    }
-
     // Validate/normalize the given pattern.
     // It stores in reachable_vars any variable that does not occur
     // in inaccessible terms.
-    expr validate_pattern(expr pat, buffer<expr> const & local_ctx, name_set & reachable_vars) {
+    expr validate_pattern(expr pat, name_set & reachable_vars) {
         if (is_inaccessible(pat))
             return pat;
         if (is_local(pat)) {
             reachable_vars.insert(mlocal_name(pat));
-            check_in_local_ctx(pat, local_ctx);
             return pat;
         }
         expr new_pat = whnf(pat);
         if (is_local(new_pat)) {
             reachable_vars.insert(mlocal_name(new_pat));
-            check_in_local_ctx(new_pat, local_ctx);
             return new_pat;
         }
         buffer<expr> pat_args;
@@ -597,7 +588,7 @@ class equation_compiler_fn {
         if (auto in = is_constructor(fn)) {
             unsigned num_params = *inductive::get_num_params(env(), *in);
             for (unsigned i = num_params; i < pat_args.size(); i++)
-                pat_args[i] = validate_pattern(pat_args[i], local_ctx, reachable_vars);
+                pat_args[i] = validate_pattern(pat_args[i], reachable_vars);
             return mk_app(fn, pat_args, pat.get_tag());
         } else {
             throw validate_exception(pat);
@@ -608,10 +599,10 @@ class equation_compiler_fn {
     // The lhs is only used to report errors.
     // It stores in reachable_vars any variable that does not occur
     // in inaccessible terms.
-    void validate_patterns(expr const & lhs, buffer<expr> const & local_ctx, buffer<expr> & patterns, name_set & reachable_vars) {
+    void validate_patterns(expr const & lhs, buffer<expr> & patterns, name_set & reachable_vars) {
         for (expr & pat : patterns) {
             try {
-                pat = validate_pattern(pat, local_ctx, reachable_vars);
+                pat = validate_pattern(pat, reachable_vars);
             } catch (validate_exception & ex) {
                 expr problem_expr = ex.m_expr;
                 throw_error(lhs, [=](formatter const & fmt) {
@@ -649,7 +640,7 @@ class equation_compiler_fn {
             buffer<expr> patterns;
             expr const & fn  = get_app_args(lhs, patterns);
             name_set reachable_vars;
-            validate_patterns(lhs, local_ctx, patterns, reachable_vars);
+            validate_patterns(lhs, patterns, reachable_vars);
             for (expr const & v : local_ctx) {
                 // every variable in the local_ctx must be "reachable".
                 if (!reachable_vars.contains(mlocal_name(v))) {

--- a/tests/lean/run/eq23.lean
+++ b/tests/lean/run/eq23.lean
@@ -10,7 +10,7 @@ with tree_list :=
 namespace tree_list
 
 definition len {A : Type} : tree_list A → nat
-| len (nil A)    := 0
+| len (nil _)    := 0
 | len (cons t l) := len l + 1
 
 theorem len_nil {A : Type} : len (nil A) = 0 :=

--- a/tests/lean/run/type_equations.lean
+++ b/tests/lean/run/type_equations.lean
@@ -27,9 +27,9 @@ infix `+` := expr.add
 set_option pp.notation false
 
 definition ev : expr → nat
-| zero             := 0
-| one              := 1
-| ((a : expr) + b) := ev a + ev b
+| zero    := 0
+| one     := 1
+| (a + b) := ev a + ev b
 
 definition foo : expr := add zero (add one one)
 

--- a/tests/lean/shadow.lean
+++ b/tests/lean/shadow.lean
@@ -1,8 +1,0 @@
-open nat
-
-variable a : nat
-
--- The variable 'a' in the following definition is not the variable 'a' above
-definition tadd : nat → nat → nat
-| tadd zero     b := b
-| tadd (succ a) b := succ (tadd a b)

--- a/tests/lean/shadow.lean.expected.out
+++ b/tests/lean/shadow.lean.expected.out
@@ -1,1 +1,0 @@
-shadow.lean:8:13: error: invalid recursive equation, variable 'a' has the same name of a variable in an outer-scope (solution: rename this variable)


### PR DESCRIPTION
When it comes to shadowing variables, Lean can currently be a bit inconsistent:

``` lean
example (xs xs : list ℕ) : -- works
  list ℕ → list ℕ → list ℕ
| [] := λxs, xs -- works
-- | (x::xs) := begin -- 'invalid recursive equation'
| (x::xs') := begin
  intro xs, -- works
  cases xs with x xs, -- actually x_1 xs_1, but that's an issue for another day
end
```

The inability to shadow variables in patterns presented a problem for my current project, where I generate tuple unpacking code like the following:

``` lean
let x := 1 in
do tmp ← f x; match tmp with -- maybe even `do (r, x) ← f x; ...` in the future...?
(r, x) := ...
end
```

Having to rename that second `x` would add quite some additional complexity to my transpiler, so it was easier to lift the restriction in Lean.

Now, the ability to shadow variables in patterns can often be confusing to beginners in functional programming, but I believe most people eventually embrace it, which I've even done subconsciously in my own proofs after implementing the feature. As far as I know, it was mostly a technical restriction anyways.
