### PR TITLE
van Kampen theorem

### DIFF
--- a/extras/depgraph/README.md
+++ b/extras/depgraph/README.md
@@ -3,7 +3,11 @@ Generating Dependency Graph
 
 Usage:
 
-    leandeps.py [options] dir/file
+    ./leandeps.py [options] dir/file
+
+For example:
+
+    ./leandeps.py ../../library/
 
 If argument is a directory, all source files below that directory will be included in the graph.
 
@@ -12,11 +16,12 @@ If argument is a directory, all source files below that directory will be includ
 
 If no output file is specified, `deps.gv` and `deps.gv.dot` is written to.
 
-You need the [graphviz python library][python-graphviz]. If you already have [pip][pip], you can do:
+You need [graphviz][graphviz] and the [graphviz python library][python-graphviz]. If you already have [pip][pip], you can do:
 
-    pip install graphviz
+    sudo apt-get install graphviz
+    sudo pip install graphviz
 
-The resulting `deps.gv.dot` file can be run through [dot][graphviz] (and maybe tred first) from graphviz to produce, 
+The resulting `deps.gv.dot` file can be run through tred and [dot][graphviz] from graphviz to produce,
 e.g., an svg file. For example:
 
     tred deps.gv.dot > treddeps.dot

--- a/extras/latex/lstlean.tex
+++ b/extras/latex/lstlean.tex
@@ -128,6 +128,8 @@ literate=
 {⬝}{{\ensuremath{\cdot}}}1
 {•}{{\ensuremath{\cdot}}}1
 {∘}{{\ensuremath{\circ}}}1
+{`}{{\ensuremath{{}^\backprime}}}1
+{'}{{\ensuremath{{}^\prime}}}1
 
 %{⁻}{{\ensuremath{^{\textup{\kern1pt\rule{2pt}{0.3pt}\kern-1pt}}}}}1
 {⁻}{{\ensuremath{^{-}}}}1
@@ -205,12 +207,13 @@ literate=
 {∀}{{\color{symbolcolor}\ensuremath{\forall}}}1
 {∃}{{\color{symbolcolor}\ensuremath{\exists}}}1
 {λ}{{\color{symbolcolor}\ensuremath{\mathrm{\lambda}}}}1
+{Ω}{{\color{symbolcolor}\ensuremath{\Omega}}}1
 
 {:=}{{\color{symbolcolor}:=}}1
 {=}{{\color{symbolcolor}=}}1
 {<}{{\color{symbolcolor}<}}1
 {+}{{\color{symbolcolor}+}}1
-{*}{{\color{symbolcolor}*}}1,
+{*}{{\color{symbolcolor}\ensuremath{{}^{*}}}}1,
 
 % Comments
 %comment=[s][\itshape \color{commentcolor}]{/-}{-/},

--- a/hott/algebra/algebra.md
+++ b/hott/algebra/algebra.md
@@ -23,6 +23,7 @@ Files which are not ported from the standard library:
 * [trunc_group](trunc_group.hlean) : truncate an infinity-group to a group
 * [homotopy_group](homotopy_group.hlean) : homotopy groups of a pointed type
 * [e_closure](e_closure.hlean) : the type of words formed by a relation
+* [graph](graph.hlean) : definition and operations on paths in a graph.
 
 Subfolders (not ported):
 

--- a/hott/algebra/category/constructions/comma.hlean
+++ b/hott/algebra/category/constructions/comma.hlean
@@ -123,7 +123,7 @@ namespace category
     (mor2 g ∘ mor2 f)
     (by rewrite [+respect_comp,-assoc,coh,assoc,coh,-assoc])
 
-  local infix `∘∘`:60 := comma_compose
+  local infix ` ∘∘ `:60 := comma_compose
 
   definition comma_id : comma_morphism x x :=
   comma_morphism.mk id id (by rewrite [+respect_id,id_left,id_right])

--- a/hott/algebra/category/constructions/constructions.md
+++ b/hott/algebra/category/constructions/constructions.md
@@ -10,11 +10,13 @@ Common categories and constructions on categories. The following files are in th
 * [product](product.hlean) : Product category
 * [comma](comma.hlean) : Comma category
 * [cone](cone.hlean) : Cone category
+* [pushout](pushout.hlean) : Pushout of categories, pushout of groupoids. Also more generally the category formed by a (quotient of) paths in a graph
+* [fundamental_groupoid](fundamental_groupoid.hlean) : The fundamental groupoid of a type
 
 Discrete, indiscrete or finite categories:
 
 * [finite_cats](finite_cats.hlean) : Some finite categories, which are diagrams of common limits (the diagram for the pullback or the equalizer). Also contains a general construction of categories where you give some generators for the morphisms, with the condition that you cannot compose two of thosex
-* [discrete](discrete.hlean)
+* [discrete](discrete.hlean) : Discrete category. Also the groupoid formed by a 1-type
 * [indiscrete](indiscrete.hlean)
 * [terminal](terminal.hlean)
 * [initial](initial.hlean)

--- a/hott/algebra/category/constructions/constructions.md
+++ b/hott/algebra/category/constructions/constructions.md
@@ -10,7 +10,8 @@ Common categories and constructions on categories. The following files are in th
 * [product](product.hlean) : Product category
 * [comma](comma.hlean) : Comma category
 * [cone](cone.hlean) : Cone category
-* [pushout](pushout.hlean) : Pushout of categories, pushout of groupoids. Also more generally the category formed by a (quotient of) paths in a graph
+* [pushout](pushout.hlean) : Categorical structure of paths in a graph and quotients of them.
+  Pushout of categories, pushout of groupoids.
 * [fundamental_groupoid](fundamental_groupoid.hlean) : The fundamental groupoid of a type
 
 Discrete, indiscrete or finite categories:

--- a/hott/algebra/category/constructions/default.hlean
+++ b/hott/algebra/category/constructions/default.hlean
@@ -4,4 +4,4 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 
-import .functor .set .opposite .product .comma .sum .discrete .indiscrete .terminal .initial
+import .functor .set .opposite .product .comma .sum .discrete .indiscrete .terminal .initial .order

--- a/hott/algebra/category/constructions/default.hlean
+++ b/hott/algebra/category/constructions/default.hlean
@@ -5,3 +5,4 @@ Authors: Floris van Doorn
 -/
 
 import .functor .set .opposite .product .comma .sum .discrete .indiscrete .terminal .initial .order
+       .pushout .fundamental_groupoid

--- a/hott/algebra/category/constructions/discrete.hlean
+++ b/hott/algebra/category/constructions/discrete.hlean
@@ -69,6 +69,4 @@ namespace category
   { intro b₁ b₂ p, induction p, induction b₁: esimp: apply id_comp_eq_comp_id},
   end
 
-
-
 end category

--- a/hott/algebra/category/constructions/functor.hlean
+++ b/hott/algebra/category/constructions/functor.hlean
@@ -44,18 +44,16 @@ namespace functor
 
   definition nat_trans_left_inverse : nat_trans_inverse η ∘n η = 1 :=
   begin
-    fapply (apd011 nat_trans.mk),
+    fapply (apdt011 nat_trans.mk),
       apply eq_of_homotopy, intro c, apply left_inverse,
-    apply eq_of_homotopy, intros, apply eq_of_homotopy, intros, apply eq_of_homotopy, intros,
-    apply is_set.elim
+    apply eq_of_homotopy3, intros, apply is_set.elim
   end
 
   definition nat_trans_right_inverse : η ∘n nat_trans_inverse η = 1 :=
   begin
-    fapply (apd011 nat_trans.mk),
+    fapply (apdt011 nat_trans.mk),
       apply eq_of_homotopy, intro c, apply right_inverse,
-    apply eq_of_homotopy, intros, apply eq_of_homotopy, intros, apply eq_of_homotopy, intros,
-    apply is_set.elim
+    apply eq_of_homotopy3, intros, apply is_set.elim
   end
 
   definition is_natural_iso [constructor] : is_iso η :=

--- a/hott/algebra/category/constructions/fundamental_groupoid.hlean
+++ b/hott/algebra/category/constructions/fundamental_groupoid.hlean
@@ -1,0 +1,32 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Authors: Floris van Doorn
+-/
+
+import ..groupoid ..functor.basic
+
+open eq is_trunc iso trunc functor
+
+namespace category
+
+  definition fundamental_precategory [constructor] (A : Type) : Precategory :=
+  precategory.MK A
+                 (λa a', trunc 0 (a = a'))
+                 _
+                 (λa₁ a₂ a₃ q p, tconcat p q)
+                 (λa, tidp)
+                 (λa₁ a₂ a₃ a₄ r q p, tassoc p q r)
+                 (λa₁ a₂, tcon_tidp)
+                 (λa₁ a₂, tidp_tcon)
+
+  definition fundamental_groupoid [constructor] (A : Type) : Groupoid :=
+  groupoid.MK (fundamental_precategory A)
+              (λa b p, is_iso.mk (tinverse p) (right_tinv p) (left_tinv p))
+
+  definition fundamental_groupoid_functor [constructor] {A B : Type} (f : A → B) :
+    fundamental_groupoid A ⇒ fundamental_groupoid B :=
+  functor.mk f (λa a', tap f) (λa, tap_tidp f) (λa₁ a₂ a₃ q p, tap_tcon f p q)
+
+end category

--- a/hott/algebra/category/constructions/pushout.hlean
+++ b/hott/algebra/category/constructions/pushout.hlean
@@ -7,342 +7,44 @@ Authors: Floris van Doorn
 The pushout of categories
 
 The morphisms in the pushout of two categories is defined as a quotient on lists of composable
-morphisms. We first define a general notion of indexed lists, such that each element in the list has two endpoints, and the endpoints between adjacent members of the list have to be the same.
+morphisms. For this we use the notion of paths in a graph.
 -/
 
-import ..category ..nat_trans hit.set_quotient algebra.relation ..groupoid
+import ..category ..nat_trans hit.set_quotient algebra.relation ..groupoid algebra.graph
 
 open eq is_trunc functor trunc sum set_quotient relation iso category sigma nat
 
-inductive indexed_list {A : Type} (R : A → A → Type) : A → A → Type :=
-| nil {} : Π{a : A}, indexed_list R a a
-| cons   : Π{a₁ a₂ a₃ : A} (r : R a₂ a₃), indexed_list R a₁ a₂ → indexed_list R a₁ a₃
-
-namespace indexed_list
-
-  notation h :: t  := cons h t
-  notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
-
-  variables {A : Type} {R : A → A → Type} {a a' a₁ a₂ a₃ a₄ : A}
-
-  definition concat (r : R a₁ a₂) (l : indexed_list R a₂ a₃) : indexed_list R a₁ a₃ :=
-  begin
-    induction l with a a₂ a₃ a₄ r' l IH,
-    { exact [r]},
-    { exact r' :: IH r}
-  end
-
-  theorem concat_nil (r : R a₁ a₂) : concat r (@nil A R a₂) = [r] := idp
-
-  theorem concat_cons (r : R a₁ a₂) (r' : R a₃ a₄) (l : indexed_list R a₂ a₃)
-    : concat r (r'::l)  = r'::(concat r l) := idp
-
-  definition append (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
-    indexed_list R a₁ a₃ :=
-  begin
-    induction l₂,
-    { exact l₁},
-    { exact cons r (v_0 l₁)}
-  end
-
-  infix ` ++ ` := append
-
-  definition nil_append (l : indexed_list R a₁ a₂) : nil ++ l = l := idp
-  definition cons_append (r : R a₃ a₄) (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
-    (r :: l₂) ++ l₁ = r :: (l₂ ++ l₁) := idp
-
-  definition singleton_append (r : R a₂ a₃) (l : indexed_list R a₁ a₂) : [r] ++ l = r :: l := idp
-  definition append_singleton (l : indexed_list R a₂ a₃) (r : R a₁ a₂) : l ++ [r] = concat r l :=
-  begin
-    induction l,
-    { reflexivity},
-    { exact ap (cons r) !v_0}
-  end
-
-  definition append_nil (l : indexed_list R a₁ a₂) : l ++ nil = l :=
-  begin
-    induction l,
-    { reflexivity},
-    { exact ap (cons r) v_0}
-  end
-
-  definition append_assoc (l₃ : indexed_list R a₃ a₄) (l₂ : indexed_list R a₂ a₃)
-    (l₁ : indexed_list R a₁ a₂) : (l₃ ++ l₂) ++ l₁ = l₃ ++ (l₂ ++ l₁) :=
-  begin
-    induction l₃,
-    { reflexivity},
-    { refine ap (cons r) !v_0}
-  end
-
-  theorem append_concat (l₂ : indexed_list R a₃ a₄) (l₁ : indexed_list R a₂ a₃) (r : R a₁ a₂) :
-    l₂ ++ concat r l₁ = concat r (l₂ ++ l₁) :=
-  begin
-    induction l₂,
-    { reflexivity},
-    { exact ap (cons r_1) !v_0}
-  end
-
-  theorem concat_append (l₂ : indexed_list R a₃ a₄) (r : R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
-    concat r l₂ ++ l₁ = l₂ ++ r :: l₁ :=
-  begin
-    induction l₂,
-    { reflexivity},
-    { exact ap (cons r) !v_0}
-  end
-
-  definition indexed_list.rec_tail {C : Π⦃a a' : A⦄, indexed_list R a a' → Type}
-  (H0 : Π {a : A}, @C a a nil)
-  (H1 : Π {a₁ a₂ a₃ : A} (r : R a₁ a₂) (l : indexed_list R a₂ a₃), C l → C (concat r l)) :
-  Π{a a' : A} (l : indexed_list R a a'), C l :=
-  begin
-    have Π{a₁ a₂ a₃ : A} (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) (c : C l₂),
-      C (l₂ ++ l₁),
-    begin
-      intros, revert a₃ l₂ c, induction l₁: intros a₃ l₂ c,
-      { rewrite append_nil, exact c},
-      { rewrite [-concat_append], apply v_0, apply H1, exact c}
-    end,
-    intros, rewrite [-nil_append], apply this, apply H0
-  end
-
-  definition cons_eq_concat (r : R a₂ a₃) (l : indexed_list R a₁ a₂) :
-    Σa (r' : R a₁ a) (l' : indexed_list R a a₃), r :: l = concat r' l' :=
-  begin
-    revert a₃ r, induction l: intros a₃' r',
-    { exact ⟨a₃', r', nil, idp⟩},
-    { cases (v_0 a₃ r) with a₄ w, cases w with r₂ w, cases w with l p, clear v_0,
-      exact ⟨a₄, r₂, r' :: l, ap (cons r') p⟩}
-  end
-
-  definition length (l : indexed_list R a₁ a₂) : ℕ :=
-  begin
-    induction l,
-    { exact 0},
-    { exact succ v_0}
-  end
-
-  definition reverse (rev : Π⦃a a'⦄, R a a' → R a' a) (l : indexed_list R a₁ a₂) :
-    indexed_list R a₂ a₁ :=
-  begin
-    induction l,
-    { exact nil},
-    { exact concat (rev r) v_0}
-  end
-
-  theorem reverse_nil (rev : Π⦃a a'⦄, R a a' → R a' a) : reverse rev (@nil A R a₁) = [] := idp
-
-  theorem reverse_cons (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₂ a₃) (l : indexed_list R a₁ a₂) :
-    reverse rev (r::l) = concat (rev r) (reverse rev l) := idp
-
-  theorem reverse_singleton (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₁ a₂) :
-    reverse rev [r] = [rev r] := idp
-
-  theorem reverse_pair (rev : Π⦃a a'⦄, R a a' → R a' a) (r₂ : R a₂ a₃) (r₁ : R a₁ a₂) :
-    reverse rev [r₂, r₁] = [rev r₁, rev r₂] := idp
-
-  theorem reverse_concat (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₁ a₂) (l : indexed_list R a₂ a₃) :
-    reverse rev (concat r l) = rev r :: (reverse rev l) :=
-  begin
-    induction l,
-    { reflexivity},
-    { rewrite [concat_cons, reverse_cons, v_0]}
-  end
-
-  theorem reverse_append (rev : Π⦃a a'⦄, R a a' → R a' a) (l₂ : indexed_list R a₂ a₃)
-    (l₁ : indexed_list R a₁ a₂) : reverse rev (l₂ ++ l₁) = reverse rev l₁ ++ reverse rev l₂ :=
-  begin
-    induction l₂,
-    { exact !append_nil⁻¹},
-    { rewrite [cons_append, +reverse_cons, append_concat, v_0]}
-  end
-
-  definition realize (P : A → A → Type) (f : Π⦃a a'⦄, R a a' → P a a') (ρ : Πa, P a a)
-    (c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃)
-    ⦃a a' : A⦄ (l : indexed_list R a a') : P a a' :=
-  begin
-    induction l,
-    { exact ρ a},
-    { exact c v_0 (f r)}
-  end
-
-  definition realize_nil (P : A → A → Type) (f : Π⦃a a'⦄, R a a' → P a a') (ρ : Πa, P a a)
-    (c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃) (a : A) :
-    realize P f ρ c nil = ρ a :=
-  idp
-
-  definition realize_cons (P : A → A → Type) (f : Π⦃a a'⦄, R a a' → P a a') (ρ : Πa, P a a)
-    (c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃)
-    ⦃a₁ a₂ a₃ : A⦄ (r : R a₂ a₃) (l : indexed_list R a₁ a₂) :
-    realize P f ρ c (r :: l) = c (realize P f ρ c l) (f r) :=
-  idp
-
-  theorem realize_singleton {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
-    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
-    (id_left : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c (ρ a₁) p = p)
-    ⦃a₁ a₂ : A⦄ (r : R a₁ a₂) :
-    realize P f ρ c [r] = f r :=
-  id_left (f r)
-
-  theorem realize_pair {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
-    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
-    (id_left : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c (ρ a₁) p = p)
-    ⦃a₁ a₂ a₃ : A⦄ (r₂ : R a₂ a₃) (r₁ : R a₁ a₂) :
-    realize P f ρ c [r₂, r₁] = c (f r₁) (f r₂) :=
-  ap (λx, c x (f r₂)) (realize_singleton id_left r₁)
-
-  theorem realize_append {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
-    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
-    (assoc : Π⦃a₁ a₂ a₃ a₄⦄ (p : P a₁ a₂) (q : P a₂ a₃) (r : P a₃ a₄), c (c p q) r = c p (c q r))
-    (id_right : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c p (ρ a₂) = p)
-    ⦃a₁ a₂ a₃ : A⦄ (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
-    realize P f ρ c (l₂ ++ l₁) = c (realize P f ρ c l₁) (realize P f ρ c l₂) :=
-  begin
-    induction l₂,
-    { exact !id_right⁻¹},
-    { rewrite [cons_append, +realize_cons, v_0, assoc]}
-  end
-
-  inductive indexed_list_rel {A : Type} {R : A → A → Type}
-    (Q : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type)
-    : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type :=
-  | rrefl  : Π{a a' : A} (l : indexed_list R a a'), indexed_list_rel Q l l
-  | rel    : Π{a₁ a₂ a₃ : A} {l₂ l₃ : indexed_list R a₂ a₃} (l : indexed_list R a₁ a₂) (q : Q l₂ l₃),
-      indexed_list_rel Q (l₂ ++ l) (l₃ ++ l)
-  | rcons  : Π{a₁ a₂ a₃ : A} {l₁ l₂ : indexed_list R a₁ a₂} (r : R a₂ a₃),
-      indexed_list_rel Q l₁ l₂ → indexed_list_rel Q (cons r l₁) (cons r l₂)
-  | rtrans : Π{a₁ a₂ : A} {l₁ l₂ l₃ : indexed_list R a₁ a₂},
-      indexed_list_rel Q l₁ l₂ → indexed_list_rel Q l₂ l₃ → indexed_list_rel Q l₁ l₃
-
-  open indexed_list_rel
-  attribute rrefl [refl]
-  attribute rtrans [trans]
-  variables {Q : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type}
-
-  definition indexed_list_rel_of_Q {l₁ l₂ : indexed_list R a₁ a₂} (q : Q l₁ l₂) :
-    indexed_list_rel Q l₁ l₂ :=
-  begin
-    rewrite [-append_nil l₁, -append_nil l₂], exact rel nil q,
-  end
-
-  theorem rel_respect_append_left (l : indexed_list R a₂ a₃) {l₃ l₄ : indexed_list R a₁ a₂}
-    (H : indexed_list_rel Q l₃ l₄) : indexed_list_rel Q (l ++ l₃) (l ++ l₄) :=
-  begin
-    induction l,
-    { exact H},
-    { exact rcons r (v_0 _ _ H)}
-  end
-
-  theorem rel_respect_append_right {l₁ l₂ : indexed_list R a₂ a₃} (l : indexed_list R a₁ a₂)
-    (H₁ : indexed_list_rel Q l₁ l₂) : indexed_list_rel Q (l₁ ++ l) (l₂ ++ l) :=
-  begin
-    induction H₁ with a₁ a₂ l₁
-                      a₂ a₃ a₄ l₂ l₂' l₁ q
-                      a₂ a₃ a₄ l₁ l₂ r H₁ IH
-                      a₂ a₃ l₁ l₂ l₂' H₁ H₁' IH IH',
-    { reflexivity},
-    { rewrite [+ append_assoc], exact rel _ q},
-    { exact rcons r (IH l) },
-    { exact rtrans (IH l) (IH' l)}
-  end
-
-  theorem rel_respect_append {l₁ l₂ : indexed_list R a₂ a₃} {l₃ l₄ : indexed_list R a₁ a₂}
-    (H₁ : indexed_list_rel Q l₁ l₂) (H₂ : indexed_list_rel Q l₃ l₄) :
-    indexed_list_rel Q (l₁ ++ l₃) (l₂ ++ l₄) :=
-  begin
-    induction H₁ with a₁ a₂ l
-                      a₂ a₃ a₄ l₂ l₂' l q
-                      a₂ a₃ a₄ l₁ l₂ r H₁ IH
-                      a₂ a₃ l₁ l₂ l₂' H₁ H₁' IH IH',
-    { exact rel_respect_append_left _ H₂},
-    { rewrite [+ append_assoc], transitivity _, exact rel _ q,
-      apply rel_respect_append_left, apply rel_respect_append_left, exact H₂},
-    { exact rcons r (IH _ _ H₂) },
-    { refine rtrans (IH _ _ H₂) _, apply rel_respect_append_right, exact H₁'}
-  end
-
-  theorem rel_respect_reverse (rev : Π⦃a a'⦄, R a a' → R a' a) {l₁ l₂ : indexed_list R a₁ a₂}
-    (H : indexed_list_rel Q l₁ l₂)
-    (rev_rel : Π⦃a a' : A⦄ {l l' : indexed_list R a a'},
-      Q l l' → indexed_list_rel Q (reverse rev l) (reverse rev l')) :
-    indexed_list_rel Q (reverse rev l₁) (reverse rev l₂) :=
-  begin
-    induction H,
-    { reflexivity},
-    { rewrite [+ reverse_append], apply rel_respect_append_left, apply rev_rel q},
-    { rewrite [+reverse_cons,-+append_singleton], apply rel_respect_append_right, exact v_0},
-    { exact rtrans v_0 v_1}
-  end
-
-  theorem rel_left_inv (rev : Π⦃a a'⦄, R a a' → R a' a) (l : indexed_list R a₁ a₂)
-    (li : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [rev r, r] nil) :
-    indexed_list_rel Q (reverse rev l ++ l) nil :=
-  begin
-    induction l,
-    { reflexivity},
-    { rewrite [reverse_cons, concat_append],
-      refine rtrans _ v_0, apply rel_respect_append_left,
-      exact rel_respect_append_right _ (li r)}
-  end
-
-  theorem rel_right_inv (rev : Π⦃a a'⦄, R a a' → R a' a) (l : indexed_list R a₁ a₂)
-    (ri : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [r, rev r] nil) :
-    indexed_list_rel Q (l ++ reverse rev l) nil :=
-  begin
-    induction l using indexed_list.rec_tail,
-    { reflexivity},
-    { rewrite [reverse_concat, concat_append],
-      refine rtrans _ a, apply rel_respect_append_left,
-      exact rel_respect_append_right _ (ri r)}
-  end
-
-  definition realize_eq {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
-    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
-    (assoc : Π⦃a₁ a₂ a₃ a₄⦄ (p : P a₁ a₂) (q : P a₂ a₃) (r : P a₃ a₄), c (c p q) r = c p (c q r))
-    (id_right : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c p (ρ a₂) = p)
-    (resp_rel : Π⦃a₁ a₂⦄ {l₁ l₂ : indexed_list R a₁ a₂}, Q l₁ l₂ →
-      realize P f ρ c l₁ = realize P f ρ c l₂)
-    ⦃a a' : A⦄ {l l' : indexed_list R a a'} (H : indexed_list_rel Q l l') :
-    realize P f ρ c l = realize P f ρ c l' :=
-  begin
-    induction H,
-    { reflexivity},
-    { rewrite [+realize_append assoc id_right], apply ap (c _), exact resp_rel q},
-    { exact ap (λx, c x (f r)) v_0},
-    { exact v_0 ⬝ v_1}
-  end
-
-
-end indexed_list
-namespace indexed_list
+  /- we first define the categorical structure on paths in a graph -/
+namespace paths
   section
   parameters {A : Type} {R : A → A → Type}
-    (Q : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type)
+    (Q : Π⦃a a' : A⦄, paths R a a' → paths R a a' → Type)
   variables ⦃a a' a₁ a₂ a₃ a₄ : A⦄
-  definition indexed_list_trel [constructor] (l l' : indexed_list R a a') : Prop :=
-  ∥indexed_list_rel Q l l'∥
+  definition paths_trel [constructor] (l l' : paths R a a') : Prop :=
+  ∥paths_rel Q l l'∥
 
-  local notation `S` := @indexed_list_trel
-  definition indexed_list_quotient (a a' : A) : Type := set_quotient (@S a a')
-  local notation `mor` := indexed_list_quotient
-  local attribute indexed_list_quotient [reducible]
+  local notation `S` := @paths_trel
+  definition paths_quotient (a a' : A) : Type := set_quotient (@S a a')
+  local notation `mor` := paths_quotient
+  local attribute paths_quotient [reducible]
 
   definition is_reflexive_R : is_reflexive (@S a a') :=
   begin constructor, intro s, apply tr, constructor end
   local attribute is_reflexive_R [instance]
 
-  definition indexed_list_compose [unfold 7 8] (g : mor a₂ a₃) (f : mor a₁ a₂) : mor a₁ a₃ :=
+  definition paths_compose [unfold 7 8] (g : mor a₂ a₃) (f : mor a₁ a₂) : mor a₁ a₃ :=
   begin
     refine quotient_binary_map _ _ g f, exact append,
     intros, refine trunc_functor2 _ r s, exact rel_respect_append
   end
 
-  definition indexed_list_id [constructor] (a : A) : mor a a :=
+  definition paths_id [constructor] (a : A) : mor a a :=
   class_of nil
 
-  local infix ` ∘∘ `:60 := indexed_list_compose
-  local notation `p1` := indexed_list_id _
+  local infix ` ∘∘ `:60 := paths_compose
+  local notation `p1` := paths_id _
 
-  theorem indexed_list_assoc (h : mor a₃ a₄) (g : mor a₂ a₃) (f : mor a₁ a₂) :
+  theorem paths_assoc (h : mor a₃ a₄) (g : mor a₂ a₃) (f : mor a₁ a₂) :
     h ∘∘ (g ∘∘ f) = (h ∘∘ g) ∘∘ f :=
   begin
     induction h using set_quotient.rec_prop with h,
@@ -351,163 +53,109 @@ namespace indexed_list
     rewrite [▸*, append_assoc]
   end
 
-  theorem indexed_list_id_left (f : mor a a') : p1 ∘∘ f = f :=
+  theorem paths_id_left (f : mor a a') : p1 ∘∘ f = f :=
   begin
     induction f using set_quotient.rec_prop with f,
     reflexivity
   end
 
-  theorem indexed_list_id_right (f : mor a a') : f ∘∘ p1 = f :=
+  theorem paths_id_right (f : mor a a') : f ∘∘ p1 = f :=
   begin
     induction f using set_quotient.rec_prop with f,
     rewrite [▸*, append_nil]
   end
 
-  definition Precategory_indexed_list [constructor] : Precategory :=
+  definition Precategory_paths [constructor] : Precategory :=
   precategory.MK A
                  mor
                  _
-                 indexed_list_compose
-                 indexed_list_id
-                 indexed_list_assoc
-                 indexed_list_id_left
-                 indexed_list_id_right
+                 paths_compose
+                 paths_id
+                 paths_assoc
+                 paths_id_left
+                 paths_id_right
 
+  /- given a way to reverse edges and some additional properties we can extend this to a
+    groupoid structure -/
   parameters (inv : Π⦃a a' : A⦄, R a a' → R a' a)
-    (rel_inv : Π⦃a a' : A⦄ {l l' : indexed_list R a a'},
-      Q l l' → indexed_list_rel Q (reverse inv l) (reverse inv l'))
-    (li : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [inv r, r] nil)
-    (ri : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [r, inv r] nil)
+    (rel_inv : Π⦃a a' : A⦄ {l l' : paths R a a'},
+      Q l l' → paths_rel Q (reverse inv l) (reverse inv l'))
+    (li : Π⦃a a' : A⦄ (r : R a a'), paths_rel Q [inv r, r] nil)
+    (ri : Π⦃a a' : A⦄ (r : R a a'), paths_rel Q [r, inv r] nil)
 
   include rel_inv li ri
-  definition indexed_list_inv [unfold 8] (f : mor a a') : mor a' a :=
+  definition paths_inv [unfold 8] (f : mor a a') : mor a' a :=
   begin
     refine quotient_unary_map (reverse inv) _ f,
     intros, refine trunc_functor _ _ r, esimp,
     intro s, apply rel_respect_reverse inv s rel_inv
   end
 
-  local postfix `^`:max := indexed_list_inv
+  local postfix `^`:max := paths_inv
 
-  theorem indexed_list_left_inv (f : mor a₁ a₂) : f^ ∘∘ f = p1 :=
+  theorem paths_left_inv (f : mor a₁ a₂) : f^ ∘∘ f = p1 :=
   begin
     induction f using set_quotient.rec_prop with f,
     esimp, apply eq_of_rel, apply tr,
     apply rel_left_inv, apply li
   end
 
-  theorem indexed_list_right_inv (f : mor a₁ a₂) : f ∘∘ f^ = p1 :=
+  theorem paths_right_inv (f : mor a₁ a₂) : f ∘∘ f^ = p1 :=
   begin
     induction f using set_quotient.rec_prop with f,
     esimp, apply eq_of_rel, apply tr,
     apply rel_right_inv, apply ri
   end
 
-  definition Groupoid_indexed_list [constructor] : Groupoid :=
-  groupoid.MK Precategory_indexed_list
-    (λa b f, is_iso.mk (indexed_list_inv f) (indexed_list_left_inv f) (indexed_list_right_inv f))
+  definition Groupoid_paths [constructor] : Groupoid :=
+  groupoid.MK Precategory_paths
+    (λa b f, is_iso.mk (paths_inv f) (paths_left_inv f) (paths_right_inv f))
 
   end
 
-
-end indexed_list
-open indexed_list
+end paths
+open paths
 
 namespace category
 
-  inductive pushout_prehom_index {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) :
+  /- We use this for the pushout of categories -/
+  inductive pushout_prehom_index {C : Type} (D E : Precategory) (F : C → D) (G : C → E) :
     D + E → D + E → Type :=
-  | iD : Π{d d' : D} (f : d ⟶ d'), pushout_prehom_index F G (inl d) (inl d')
-  | iE : Π{e e' : E} (g : e ⟶ e'), pushout_prehom_index F G (inr e) (inr e')
-  | DE : Π(c : C), pushout_prehom_index F G (inl (F c)) (inr (G c))
-  | ED : Π(c : C), pushout_prehom_index F G (inr (G c)) (inl (F c))
+  | iD : Π{d d' : D} (f : d ⟶ d'), pushout_prehom_index D E F G (inl d) (inl d')
+  | iE : Π{e e' : E} (g : e ⟶ e'), pushout_prehom_index D E F G (inr e) (inr e')
+  | DE : Π(c : C), pushout_prehom_index D E F G (inl (F c)) (inr (G c))
+  | ED : Π(c : C), pushout_prehom_index D E F G (inr (G c)) (inl (F c))
 
   open pushout_prehom_index
 
-  definition pushout_prehom {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) : D + E → D + E → Type :=
-  indexed_list (pushout_prehom_index F G)
+  definition pushout_prehom {C : Type} (D E : Precategory) (F : C → D) (G : C → E) :
+    D + E → D + E → Type :=
+  paths (pushout_prehom_index D E F G)
 
-  inductive pushout_hom_rel_index {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) :
-    Π⦃x x' : D + E⦄, pushout_prehom F G x x' → pushout_prehom F G x x' → Type :=
+  inductive pushout_hom_rel_index {C : Type} (D E : Precategory) (F : C → D) (G : C → E) :
+    Π⦃x x' : D + E⦄, pushout_prehom D E F G x x' → pushout_prehom D E F G x x' → Type :=
   | DD  : Π{d₁ d₂ d₃ : D} (g : d₂ ⟶ d₃) (f : d₁ ⟶ d₂),
-      pushout_hom_rel_index F G [iD F G g, iD F G f] [iD F G (g ∘ f)]
+      pushout_hom_rel_index D E F G [iD F G g, iD F G f] [iD F G (g ∘ f)]
   | EE  : Π{e₁ e₂ e₃ : E} (g : e₂ ⟶ e₃) (f : e₁ ⟶ e₂),
-      pushout_hom_rel_index F G [iE F G g, iE F G f] [iE F G (g ∘ f)]
-  | DED : Π(c : C), pushout_hom_rel_index F G [ED F G c, DE F G c] nil
-  | EDE : Π(c : C), pushout_hom_rel_index F G [DE F G c, ED F G c] nil
-  | idD : Π(d : D), pushout_hom_rel_index F G [iD F G (ID d)] nil
-  | idE : Π(e : E), pushout_hom_rel_index F G [iE F G (ID e)] nil
+      pushout_hom_rel_index D E F G [iE F G g, iE F G f] [iE F G (g ∘ f)]
+  | DED : Π(c : C), pushout_hom_rel_index D E F G [ED F G c, DE F G c] nil
+  | EDE : Π(c : C), pushout_hom_rel_index D E F G [DE F G c, ED F G c] nil
+  | idD : Π(d : D), pushout_hom_rel_index D E F G [iD F G (ID d)] nil
+  | idE : Π(e : E), pushout_hom_rel_index D E F G [iE F G (ID e)] nil
 
   open pushout_hom_rel_index
-  -- section
-  -- parameters {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E)
-  -- local notation `ob` := D + E
-  -- variables ⦃x x' x₁ x₂ x₃ x₄ : ob⦄
 
-  -- definition pushout_hom_rel [constructor] (l l' : pushout_prehom F G x x') : Prop :=
-  -- ∥indexed_list_rel (pushout_hom_rel_index F G) l l'∥
+  definition Precategory_pushout [constructor] {C : Type} (D E : Precategory)
+    (F : C → D) (G : C → E) : Precategory :=
+  Precategory_paths (pushout_hom_rel_index D E F G)
 
-  -- local notation `R` := @pushout_hom_rel
-  -- definition pushout_hom (x x' : ob) : Type := set_quotient (@R x x')
-  -- local notation `mor` := @pushout_hom
-  -- local attribute pushout_hom [reducible]
+  /- We can also take the pushout of groupoids -/
 
-  -- definition is_reflexive_R : is_reflexive (@R x x') :=
-  -- begin constructor, intro s, apply tr, constructor end
-  -- local attribute is_reflexive_R [instance]
+  variables {C : Type} (D E : Groupoid) (F : C → D) (G : C → E)
+  variables ⦃x x' x₁ x₂ x₃ x₄ : Precategory_pushout D E F G⦄
 
-  -- definition pushout_compose [unfold 9 10] (g : mor x₂ x₃) (f : mor x₁ x₂) : mor x₁ x₃ :=
-  -- begin
-  --   refine quotient_binary_map _ _ g f, exact append,
-  --   intros, refine trunc_functor2 _ r s, exact rel_respect_append
-  -- end
-
-  -- definition pushout_id [constructor] (x : ob) : mor x x :=
-  -- class_of nil
-
-  -- local infix ` ∘∘ `:60 := pushout_compose
-  -- local notation `p1` := pushout_id _
-
-  -- theorem pushout_assoc (h : mor x₃ x₄) (g : mor x₂ x₃) (f : mor x₁ x₂) :
-  --   h ∘∘ (g ∘∘ f) = (h ∘∘ g) ∘∘ f :=
-  -- begin
-  --   induction h using set_quotient.rec_prop with h,
-  --   induction g using set_quotient.rec_prop with g,
-  --   induction f using set_quotient.rec_prop with f,
-  --   rewrite [▸*, append_assoc]
-  -- end
-
-  -- theorem pushout_id_left (f : mor x x') : p1 ∘∘ f = f :=
-  -- begin
-  --   induction f using set_quotient.rec_prop with f,
-  --   reflexivity
-  -- end
-
-  -- theorem pushout_id_right (f : mor x x') : f ∘∘ p1 = f :=
-  -- begin
-  --   induction f using set_quotient.rec_prop with f,
-  --   rewrite [▸*, append_nil]
-  -- end
-
-  definition Precategory_pushout [constructor] {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) :
-    Precategory :=
-  Precategory_indexed_list (pushout_hom_rel_index F G)
-  -- precategory.MK ob
-  --                mor
-  --                _
-  --                pushout_compose
-  --                pushout_id
-  --                pushout_assoc
-  --                pushout_id_left
-  --                pushout_id_right
-
-  -- end
-
-  variables {C D E : Groupoid} (F : C ⇒ D) (G : C ⇒ E)
-  variables ⦃x x' x₁ x₂ x₃ x₄ : Precategory_pushout F G⦄
-
-  definition pushout_index_inv [unfold 8] (i : pushout_prehom_index F G x x') :
-    pushout_prehom_index F G x' x :=
+  definition pushout_index_inv [unfold 8] (i : pushout_prehom_index D E F G x x') :
+    pushout_prehom_index D E F G x' x :=
   begin
     induction i,
     { exact iD F G f⁻¹},
@@ -516,43 +164,43 @@ namespace category
     { exact DE F G c},
   end
 
-  open indexed_list.indexed_list_rel
-  theorem pushout_index_reverse {l l' : pushout_prehom F G x x'}
-    (q : pushout_hom_rel_index F G l l') : indexed_list_rel (pushout_hom_rel_index F G)
-      (reverse (pushout_index_inv F G) l) (reverse (pushout_index_inv F G) l') :=
+  open paths.paths_rel
+  theorem pushout_index_reverse {l l' : pushout_prehom D E F G x x'}
+    (q : pushout_hom_rel_index D E F G l l') : paths_rel (pushout_hom_rel_index D E F G)
+      (reverse (pushout_index_inv D E F G) l) (reverse (pushout_index_inv D E F G) l') :=
   begin
-    induction q: apply indexed_list_rel_of_Q;
+    induction q: apply paths_rel_of_Q;
     try rewrite reverse_singleton; try rewrite reverse_pair; try rewrite reverse_nil; esimp;
     try rewrite [comp_inverse]; try rewrite [id_inverse]; constructor,
   end
 
-  theorem pushout_index_li (i : pushout_prehom_index F G x x') :
-    indexed_list_rel (pushout_hom_rel_index F G) [pushout_index_inv F G i, i] nil :=
+  theorem pushout_index_li (i : pushout_prehom_index D E F G x x') :
+    paths_rel (pushout_hom_rel_index D E F G) [pushout_index_inv D E F G i, i] nil :=
   begin
     induction i: esimp,
-    { refine rtrans (indexed_list_rel_of_Q !DD) _,
-      rewrite [comp.left_inverse], exact indexed_list_rel_of_Q !idD},
-    { refine rtrans (indexed_list_rel_of_Q !EE) _,
-      rewrite [comp.left_inverse], exact indexed_list_rel_of_Q !idE},
-    { exact indexed_list_rel_of_Q !DED},
-    { exact indexed_list_rel_of_Q !EDE}
+    { refine rtrans (paths_rel_of_Q !DD) _,
+      rewrite [comp.left_inverse], exact paths_rel_of_Q !idD},
+    { refine rtrans (paths_rel_of_Q !EE) _,
+      rewrite [comp.left_inverse], exact paths_rel_of_Q !idE},
+    { exact paths_rel_of_Q !DED},
+    { exact paths_rel_of_Q !EDE}
   end
 
-  theorem pushout_index_ri (i : pushout_prehom_index F G x x') :
-    indexed_list_rel (pushout_hom_rel_index F G) [i, pushout_index_inv F G i] nil :=
+  theorem pushout_index_ri (i : pushout_prehom_index D E F G x x') :
+    paths_rel (pushout_hom_rel_index D E F G) [i, pushout_index_inv D E F G i] nil :=
   begin
     induction i: esimp,
-    { refine rtrans (indexed_list_rel_of_Q !DD) _,
-      rewrite [comp.right_inverse], exact indexed_list_rel_of_Q !idD},
-    { refine rtrans (indexed_list_rel_of_Q !EE) _,
-      rewrite [comp.right_inverse], exact indexed_list_rel_of_Q !idE},
-    { exact indexed_list_rel_of_Q !EDE},
-    { exact indexed_list_rel_of_Q !DED}
+    { refine rtrans (paths_rel_of_Q !DD) _,
+      rewrite [comp.right_inverse], exact paths_rel_of_Q !idD},
+    { refine rtrans (paths_rel_of_Q !EE) _,
+      rewrite [comp.right_inverse], exact paths_rel_of_Q !idE},
+    { exact paths_rel_of_Q !EDE},
+    { exact paths_rel_of_Q !DED}
   end
 
   definition Groupoid_pushout [constructor] : Groupoid :=
-  Groupoid_indexed_list (pushout_hom_rel_index F G) (pushout_index_inv F G)
-    (pushout_index_reverse F G) (pushout_index_li F G) (pushout_index_ri F G)
+  Groupoid_paths (pushout_hom_rel_index D E F G) (pushout_index_inv D E F G)
+    (pushout_index_reverse D E F G) (pushout_index_li D E F G) (pushout_index_ri D E F G)
 
 
 end category

--- a/hott/algebra/category/constructions/pushout.hlean
+++ b/hott/algebra/category/constructions/pushout.hlean
@@ -1,0 +1,507 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Authors: Floris van Doorn
+
+The pushout of categories
+
+The morphisms in the pushout of two categories is defined as a quotient on lists of composable
+morphisms. We first define a general notion of indexed lists, such that each element in the list has two endpoints, and the endpoints between adjacent members of the list have to be the same.
+-/
+
+import ..category ..nat_trans hit.set_quotient algebra.relation ..groupoid
+
+open eq is_trunc functor trunc sum set_quotient relation iso category sigma nat
+
+inductive indexed_list {A : Type} (R : A → A → Type) : A → A → Type :=
+| nil {} : Π{a : A}, indexed_list R a a
+| cons   : Π{a₁ a₂ a₃ : A} (r : R a₂ a₃), indexed_list R a₁ a₂ → indexed_list R a₁ a₃
+
+namespace indexed_list
+
+  notation h :: t  := cons h t
+  notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
+
+  variables {A : Type} {R : A → A → Type} {a a' a₁ a₂ a₃ a₄ : A}
+
+  definition concat (r : R a₁ a₂) (l : indexed_list R a₂ a₃) : indexed_list R a₁ a₃ :=
+  begin
+    induction l with a a₂ a₃ a₄ r' l IH,
+    { exact [r]},
+    { exact r' :: IH r}
+  end
+
+  theorem concat_nil (r : R a₁ a₂) : concat r (@nil A R a₂) = [r] := idp
+
+  theorem concat_cons (r : R a₁ a₂) (r' : R a₃ a₄) (l : indexed_list R a₂ a₃)
+    : concat r (r'::l)  = r'::(concat r l) := idp
+
+  definition append (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
+    indexed_list R a₁ a₃ :=
+  begin
+    induction l₂,
+    { exact l₁},
+    { exact cons r (v_0 l₁)}
+  end
+
+  infix ` ++ ` := append
+
+  definition nil_append (l : indexed_list R a₁ a₂) : nil ++ l = l := idp
+  definition cons_append (r : R a₃ a₄) (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
+    (r :: l₂) ++ l₁ = r :: (l₂ ++ l₁) := idp
+
+  definition singleton_append (r : R a₂ a₃) (l : indexed_list R a₁ a₂) : [r] ++ l = r :: l := idp
+  definition append_singleton (l : indexed_list R a₂ a₃) (r : R a₁ a₂) : l ++ [r] = concat r l :=
+  begin
+    induction l,
+    { reflexivity},
+    { exact ap (cons r) !v_0}
+  end
+
+  definition append_nil (l : indexed_list R a₁ a₂) : l ++ nil = l :=
+  begin
+    induction l,
+    { reflexivity},
+    { exact ap (cons r) v_0}
+  end
+
+  definition append_assoc (l₃ : indexed_list R a₃ a₄) (l₂ : indexed_list R a₂ a₃)
+    (l₁ : indexed_list R a₁ a₂) : (l₃ ++ l₂) ++ l₁ = l₃ ++ (l₂ ++ l₁) :=
+  begin
+    induction l₃,
+    { reflexivity},
+    { refine ap (cons r) !v_0}
+  end
+
+  theorem append_concat (l₂ : indexed_list R a₃ a₄) (l₁ : indexed_list R a₂ a₃) (r : R a₁ a₂) :
+    l₂ ++ concat r l₁ = concat r (l₂ ++ l₁) :=
+  begin
+    induction l₂,
+    { reflexivity},
+    { exact ap (cons r_1) !v_0}
+  end
+
+  theorem concat_append (l₂ : indexed_list R a₃ a₄) (r : R a₂ a₃) (l₁ : indexed_list R a₁ a₂) :
+    concat r l₂ ++ l₁ = l₂ ++ r :: l₁ :=
+  begin
+    induction l₂,
+    { reflexivity},
+    { exact ap (cons r) !v_0}
+  end
+
+  definition indexed_list.rec_tail {C : Π⦃a a' : A⦄, indexed_list R a a' → Type}
+  (H0 : Π {a : A}, @C a a nil)
+  (H1 : Π {a₁ a₂ a₃ : A} (r : R a₁ a₂) (l : indexed_list R a₂ a₃), C l → C (concat r l)) :
+  Π{a a' : A} (l : indexed_list R a a'), C l :=
+  begin
+    have Π{a₁ a₂ a₃ : A} (l₂ : indexed_list R a₂ a₃) (l₁ : indexed_list R a₁ a₂) (c : C l₂),
+      C (l₂ ++ l₁),
+    begin
+      intros, revert a₃ l₂ c, induction l₁: intros a₃ l₂ c,
+      { rewrite append_nil, exact c},
+      { rewrite [-concat_append], apply v_0, apply H1, exact c}
+    end,
+    intros, rewrite [-nil_append], apply this, apply H0
+  end
+
+  definition cons_eq_concat (r : R a₂ a₃) (l : indexed_list R a₁ a₂) :
+    Σa (r' : R a₁ a) (l' : indexed_list R a a₃), r :: l = concat r' l' :=
+  begin
+    revert a₃ r, induction l: intros a₃' r',
+    { exact ⟨a₃', r', nil, idp⟩},
+    { cases (v_0 a₃ r) with a₄ w, cases w with r₂ w, cases w with l p, clear v_0,
+      exact ⟨a₄, r₂, r' :: l, ap (cons r') p⟩}
+  end
+
+  definition length (l : indexed_list R a₁ a₂) : ℕ :=
+  begin
+    induction l,
+    { exact 0},
+    { exact succ v_0}
+  end
+
+  definition reverse (rev : Π⦃a a'⦄, R a a' → R a' a) (l : indexed_list R a₁ a₂) :
+    indexed_list R a₂ a₁ :=
+  begin
+    induction l,
+    { exact nil},
+    { exact concat (rev r) v_0}
+  end
+
+  theorem reverse_nil (rev : Π⦃a a'⦄, R a a' → R a' a) : reverse rev (@nil A R a₁) = [] := idp
+
+  theorem reverse_cons (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₂ a₃) (l : indexed_list R a₁ a₂) :
+    reverse rev (r::l) = concat (rev r) (reverse rev l) := idp
+
+  theorem reverse_singleton (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₁ a₂) :
+    reverse rev [r] = [rev r] := idp
+
+  theorem reverse_pair (rev : Π⦃a a'⦄, R a a' → R a' a) (r₂ : R a₂ a₃) (r₁ : R a₁ a₂) :
+    reverse rev [r₂, r₁] = [rev r₁, rev r₂] := idp
+
+  theorem reverse_concat (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₁ a₂) (l : indexed_list R a₂ a₃) :
+    reverse rev (concat r l) = rev r :: (reverse rev l) :=
+  begin
+    induction l,
+    { reflexivity},
+    { rewrite [concat_cons, reverse_cons, v_0]}
+  end
+
+  theorem reverse_append (rev : Π⦃a a'⦄, R a a' → R a' a) (l₂ : indexed_list R a₂ a₃)
+    (l₁ : indexed_list R a₁ a₂) : reverse rev (l₂ ++ l₁) = reverse rev l₁ ++ reverse rev l₂ :=
+  begin
+    induction l₂,
+    { exact !append_nil⁻¹},
+    { rewrite [cons_append, +reverse_cons, append_concat, v_0]}
+  end
+
+  inductive indexed_list_rel {A : Type} {R : A → A → Type}
+    (Q : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type)
+    : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type :=
+  | rrefl  : Π{a a' : A} (l : indexed_list R a a'), indexed_list_rel Q l l
+  | rel    : Π{a₁ a₂ a₃ : A} {l₂ l₃ : indexed_list R a₂ a₃} (l : indexed_list R a₁ a₂) (q : Q l₂ l₃),
+      indexed_list_rel Q (l₂ ++ l) (l₃ ++ l)
+  | rcons  : Π{a₁ a₂ a₃ : A} {l₁ l₂ : indexed_list R a₁ a₂} (r : R a₂ a₃),
+      indexed_list_rel Q l₁ l₂ → indexed_list_rel Q (cons r l₁) (cons r l₂)
+  | rtrans : Π{a₁ a₂ : A} {l₁ l₂ l₃ : indexed_list R a₁ a₂},
+      indexed_list_rel Q l₁ l₂ → indexed_list_rel Q l₂ l₃ → indexed_list_rel Q l₁ l₃
+
+  open indexed_list_rel
+  attribute rrefl [refl]
+  attribute rtrans [trans]
+  variables {Q : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type}
+
+  definition indexed_list_rel_of_Q {l₁ l₂ : indexed_list R a₁ a₂} (q : Q l₁ l₂) :
+    indexed_list_rel Q l₁ l₂ :=
+  begin
+    rewrite [-append_nil l₁, -append_nil l₂], exact rel nil q,
+  end
+
+  theorem rel_respect_append_left (l : indexed_list R a₂ a₃) {l₃ l₄ : indexed_list R a₁ a₂}
+    (H : indexed_list_rel Q l₃ l₄) : indexed_list_rel Q (l ++ l₃) (l ++ l₄) :=
+  begin
+    induction l,
+    { exact H},
+    { exact rcons r (v_0 _ _ H)}
+  end
+
+  theorem rel_respect_append_right {l₁ l₂ : indexed_list R a₂ a₃} (l : indexed_list R a₁ a₂)
+    (H₁ : indexed_list_rel Q l₁ l₂) : indexed_list_rel Q (l₁ ++ l) (l₂ ++ l) :=
+  begin
+    induction H₁ with a₁ a₂ l₁
+                      a₂ a₃ a₄ l₂ l₂' l₁ q
+                      a₂ a₃ a₄ l₁ l₂ r H₁ IH
+                      a₂ a₃ l₁ l₂ l₂' H₁ H₁' IH IH',
+    { reflexivity},
+    { rewrite [+ append_assoc], exact rel _ q},
+    { exact rcons r (IH l) },
+    { exact rtrans (IH l) (IH' l)}
+  end
+
+  theorem rel_respect_append {l₁ l₂ : indexed_list R a₂ a₃} {l₃ l₄ : indexed_list R a₁ a₂}
+    (H₁ : indexed_list_rel Q l₁ l₂) (H₂ : indexed_list_rel Q l₃ l₄) :
+    indexed_list_rel Q (l₁ ++ l₃) (l₂ ++ l₄) :=
+  begin
+    induction H₁ with a₁ a₂ l
+                      a₂ a₃ a₄ l₂ l₂' l q
+                      a₂ a₃ a₄ l₁ l₂ r H₁ IH
+                      a₂ a₃ l₁ l₂ l₂' H₁ H₁' IH IH',
+    { exact rel_respect_append_left _ H₂},
+    { rewrite [+ append_assoc], transitivity _, exact rel _ q,
+      apply rel_respect_append_left, apply rel_respect_append_left, exact H₂},
+    { exact rcons r (IH _ _ H₂) },
+    { refine rtrans (IH _ _ H₂) _, apply rel_respect_append_right, exact H₁'}
+  end
+
+  theorem rel_respect_reverse (rev : Π⦃a a'⦄, R a a' → R a' a) {l₁ l₂ : indexed_list R a₁ a₂}
+    (H : indexed_list_rel Q l₁ l₂)
+    (rev_rel : Π⦃a a' : A⦄ {l l' : indexed_list R a a'},
+      Q l l' → indexed_list_rel Q (reverse rev l) (reverse rev l')) :
+    indexed_list_rel Q (reverse rev l₁) (reverse rev l₂) :=
+  begin
+    induction H,
+    { reflexivity},
+    { rewrite [+ reverse_append], apply rel_respect_append_left, apply rev_rel q},
+    { rewrite [+reverse_cons,-+append_singleton], apply rel_respect_append_right, exact v_0},
+    { exact rtrans v_0 v_1}
+  end
+
+  theorem rel_left_inv (rev : Π⦃a a'⦄, R a a' → R a' a) (l : indexed_list R a₁ a₂)
+    (li : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [rev r, r] nil) :
+    indexed_list_rel Q (reverse rev l ++ l) nil :=
+  begin
+    induction l,
+    { reflexivity},
+    { rewrite [reverse_cons, concat_append],
+      refine rtrans _ v_0, apply rel_respect_append_left,
+      exact rel_respect_append_right _ (li r)}
+  end
+
+  theorem rel_right_inv (rev : Π⦃a a'⦄, R a a' → R a' a) (l : indexed_list R a₁ a₂)
+    (ri : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [r, rev r] nil) :
+    indexed_list_rel Q (l ++ reverse rev l) nil :=
+  begin
+    induction l using indexed_list.rec_tail,
+    { reflexivity},
+    { rewrite [reverse_concat, concat_append],
+      refine rtrans _ a, apply rel_respect_append_left,
+      exact rel_respect_append_right _ (ri r)}
+  end
+
+end indexed_list
+namespace indexed_list
+  section
+  parameters {A : Type} {R : A → A → Type}
+    (Q : Π⦃a a' : A⦄, indexed_list R a a' → indexed_list R a a' → Type)
+  variables ⦃a a' a₁ a₂ a₃ a₄ : A⦄
+  definition indexed_list_trel [constructor] (l l' : indexed_list R a a') : Prop :=
+  ∥indexed_list_rel Q l l'∥
+
+  local notation `S` := @indexed_list_trel
+  definition indexed_list_quotient (a a' : A) : Type := set_quotient (@S a a')
+  local notation `mor` := indexed_list_quotient
+  local attribute indexed_list_quotient [reducible]
+
+  definition is_reflexive_R : is_reflexive (@S a a') :=
+  begin constructor, intro s, apply tr, constructor end
+  local attribute is_reflexive_R [instance]
+
+  definition indexed_list_compose [unfold 7 8] (g : mor a₂ a₃) (f : mor a₁ a₂) : mor a₁ a₃ :=
+  begin
+    refine quotient_binary_map _ _ g f, exact append,
+    intros, refine trunc_functor2 _ r s, exact rel_respect_append
+  end
+
+  definition indexed_list_id [constructor] (a : A) : mor a a :=
+  class_of nil
+
+  local infix ` ∘∘ `:60 := indexed_list_compose
+  local notation `p1` := indexed_list_id _
+
+  theorem indexed_list_assoc (h : mor a₃ a₄) (g : mor a₂ a₃) (f : mor a₁ a₂) :
+    h ∘∘ (g ∘∘ f) = (h ∘∘ g) ∘∘ f :=
+  begin
+    induction h using set_quotient.rec_prop with h,
+    induction g using set_quotient.rec_prop with g,
+    induction f using set_quotient.rec_prop with f,
+    rewrite [▸*, append_assoc]
+  end
+
+  theorem indexed_list_id_left (f : mor a a') : p1 ∘∘ f = f :=
+  begin
+    induction f using set_quotient.rec_prop with f,
+    reflexivity
+  end
+
+  theorem indexed_list_id_right (f : mor a a') : f ∘∘ p1 = f :=
+  begin
+    induction f using set_quotient.rec_prop with f,
+    rewrite [▸*, append_nil]
+  end
+
+  definition Precategory_indexed_list [constructor] : Precategory :=
+  precategory.MK A
+                 mor
+                 _
+                 indexed_list_compose
+                 indexed_list_id
+                 indexed_list_assoc
+                 indexed_list_id_left
+                 indexed_list_id_right
+
+  parameters (inv : Π⦃a a' : A⦄, R a a' → R a' a)
+    (rel_inv : Π⦃a a' : A⦄ {l l' : indexed_list R a a'},
+      Q l l' → indexed_list_rel Q (reverse inv l) (reverse inv l'))
+    (li : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [inv r, r] nil)
+    (ri : Π⦃a a' : A⦄ (r : R a a'), indexed_list_rel Q [r, inv r] nil)
+
+  include rel_inv li ri
+  definition indexed_list_inv [unfold 8] (f : mor a a') : mor a' a :=
+  begin
+    refine quotient_unary_map (reverse inv) _ f,
+    intros, refine trunc_functor _ _ r, esimp,
+    intro s, apply rel_respect_reverse inv s rel_inv
+  end
+
+  local postfix `^`:max := indexed_list_inv
+
+  theorem indexed_list_left_inv (f : mor a₁ a₂) : f^ ∘∘ f = p1 :=
+  begin
+    induction f using set_quotient.rec_prop with f,
+    esimp, apply eq_of_rel, apply tr,
+    apply rel_left_inv, apply li
+  end
+
+  theorem indexed_list_right_inv (f : mor a₁ a₂) : f ∘∘ f^ = p1 :=
+  begin
+    induction f using set_quotient.rec_prop with f,
+    esimp, apply eq_of_rel, apply tr,
+    apply rel_right_inv, apply ri
+  end
+
+  definition Groupoid_indexed_list [constructor] : Groupoid :=
+  groupoid.MK Precategory_indexed_list
+    (λa b f, is_iso.mk (indexed_list_inv f) (indexed_list_left_inv f) (indexed_list_right_inv f))
+
+  end
+
+
+
+end indexed_list
+open indexed_list
+
+namespace category
+
+  inductive pushout_prehom_index {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) :
+    D + E → D + E → Type :=
+  | il : Π{d d' : D} (f : d ⟶ d'), pushout_prehom_index F G (inl d) (inl d')
+  | ir : Π{e e' : E} (g : e ⟶ e'), pushout_prehom_index F G (inr e) (inr e')
+  | lr : Π{c c' : C} (h : c ⟶ c'), pushout_prehom_index F G (inl (F c)) (inr (G c'))
+  | rl : Π{c c' : C} (h : c ⟶ c'), pushout_prehom_index F G (inr (G c)) (inl (F c'))
+
+  open pushout_prehom_index
+
+  definition pushout_prehom {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) : D + E → D + E → Type :=
+  indexed_list (pushout_prehom_index F G)
+
+  inductive pushout_hom_rel_index {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) :
+    Π⦃x x' : D + E⦄, pushout_prehom F G x x' → pushout_prehom F G x x' → Type :=
+  | DD  : Π{d₁ d₂ d₃ : D} (g : d₂ ⟶ d₃) (f : d₁ ⟶ d₂),
+      pushout_hom_rel_index F G [il F G g, il F G f] [il F G (g ∘ f)]
+  | EE  : Π{e₁ e₂ e₃ : E} (g : e₂ ⟶ e₃) (f : e₁ ⟶ e₂),
+      pushout_hom_rel_index F G [ir F G g, ir F G f] [ir F G (g ∘ f)]
+  | DED : Π{c₁ c₂ c₃ : C} (g : c₂ ⟶ c₃) (f : c₁ ⟶ c₂),
+      pushout_hom_rel_index F G [rl F G g, lr F G f] [il F G (to_fun_hom F (g ∘ f))]
+  | EDE : Π{c₁ c₂ c₃ : C} (g : c₂ ⟶ c₃) (f : c₁ ⟶ c₂),
+      pushout_hom_rel_index F G [lr F G g, rl F G f] [ir F G (to_fun_hom G (g ∘ f))]
+  | idD : Π(d : D), pushout_hom_rel_index F G [il F G (ID d)] nil
+  | idE : Π(e : E), pushout_hom_rel_index F G [ir F G (ID e)] nil
+
+  open pushout_hom_rel_index
+  -- section
+  -- parameters {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E)
+  -- local notation `ob` := D + E
+  -- variables ⦃x x' x₁ x₂ x₃ x₄ : ob⦄
+
+  -- definition pushout_hom_rel [constructor] (l l' : pushout_prehom F G x x') : Prop :=
+  -- ∥indexed_list_rel (pushout_hom_rel_index F G) l l'∥
+
+  -- local notation `R` := @pushout_hom_rel
+  -- definition pushout_hom (x x' : ob) : Type := set_quotient (@R x x')
+  -- local notation `mor` := @pushout_hom
+  -- local attribute pushout_hom [reducible]
+
+  -- definition is_reflexive_R : is_reflexive (@R x x') :=
+  -- begin constructor, intro s, apply tr, constructor end
+  -- local attribute is_reflexive_R [instance]
+
+  -- definition pushout_compose [unfold 9 10] (g : mor x₂ x₃) (f : mor x₁ x₂) : mor x₁ x₃ :=
+  -- begin
+  --   refine quotient_binary_map _ _ g f, exact append,
+  --   intros, refine trunc_functor2 _ r s, exact rel_respect_append
+  -- end
+
+  -- definition pushout_id [constructor] (x : ob) : mor x x :=
+  -- class_of nil
+
+  -- local infix ` ∘∘ `:60 := pushout_compose
+  -- local notation `p1` := pushout_id _
+
+  -- theorem pushout_assoc (h : mor x₃ x₄) (g : mor x₂ x₃) (f : mor x₁ x₂) :
+  --   h ∘∘ (g ∘∘ f) = (h ∘∘ g) ∘∘ f :=
+  -- begin
+  --   induction h using set_quotient.rec_prop with h,
+  --   induction g using set_quotient.rec_prop with g,
+  --   induction f using set_quotient.rec_prop with f,
+  --   rewrite [▸*, append_assoc]
+  -- end
+
+  -- theorem pushout_id_left (f : mor x x') : p1 ∘∘ f = f :=
+  -- begin
+  --   induction f using set_quotient.rec_prop with f,
+  --   reflexivity
+  -- end
+
+  -- theorem pushout_id_right (f : mor x x') : f ∘∘ p1 = f :=
+  -- begin
+  --   induction f using set_quotient.rec_prop with f,
+  --   rewrite [▸*, append_nil]
+  -- end
+
+  definition Precategory_pushout [constructor] {C D E : Precategory} (F : C ⇒ D) (G : C ⇒ E) :
+    Precategory :=
+  Precategory_indexed_list (pushout_hom_rel_index F G)
+  -- precategory.MK ob
+  --                mor
+  --                _
+  --                pushout_compose
+  --                pushout_id
+  --                pushout_assoc
+  --                pushout_id_left
+  --                pushout_id_right
+
+  -- end
+
+  variables {C D E : Groupoid} (F : C ⇒ D) (G : C ⇒ E)
+  variables ⦃x x' x₁ x₂ x₃ x₄ : Precategory_pushout F G⦄
+
+  definition pushout_index_inv [unfold 8] (i : pushout_prehom_index F G x x') :
+    pushout_prehom_index F G x' x :=
+  begin
+    induction i,
+    { exact il F G f⁻¹},
+    { exact ir F G g⁻¹},
+    { exact rl F G h⁻¹},
+    { exact lr F G h⁻¹},
+  end
+
+  open indexed_list.indexed_list_rel
+  theorem pushout_index_reverse {l l' : pushout_prehom F G x x'}
+    (q : pushout_hom_rel_index F G l l') : indexed_list_rel (pushout_hom_rel_index F G)
+      (reverse (pushout_index_inv F G) l) (reverse (pushout_index_inv F G) l') :=
+  begin
+    induction q: apply indexed_list_rel_of_Q; rewrite reverse_singleton; try rewrite reverse_pair;
+    try rewrite reverse_nil; esimp,
+    { rewrite [comp_inverse], constructor},
+    { rewrite [comp_inverse], constructor},
+    { rewrite [-respect_inv, comp_inverse], constructor},
+    { rewrite [-respect_inv, comp_inverse], constructor},
+    { rewrite [id_inverse], constructor},
+    { rewrite [id_inverse], constructor}
+  end
+
+  theorem pushout_index_li (i : pushout_prehom_index F G x x') :
+    indexed_list_rel (pushout_hom_rel_index F G) [pushout_index_inv F G i, i] nil :=
+  begin
+    induction i: esimp,
+    { refine rtrans (indexed_list_rel_of_Q !DD) _,
+      rewrite [comp.left_inverse], exact indexed_list_rel_of_Q !idD},
+    { refine rtrans (indexed_list_rel_of_Q !EE) _,
+      rewrite [comp.left_inverse], exact indexed_list_rel_of_Q !idE},
+    { refine rtrans (indexed_list_rel_of_Q !DED) _,
+      rewrite [comp.left_inverse, respect_id], exact indexed_list_rel_of_Q !idD},
+    { refine rtrans (indexed_list_rel_of_Q !EDE) _,
+      rewrite [comp.left_inverse, respect_id], exact indexed_list_rel_of_Q !idE}
+  end
+
+  theorem pushout_index_ri (i : pushout_prehom_index F G x x') :
+    indexed_list_rel (pushout_hom_rel_index F G) [i, pushout_index_inv F G i] nil :=
+  begin
+    induction i: esimp,
+    { refine rtrans (indexed_list_rel_of_Q !DD) _,
+      rewrite [comp.right_inverse], exact indexed_list_rel_of_Q !idD},
+    { refine rtrans (indexed_list_rel_of_Q !EE) _,
+      rewrite [comp.right_inverse], exact indexed_list_rel_of_Q !idE},
+    { refine rtrans (indexed_list_rel_of_Q !EDE) _,
+      rewrite [comp.right_inverse, respect_id], exact indexed_list_rel_of_Q !idE},
+    { refine rtrans (indexed_list_rel_of_Q !DED) _,
+      rewrite [comp.right_inverse, respect_id], exact indexed_list_rel_of_Q !idD}
+  end
+
+  definition Groupoid_pushout [constructor] : Groupoid :=
+  Groupoid_indexed_list (pushout_hom_rel_index F G) (pushout_index_inv F G)
+    (pushout_index_reverse F G) (pushout_index_li F G) (pushout_index_ri F G)
+
+
+end category

--- a/hott/algebra/category/default.hlean
+++ b/hott/algebra/category/default.hlean
@@ -4,4 +4,4 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 
-import .category .strict .groupoid .constructions
+import .category .strict .groupoid .constructions .limits .functor

--- a/hott/algebra/category/functor/adjoint.hlean
+++ b/hott/algebra/category/functor/adjoint.hlean
@@ -52,7 +52,7 @@ namespace category
       → is_left_adjoint.mk G η ε H K = is_left_adjoint.mk G' η' ε' H' K',
     begin
       intros p q r, induction p, induction q, induction r, esimp,
-      apply apd011 (is_left_adjoint.mk G η ε) !is_prop.elim !is_prop.elim
+      apply apd011 (is_left_adjoint.mk G η ε) !is_prop.elim !is_prop.elimo
     end,
     have lem₂ : Π (d : carrier D),
                     (to_fun_hom G (natural_map ε' d) ∘

--- a/hott/algebra/category/functor/basic.hlean
+++ b/hott/algebra/category/functor/basic.hlean
@@ -56,7 +56,7 @@ namespace functor
     {H₂ : Π(a b : C), hom a b → hom (F₂ a) (F₂ b)} (id₁ id₂ comp₁ comp₂)
     (pF : F₁ = F₂) (pH : pF ▸ H₁ = H₂)
       : functor.mk F₁ H₁ id₁ comp₁ = functor.mk F₂ H₂ id₂ comp₂ :=
-  apd01111 functor.mk pF pH !is_prop.elim !is_prop.elim
+  apdt01111 functor.mk pF pH !is_prop.elim !is_prop.elim
 
   definition functor_eq' {F₁ F₂ : C ⇒ D} : Π(p : to_fun_ob F₁ = to_fun_ob F₂),
     (transport (λx, Πa b f, hom (x a) (x b)) p @(to_fun_hom F₁) = @(to_fun_hom F₂)) → F₁ = F₂ :=
@@ -192,9 +192,9 @@ namespace functor
   definition functor_mk_eq'_idp (F : C → D) (H : Π(a b : C), hom a b → hom (F a) (F b))
     (id comp) : functor_mk_eq' id id comp comp (idpath F) (idpath H) = idp :=
   begin
-    fapply apd011 (apd01111 functor.mk idp idp),
-    apply is_set.elim,
-    apply is_set.elim
+    fapply apd011 (apdt01111 functor.mk idp idp),
+    apply is_prop.elim,
+    apply is_prop.elimo
   end
 
   definition functor_eq'_idp (F : C ⇒ D) : functor_eq' idp idp = (idpath F) :=
@@ -225,9 +225,9 @@ namespace functor
 
   theorem ap010_apd01111_functor {F₁ F₂ : C → D} {H₁ : Π(a b : C), hom a b → hom (F₁ a) (F₁ b)}
     {H₂ : Π(a b : C), hom a b → hom (F₂ a) (F₂ b)} {id₁ id₂ comp₁ comp₂}
-    (pF : F₁ = F₂) (pH : pF ▸ H₁ = H₂) (pid : cast (apd011 _ pF pH) id₁ = id₂)
-    (pcomp : cast (apd0111 _ pF pH pid) comp₁ = comp₂) (c : C)
-      : ap010 to_fun_ob (apd01111 functor.mk pF pH pid pcomp) c = ap10 pF c :=
+    (pF : F₁ = F₂) (pH : pF ▸ H₁ = H₂) (pid : cast (apdt011 _ pF pH) id₁ = id₂)
+    (pcomp : cast (apdt0111 _ pF pH pid) comp₁ = comp₂) (c : C)
+      : ap010 to_fun_ob (apdt01111 functor.mk pF pH pid pcomp) c = ap10 pF c :=
   by induction pF; induction pH; induction pid; induction pcomp; reflexivity
 
   definition ap010_functor_eq {F₁ F₂ : C ⇒ D} (p : to_fun_ob F₁ ~ to_fun_ob F₂)

--- a/hott/algebra/category/functor/default.hlean
+++ b/hott/algebra/category/functor/default.hlean
@@ -4,4 +4,4 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 
-import .basic
+import .exponential_laws

--- a/hott/algebra/category/functor/equivalence.hlean
+++ b/hott/algebra/category/functor/equivalence.hlean
@@ -334,13 +334,13 @@ namespace category
   definition equivalence_eq {C : Category} {D : Precategory} {F F' : C ≃c D}
     (p : equivalence.to_functor F = equivalence.to_functor F') : F = F' :=
   begin
-    induction F, induction F', exact apd011 equivalence.mk p !is_prop.elim
+    induction F, induction F', exact apd011 equivalence.mk p !is_prop.elimo
   end
 
   definition isomorphism_eq {F F' : C ≅c D}
     (p : isomorphism.to_functor F = isomorphism.to_functor F') : F = F' :=
   begin
-    induction F, induction F', exact apd011 isomorphism.mk p !is_prop.elim
+    induction F, induction F', exact apd011 isomorphism.mk p !is_prop.elimo
   end
 
   definition is_equiv_isomorphism_of_equivalence [constructor] (C D : Category)

--- a/hott/algebra/category/groupoid.hlean
+++ b/hott/algebra/category/groupoid.hlean
@@ -17,8 +17,8 @@ namespace category
 
   abbreviation all_iso := @groupoid.all_iso
   attribute groupoid.all_iso [instance] [priority 3000]
-
-  definition groupoid.mk [reducible] {ob : Type} (C : precategory ob)
+  attribute groupoid.to_precategory [unfold 2]
+  definition groupoid.mk [reducible] [constructor] {ob : Type} (C : precategory ob)
     (H : Π (a b : ob) (f : a ⟶ b), is_iso f) : groupoid ob :=
   precategory.rec_on C groupoid.mk' H
 

--- a/hott/algebra/category/iso.hlean
+++ b/hott/algebra/category/iso.hlean
@@ -121,8 +121,8 @@ namespace iso
       apply left_inverse_eq_right_inverse,
         apply li,
         apply ri',
-      apply is_prop.elim,
-      apply is_prop.elim,
+      apply is_prop.elimo,
+      apply is_prop.elimo,
   end
 end iso open iso
 
@@ -174,7 +174,7 @@ namespace iso
 
   definition iso_mk_eq {f f' : a ⟶ b} [H : is_iso f] [H' : is_iso f'] (p : f = f')
       : iso.mk f _ = iso.mk f' _ :=
-  apd011 iso.mk p !is_prop.elim
+  apd011 iso.mk p !is_prop.elimo
 
   variable {C}
   definition iso_eq {f f' : a ≅ b} (p : to_hom f = to_hom f') : f = f' :=

--- a/hott/algebra/category/limits/default.hlean
+++ b/hott/algebra/category/limits/default.hlean
@@ -4,4 +4,4 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 
-import .limits .colimits
+import .set .functor .adjoint .functor_preserve

--- a/hott/algebra/category/nat_trans.hlean
+++ b/hott/algebra/category/nat_trans.hlean
@@ -52,7 +52,7 @@ namespace nat_trans
     (nat₂ : Π (a b : C) (f : hom a b), G f ∘ η₂ a = η₂ b ∘ F f)
     (p : η₁ ~ η₂)
       : nat_trans.mk η₁ nat₁ = nat_trans.mk η₂ nat₂ :=
-  apd011 nat_trans.mk (eq_of_homotopy p) !is_prop.elim
+  apd011 nat_trans.mk (eq_of_homotopy p) !is_prop.elimo
 
   definition nat_trans_eq {η₁ η₂ : F ⟹ G} : natural_map η₁ ~ natural_map η₂ → η₁ = η₂ :=
   by induction η₁; induction η₂; apply nat_trans_mk_eq

--- a/hott/algebra/default.hlean
+++ b/hott/algebra/default.hlean
@@ -1,0 +1,7 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+
+import .homotopy_group .ordered_field

--- a/hott/algebra/graph.hlean
+++ b/hott/algebra/graph.hlean
@@ -1,0 +1,330 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Authors: Floris van Doorn
+
+Graphs and operations on graphs
+
+Currently we only define the notion of a path in a graph, and prove properties and operations on
+paths.
+-/
+
+open eq sigma nat
+
+/-
+  A path is a list of vertexes which are adjacent. We maybe use a weird ordering of cons, because
+  the major example where we use this is a category where this ordering makes more sense.
+  For the operations on paths we use the names from the corresponding operations on lists. Opening
+  both the list and the paths namespace will lead to many name clashes, so that is not advised.
+-/
+
+inductive paths {A : Type} (R : A → A → Type) : A → A → Type :=
+| nil {} : Π{a : A}, paths R a a
+| cons   : Π{a₁ a₂ a₃ : A} (r : R a₂ a₃), paths R a₁ a₂ → paths R a₁ a₃
+
+namespace paths
+
+  notation h :: t  := cons h t
+  notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
+
+  variables {A : Type} {R : A → A → Type} {a a' a₁ a₂ a₃ a₄ : A}
+
+  definition concat (r : R a₁ a₂) (l : paths R a₂ a₃) : paths R a₁ a₃ :=
+  begin
+    induction l with a a₂ a₃ a₄ r' l IH,
+    { exact [r]},
+    { exact r' :: IH r}
+  end
+
+  theorem concat_nil (r : R a₁ a₂) : concat r (@nil A R a₂) = [r] := idp
+
+  theorem concat_cons (r : R a₁ a₂) (r' : R a₃ a₄) (l : paths R a₂ a₃)
+    : concat r (r'::l)  = r'::(concat r l) := idp
+
+  definition append (l₂ : paths R a₂ a₃) (l₁ : paths R a₁ a₂) :
+    paths R a₁ a₃ :=
+  begin
+    induction l₂,
+    { exact l₁},
+    { exact cons r (v_0 l₁)}
+  end
+
+  infix ` ++ ` := append
+
+  definition nil_append (l : paths R a₁ a₂) : nil ++ l = l := idp
+  definition cons_append (r : R a₃ a₄) (l₂ : paths R a₂ a₃) (l₁ : paths R a₁ a₂) :
+    (r :: l₂) ++ l₁ = r :: (l₂ ++ l₁) := idp
+
+  definition singleton_append (r : R a₂ a₃) (l : paths R a₁ a₂) : [r] ++ l = r :: l := idp
+  definition append_singleton (l : paths R a₂ a₃) (r : R a₁ a₂) : l ++ [r] = concat r l :=
+  begin
+    induction l,
+    { reflexivity},
+    { exact ap (cons r) !v_0}
+  end
+
+  definition append_nil (l : paths R a₁ a₂) : l ++ nil = l :=
+  begin
+    induction l,
+    { reflexivity},
+    { exact ap (cons r) v_0}
+  end
+
+  definition append_assoc (l₃ : paths R a₃ a₄) (l₂ : paths R a₂ a₃)
+    (l₁ : paths R a₁ a₂) : (l₃ ++ l₂) ++ l₁ = l₃ ++ (l₂ ++ l₁) :=
+  begin
+    induction l₃,
+    { reflexivity},
+    { refine ap (cons r) !v_0}
+  end
+
+  theorem append_concat (l₂ : paths R a₃ a₄) (l₁ : paths R a₂ a₃) (r : R a₁ a₂) :
+    l₂ ++ concat r l₁ = concat r (l₂ ++ l₁) :=
+  begin
+    induction l₂,
+    { reflexivity},
+    { exact ap (cons r_1) !v_0}
+  end
+
+  theorem concat_append (l₂ : paths R a₃ a₄) (r : R a₂ a₃) (l₁ : paths R a₁ a₂) :
+    concat r l₂ ++ l₁ = l₂ ++ r :: l₁ :=
+  begin
+    induction l₂,
+    { reflexivity},
+    { exact ap (cons r) !v_0}
+  end
+
+  definition paths.rec_tail {C : Π⦃a a' : A⦄, paths R a a' → Type}
+  (H0 : Π {a : A}, @C a a nil)
+  (H1 : Π {a₁ a₂ a₃ : A} (r : R a₁ a₂) (l : paths R a₂ a₃), C l → C (concat r l)) :
+  Π{a a' : A} (l : paths R a a'), C l :=
+  begin
+    have Π{a₁ a₂ a₃ : A} (l₂ : paths R a₂ a₃) (l₁ : paths R a₁ a₂) (c : C l₂),
+      C (l₂ ++ l₁),
+    begin
+      intros, revert a₃ l₂ c, induction l₁: intros a₃ l₂ c,
+      { rewrite append_nil, exact c},
+      { rewrite [-concat_append], apply v_0, apply H1, exact c}
+    end,
+    intros, rewrite [-nil_append], apply this, apply H0
+  end
+
+  definition cons_eq_concat (r : R a₂ a₃) (l : paths R a₁ a₂) :
+    Σa (r' : R a₁ a) (l' : paths R a a₃), r :: l = concat r' l' :=
+  begin
+    revert a₃ r, induction l: intros a₃' r',
+    { exact ⟨a₃', r', nil, idp⟩},
+    { cases (v_0 a₃ r) with a₄ w, cases w with r₂ w, cases w with l p, clear v_0,
+      exact ⟨a₄, r₂, r' :: l, ap (cons r') p⟩}
+  end
+
+  definition length (l : paths R a₁ a₂) : ℕ :=
+  begin
+    induction l,
+    { exact 0},
+    { exact succ v_0}
+  end
+
+  /- If we can reverse edges in the graph we can reverse paths -/
+
+  definition reverse (rev : Π⦃a a'⦄, R a a' → R a' a) (l : paths R a₁ a₂) :
+    paths R a₂ a₁ :=
+  begin
+    induction l,
+    { exact nil},
+    { exact concat (rev r) v_0}
+  end
+
+  theorem reverse_nil (rev : Π⦃a a'⦄, R a a' → R a' a) : reverse rev (@nil A R a₁) = [] := idp
+
+  theorem reverse_cons (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₂ a₃) (l : paths R a₁ a₂) :
+    reverse rev (r::l) = concat (rev r) (reverse rev l) := idp
+
+  theorem reverse_singleton (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₁ a₂) :
+    reverse rev [r] = [rev r] := idp
+
+  theorem reverse_pair (rev : Π⦃a a'⦄, R a a' → R a' a) (r₂ : R a₂ a₃) (r₁ : R a₁ a₂) :
+    reverse rev [r₂, r₁] = [rev r₁, rev r₂] := idp
+
+  theorem reverse_concat (rev : Π⦃a a'⦄, R a a' → R a' a) (r : R a₁ a₂) (l : paths R a₂ a₃) :
+    reverse rev (concat r l) = rev r :: (reverse rev l) :=
+  begin
+    induction l,
+    { reflexivity},
+    { rewrite [concat_cons, reverse_cons, v_0]}
+  end
+
+  theorem reverse_append (rev : Π⦃a a'⦄, R a a' → R a' a) (l₂ : paths R a₂ a₃)
+    (l₁ : paths R a₁ a₂) : reverse rev (l₂ ++ l₁) = reverse rev l₁ ++ reverse rev l₂ :=
+  begin
+    induction l₂,
+    { exact !append_nil⁻¹},
+    { rewrite [cons_append, +reverse_cons, append_concat, v_0]}
+  end
+
+  definition realize (P : A → A → Type) (f : Π⦃a a'⦄, R a a' → P a a') (ρ : Πa, P a a)
+    (c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃)
+    ⦃a a' : A⦄ (l : paths R a a') : P a a' :=
+  begin
+    induction l,
+    { exact ρ a},
+    { exact c v_0 (f r)}
+  end
+
+  definition realize_nil (P : A → A → Type) (f : Π⦃a a'⦄, R a a' → P a a') (ρ : Πa, P a a)
+    (c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃) (a : A) :
+    realize P f ρ c nil = ρ a :=
+  idp
+
+  definition realize_cons (P : A → A → Type) (f : Π⦃a a'⦄, R a a' → P a a') (ρ : Πa, P a a)
+    (c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃)
+    ⦃a₁ a₂ a₃ : A⦄ (r : R a₂ a₃) (l : paths R a₁ a₂) :
+    realize P f ρ c (r :: l) = c (realize P f ρ c l) (f r) :=
+  idp
+
+  theorem realize_singleton {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
+    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
+    (id_left : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c (ρ a₁) p = p)
+    ⦃a₁ a₂ : A⦄ (r : R a₁ a₂) :
+    realize P f ρ c [r] = f r :=
+  id_left (f r)
+
+  theorem realize_pair {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
+    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
+    (id_left : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c (ρ a₁) p = p)
+    ⦃a₁ a₂ a₃ : A⦄ (r₂ : R a₂ a₃) (r₁ : R a₁ a₂) :
+    realize P f ρ c [r₂, r₁] = c (f r₁) (f r₂) :=
+  ap (λx, c x (f r₂)) (realize_singleton id_left r₁)
+
+  theorem realize_append {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
+    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
+    (assoc : Π⦃a₁ a₂ a₃ a₄⦄ (p : P a₁ a₂) (q : P a₂ a₃) (r : P a₃ a₄), c (c p q) r = c p (c q r))
+    (id_right : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c p (ρ a₂) = p)
+    ⦃a₁ a₂ a₃ : A⦄ (l₂ : paths R a₂ a₃) (l₁ : paths R a₁ a₂) :
+    realize P f ρ c (l₂ ++ l₁) = c (realize P f ρ c l₁) (realize P f ρ c l₂) :=
+  begin
+    induction l₂,
+    { exact !id_right⁻¹},
+    { rewrite [cons_append, +realize_cons, v_0, assoc]}
+  end
+
+  /-
+    We sometimes want to take quotients of paths (this library was developed to define the pushout of
+    categories). The definition paths_rel will - given some basic reduction rules codified by Q -
+    extend the reduction to a reflexive transitive relation respecting concatenation of paths.
+  -/
+
+  inductive paths_rel {A : Type} {R : A → A → Type}
+    (Q : Π⦃a a' : A⦄, paths R a a' → paths R a a' → Type)
+    : Π⦃a a' : A⦄, paths R a a' → paths R a a' → Type :=
+  | rrefl  : Π{a a' : A} (l : paths R a a'), paths_rel Q l l
+  | rel    : Π{a₁ a₂ a₃ : A} {l₂ l₃ : paths R a₂ a₃} (l : paths R a₁ a₂) (q : Q l₂ l₃),
+      paths_rel Q (l₂ ++ l) (l₃ ++ l)
+  | rcons  : Π{a₁ a₂ a₃ : A} {l₁ l₂ : paths R a₁ a₂} (r : R a₂ a₃),
+      paths_rel Q l₁ l₂ → paths_rel Q (cons r l₁) (cons r l₂)
+  | rtrans : Π{a₁ a₂ : A} {l₁ l₂ l₃ : paths R a₁ a₂},
+      paths_rel Q l₁ l₂ → paths_rel Q l₂ l₃ → paths_rel Q l₁ l₃
+
+  open paths_rel
+  attribute rrefl [refl]
+  attribute rtrans [trans]
+  variables {Q : Π⦃a a' : A⦄, paths R a a' → paths R a a' → Type}
+
+  definition paths_rel_of_Q {l₁ l₂ : paths R a₁ a₂} (q : Q l₁ l₂) :
+    paths_rel Q l₁ l₂ :=
+  begin
+    rewrite [-append_nil l₁, -append_nil l₂], exact rel nil q,
+  end
+
+  theorem rel_respect_append_left (l : paths R a₂ a₃) {l₃ l₄ : paths R a₁ a₂}
+    (H : paths_rel Q l₃ l₄) : paths_rel Q (l ++ l₃) (l ++ l₄) :=
+  begin
+    induction l,
+    { exact H},
+    { exact rcons r (v_0 _ _ H)}
+  end
+
+  theorem rel_respect_append_right {l₁ l₂ : paths R a₂ a₃} (l : paths R a₁ a₂)
+    (H₁ : paths_rel Q l₁ l₂) : paths_rel Q (l₁ ++ l) (l₂ ++ l) :=
+  begin
+    induction H₁ with a₁ a₂ l₁
+                      a₂ a₃ a₄ l₂ l₂' l₁ q
+                      a₂ a₃ a₄ l₁ l₂ r H₁ IH
+                      a₂ a₃ l₁ l₂ l₂' H₁ H₁' IH IH',
+    { reflexivity},
+    { rewrite [+ append_assoc], exact rel _ q},
+    { exact rcons r (IH l) },
+    { exact rtrans (IH l) (IH' l)}
+  end
+
+  theorem rel_respect_append {l₁ l₂ : paths R a₂ a₃} {l₃ l₄ : paths R a₁ a₂}
+    (H₁ : paths_rel Q l₁ l₂) (H₂ : paths_rel Q l₃ l₄) :
+    paths_rel Q (l₁ ++ l₃) (l₂ ++ l₄) :=
+  begin
+    induction H₁ with a₁ a₂ l
+                      a₂ a₃ a₄ l₂ l₂' l q
+                      a₂ a₃ a₄ l₁ l₂ r H₁ IH
+                      a₂ a₃ l₁ l₂ l₂' H₁ H₁' IH IH',
+    { exact rel_respect_append_left _ H₂},
+    { rewrite [+ append_assoc], transitivity _, exact rel _ q,
+      apply rel_respect_append_left, apply rel_respect_append_left, exact H₂},
+    { exact rcons r (IH _ _ H₂) },
+    { refine rtrans (IH _ _ H₂) _, apply rel_respect_append_right, exact H₁'}
+  end
+
+  /- assuming some extra properties the relation respects reversing -/
+
+  theorem rel_respect_reverse (rev : Π⦃a a'⦄, R a a' → R a' a) {l₁ l₂ : paths R a₁ a₂}
+    (H : paths_rel Q l₁ l₂)
+    (rev_rel : Π⦃a a' : A⦄ {l l' : paths R a a'},
+      Q l l' → paths_rel Q (reverse rev l) (reverse rev l')) :
+    paths_rel Q (reverse rev l₁) (reverse rev l₂) :=
+  begin
+    induction H,
+    { reflexivity},
+    { rewrite [+ reverse_append], apply rel_respect_append_left, apply rev_rel q},
+    { rewrite [+reverse_cons,-+append_singleton], apply rel_respect_append_right, exact v_0},
+    { exact rtrans v_0 v_1}
+  end
+
+  theorem rel_left_inv (rev : Π⦃a a'⦄, R a a' → R a' a) (l : paths R a₁ a₂)
+    (li : Π⦃a a' : A⦄ (r : R a a'), paths_rel Q [rev r, r] nil) :
+    paths_rel Q (reverse rev l ++ l) nil :=
+  begin
+    induction l,
+    { reflexivity},
+    { rewrite [reverse_cons, concat_append],
+      refine rtrans _ v_0, apply rel_respect_append_left,
+      exact rel_respect_append_right _ (li r)}
+  end
+
+  theorem rel_right_inv (rev : Π⦃a a'⦄, R a a' → R a' a) (l : paths R a₁ a₂)
+    (ri : Π⦃a a' : A⦄ (r : R a a'), paths_rel Q [r, rev r] nil) :
+    paths_rel Q (l ++ reverse rev l) nil :=
+  begin
+    induction l using paths.rec_tail,
+    { reflexivity},
+    { rewrite [reverse_concat, concat_append],
+      refine rtrans _ a, apply rel_respect_append_left,
+      exact rel_respect_append_right _ (ri r)}
+  end
+
+  definition realize_eq {P : A → A → Type} {f : Π⦃a a'⦄, R a a' → P a a'} {ρ : Πa, P a a}
+    {c : Π⦃a₁ a₂ a₃⦄, P a₁ a₂ → P a₂ a₃ → P a₁ a₃}
+    (assoc : Π⦃a₁ a₂ a₃ a₄⦄ (p : P a₁ a₂) (q : P a₂ a₃) (r : P a₃ a₄), c (c p q) r = c p (c q r))
+    (id_right : Π⦃a₁ a₂⦄ (p : P a₁ a₂), c p (ρ a₂) = p)
+    (resp_rel : Π⦃a₁ a₂⦄ {l₁ l₂ : paths R a₁ a₂}, Q l₁ l₂ →
+      realize P f ρ c l₁ = realize P f ρ c l₂)
+    ⦃a a' : A⦄ {l l' : paths R a a'} (H : paths_rel Q l l') :
+    realize P f ρ c l = realize P f ρ c l' :=
+  begin
+    induction H,
+    { reflexivity},
+    { rewrite [+realize_append assoc id_right], apply ap (c _), exact resp_rel q},
+    { exact ap (λx, c x (f r)) v_0},
+    { exact v_0 ⬝ v_1}
+  end
+
+
+end paths

--- a/hott/algebra/group_theory.hlean
+++ b/hott/algebra/group_theory.hlean
@@ -16,9 +16,9 @@ set_option class.force_new true
 
 namespace group
 
-  definition pointed_Group [instance] (G : Group) : pointed G := pointed.mk one
-  definition pType_of_Group [reducible] (G : Group) : Type* := pointed.mk' G
-  definition Set_of_Group (G : Group) : Set := trunctype.mk G _
+  definition pointed_Group [instance] [constructor] (G : Group) : pointed G := pointed.mk 1
+  definition pType_of_Group [constructor] [reducible] (G : Group) : Type* := pointed.MK G 1
+  definition Set_of_Group [constructor] (G : Group) : Set := trunctype.mk G _
 
   definition Group_of_CommGroup [coercion] [constructor] (G : CommGroup) : Group :=
   Group.mk G _
@@ -112,9 +112,8 @@ namespace group
     apply is_trunc_equiv_closed_rev, exact H
   end
 
-  local attribute group_pType_of_Group pointed.mk' [reducible]
   definition pmap_of_homomorphism [constructor] /- φ -/ : pType_of_Group G₁ →* pType_of_Group G₂ :=
-  pmap.mk φ (respect_one φ)
+  pmap.mk φ begin esimp, exact respect_one φ end
 
   definition homomorphism_eq (p : group_fun φ₁ ~ group_fun φ₂) : φ₁ = φ₂ :=
   begin
@@ -146,7 +145,7 @@ namespace group
 
   definition pequiv_of_isomorphism [constructor] (φ : G₁ ≃g G₂) :
     pType_of_Group G₁ ≃* pType_of_Group G₂ :=
-  pequiv.mk φ _ (respect_one φ)
+  pequiv.mk φ begin esimp, exact _ end begin esimp, exact respect_one φ end
 
   definition isomorphism_of_equiv [constructor] (φ : G₁ ≃ G₂)
     (p : Πg₁ g₂, φ (g₁ * g₂) = φ g₁ * φ g₂) : G₁ ≃g G₂ :=

--- a/hott/algebra/homotopy_group.hlean
+++ b/hott/algebra/homotopy_group.hlean
@@ -69,14 +69,19 @@ namespace eq
     exact loopn_pequiv_loopn k (pequiv_of_eq begin rewrite [trunc_index.zero_add] end)
   end
 
+  open trunc_index
+  definition phomotopy_group_ptrunc_of_le [constructor] {k n : ℕ} (H : k ≤ n) (A : Type*) :
+    π*[k] (ptrunc n A) ≃* π*[k] A :=
+  calc
+    π*[k] (ptrunc n A) ≃* Ω[k] (ptrunc k (ptrunc n A))
+             : phomotopy_group_pequiv_loop_ptrunc k (ptrunc n A)
+      ... ≃* Ω[k] (ptrunc k A)
+             : loopn_pequiv_loopn k (ptrunc_ptrunc_pequiv_left A (of_nat_le_of_nat H))
+      ... ≃* π*[k] A : (phomotopy_group_pequiv_loop_ptrunc k A)⁻¹ᵉ*
+
   definition phomotopy_group_ptrunc [constructor] (k : ℕ) (A : Type*) :
     π*[k] (ptrunc k A) ≃* π*[k] A :=
-  calc
-    π*[k] (ptrunc k A) ≃* Ω[k] (ptrunc k (ptrunc k A))
-             : phomotopy_group_pequiv_loop_ptrunc k (ptrunc k A)
-      ... ≃* Ω[k] (ptrunc k A)
-             : loopn_pequiv_loopn k (ptrunc_pequiv k (ptrunc k A) _)
-      ... ≃* π*[k] A : (phomotopy_group_pequiv_loop_ptrunc k A)⁻¹ᵉ*
+  phomotopy_group_ptrunc_of_le (le.refl k) A
 
   theorem trivial_homotopy_of_is_set (A : Type*) [H : is_set A] (n : ℕ) : πg[n+1] A ≃g G0 :=
   begin
@@ -149,7 +154,7 @@ namespace eq
   definition is_equiv_phomotopy_group_functor_ap1 (n : ℕ) {A B : Type*} (f : A →* B)
     [is_equiv (π→*[n + 1] f)] : is_equiv (π→*[n] (Ω→ f)) :=
   have is_equiv (pcast (phomotopy_group_succ_in B n) ∘* π→*[n + 1] f),
-  begin apply @(is_equiv_compose (π→*[n + 1] f) _) end,
+  from is_equiv_compose _ (π→*[n + 1] f),
   have is_equiv (π→*[n] (Ω→ f) ∘ pcast (phomotopy_group_succ_in A n)),
   from is_equiv.homotopy_closed _ (phomotopy_group_functor_succ_phomotopy_in n f),
   is_equiv.cancel_right (pcast (phomotopy_group_succ_in A n)) _

--- a/hott/algebra/hott.hlean
+++ b/hott/algebra/hott.hlean
@@ -69,7 +69,7 @@ namespace algebra
     (resp_mul : Π(g h : G), cast p (g * h) = cast p g * cast p h) : G = H :=
   begin
     cases G with Gc G, cases H with Hc H,
-    apply (apo011 mk p),
+    apply (apd011 mk p),
     exact group_pathover resp_mul
   end
 

--- a/hott/arity.hlean
+++ b/hott/arity.hlean
@@ -79,29 +79,29 @@ namespace eq
   definition ap01000 (f : X → Πa b c, D a b c) (Hx : x = x') : f x ~3 f x' :=
   by intros; cases Hx; reflexivity
 
-  definition apd011 (f : Πa, B a → Z) (Ha : a = a') (Hb : transport B Ha b = b')
+  definition apdt011 (f : Πa, B a → Z) (Ha : a = a') (Hb : transport B Ha b = b')
       : f a b = f a' b' :=
   by cases Ha; cases Hb; reflexivity
 
-  definition apd0111 (f : Πa b, C a b → Z) (Ha : a = a') (Hb : transport B Ha b = b')
-    (Hc : cast (apd011 C Ha Hb) c = c')
+  definition apdt0111 (f : Πa b, C a b → Z) (Ha : a = a') (Hb : transport B Ha b = b')
+    (Hc : cast (apdt011 C Ha Hb) c = c')
       : f a b c = f a' b' c' :=
   by cases Ha; cases Hb; cases Hc; reflexivity
 
-  definition apd01111 (f : Πa b c, D a b c → Z) (Ha : a = a') (Hb : transport B Ha b = b')
-    (Hc : cast (apd011 C Ha Hb) c = c') (Hd : cast (apd0111 D Ha Hb Hc) d = d')
+  definition apdt01111 (f : Πa b c, D a b c → Z) (Ha : a = a') (Hb : transport B Ha b = b')
+    (Hc : cast (apdt011 C Ha Hb) c = c') (Hd : cast (apdt0111 D Ha Hb Hc) d = d')
       : f a b c d = f a' b' c' d' :=
   by cases Ha; cases Hb; cases Hc; cases Hd; reflexivity
 
-  definition apd011111 (f : Πa b c d, E a b c d → Z) (Ha : a = a') (Hb : transport B Ha b = b')
-    (Hc : cast (apd011 C Ha Hb) c = c') (Hd : cast (apd0111 D Ha Hb Hc) d = d')
-    (He : cast (apd01111 E Ha Hb Hc Hd) e = e')
+  definition apdt011111 (f : Πa b c d, E a b c d → Z) (Ha : a = a') (Hb : transport B Ha b = b')
+    (Hc : cast (apdt011 C Ha Hb) c = c') (Hd : cast (apdt0111 D Ha Hb Hc) d = d')
+    (He : cast (apdt01111 E Ha Hb Hc Hd) e = e')
     : f a b c d e = f a' b' c' d' e' :=
   by cases Ha; cases Hb; cases Hc; cases Hd; cases He; reflexivity
 
-  definition apd0111111 (f : Πa b c d e, F a b c d e → Z) (Ha : a = a') (Hb : transport B Ha b = b')
-    (Hc : cast (apd011 C Ha Hb) c = c') (Hd : cast (apd0111 D Ha Hb Hc) d = d')
-    (He : cast (apd01111 E Ha Hb Hc Hd) e = e') (Hf : cast (apd011111 F Ha Hb Hc Hd He) ff = f')
+  definition apdt0111111 (f : Πa b c d e, F a b c d e → Z) (Ha : a = a') (Hb : transport B Ha b = b')
+    (Hc : cast (apdt011 C Ha Hb) c = c') (Hd : cast (apdt0111 D Ha Hb Hc) d = d')
+    (He : cast (apdt01111 E Ha Hb Hc Hd) e = e') (Hf : cast (apdt011111 F Ha Hb Hc Hd He) ff = f')
     : f a b c d e ff = f a' b' c' d' e' f' :=
   begin cases Ha, cases Hb, cases Hc, cases Hd, cases He, cases Hf, reflexivity end
 

--- a/hott/book.md
+++ b/hott/book.md
@@ -22,7 +22,7 @@ The rows indicate the chapters, the columns the sections.
 | Ch 5  | - | . | ½ | - | - | . | . | ½ |   |    |    |    |    |    |    |
 | Ch 6  | . | + | + | + | + | + | + | + | ¾ | ¼  | ¾  | +  | .  |    |    |
 | Ch 7  | + | + | + | - | ¾ | - | - |   |   |    |    |    |    |    |    |
-| Ch 8  | + | + | + | + | ¾ | ¾ | - | ¾ | ½ | ¼  |    |    |    |    |    |
+| Ch 8  | + | + | + | + | + | ¾ | - | + | + | ¼  |    |    |    |    |    |
 | Ch 9  | ¾ | + | + | ½ | ¾ | ½ | - | - | - |    |    |    |    |    |    |
 | Ch 10 | ¼ | - | - | - | - |   |   |   |   |    |    |    |    |    |    |
 | Ch 11 | - | - | - | - | - | - |   |   |   |    |    |    |    |    |    |
@@ -149,11 +149,11 @@ Every file is in the folder [homotopy](homotopy/homotopy.md)
 - 8.2 (Connectedness of suspensions): [susp](homotopy/susp.hlean) (different proof of Theorem 8.2.1)
 - 8.3 (πk≤n of an n-connected space and π_{k<n}(S^n)): [homotopy_group](homotopy/homotopy_group.hlean)
 - 8.4 (Fiber sequences and the long exact sequence): Mostly in [homotopy.chain_complex](homotopy/chain_complex.hlean), [homotopy.LES_of_homotopy_groups](homotopy/LES_of_homotopy_groups.hlean). Definitions 8.4.1 and 8.4.2 in [types.pointed](types/pointed.hlean), Corollary 8.4.8 in [homotopy.homotopy_group](homotopy/homotopy_group.hlean).
-- 8.5 (The Hopf fibration): [circle](homotopy/circle.hlean) (multiplication on the circle, Lemma 8.5.8), [join](homotopy/join.hlean) (join is associative, Lemma 8.5.9), [hopf](homotopy/hopf.hlean) (The Hopf construction, Lemmas 8.5.5 and 8.5.7), [complex_hopf](homotopy/complex_hopf.hlean) (the H-space structure on the circle and the complex Hopf fibration)
-- 8.6 (The Freudenthal suspension theorem): [connectedness](homotopy/connectedness.hlean) (Lemma 8.6.1), [wedge](homotopy/wedge.hlean) (Wedge connectivity, Lemma 8.6.2). Corollary 8.6.14 is proven directly in [homotopy.freudenthal](homotopy/freudenthal.hlean), however, we don't prove it as a Corollary of Theorem 8.6.4, which is not proven. Stability of iterated suspensions is also in [homotopy.freudenthal](homotopy/freudenthal.hlean). The homotopy groups of spheres in this section are computed in [homotopy.sphere2](homotopy/sphere2.hlean).
+- 8.5 (The Hopf fibration): [hit.pushout](hit/pushout.hlean) (Lemma 8.5.3), [hopf](homotopy/hopf.hlean) (The Hopf construction, Lemmas 8.5.5 and 8.5.7), [susp](homotopy/susp.hlean) (Definition 8.5.6), [circle](homotopy/circle.hlean) (multiplication on the circle, Lemma 8.5.8), [join](homotopy/join.hlean) (join is associative, Lemma 8.5.9), [complex_hopf](homotopy/complex_hopf.hlean) (the H-space structure on the circle and the complex Hopf fibration, i.e. Theorem 8.5.1), [sphere2](homotopy/sphere2.hlean) (Corollary 8.5.2)
+- 8.6 (The Freudenthal suspension theorem): [connectedness](homotopy/connectedness.hlean) (Lemma 8.6.1), [wedge](homotopy/wedge.hlean) (Wedge connectivity, Lemma 8.6.2). Corollary 8.6.14 is proven directly in [freudenthal](homotopy/freudenthal.hlean), however, we don't prove Theorem 8.6.4. Stability of iterated suspensions is also in [freudenthal](homotopy/freudenthal.hlean). The homotopy groups of spheres in this section are computed in [sphere2](homotopy/sphere2.hlean).
 - 8.7 (The van Kampen theorem): not formalized
-- 8.8 (Whitehead’s theorem and Whitehead’s principle): 8.8.1 and 8.8.2 at the bottom of [types.trunc](types/trunc.hlean), 8.8.3 in [homotopy.homotopy_group](homotopy/homotopy_group.hlean).
-- 8.9 (A general statement of the encode-decode method): One variation of the encode-decode method is in [types.eq](types/eq.hlean).
+- 8.8 (Whitehead’s theorem and Whitehead’s principle): 8.8.1 and 8.8.2 at the bottom of [types.trunc](types/trunc.hlean), 8.8.3 in [homotopy_group](homotopy/homotopy_group.hlean). [Rest to be moved]
+- 8.9 (A general statement of the encode-decode method): [types.eq](types/eq.hlean).
 - 8.10 (Additional Results): Theorem 8.10.3 is formalized in [homotopy.EM](homotopy/EM.hlean).
 
 Chapter 9: Category theory

--- a/hott/book.md
+++ b/hott/book.md
@@ -22,7 +22,7 @@ The rows indicate the chapters, the columns the sections.
 | Ch 5  | - | . | ½ | - | - | . | . | ½ |   |    |    |    |    |    |    |
 | Ch 6  | . | + | + | + | + | + | + | + | ¾ | ¼  | ¾  | +  | .  |    |    |
 | Ch 7  | + | + | + | - | ¾ | - | - |   |   |    |    |    |    |    |    |
-| Ch 8  | + | + | + | + | + | ¾ | ½ | + | + | ¼  |    |    |    |    |    |
+| Ch 8  | + | + | + | + | + | ¾ | + | + | + | ¼  |    |    |    |    |    |
 | Ch 9  | ¾ | + | + | ½ | ¾ | ½ | - | - | - |    |    |    |    |    |    |
 | Ch 10 | ¼ | - | - | - | - |   |   |   |   |    |    |    |    |    |    |
 | Ch 11 | - | - | - | - | - | - |   |   |   |    |    |    |    |    |    |
@@ -151,7 +151,7 @@ Every file is in the folder [homotopy](homotopy/homotopy.md)
 - 8.4 (Fiber sequences and the long exact sequence): Mostly in [homotopy.chain_complex](homotopy/chain_complex.hlean), [homotopy.LES_of_homotopy_groups](homotopy/LES_of_homotopy_groups.hlean). Definitions 8.4.1 and 8.4.2 in [types.pointed](types/pointed.hlean), Corollary 8.4.8 in [homotopy.homotopy_group](homotopy/homotopy_group.hlean).
 - 8.5 (The Hopf fibration): [hit.pushout](hit/pushout.hlean) (Lemma 8.5.3), [hopf](homotopy/hopf.hlean) (The Hopf construction, Lemmas 8.5.5 and 8.5.7), [susp](homotopy/susp.hlean) (Definition 8.5.6), [circle](homotopy/circle.hlean) (multiplication on the circle, Lemma 8.5.8), [join](homotopy/join.hlean) (join is associative, Lemma 8.5.9), [complex_hopf](homotopy/complex_hopf.hlean) (the H-space structure on the circle and the complex Hopf fibration, i.e. Theorem 8.5.1), [sphere2](homotopy/sphere2.hlean) (Corollary 8.5.2)
 - 8.6 (The Freudenthal suspension theorem): [connectedness](homotopy/connectedness.hlean) (Lemma 8.6.1), [wedge](homotopy/wedge.hlean) (Wedge connectivity, Lemma 8.6.2). Corollary 8.6.14 is proven directly in [freudenthal](homotopy/freudenthal.hlean), however, we don't prove Theorem 8.6.4. Stability of iterated suspensions is also in [freudenthal](homotopy/freudenthal.hlean). The homotopy groups of spheres in this section are computed in [sphere2](homotopy/sphere2.hlean).
-- 8.7 (The van Kampen theorem): Naive van Kampen is proven in [vankampen](homotopy/vankampen.hlean) (the pushout of Groupoids is formalized in [algebra.category.constructions.pushout](algebra/category/constructions/pushout.hlean)
+- 8.7 (The van Kampen theorem): [vankampen](homotopy/vankampen.hlean) (the pushout of Groupoids is formalized in [algebra.category.constructions.pushout](algebra/category/constructions/pushout.hlean) with some definitions in [algebra.graph](algebra/graph.hlean))
 - 8.8 (Whitehead’s theorem and Whitehead’s principle): 8.8.1 and 8.8.2 at the bottom of [types.trunc](types/trunc.hlean), 8.8.3 in [homotopy_group](homotopy/homotopy_group.hlean). [Rest to be moved]
 - 8.9 (A general statement of the encode-decode method): [types.eq](types/eq.hlean).
 - 8.10 (Additional Results): Theorem 8.10.3 is formalized in [homotopy.EM](homotopy/EM.hlean).

--- a/hott/book.md
+++ b/hott/book.md
@@ -22,7 +22,7 @@ The rows indicate the chapters, the columns the sections.
 | Ch 5  | - | . | ½ | - | - | . | . | ½ |   |    |    |    |    |    |    |
 | Ch 6  | . | + | + | + | + | + | + | + | ¾ | ¼  | ¾  | +  | .  |    |    |
 | Ch 7  | + | + | + | - | ¾ | - | - |   |   |    |    |    |    |    |    |
-| Ch 8  | + | + | + | + | + | ¾ | - | + | + | ¼  |    |    |    |    |    |
+| Ch 8  | + | + | + | + | + | ¾ | ½ | + | + | ¼  |    |    |    |    |    |
 | Ch 9  | ¾ | + | + | ½ | ¾ | ½ | - | - | - |    |    |    |    |    |    |
 | Ch 10 | ¼ | - | - | - | - |   |   |   |   |    |    |    |    |    |    |
 | Ch 11 | - | - | - | - | - | - |   |   |   |    |    |    |    |    |    |
@@ -151,7 +151,7 @@ Every file is in the folder [homotopy](homotopy/homotopy.md)
 - 8.4 (Fiber sequences and the long exact sequence): Mostly in [homotopy.chain_complex](homotopy/chain_complex.hlean), [homotopy.LES_of_homotopy_groups](homotopy/LES_of_homotopy_groups.hlean). Definitions 8.4.1 and 8.4.2 in [types.pointed](types/pointed.hlean), Corollary 8.4.8 in [homotopy.homotopy_group](homotopy/homotopy_group.hlean).
 - 8.5 (The Hopf fibration): [hit.pushout](hit/pushout.hlean) (Lemma 8.5.3), [hopf](homotopy/hopf.hlean) (The Hopf construction, Lemmas 8.5.5 and 8.5.7), [susp](homotopy/susp.hlean) (Definition 8.5.6), [circle](homotopy/circle.hlean) (multiplication on the circle, Lemma 8.5.8), [join](homotopy/join.hlean) (join is associative, Lemma 8.5.9), [complex_hopf](homotopy/complex_hopf.hlean) (the H-space structure on the circle and the complex Hopf fibration, i.e. Theorem 8.5.1), [sphere2](homotopy/sphere2.hlean) (Corollary 8.5.2)
 - 8.6 (The Freudenthal suspension theorem): [connectedness](homotopy/connectedness.hlean) (Lemma 8.6.1), [wedge](homotopy/wedge.hlean) (Wedge connectivity, Lemma 8.6.2). Corollary 8.6.14 is proven directly in [freudenthal](homotopy/freudenthal.hlean), however, we don't prove Theorem 8.6.4. Stability of iterated suspensions is also in [freudenthal](homotopy/freudenthal.hlean). The homotopy groups of spheres in this section are computed in [sphere2](homotopy/sphere2.hlean).
-- 8.7 (The van Kampen theorem): not formalized
+- 8.7 (The van Kampen theorem): Naive van Kampen is proven in [vankampen](homotopy/vankampen.hlean) (the pushout of Groupoids is formalized in [algebra.category.constructions.pushout](algebra/category/constructions/pushout.hlean)
 - 8.8 (Whitehead’s theorem and Whitehead’s principle): 8.8.1 and 8.8.2 at the bottom of [types.trunc](types/trunc.hlean), 8.8.3 in [homotopy_group](homotopy/homotopy_group.hlean). [Rest to be moved]
 - 8.9 (A general statement of the encode-decode method): [types.eq](types/eq.hlean).
 - 8.10 (Additional Results): Theorem 8.10.3 is formalized in [homotopy.EM](homotopy/EM.hlean).

--- a/hott/core.hlean
+++ b/hott/core.hlean
@@ -6,7 +6,4 @@ Authors: Floris van Doorn
 The core of the HoTT library
 -/
 
-import types
-import cubical
-import homotopy.circle
-import algebra.hott
+import types cubical homotopy hit choice

--- a/hott/cubical/pathover2.hlean
+++ b/hott/cubical/pathover2.hlean
@@ -37,8 +37,8 @@ namespace eq
     : pathover_of_tr_eq r = pathover_tr p b ⬝o pathover_idp_of_eq r :=
   by induction r; induction p; reflexivity
 
-  definition apo011_eq_apo11_apd (f : Πa, B a → A') (p : a = a₂) (q : b =[p] b₂)
-      : apo011 f p q = eq_of_pathover (apo11 (apd f p) q) :=
+  definition apd011_eq_apo11_apd (f : Πa, B a → A') (p : a = a₂) (q : b =[p] b₂)
+      : apd011 f p q = apo11_constant_right (apd f p) q :=
   by induction q; reflexivity
 
   definition change_path_con (q : p = p') (q' : p' = p'') (r : b =[p] b₂) :
@@ -124,5 +124,10 @@ namespace eq
   definition cono_invo_eq_idpo {q q' : b =[p] b₂} (r : q = q')
     : change_path (con.right_inv p) (q ⬝o q'⁻¹ᵒ) = idpo :=
   by induction r; induction q; reflexivity
+
+  definition tr_eq_of_pathover_concato_eq {A : Type} {B : A → Type} {a a' : A} {p : a = a'}
+    {b : B a} {b' b'' : B a'} (q : b =[p] b') (r : b' = b'') :
+    tr_eq_of_pathover (q ⬝op r) = tr_eq_of_pathover q ⬝ r :=
+  by induction r; reflexivity
 
 end eq

--- a/hott/cubical/square.hlean
+++ b/hott/cubical/square.hlean
@@ -60,6 +60,10 @@ namespace eq
     : square p₁₀ p₁₄ (p₀₁ ⬝ p₀₃) (p₂₁ ⬝ p₂₃) :=
   by induction s₁₃; exact s₁₁
 
+  definition dconcat [unfold 14] {p₀₀ : a₀₀ = a} {p₂₂ : a = a₂₂}
+    (s₂₁ : square p₀₀ p₁₂ p₀₁ p₂₂) (s₁₂ : square p₁₀ p₂₂ p₀₀ p₂₁) : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  by induction s₁₂; exact s₂₁
+
   definition hinverse [unfold 10] (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁) : square p₁₀⁻¹ p₁₂⁻¹ p₂₁ p₀₁ :=
   by induction s₁₁;exact ids
 
@@ -94,7 +98,7 @@ namespace eq
   definition transpose [unfold 10] (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁) : square p₀₁ p₂₁ p₁₀ p₁₂ :=
   by induction s₁₁;exact ids
 
-  definition aps [unfold 12] {B : Type} (f : A → B) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
+  definition aps [unfold 12] (f : A → B) (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁)
     : square (ap f p₁₀) (ap f p₁₂) (ap f p₀₁) (ap f p₂₁) :=
   by induction s₁₁;exact ids
 
@@ -541,15 +545,15 @@ namespace eq
 
   /- Squares having an 'ap' term on one face -/
   --TODO find better names
-  definition square_Flr_ap_idp {A B : Type} {c : B} {f : A → B} (p : Π a, f a = c)
+  definition square_Flr_ap_idp {c : B} {f : A → B} (p : Π a, f a = c)
     {a b : A} (q : a = b) : square (p a) (p b) (ap f q) idp  :=
   by induction q; apply vrfl
 
-  definition square_Flr_idp_ap {A B : Type} {c : B} {f : A → B} (p : Π a, c = f a)
+  definition square_Flr_idp_ap {c : B} {f : A → B} (p : Π a, c = f a)
     {a b : A} (q : a = b) : square (p a) (p b) idp (ap f q) :=
   by induction q; apply vrfl
 
-  definition square_ap_idp_Flr {A B : Type} {b : B} {f : A → B} (p : Π a, f a = b)
+  definition square_ap_idp_Flr {b : B} {f : A → B} (p : Π a, f a = b)
     {a b : A} (q : a = b) : square (ap f q) idp (p a) (p b) :=
   by induction q; apply hrfl
 
@@ -579,5 +583,36 @@ namespace eq
   definition vp_eq_v {p : a₀₂ = a₂₂} (r : p₁₂ = p) :
     s₁₁ ⬝vp r = s₁₁ ⬝v vdeg_square r :=
   by cases r; cases s₁₁; esimp
+
+  definition natural_square011 {A A' : Type} {B : A → Type}
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} (q : b =[p] b')
+    {l r  : Π⦃a⦄, B a → A'} (g : Π⦃a⦄ (b : B a), l b = r b)
+    : square (apd011 l p q) (apd011 r p q) (g b) (g b') :=
+  begin
+    induction q, exact hrfl
+  end
+
+  definition natural_square0111' {A A' : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} {q : b =[p] b'}
+    {c : C b} {c' : C b'} (s : c =[apd011 C p q] c')
+    {l r  : Π⦃a⦄ {b : B a}, C b → A'}
+    (g : Π⦃a⦄ {b : B a} (c : C b), l c = r c)
+    : square (apd0111 l p q s) (apd0111 r p q s) (g c) (g c') :=
+  begin
+    induction q, esimp at s, induction s using idp_rec_on, exact hrfl
+  end
+
+  -- this can be generalized a bit, by making the domain and codomain of k different, and also have
+  -- a function at the RHS of s (similar to m)
+  definition natural_square0111 {A A' : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} {q : b =[p] b'}
+    {c : C b} {c' : C b'} (r : c =[apd011 C p q] c')
+    {k : A → A} {l : Π⦃a⦄, B a → B (k a)} (m : Π⦃a⦄ {b : B a}, C b → C (l b))
+    {f  : Π⦃a⦄ {b : B a}, C b → A'}
+    (s : Π⦃a⦄ {b : B a} (c : C b), f (m c) = f c)
+    : square (apd0111 (λa b c, f (m c)) p q r) (apd0111 f p q r) (s c) (s c') :=
+  begin
+    induction q, esimp at r, induction r using idp_rec_on, exact hrfl
+  end
 
 end eq

--- a/hott/cubical/squareover.hlean
+++ b/hott/cubical/squareover.hlean
@@ -8,7 +8,7 @@ Squareovers
 
 import .square
 
-open eq equiv is_equiv
+open eq equiv is_equiv sigma
 
 namespace eq
 
@@ -276,5 +276,25 @@ namespace eq
     {q₂₁ : b₂₀ =[p₂₁'] b₂₂} (t : squareover B (s₁₁ ⬝hp r) q₁₀ q₁₂ q₀₁ q₂₁)
   : squareover B s₁₁ q₁₀ q₁₂ q₀₁ (change_path r⁻¹ q₂₁) :=
   by induction r; exact t
+
+  /- You can construct a square in a sigma-type by giving a squareover -/
+  definition square_dpair_eq_dpair {a₀₀ a₂₀ a₀₂ a₂₂ : A}
+    {p₁₀ : a₀₀ = a₂₀} {p₀₁ : a₀₀ = a₀₂} {p₂₁ : a₂₀ = a₂₂} {p₁₂ : a₀₂ = a₂₂}
+    (s₁₁ : square p₁₀ p₁₂ p₀₁ p₂₁) {b₀₀ : B a₀₀} {b₂₀ : B a₂₀} {b₀₂ : B a₀₂} {b₂₂ : B a₂₂}
+    {q₁₀ : b₀₀ =[p₁₀] b₂₀} {q₀₁ : b₀₀ =[p₀₁] b₀₂} {q₂₁ : b₂₀ =[p₂₁] b₂₂} {q₁₂ : b₀₂ =[p₁₂] b₂₂}
+    (t₁₁ : squareover B s₁₁ q₁₀ q₁₂ q₀₁ q₂₁) :
+    square (dpair_eq_dpair p₁₀ q₁₀) (dpair_eq_dpair p₁₂ q₁₂)
+           (dpair_eq_dpair p₀₁ q₀₁) (dpair_eq_dpair p₂₁ q₂₁) :=
+  by induction t₁₁; constructor
+
+  definition sigma_square {v₀₀ v₂₀ v₀₂ v₂₂ : Σa, B a}
+    {p₁₀ : v₀₀ = v₂₀} {p₀₁ : v₀₀ = v₀₂} {p₂₁ : v₂₀ = v₂₂} {p₁₂ : v₀₂ = v₂₂}
+    (s₁₁ : square p₁₀..1 p₁₂..1 p₀₁..1 p₂₁..1)
+    (t₁₁ : squareover B s₁₁ p₁₀..2 p₁₂..2 p₀₁..2 p₂₁..2) : square p₁₀ p₁₂ p₀₁ p₂₁ :=
+  begin
+    induction v₀₀, induction v₂₀, induction v₀₂, induction v₂₂,
+    rewrite [▸* at *, -sigma_eq_eta p₁₀, -sigma_eq_eta p₁₂, -sigma_eq_eta p₀₁, -sigma_eq_eta p₂₁],
+    exact square_dpair_eq_dpair s₁₁ t₁₁
+  end
 
 end eq

--- a/hott/hit/coeq.hlean
+++ b/hott/hit/coeq.hlean
@@ -49,7 +49,7 @@ parameters {A B : Type.{u}} (f g : A → B)
 
   protected definition elim {P : Type} (P_i : B → P)
     (Pcp : Π(x : A), P_i (f x) = P_i (g x)) (y : coeq) : P :=
-  rec P_i (λx, pathover_of_eq (Pcp x)) y
+  rec P_i (λx, pathover_of_eq _ (Pcp x)) y
 
   protected definition elim_on [reducible] {P : Type} (y : coeq) (P_i : B → P)
     (Pcp : Π(x : A), P_i (f x) = P_i (g x)) : P :=
@@ -123,12 +123,12 @@ section
       begin
         change
            quotient.rec P_i
-           (λb b' r, coeq_rel.cases_on r (λx, pathover_of_eq (ua (Pcp x))))
+           (λb b' r, coeq_rel.cases_on r (λx, pathover_of_eq _ (ua (Pcp x))))
            = quotient.rec P_i
-           (λb b' r, pathover_of_eq (ua (coeq_rel.cases_on r Pcp))),
+           (λb b' r, pathover_of_eq _ (ua (coeq_rel.cases_on r Pcp))),
         have H2 : Π⦃b b' : B⦄ (r : coeq_rel f g b b'),
-          coeq_rel.cases_on r (λx, pathover_of_eq (ua (Pcp x)))
-          = pathover_of_eq (ua (coeq_rel.cases_on r Pcp))
+          coeq_rel.cases_on r (λx, pathover_of_eq _ (ua (Pcp x)))
+          = pathover_of_eq _ (ua (coeq_rel.cases_on r Pcp))
             :> P_i b =[eq_of_rel (coeq_rel f g) r] P_i b',
         begin intros b b' r, cases r, reflexivity end,
         rewrite (eq_of_homotopy3 H2)

--- a/hott/hit/colimit.hlean
+++ b/hott/hit/colimit.hlean
@@ -55,7 +55,7 @@ section
 
   protected definition elim {P : Type} (Pincl : Π⦃i : I⦄ (x : A i), P)
     (Pglue : Π(j : J) (x : A (dom j)), Pincl (f j x) = Pincl x) (y : colimit) : P :=
-  rec Pincl (λj a, pathover_of_eq (Pglue j a)) y
+  rec Pincl (λj a, pathover_of_eq _ (Pglue j a)) y
 
   protected definition elim_on [reducible] {P : Type} (y : colimit)
     (Pincl : Π⦃i : I⦄ (x : A i), P)
@@ -146,7 +146,7 @@ section
 
   protected definition elim {P : Type} (Pincl : Π⦃n : ℕ⦄ (a : A n), P)
     (Pglue : Π⦃n : ℕ⦄ (a : A n), Pincl (f a) = Pincl a) : seq_colim → P :=
-  rec Pincl (λn a, pathover_of_eq (Pglue a))
+  rec Pincl (λn a, pathover_of_eq _ (Pglue a))
 
   protected definition elim_on [reducible] {P : Type} (aa : seq_colim)
     (Pincl : Π⦃n : ℕ⦄ (a : A n), P)
@@ -174,6 +174,11 @@ section
     (Pglue : Π⦃n : ℕ⦄ (a : A n), Pincl (f a) ≃ Pincl a) {n : ℕ} (a : A n)
       : transport (elim_type Pincl Pglue) (glue a) = Pglue a :=
   by rewrite [tr_eq_cast_ap_fn,↑elim_type,elim_glue]; apply cast_ua_fn
+
+  theorem elim_type_glue_inv (Pincl : Π⦃n : ℕ⦄ (a : A n), Type)
+    (Pglue : Π⦃n : ℕ⦄ (a : A n), Pincl (f a) ≃ Pincl a) {n : ℕ} (a : A n)
+    : transport (seq_colim.elim_type f Pincl Pglue) (glue a)⁻¹ = to_inv (Pglue a) :=
+  by rewrite [tr_eq_cast_ap_fn, ↑seq_colim.elim_type, ap_inv, elim_glue]; apply cast_ua_inv_fn
 
   protected definition rec_prop {P : seq_colim → Type} [H : Πx, is_prop (P x)]
     (Pincl : Π⦃n : ℕ⦄ (a : A n), P (sι a)) (aa : seq_colim) : P aa :=

--- a/hott/hit/colimit.hlean
+++ b/hott/hit/colimit.hlean
@@ -173,7 +173,7 @@ section
   theorem elim_type_glue (Pincl : Π⦃n : ℕ⦄ (a : A n), Type)
     (Pglue : Π⦃n : ℕ⦄ (a : A n), Pincl (f a) ≃ Pincl a) {n : ℕ} (a : A n)
       : transport (elim_type Pincl Pglue) (glue a) = Pglue a :=
-  by rewrite [tr_eq_cast_ap_fn,↑elim_type,elim_glue];apply cast_ua_fn
+  by rewrite [tr_eq_cast_ap_fn,↑elim_type,elim_glue]; apply cast_ua_fn
 
   protected definition rec_prop {P : seq_colim → Type} [H : Πx, is_prop (P x)]
     (Pincl : Π⦃n : ℕ⦄ (a : A n), P (sι a)) (aa : seq_colim) : P aa :=

--- a/hott/hit/default.hlean
+++ b/hott/hit/default.hlean
@@ -1,0 +1,8 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+
+-/
+
+import .two_quotient .colimit .coeq .refl_quotient

--- a/hott/hit/groupoid_quotient.hlean
+++ b/hott/hit/groupoid_quotient.hlean
@@ -192,7 +192,7 @@ section
   end
 
   local abbreviation encode [unfold_full] := @groupoid_quotient.encode G a
-  local abbreviation decode [unfold 3] := @groupoid_quotient.decode G a
+  local abbreviation decode [unfold_full] := @groupoid_quotient.decode G a
 
   protected definition decode_encode (x : groupoid_quotient G) (p : elt a = x) :
     decode x (encode x p) = p :=

--- a/hott/hit/groupoid_quotient.hlean
+++ b/hott/hit/groupoid_quotient.hlean
@@ -243,3 +243,5 @@ section
 end
 
 end groupoid_quotient
+
+export [unfold] groupoid_quotient

--- a/hott/hit/hit.md
+++ b/hott/hit/hit.md
@@ -20,6 +20,7 @@ Files in this folder:
 * [pushout](pushout.hlean): Pushouts, defined using quotients
 * [coeq](coeq.hlean): Co-equalizers, defined using quotients
 * [set_quotient](set_quotient.hlean): Set-quotients, defined using quotients and set-truncation
+* [prop_trunc](prop_trunc.hlean): The construction of the propositional truncation from quotients.
 
 The following hits have also 2-constructors. They are defined only using quotients.
 * [two_quotient](two_quotient.hlean): Quotients where you can also specify 2-paths. These are used for all hits which have 2-constructors, and they are almost fully general for such hits, as long as they are nonrecursive

--- a/hott/hit/prop_trunc.hlean
+++ b/hott/hit/prop_trunc.hlean
@@ -63,7 +63,7 @@ namespace one_step_tr
 
   protected definition elim {P : Type} (Pt : A → P)
     (Pe : Π(a a' : A), Pt a = Pt a') (x : one_step_tr) : P :=
-  rec Pt (λa a', pathover_of_eq (Pe a a')) x
+  rec Pt (λa a', pathover_of_eq _ (Pe a a')) x
 
   protected definition elim_on [reducible] {P : Type} (x : one_step_tr) (Pt : A → P)
     (Pe : Π(a a' : A), Pt a = Pt a') : P :=

--- a/hott/hit/prop_trunc.hlean
+++ b/hott/hit/prop_trunc.hlean
@@ -32,17 +32,6 @@ open eq is_trunc unit quotient seq_colim pi nat equiv sum algebra is_conn functi
   See the comment below for a sketch of the proof that (trunc A) is actually a mere proposition.
 -/
 
-
-/-
-  Call a function f weakly constant if (Πa a', f a = f a')
-  This theorem states that if f is weakly constant, then (ap f) is weakly constant.
--/
-  -- definition weakly_constant_ap {A B : Type} {f : A → B} {a a' : A} (p q : a = a')
-  --   (H : Π(a a' : A), f a = f a') : ap f p = ap f q :=
-  -- have L : Π{b c : A} {r : b = c}, (H a b)⁻¹ ⬝ H a c = ap f r, from
-  --   (λb c r, eq.rec_on r !con.left_inv),
-  -- L⁻¹ ⬝ L
-
 /- definition of "one step truncation" in terms of quotients -/
 
 namespace one_step_tr
@@ -416,7 +405,7 @@ namespace prop_trunc
 
 end prop_trunc
 
-open prop_trunc
+open prop_trunc trunc
 -- Corollaries for the actual truncation.
 namespace is_trunc
   local attribute is_prop_trunc_one_step_tr [instance]
@@ -431,8 +420,8 @@ namespace is_trunc
     { exact p a a'}
   end
 
-  example {A : Type} {P : Type} [is_set P] (f : A → P) (p : Πa a', f a = f a') (a : A) :
-    is_prop.elim_set f p (trunc.tr a) = f a :=
+  definition is_prop.elim_set_tr {A : Type} {P : Type} {H : is_set P} (f : A → P)
+    (p : Πa a', f a = f a') (a : A) : is_prop.elim_set f p (tr a) = f a :=
   by reflexivity
 
 end is_trunc

--- a/hott/hit/prop_trunc.hlean
+++ b/hott/hit/prop_trunc.hlean
@@ -1,0 +1,438 @@
+import function types.trunc hit.colimit homotopy.connectedness --types.nat.hott hit.trunc cubical.square
+
+open eq is_trunc unit quotient seq_colim pi nat equiv sum algebra is_conn function
+
+/-
+  In this file we define the propositional truncation, which, given (X : Type)
+  has constructors
+  * tr             : X → trunc X
+  * is_prop_trunc  : is_prop (trunc X)
+  and with a recursor which recurses to any family of mere propositions.
+
+  The construction uses a "one step truncation" of X, with two constructors:
+  * tr    : X → one_step_tr X
+  * tr_eq : Π(a b : X), tr a = tr b
+  This is like a truncation, but taking out the recursive part.
+  Martin Escardo calls this construction the generalized circle, since the one step truncation of the
+    unit type is the circle.
+
+  Then we can repeat this n times:
+    A 0 = X,
+    A (n + 1) = one_step_tr (A n)
+  We have a map
+    f {n : ℕ} : A n → A (n + 1) := tr
+  Then trunc is defined as the sequential colimit of (A, f).
+
+  Both the one step truncation and the sequential colimit can be defined as a quotient, which is a
+  primitive HIT in Lean. Here, with a quotient, we mean the following HIT:
+  Given {X : Type} (R : X → X → Type) we have the constructors
+  * class_of  : X → quotient R
+  * eq_of_rel : Π{a a' : X}, R a a' → a = a'
+
+  See the comment below for a sketch of the proof that (trunc A) is actually a mere proposition.
+-/
+
+
+/-
+  Call a function f weakly constant if (Πa a', f a = f a')
+  This theorem states that if f is weakly constant, then (ap f) is weakly constant.
+-/
+  -- definition weakly_constant_ap {A B : Type} {f : A → B} {a a' : A} (p q : a = a')
+  --   (H : Π(a a' : A), f a = f a') : ap f p = ap f q :=
+  -- have L : Π{b c : A} {r : b = c}, (H a b)⁻¹ ⬝ H a c = ap f r, from
+  --   (λb c r, eq.rec_on r !con.left_inv),
+  -- L⁻¹ ⬝ L
+
+/- definition of "one step truncation" in terms of quotients -/
+
+namespace one_step_tr
+  section
+  parameters {A : Type}
+  variables (a a' : A)
+
+  protected definition R (a a' : A) : Type₀ := unit
+  parameter (A)
+  definition one_step_tr : Type := quotient R
+  parameter {A}
+  definition tr : one_step_tr :=
+  class_of R a
+
+  definition tr_eq : tr a = tr a' :=
+  eq_of_rel _ star
+
+  protected definition rec {P : one_step_tr → Type} (Pt : Π(a : A), P (tr a))
+    (Pe : Π(a a' : A), Pt a =[tr_eq a a'] Pt a') (x : one_step_tr) : P x :=
+  begin
+    fapply (quotient.rec_on x),
+    { intro a, apply Pt},
+    { intro a a' H, cases H, apply Pe}
+  end
+
+  protected definition rec_on [reducible] {P : one_step_tr → Type} (x : one_step_tr)
+    (Pt : Π(a : A), P (tr a)) (Pe : Π(a a' : A), Pt a =[tr_eq a a'] Pt a') : P x :=
+  rec Pt Pe x
+
+  protected definition elim {P : Type} (Pt : A → P)
+    (Pe : Π(a a' : A), Pt a = Pt a') (x : one_step_tr) : P :=
+  rec Pt (λa a', pathover_of_eq (Pe a a')) x
+
+  protected definition elim_on [reducible] {P : Type} (x : one_step_tr) (Pt : A → P)
+    (Pe : Π(a a' : A), Pt a = Pt a') : P :=
+  elim Pt Pe x
+
+  theorem rec_tr_eq {P : one_step_tr → Type} (Pt : Π(a : A), P (tr a))
+    (Pe : Π(a a' : A), Pt a =[tr_eq a a'] Pt a') (a a' : A)
+    : apd (rec Pt Pe) (tr_eq a a') = Pe a a' :=
+  !rec_eq_of_rel
+
+  theorem elim_tr_eq {P : Type} (Pt : A → P)
+    (Pe : Π(a a' : A), Pt a = Pt a') (a a' : A)
+    : ap (elim Pt Pe) (tr_eq a a') = Pe a a' :=
+  begin
+    apply eq_of_fn_eq_fn_inv !(pathover_constant (tr_eq a a')),
+    rewrite [▸*,-apd_eq_pathover_of_eq_ap,↑elim,rec_tr_eq],
+  end
+
+  end
+
+  definition n_step_tr [reducible] (A : Type) (n : ℕ) : Type :=
+  nat.rec_on n A (λn' A', one_step_tr A')
+
+end one_step_tr
+
+attribute one_step_tr.rec one_step_tr.elim [recursor 5] [unfold 5]
+attribute one_step_tr.rec_on one_step_tr.elim_on [unfold 2]
+attribute one_step_tr.tr [constructor]
+
+namespace one_step_tr
+  /- Theorems about the one-step truncation -/
+  open homotopy trunc prod
+  theorem tr_eq_ne_idp {A : Type} (a : A) : tr_eq a a ≠ idp :=
+  begin
+    intro p,
+    have H2 : Π{X : Type₁} {x : X} {q : x = x}, q = idp,
+      from λX x q, calc
+        q   = ap (one_step_tr.elim (λa, x) (λa b, q)) (tr_eq a a)               : elim_tr_eq
+        ... = ap (one_step_tr.elim (λa, x) (λa b, q)) (refl (one_step_tr.tr a)) : by rewrite p
+        ... = idp                                                               : idp,
+    exact bool.eq_bnot_ne_idp H2
+  end
+
+  theorem tr_eq_ne_ap_tr {A : Type} {a b : A} (p : a = b) : tr_eq a b ≠ ap tr p :=
+  by induction p; apply tr_eq_ne_idp
+
+  theorem not_inhabited_set_trunc_one_step_tr (A : Type)
+    : ¬(trunc 1 (one_step_tr A) × is_set (trunc 1 (one_step_tr A))) :=
+  begin
+    intro H, induction H with x H,
+    refine trunc.elim_on x _, clear x, intro x,
+    induction x,
+    { have q : trunc -1 ((tr_eq a a) = idp),
+      begin
+        refine to_fun !tr_eq_tr_equiv _,
+        refine @is_prop.elim _ _ _ _, apply is_trunc_equiv_closed, apply tr_eq_tr_equiv
+      end,
+      refine trunc.elim_on q _, clear q, intro p, exact !tr_eq_ne_idp p},
+    { apply is_prop.elim}
+  end
+
+  theorem not_is_conn_one_step_tr (A : Type) : ¬is_conn 1 (one_step_tr A) :=
+  λH, not_inhabited_set_trunc_one_step_tr A (!center, _)
+
+  theorem is_prop_trunc_one_step_tr (A : Type) : is_prop (trunc 0 (one_step_tr A)) :=
+  begin
+    apply is_prop.mk,
+    intro x y,
+    refine trunc.rec_on x _, refine trunc.rec_on y _, clear x y, intro y x,
+    induction x,
+    { induction y,
+      { exact ap trunc.tr !tr_eq},
+      { apply is_prop.elimo}},
+    { apply is_prop.elimo}
+  end
+
+  local attribute is_prop_trunc_one_step_tr [instance]
+
+  theorem trunc_0_one_step_tr_equiv (A : Type) : trunc 0 (one_step_tr A) ≃ ∥ A ∥ :=
+  begin
+    apply equiv_of_is_prop,
+    { intro x, refine trunc.rec _ x, clear x, intro x, induction x,
+      { exact trunc.tr a},
+      { apply is_prop.elim}},
+    { intro x, refine trunc.rec _ x, clear x, intro a, exact trunc.tr (tr a)},
+  end
+
+  definition one_step_tr_functor [unfold 4] {A B : Type} (f : A → B) (x : one_step_tr A)
+    : one_step_tr B :=
+  begin
+    induction x,
+    { exact tr (f a)},
+    { apply tr_eq}
+  end
+
+  definition one_step_tr_universal_property [constructor] (A B : Type)
+    : (one_step_tr A → B) ≃ Σ(f : A → B), Π(x y : A), f x = f y :=
+  begin
+    fapply equiv.MK,
+    { intro f, fconstructor, intro a, exact f (tr a), intros, exact ap f !tr_eq},
+    { intro v a, induction v with f p, induction a, exact f a, apply p},
+    { intro v, induction v with f p, esimp, apply ap (sigma.mk _), apply eq_of_homotopy2,
+      intro a a', apply elim_tr_eq},
+    { intro f, esimp, apply eq_of_homotopy, intro a, induction a,
+        reflexivity,
+        apply eq_pathover, apply hdeg_square, rewrite [▸*,elim_tr_eq]},
+  end
+
+
+end one_step_tr
+open one_step_tr
+
+namespace prop_trunc
+namespace hide
+  section
+  parameter {X : Type}
+
+  /- basic constructors -/
+  definition A [reducible] (n : ℕ) : Type := nat.rec_on n X (λn' X', one_step_tr X')
+  definition f [reducible] ⦃n : ℕ⦄ (a : A n) : A (succ n)                 := tr a
+  definition f_eq [reducible] {n : ℕ} (a a' : A n) : f a = f a'   := tr_eq a a'
+  definition truncX [reducible] : Type                                    := @seq_colim A f
+  definition i [reducible] {n : ℕ} (a : A n) : truncX                     := inclusion f a
+  definition g [reducible] {n : ℕ} (a : A n) : i (f a) = i a      := glue f a
+
+  /- defining the normal recursor is easy -/
+  definition rec {P : truncX → Type} [Pt : Πx, is_prop (P x)]
+    (H : Π(a : X), P (@i 0 a)) (x : truncX) : P x :=
+  begin
+    induction x,
+    { induction n with n IH,
+      { exact H a},
+      { induction a,
+        { exact !g⁻¹ ▸ IH a},
+        { apply is_prop.elimo}}},
+    { apply is_prop.elimo}
+  end
+
+  /-
+    The main effort is to prove that truncX is a mere proposition.
+    We prove
+      Π(a b : truncX), a = b
+    first by induction on a, using the induction principle we just proven and then by induction on b
+
+    On the point level we need to construct
+      (1) a : A n, b : A m ⊢ p a b : i a = i b
+    On the path level (for the induction on b) we need to show that
+      (2) a : A n, b : A m ⊢ p a (f b) ⬝ g b = p a b
+    The path level for a is automatic, since (Πb, a = b) is a mere proposition
+    Thanks to Egbert Rijke for pointing this out
+
+    For (1) we distinguish the cases n ≤ m and n ≥ m,
+      and we prove that the two constructions coincide for n = m
+
+    For (2) we distinguish the cases n ≤ m and n > m
+
+    During the proof we heavily use induction on inequalities.
+    (n ≤ m), or (le n m), is defined as an inductive family:
+      inductive le (n : ℕ) : ℕ → Type₀ :=
+      | refl : le n n
+      | step : Π {m}, le n m → le n (succ m)
+  -/
+
+
+  /- point operations -/
+
+  definition fr [reducible] [unfold 2] (n : ℕ) (a : X) : A n :=
+  begin
+    induction n with n x,
+    { exact a},
+    { exact f x},
+  end
+
+  /- path operations -/
+
+  definition i_fr [unfold 2] (n : ℕ) (a : X) : i (fr n a) = @i 0 a :=
+  begin
+    induction n with n p,
+    { reflexivity},
+    { exact g (fr n a) ⬝ p},
+  end
+
+  definition eq_same {n : ℕ} (a a' : A n) : i a = i a' :=
+  calc
+    i a = i (f a)  : g
+    ... = i (f a') : ap i (f_eq a a')
+    ... = i a'     : g
+
+  definition eq_constructors {n : ℕ} (a : X) (b : A n) : @i 0 a = i b :=
+  calc
+    i a = i (fr n a) : i_fr
+    ... = i b        : eq_same
+
+  /- 2-dimensional path operations -/
+
+  theorem ap_i_ap_f {n : ℕ} {a a' : A n} (p : a = a') : !g⁻¹ ⬝ ap i (ap !f p) ⬝ !g = ap i p :=
+  by induction p; apply con.left_inv
+
+  theorem ap_i_eq_ap_i_same {n : ℕ} {a a' : A n} (p q : a = a') : ap i p = ap i q :=
+  @(is_weakly_constant_ap i) eq_same a a' p q
+
+  theorem ap_f_eq_f {n : ℕ} (a a' : A n)
+    : !g⁻¹ ⬝ ap i (f_eq (f a) (f a')) ⬝ !g = ap i (f_eq a a') :=
+  ap _ !ap_i_eq_ap_i_same ⬝ !ap_i_ap_f
+
+  theorem eq_same_f {n : ℕ} (a a' : A n)
+    : (g a)⁻¹ ⬝ eq_same (f a) (f a') ⬝ g a' = eq_same a a' :=
+  begin
+   esimp [eq_same],
+   apply (ap (λx, _ ⬝ x ⬝ _)),
+   apply (ap_f_eq_f a a'),
+  end
+
+  theorem eq_constructors_comp {n : ℕ} (a : X) (b : A n)
+    : eq_constructors a (f b) ⬝ g b  = eq_constructors a b :=
+  begin
+    rewrite [↑eq_constructors,▸*,↓fr n a,↓i_fr n a,con_inv,+con.assoc],
+    apply ap (λx, _ ⬝ x),
+    rewrite -con.assoc, exact !eq_same_f
+  end
+
+  theorem is_prop_truncX : is_prop truncX :=
+  begin
+    apply is_prop_of_imp_is_contr,
+    intro a,
+    refine @rec _ _ _ a,
+    clear a, intro a,
+    fapply is_contr.mk,
+    exact @i 0 a,
+    intro b,
+    induction b with n b n b,
+    { apply eq_constructors},
+    { apply (equiv.to_inv !pathover_eq_equiv_r), apply eq_constructors_comp}
+  end
+
+  end
+end hide
+end prop_trunc
+
+namespace prop_trunc
+  open hide
+  definition ptrunc.{u} (A : Type.{u}) : Type.{u}            := @truncX A
+  definition ptr {A : Type} : A → ptrunc A                   := @i A 0
+  definition is_prop_trunc (A : Type) : is_prop (ptrunc A)   := is_prop_truncX
+  protected definition ptrunc.rec {A : Type} {P : ptrunc A → Type}
+    [Pt : Π(x : ptrunc A), is_prop (P x)]
+    (H : Π(a : A), P (ptr a)) : Π(x : ptrunc A), P x          := @rec A P Pt H
+
+  example {A : Type} {P : ptrunc A → Type} [Pt : Πaa, is_prop (P aa)]
+          (H : Πa, P (ptr a)) (a : A) : (ptrunc.rec H) (ptr a) = H a := by reflexivity
+
+  open sigma prod
+
+  -- the constructed truncation is equivalent to the "standard" propositional truncation
+  -- (called _root_.trunc -1 below)
+  open trunc
+  attribute is_prop_trunc [instance]
+  definition ptrunc_equiv_trunc (A : Type) : ptrunc A ≃ trunc -1 A :=
+  begin
+    fapply equiv.MK,
+    { intro x, induction x using ptrunc.rec with a, exact tr a},
+    { intro x, refine trunc.rec _ x, intro a, exact ptr a},
+    { intro x, induction x with a, reflexivity},
+    { intro x, induction x using ptrunc.rec with a, reflexivity}
+  end
+
+  -- some other recursors we get from this construction:
+  definition trunc.elim2 {A P : Type} (h : Π{n}, n_step_tr A n → P)
+    (coh : Π(n : ℕ) (a : n_step_tr A n), h (f a) = h a) (x : ptrunc A) : P :=
+  begin
+    induction x,
+    { exact h a},
+    { apply coh}
+  end
+
+  definition trunc.rec2 {A : Type} {P : truncX → Type} (h : Π{n} (a : n_step_tr A n), P (i a))
+    (coh : Π(n : ℕ) (a : n_step_tr A n), h (f a) =[g a] h a)
+    (x : ptrunc A) : P x :=
+  begin
+    induction x,
+    { exact h a},
+    { apply coh}
+  end
+
+  definition elim2_equiv [constructor] (A P : Type) : (ptrunc A → P) ≃
+    Σ(h : Π{n}, n_step_tr A n → P),
+      Π(n : ℕ) (a : n_step_tr A n), @h (succ n) (one_step_tr.tr a) = h a :=
+  begin
+    fapply equiv.MK,
+    { intro h, fconstructor,
+      { intro n a, refine h (i a)},
+      { intro n a, exact ap h (g a)}},
+    { intro x a, induction x with h p, induction a,
+        exact h a,
+        apply p},
+    { intro x, induction x with h p, fapply sigma_eq,
+      { reflexivity},
+      { esimp, apply pathover_idp_of_eq, apply eq_of_homotopy2, intro n a, xrewrite elim_glue}},
+    { intro h, apply eq_of_homotopy, intro a, esimp, induction a,
+        esimp,
+        apply eq_pathover, apply hdeg_square, esimp, rewrite elim_glue}
+  end
+
+  open sigma.ops
+  definition conditionally_constant_equiv {A P : Type} (k : A → P) :
+    (Σ(g : ptrunc A → P), Πa, g (ptr a) = k a) ≃
+      Σ(h : Π{n}, n_step_tr A n → P),
+        (Π(n : ℕ) (a : n_step_tr A n), h (f a) = h a) × (Πa, @h 0 a = k a) :=
+  calc
+    (Σ(g : ptrunc A → P), Πa, g (ptr a) = k a)
+      ≃ Σ(v : Σ(h : Π{n}, n_step_tr A n → P), Π(n : ℕ) (a : n_step_tr A n), h (f a) = h a),
+          Πa, (v.1) 0 a = k a
+                    : sigma_equiv_sigma !elim2_equiv (λg, equiv.rfl)
+  ... ≃ Σ(h : Π{n}, n_step_tr A n → P) (p : Π(n : ℕ) (a : n_step_tr A n), h (f a) = h a),
+          Πa, @h 0 a = k a
+                    : sigma_assoc_equiv
+  ... ≃ Σ(h : Π{n}, n_step_tr A n → P),
+          (Π(n : ℕ) (a : n_step_tr A n), h (f a) = h a) × (Πa, @h 0 a = k a)
+                    : sigma_equiv_sigma_right (λa, !equiv_prod)
+
+  definition cocone_of_is_collapsible {A : Type} (f : A → A) (p : Πa a', f a = f a')
+    (n : ℕ) (x : n_step_tr A n) : A :=
+  begin
+    apply f,
+    induction n with n h,
+    { exact x},
+    { apply to_inv !one_step_tr_universal_property ⟨f, p⟩, exact one_step_tr_functor h x}
+  end
+
+  definition has_split_support_of_is_collapsible {A : Type} (f : A → A) (p : Πa a', f a = f a')
+    : ptrunc A → A :=
+  begin
+    fapply to_inv !elim2_equiv,
+    fconstructor,
+    { exact cocone_of_is_collapsible f p},
+    { intro n a, apply p}
+
+  end
+
+end prop_trunc
+
+open prop_trunc
+-- Corollaries for the actual truncation.
+namespace is_trunc
+  local attribute is_prop_trunc_one_step_tr [instance]
+  definition is_prop.elim_set {A : Type} {P : Type} [is_set P] (f : A → P)
+    (p : Πa a', f a = f a') (x : trunc -1 A) : P :=
+  begin
+    have y : trunc 0 (one_step_tr A),
+    by induction x; exact trunc.tr (one_step_tr.tr a),
+    induction y with y,
+    induction y,
+    { exact f a},
+    { exact p a a'}
+  end
+
+  example {A : Type} {P : Type} [is_set P] (f : A → P) (p : Πa a', f a = f a') (a : A) :
+    is_prop.elim_set f p (trunc.tr a) = f a :=
+  by reflexivity
+
+end is_trunc

--- a/hott/hit/pushout.hlean
+++ b/hott/hit/pushout.hlean
@@ -56,7 +56,7 @@ parameters {TL BL TR : Type} (f : TL → BL) (g : TL → TR)
 
   protected definition elim {P : Type} (Pinl : BL → P) (Pinr : TR → P)
     (Pglue : Π(x : TL), Pinl (f x) = Pinr (g x)) (y : pushout) : P :=
-  rec Pinl Pinr (λx, pathover_of_eq (Pglue x)) y
+  rec Pinl Pinr (λx, pathover_of_eq _ (Pglue x)) y
 
   protected definition elim_on [reducible] {P : Type} (y : pushout) (Pinl : BL → P)
     (Pinr : TR → P) (Pglue : Π(x : TL), Pinl (f x) = Pinr (g x)) : P :=

--- a/hott/hit/quotient.hlean
+++ b/hott/hit/quotient.hlean
@@ -24,7 +24,7 @@ namespace quotient
 
   protected definition elim {P : Type} (Pc : A → P) (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a = Pc a')
     (x : quotient R) : P :=
-  quotient.rec Pc (λa a' H, pathover_of_eq (Pp H)) x
+  quotient.rec Pc (λa a' H, pathover_of_eq _ (Pp H)) x
 
   protected definition elim_on [reducible] {P : Type} (x : quotient R)
     (Pc : A → P) (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a = Pc a') : P :=
@@ -178,8 +178,10 @@ namespace quotient
       (c : C a) : ap (elim @Qpt Qeq) (Peq r c) = Qeq r c :=
     begin
       refine !ap_dpair_eq_dpair ⬝ _,
-      rewrite [apo011_eq_apo11_apd, rec_eq_of_rel, ▸*, apo011_arrow_pathover_constant_right,
-               ↑elim_type_eq_of_rel', to_right_inv !pathover_equiv_tr_eq, ap_inv],
+      refine !apd011_eq_apo11_apd ⬝ _,
+      rewrite [rec_eq_of_rel, ▸*],
+      refine !apo11_arrow_pathover_constant_right ⬝ _,
+      rewrite [↑elim_type_eq_of_rel', to_right_inv !pathover_equiv_tr_eq, ap_inv],
       apply inv_con_cancel_right
     end
 

--- a/hott/hit/quotient.hlean
+++ b/hott/hit/quotient.hlean
@@ -58,10 +58,17 @@ namespace quotient
     : transport (quotient.elim_type Pc Pp) (eq_of_rel R H) = to_fun (Pp H) :=
   by rewrite [tr_eq_cast_ap_fn, ↑quotient.elim_type, elim_eq_of_rel];apply cast_ua_fn
 
+  -- rename to elim_type_eq_of_rel_fn_inv
   theorem elim_type_eq_of_rel_inv (Pc : A → Type)
     (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a ≃ Pc a') {a a' : A} (H : R a a')
     : transport (quotient.elim_type Pc Pp) (eq_of_rel R H)⁻¹ = to_inv (Pp H) :=
   by rewrite [tr_eq_cast_ap_fn, ↑quotient.elim_type, ap_inv, elim_eq_of_rel];apply cast_ua_inv_fn
+
+  -- remove '
+  theorem elim_type_eq_of_rel_inv' (Pc : A → Type)
+    (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a ≃ Pc a') {a a' : A} (H : R a a') (x : Pc a')
+    : transport (quotient.elim_type Pc Pp) (eq_of_rel R H)⁻¹ x = to_inv (Pp H) x :=
+  ap10 (elim_type_eq_of_rel_inv Pc Pp H) x
 
   theorem elim_type_eq_of_rel.{u} (Pc : A → Type.{u})
     (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a ≃ Pc a') {a a' : A} (H : R a a') (p : Pc a)

--- a/hott/hit/quotient.hlean
+++ b/hott/hit/quotient.hlean
@@ -56,13 +56,13 @@ namespace quotient
   theorem elim_type_eq_of_rel_fn (Pc : A → Type)
     (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a ≃ Pc a') {a a' : A} (H : R a a')
     : transport (quotient.elim_type Pc Pp) (eq_of_rel R H) = to_fun (Pp H) :=
-  by rewrite [tr_eq_cast_ap_fn, ↑quotient.elim_type, elim_eq_of_rel];apply cast_ua_fn
+  by rewrite [tr_eq_cast_ap_fn, ↑quotient.elim_type, elim_eq_of_rel]; apply cast_ua_fn
 
   -- rename to elim_type_eq_of_rel_fn_inv
   theorem elim_type_eq_of_rel_inv (Pc : A → Type)
     (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a ≃ Pc a') {a a' : A} (H : R a a')
     : transport (quotient.elim_type Pc Pp) (eq_of_rel R H)⁻¹ = to_inv (Pp H) :=
-  by rewrite [tr_eq_cast_ap_fn, ↑quotient.elim_type, ap_inv, elim_eq_of_rel];apply cast_ua_inv_fn
+  by rewrite [tr_eq_cast_ap_fn, ↑quotient.elim_type, ap_inv, elim_eq_of_rel]; apply cast_ua_inv_fn
 
   -- remove '
   theorem elim_type_eq_of_rel_inv' (Pc : A → Type)

--- a/hott/hit/set_quotient.hlean
+++ b/hott/hit/set_quotient.hlean
@@ -49,7 +49,7 @@ section
 
   protected definition elim {P : Type} [Pt : is_set P] (Pc : A → P)
     (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a = Pc a') (x : set_quotient) : P :=
-  rec Pc (λa a' H, pathover_of_eq (Pp H)) x
+  rec Pc (λa a' H, pathover_of_eq _ (Pp H)) x
 
   protected definition elim_on [reducible] {P : Type} (x : set_quotient) [Pt : is_set P]
     (Pc : A → P) (Pp : Π⦃a a' : A⦄ (H : R a a'), Pc a = Pc a')  : P :=

--- a/hott/hit/set_quotient.hlean
+++ b/hott/hit/set_quotient.hlean
@@ -128,7 +128,7 @@ namespace set_quotient
     set_quotient R → set_quotient S :=
   set_quotient.elim (class_of ∘ f) (λa a' r, eq_of_rel (H r))
 
-  definition quotient_binary_map [unfold 10 11] (f : A → B → C)
+  definition quotient_binary_map [unfold 11 12] (f : A → B → C)
     (H : Π{a a'} (r : R a a') {b b'} (s : S b b'), T (f a b) (f a' b'))
     [HR : is_reflexive R] [HS : is_reflexive S] :
     set_quotient R → set_quotient S → set_quotient T :=

--- a/hott/hit/two_quotient.hlean
+++ b/hott/hit/two_quotient.hlean
@@ -80,7 +80,7 @@ namespace simple_two_quotient
   protected definition pre_elim [unfold 8] {P : Type} (Pj : A → P)
     (Pa : Π⦃a : A⦄ ⦃r : T a a⦄, Q r → P) (Pe : Π⦃a a' : A⦄ (s : R a a'), Pj a = Pj a') (x : C)
     : P :=
-  pre_rec Pj Pa (λa a' s, pathover_of_eq (Pe s)) x
+  pre_rec Pj Pa (λa a' s, pathover_of_eq _ (Pe s)) x
 
   protected theorem rec_e {P : C → Type}
     (Pj : Πa, P (j a)) (Pa : Π⦃a : A⦄ ⦃r : T a a⦄ (q : Q r), P (pre_aux q))

--- a/hott/homotopy/EM.hlean
+++ b/hott/homotopy/EM.hlean
@@ -9,6 +9,7 @@ Eilenberg MacLane spaces
 
 import hit.groupoid_quotient .hopf .freudenthal .homotopy_group
 open algebra pointed nat eq category group algebra is_trunc iso pointed unit trunc equiv is_conn
+     function is_equiv
 
 namespace EM
   open groupoid_quotient
@@ -150,7 +151,7 @@ namespace EM
       { exact abstract begin apply loop_pathover, apply square_of_eq,
           refine !resp_mul⁻¹ ⬝ _ ⬝ !resp_mul,
           exact ap pth !mul.comm end end}},
-    { refine EM.prop_rec _ x', esimp, apply resp_mul},
+    { refine EM.prop_rec _ x', apply resp_mul}
   end
 
   definition EM1_mul_one (G : CommGroup) (x : EM1 G) : EM1_mul x base = x :=
@@ -235,6 +236,52 @@ namespace EM
     { apply is_trunc_EMadd1}
   end
 
+  /- Uniqueness of K(G, 1) -/
+  definition pEM1_pmap [constructor] {G : Group} {X : Type*} (e : Ω X ≃ G)
+    (r : Πp q, e (p ⬝ q) = e p * e q) [is_conn 0 X] [is_trunc 1 X] : pEM1 G →* X :=
+  begin
+    apply pmap.mk (EM1_map e r),
+    reflexivity,
+  end
 
+  definition loop_pEM1 [constructor] (G : Group) : Ω (pEM1 G) ≃* pType_of_Group G :=
+  pequiv_of_equiv (base_eq_base_equiv G) idp
+
+  definition loop_pEM1_pmap {G : Group} {X : Type*} (e : Ω X ≃ G)
+    (r : Πp q, e (p ⬝ q) = e p * e q) [is_conn 0 X] [is_trunc 1 X] :
+    Ω→(pEM1_pmap e r) ~ e⁻¹ᵉ ∘ base_eq_base_equiv G :=
+  begin
+    apply homotopy_of_inv_homotopy_pre (base_eq_base_equiv G),
+    intro g, exact !idp_con ⬝ !elim_pth
+  end
+
+  open trunc_index
+  definition pEM1_pequiv'.{u} {G : Group.{u}} {X : pType.{u}} (e : Ω X ≃ G)
+    (r : Πp q, e (p ⬝ q) = e p * e q) [is_conn 0 X] [is_trunc 1 X] : pEM1 G ≃* X :=
+  begin
+    apply pequiv_of_pmap (pEM1_pmap e r),
+    apply whitehead_principle_pointed 1,
+    intro k, cases k with k,
+    { apply @is_equiv_of_is_contr,
+      all_goals (esimp; exact _)},
+    { cases k with k,
+      { apply is_equiv_trunc_functor, esimp,
+        apply is_equiv.homotopy_closed, rotate 1,
+        { symmetry, exact loop_pEM1_pmap _ _},
+        apply is_equiv_compose, apply to_is_equiv},
+      { apply @is_equiv_of_is_contr,
+        do 2 exact trivial_homotopy_group_of_is_trunc _ (succ_lt_succ !zero_lt_succ)}}
+  end
+
+  definition pEM1_pequiv.{u} {G : Group.{u}} {X : pType.{u}} (e : π₁ X ≃g G)
+    [is_conn 0 X] [is_trunc 1 X] : pEM1 G ≃* X :=
+  begin
+    apply pEM1_pequiv' (!trunc_equiv⁻¹ᵉ ⬝e equiv_of_isomorphism e),
+    intro p q, esimp, exact respect_mul e (tr p) (tr q)
+  end
+
+  definition KG1_pequiv.{u} {X Y : pType.{u}} (e : π₁ X ≃g π₁ Y)
+    [is_conn 0 X] [is_trunc 1 X] [is_conn 0 Y] [is_trunc 1 Y] : X ≃* Y :=
+  (pEM1_pequiv e)⁻¹ᵉ* ⬝e* pEM1_pequiv !isomorphism.refl
 
 end EM

--- a/hott/homotopy/EM.hlean
+++ b/hott/homotopy/EM.hlean
@@ -93,7 +93,6 @@ namespace EM
 
 end EM
 
--- attribute EM.rec EM.elim [recursor 7]
 attribute EM.base [constructor]
 attribute EM.rec EM.elim [unfold 7] [recursor 7]
 attribute EM.rec_on EM.elim_on [unfold 4]
@@ -126,8 +125,6 @@ namespace EM
   proposition is_conn_pEM1 [instance] (G : Group) : is_conn 0 (pEM1 G) :=
   is_conn_EM1 G
 
-  -- TODO: prove this using truncated Whitehead.
-
   definition EM1_map [unfold 7] {G : Group} {X : Type*} (e : Ω X ≃ G)
     (r : Πp q, e (p ⬝ q) = e p * e q) [is_conn 0 X] [is_trunc 1 X] : EM1 G → X :=
   begin
@@ -136,22 +133,6 @@ namespace EM
     { note p := e⁻¹ᵉ g, exact p},
     { exact inv_preserve_binary e concat mul r g h}
   end
-
-  -- TODO
-  -- definition EM1_equiv {G : Group} {X : Type*} (e : Ω X ≃ G)
-  --   (r : Πp q, e (p ⬝ q) = e p * e q) [is_conn 0 X] [is_trunc 1 X] : EM1 G ≃ X :=
-  -- begin
-  --   apply equiv.mk (EM1_map e r),
-  --   apply whiteheads_principle 1,
-  --   { apply is_equiv_of_is_contr},
-  --   { intro x n, cases n with n,
-  --     { exact sorry},
-  --     { apply @is_equiv_of_is_contr, do 2 exact sorry}}
-  -- end
-
-  -- definition pequiv_pEM1 {G : Group} {X : Type*} (e : π₁ X ≃g G) [is_conn 0 X] [is_trunc 1 X]
-  --   : X ≃* pEM1 G :=
-  -- sorry
 
 end EM
 
@@ -222,7 +203,7 @@ namespace EM
 
   definition is_trunc_EMadd1 (G : CommGroup) (n : ℕ) : is_trunc (n+1) (EMadd1 G n) := _
 
-  /- K(G, n+1) -/
+  /- K(G, n) -/
   definition EM (G : CommGroup) : ℕ → Type*
   | 0     := pType_of_Group G
   | (k+1) := EMadd1 G k

--- a/hott/homotopy/cellcomplex.hlean
+++ b/hott/homotopy/cellcomplex.hlean
@@ -10,14 +10,6 @@ open eq is_trunc is_equiv nat equiv trunc prod pushout sigma sphere_index unit
 -- where should this be?
 definition family : Type := ΣX, X → Type
 
--- this should be in init!
-namespace nat
-
-  definition cases {M : ℕ → Type} (mz : M zero) (ms : Πn, M (succ n)) : Πn, M n :=
-  nat.rec mz (λn dummy, ms n)
-
-end nat
-
 namespace cellcomplex
 
   /-

--- a/hott/homotopy/chain_complex.hlean
+++ b/hott/homotopy/chain_complex.hlean
@@ -517,6 +517,19 @@ namespace chain_complex
     { apply is_surjective_of_trivial X, apply H1},
   end
 
+  definition is_contr_of_is_embedding_of_is_surjective {N : succ_str} (X : chain_complex N) {n : N}
+    (H : is_exact_at X (S n)) [is_embedding (cc_to_fn X n)]
+    [H2 : is_surjective (cc_to_fn X (S (S (S n))))] : is_contr (X (S (S n))) :=
+  begin
+    apply is_contr.mk pt, intro x,
+    have p : cc_to_fn X n (cc_to_fn X (S n) x) = cc_to_fn X n pt,
+      from !cc_is_chain_complex ⬝ !respect_pt⁻¹,
+    have q : cc_to_fn X (S n) x = pt, from is_injective_of_is_embedding p,
+    induction H x q with y r,
+    induction H2 y with z s,
+    exact (cc_is_chain_complex X _ z)⁻¹ ⬝ ap (cc_to_fn X _) s ⬝ r
+  end
+
   end
 
 end chain_complex

--- a/hott/homotopy/circle.hlean
+++ b/hott/homotopy/circle.hlean
@@ -10,7 +10,7 @@ import .sphere
 import types.int.hott
 import algebra.homotopy_group .connectedness
 
-open eq susp bool sphere_index is_equiv equiv is_trunc is_conn pi algebra
+open eq susp bool sphere_index is_equiv equiv is_trunc is_conn pi algebra pointed
 
 definition circle : Type₀ := sphere 1
 
@@ -336,6 +336,9 @@ namespace circle
 
   proposition is_conn_circle [instance] : is_conn 0 S¹ :=
   sphere.is_conn_sphere -1.+2
+
+  definition is_conn_pcircle [instance] : is_conn 0 S¹. := !is_conn_circle
+  definition is_trunc_pcircle [instance] : is_trunc 1 S¹. := !is_trunc_circle
 
   definition circle_mul [reducible] (x y : S¹) : S¹ :=
   circle.elim y (circle_turn y) x

--- a/hott/homotopy/circle.hlean
+++ b/hott/homotopy/circle.hlean
@@ -51,7 +51,7 @@ namespace circle
   !rec_merid
 
   definition elim2 {P : Type} (Pb1 Pb2 : P) (Ps1 Ps2 : Pb1 = Pb2) (x : S¹) : P :=
-  rec2 Pb1 Pb2 (pathover_of_eq Ps1) (pathover_of_eq Ps2) x
+  rec2 Pb1 Pb2 (pathover_of_eq _ Ps1) (pathover_of_eq _ Ps2) x
 
   definition elim2_on [reducible] {P : Type} (x : S¹) (Pb1 Pb2 : P)
     (Ps1 : Pb1 = Pb2) (Ps2 : Pb1 = Pb2) : P :=
@@ -117,7 +117,7 @@ namespace circle
 
   protected definition elim {P : Type} (Pbase : P) (Ploop : Pbase = Pbase)
     (x : S¹) : P :=
-  circle.rec Pbase (pathover_of_eq Ploop) x
+  circle.rec Pbase (pathover_of_eq _ Ploop) x
 
   protected definition elim_on [reducible] {P : Type} (x : S¹) (Pbase : P)
     (Ploop : Pbase = Pbase) : P :=
@@ -147,8 +147,8 @@ namespace circle
     rewrite [↑circle.rec2_on,rec2_seg2],
     assert l : Π(A B : Type)(a a₂ a₂' : A)(b b' : B)(p : a = a₂)(p' : a₂' = a₂)
                    (q : b = b'),
-             pathover_tr_of_pathover (pathover_of_eq q)
-           = pathover_of_eq (q ⬝ (tr_constant p' b')⁻¹)
+             pathover_tr_of_pathover (pathover_of_eq _ q)
+           = pathover_of_eq _ (q ⬝ (tr_constant p' b')⁻¹)
            :> b =[p] p' ▸ b',
     { intros, cases q, cases p', cases p, reflexivity },
     apply l

--- a/hott/homotopy/circle.hlean
+++ b/hott/homotopy/circle.hlean
@@ -16,16 +16,16 @@ definition circle : Type₀ := sphere 1
 
 namespace circle
   notation `S¹` := circle
-  definition base1 : circle := !north
-  definition base2 : circle := !south
+  definition base1 : S¹ := !north
+  definition base2 : S¹ := !south
   definition seg1 : base1 = base2 := merid !north
   definition seg2 : base1 = base2 := merid !south
 
-  definition base : circle := base1
+  definition base : S¹ := base1
   definition loop : base = base := seg2 ⬝ seg1⁻¹
 
-  definition rec2 {P : circle → Type} (Pb1 : P base1) (Pb2 : P base2)
-    (Ps1 : Pb1 =[seg1] Pb2) (Ps2 : Pb1 =[seg2] Pb2) (x : circle) : P x :=
+  definition rec2 {P : S¹ → Type} (Pb1 : P base1) (Pb2 : P base2)
+    (Ps1 : Pb1 =[seg1] Pb2) (Ps2 : Pb1 =[seg2] Pb2) (x : S¹) : P x :=
   begin
     induction x with b,
     { exact Pb1},
@@ -36,24 +36,24 @@ namespace circle
       { cases y}},
   end
 
-  definition rec2_on [reducible] {P : circle → Type} (x : circle) (Pb1 : P base1) (Pb2 : P base2)
+  definition rec2_on [reducible] {P : S¹ → Type} (x : S¹) (Pb1 : P base1) (Pb2 : P base2)
     (Ps1 : Pb1 =[seg1] Pb2) (Ps2 : Pb1 =[seg2] Pb2) : P x :=
   circle.rec2 Pb1 Pb2 Ps1 Ps2 x
 
-  theorem rec2_seg1 {P : circle → Type} (Pb1 : P base1) (Pb2 : P base2)
+  theorem rec2_seg1 {P : S¹ → Type} (Pb1 : P base1) (Pb2 : P base2)
     (Ps1 : Pb1 =[seg1] Pb2) (Ps2 : Pb1 =[seg2] Pb2)
       : apd (rec2 Pb1 Pb2 Ps1 Ps2) seg1 = Ps1 :=
   !rec_merid
 
-  theorem rec2_seg2 {P : circle → Type} (Pb1 : P base1) (Pb2 : P base2)
+  theorem rec2_seg2 {P : S¹ → Type} (Pb1 : P base1) (Pb2 : P base2)
     (Ps1 : Pb1 =[seg1] Pb2) (Ps2 : Pb1 =[seg2] Pb2)
       : apd (rec2 Pb1 Pb2 Ps1 Ps2) seg2 = Ps2 :=
   !rec_merid
 
-  definition elim2 {P : Type} (Pb1 Pb2 : P) (Ps1 Ps2 : Pb1 = Pb2) (x : circle) : P :=
+  definition elim2 {P : Type} (Pb1 Pb2 : P) (Ps1 Ps2 : Pb1 = Pb2) (x : S¹) : P :=
   rec2 Pb1 Pb2 (pathover_of_eq Ps1) (pathover_of_eq Ps2) x
 
-  definition elim2_on [reducible] {P : Type} (x : circle) (Pb1 Pb2 : P)
+  definition elim2_on [reducible] {P : Type} (x : S¹) (Pb1 Pb2 : P)
     (Ps1 : Pb1 = Pb2) (Ps2 : Pb1 = Pb2) : P :=
   elim2 Pb1 Pb2 Ps1 Ps2 x
 
@@ -71,10 +71,10 @@ namespace circle
     rewrite [▸*,-apd_eq_pathover_of_eq_ap,↑elim2,rec2_seg2],
   end
 
-  definition elim2_type (Pb1 Pb2 : Type) (Ps1 Ps2 : Pb1 ≃ Pb2) (x : circle) : Type :=
+  definition elim2_type (Pb1 Pb2 : Type) (Ps1 Ps2 : Pb1 ≃ Pb2) (x : S¹) : Type :=
   elim2 Pb1 Pb2 (ua Ps1) (ua Ps2) x
 
-  definition elim2_type_on [reducible] (x : circle) (Pb1 Pb2 : Type) (Ps1 Ps2 : Pb1 ≃ Pb2)
+  definition elim2_type_on [reducible] (x : S¹) (Pb1 Pb2 : Type) (Ps1 Ps2 : Pb1 ≃ Pb2)
     : Type :=
   elim2_type Pb1 Pb2 Ps1 Ps2 x
 
@@ -86,8 +86,8 @@ namespace circle
     : transport (elim2_type Pb1 Pb2 Ps1 Ps2) seg2 = Ps2 :=
   by rewrite [tr_eq_cast_ap_fn,↑elim2_type,elim2_seg2];apply cast_ua_fn
 
-  protected definition rec {P : circle → Type} (Pbase : P base) (Ploop : Pbase =[loop] Pbase)
-    (x : circle) : P x :=
+  protected definition rec {P : S¹ → Type} (Pbase : P base) (Ploop : Pbase =[loop] Pbase)
+    (x : S¹) : P x :=
   begin
     fapply (rec2_on x),
     { exact Pbase},
@@ -96,7 +96,7 @@ namespace circle
     { apply pathover_tr_of_pathover, exact Ploop}
   end
 
-  protected definition rec_on [reducible] {P : circle → Type} (x : circle) (Pbase : P base)
+  protected definition rec_on [reducible] {P : S¹ → Type} (x : S¹) (Pbase : P base)
     (Ploop : Pbase =[loop] Pbase) : P x :=
   circle.rec Pbase Ploop x
 
@@ -108,7 +108,7 @@ namespace circle
   definition con_refl {A : Type} {x y : A} (p : x = y) : p ⬝ refl _ = p :=
   eq.rec_on p idp
 
-  theorem rec_loop {P : circle → Type} (Pbase : P base) (Ploop : Pbase =[loop] Pbase) :
+  theorem rec_loop {P : S¹ → Type} (Pbase : P base) (Ploop : Pbase =[loop] Pbase) :
     apd (circle.rec Pbase Ploop) loop = Ploop :=
   begin
     rewrite [↑loop,apd_con,↑circle.rec,↑circle.rec2_on,↑base,rec2_seg2,apd_inv,rec2_seg1],
@@ -116,10 +116,10 @@ namespace circle
   end
 
   protected definition elim {P : Type} (Pbase : P) (Ploop : Pbase = Pbase)
-    (x : circle) : P :=
+    (x : S¹) : P :=
   circle.rec Pbase (pathover_of_eq Ploop) x
 
-  protected definition elim_on [reducible] {P : Type} (x : circle) (Pbase : P)
+  protected definition elim_on [reducible] {P : Type} (x : S¹) (Pbase : P)
     (Ploop : Pbase = Pbase) : P :=
   circle.elim Pbase Ploop x
 
@@ -155,10 +155,10 @@ namespace circle
   end
 
   protected definition elim_type (Pbase : Type) (Ploop : Pbase ≃ Pbase)
-    (x : circle) : Type :=
+    (x : S¹) : Type :=
   circle.elim Pbase (ua Ploop) x
 
-  protected definition elim_type_on [reducible] (x : circle) (Pbase : Type)
+  protected definition elim_type_on [reducible] (x : S¹) (Pbase : Type)
     (Ploop : Pbase ≃ Pbase) : Type :=
   circle.elim_type Pbase Ploop x
 
@@ -230,7 +230,7 @@ namespace circle
       ... = ap (circle.elim a p) (refl base) : by rewrite H,
   eq_bnot_ne_idp H2
 
-  definition nonidp (x : circle) : x = x :=
+  definition nonidp (x : S¹) : x = x :=
   begin
     induction x,
     { exact loop},
@@ -244,7 +244,7 @@ namespace circle
 
   open int
 
-  protected definition code [unfold 1] (x : circle) : Type₀ :=
+  protected definition code [unfold 1] (x : S¹) : Type₀ :=
   circle.elim_type_on x ℤ equiv_succ
 
   definition transport_code_loop (a : ℤ) : transport circle.code loop a = succ a :=
@@ -253,10 +253,10 @@ namespace circle
   definition transport_code_loop_inv (a : ℤ) : transport circle.code loop⁻¹ a = pred a :=
   ap10 !elim_type_loop_inv a
 
-  protected definition encode [unfold 2] {x : circle} (p : base = x) : circle.code x :=
+  protected definition encode [unfold 2] {x : S¹} (p : base = x) : circle.code x :=
   transport circle.code p (of_num 0)
 
-  protected definition decode [unfold 1] {x : circle} : circle.code x → base = x :=
+  protected definition decode [unfold 1] {x : S¹} : circle.code x → base = x :=
   begin
     induction x,
     { exact power loop},
@@ -264,7 +264,7 @@ namespace circle
       rewrite [power_con,transport_code_loop]}
   end
 
-  definition circle_eq_equiv [constructor] (x : circle) : (base = x) ≃ circle.code x :=
+  definition circle_eq_equiv [constructor] (x : S¹) : (base = x) ≃ circle.code x :=
   begin
     fapply equiv.MK,
     { exact circle.encode},
@@ -334,7 +334,7 @@ namespace circle
     { intro x, apply is_trunc_equiv_closed_rev, apply eq_equiv_Z}
   end
 
-  proposition is_conn_circle [instance] : is_conn 0 circle :=
+  proposition is_conn_circle [instance] : is_conn 0 S¹ :=
   sphere.is_conn_sphere -1.+2
 
   definition circle_turn [reducible] (x : S¹) : x = x :=

--- a/hott/homotopy/circle.hlean
+++ b/hott/homotopy/circle.hlean
@@ -230,15 +230,15 @@ namespace circle
       ... = ap (circle.elim a p) (refl base) : by rewrite H,
   eq_bnot_ne_idp H2
 
-  definition nonidp (x : S¹) : x = x :=
+  definition circle_turn [reducible] (x : S¹) : x = x :=
   begin
     induction x,
-    { exact loop},
-    { apply concato_eq, apply pathover_eq_lr, rewrite [con.left_inv,idp_con]}
+    { exact loop },
+    { apply eq_pathover, apply square_of_eq, rewrite ap_id }
   end
 
-  definition nonidp_neq_idp : nonidp ≠ (λx, idp) :=
-  assume H : nonidp = λx, idp,
+  definition turn_neq_idp : circle_turn ≠ (λx, idp) :=
+  assume H : circle_turn = λx, idp,
   have H2 : loop = idp, from apd10 H base,
   absurd H2 loop_neq_idp
 
@@ -254,14 +254,14 @@ namespace circle
   ap10 !elim_type_loop_inv a
 
   protected definition encode [unfold 2] {x : S¹} (p : base = x) : circle.code x :=
-  transport circle.code p (of_num 0)
+  transport circle.code p (0 : ℤ)
 
   protected definition decode [unfold 1] {x : S¹} : circle.code x → base = x :=
   begin
     induction x,
     { exact power loop},
-    { apply arrow_pathover_left, intro b, apply concato_eq, apply pathover_eq_r,
-      rewrite [power_con,transport_code_loop]}
+    { apply arrow_pathover_left, intro b, apply eq_pathover_constant_left_id_right,
+      apply square_of_eq, rewrite [idp_con, power_con,transport_code_loop]}
   end
 
   definition circle_eq_equiv [constructor] (x : S¹) : (base = x) ≃ circle.code x :=
@@ -337,13 +337,6 @@ namespace circle
   proposition is_conn_circle [instance] : is_conn 0 S¹ :=
   sphere.is_conn_sphere -1.+2
 
-  definition circle_turn [reducible] (x : S¹) : x = x :=
-  begin
-    induction x,
-    { exact loop },
-    { apply eq_pathover, apply square_of_eq, rewrite ap_id }
-  end
-
   definition circle_mul [reducible] (x y : S¹) : S¹ :=
   circle.elim y (circle_turn y) x
 
@@ -351,11 +344,10 @@ namespace circle
   begin
     induction x,
     { reflexivity },
-    { apply eq_pathover, krewrite [elim_loop,ap_id], apply hrefl }
+    { apply eq_pathover_id_right, apply hdeg_square, apply elim_loop }
   end
 
-  definition circle_base_mul [reducible] (x : S¹)
-    : circle_mul base x = x :=
+  definition circle_base_mul [reducible] (x : S¹) : circle_mul base x = x :=
   idp
 
 end circle

--- a/hott/homotopy/connectedness.hlean
+++ b/hott/homotopy/connectedness.hlean
@@ -142,8 +142,7 @@ namespace is_conn
       : is_conn_fun n (const A unit.star) → is_conn n A :=
     begin
       intro H, unfold is_conn_fun at H,
-      rewrite [-(ua (fiber.fiber_star_equiv A))],
-      exact (H unit.star)
+      exact is_conn_equiv_closed n (fiber.fiber_star_equiv A) _,
     end
 
     -- now maps from unit

--- a/hott/homotopy/connectedness.hlean
+++ b/hott/homotopy/connectedness.hlean
@@ -2,15 +2,23 @@
 Copyright (c) 2015 Ulrik Buchholtz. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Ulrik Buchholtz, Floris van Doorn
+
+Connectedness of types and functions
 -/
 import types.trunc types.arrow_2 types.lift
 
-open eq is_trunc is_equiv nat equiv trunc function fiber funext pi
+open eq is_trunc is_equiv nat equiv trunc function fiber funext pi pointed
+
+definition is_conn [reducible] (n : ℕ₋₂) (A : Type) : Type :=
+is_contr (trunc n A)
+
+definition is_conn_fun [reducible] (n : ℕ₋₂) {A B : Type} (f : A → B) : Type :=
+Πb : B, is_conn n (fiber f b)
+
+definition is_conn_inf [reducible] (A : Type) : Type := Πn, is_conn n A
+definition is_conn_fun_inf [reducible] {A B : Type} (f : A → B) : Type := Πn, is_conn_fun n f
 
 namespace is_conn
-
-  definition is_conn [reducible] (n : ℕ₋₂) (A : Type) : Type :=
-  is_contr (trunc n A)
 
   definition is_conn_equiv_closed (n : ℕ₋₂) {A B : Type}
     : A ≃ B → is_conn n A → is_conn n B :=
@@ -21,9 +29,6 @@ namespace is_conn
     assumption
   end
 
-  definition is_conn_fun [reducible] (n : ℕ₋₂) {A B : Type} (f : A → B) : Type :=
-  Πb : B, is_conn n (fiber f b)
-
   theorem is_conn_of_le (A : Type) {n k : ℕ₋₂} (H : n ≤ k) [is_conn k A] : is_conn n A :=
   begin
     apply is_contr_equiv_closed,
@@ -33,6 +38,9 @@ namespace is_conn
   theorem is_conn_fun_of_le {A B : Type} (f : A → B) {n k : ℕ₋₂} (H : n ≤ k)
     [is_conn_fun k f] : is_conn_fun n f :=
   λb, is_conn_of_le _ H
+
+  definition is_conn_of_is_conn_succ (n : ℕ₋₂) (A : Type) [is_conn (n.+1) A] : is_conn n A :=
+  is_trunc_trunc_of_le A -2 (trunc_index.self_le_succ n)
 
   namespace is_conn_fun
   section
@@ -267,6 +275,15 @@ namespace is_conn
     apply is_trunc_equiv_closed, apply trunc_trunc_equiv_trunc_trunc
   end
 
+  definition is_conn_eq [instance] (n : ℕ₋₂) {A : Type} (a a' : A) [is_conn (n.+1) A] :
+    is_conn n (a = a') :=
+  begin
+    apply is_trunc_equiv_closed, apply tr_eq_tr_equiv,
+  end
+
+  definition is_conn_loop [instance] (n : ℕ₋₂) (A : Type*) [is_conn (n.+1) A] : is_conn n (Ω A) :=
+  !is_conn_eq
+
   open pointed
   definition is_conn_ptrunc [instance] (A : Type*) (n k : ℕ₋₂) [H : is_conn n A]
     : is_conn n (ptrunc k A) :=
@@ -328,6 +345,24 @@ namespace is_conn
   begin
     intro b, cases b with b, apply is_trunc_equiv_closed_rev,
     { apply trunc_equiv_trunc, apply fiber_lift_functor}
+  end
+
+  open trunc_index
+  definition is_conn_fun_inf.mk_nat {A B : Type} {f : A → B} (H : Π(n : ℕ), is_conn_fun n f)
+    : is_conn_fun_inf f :=
+  begin
+    intro n,
+    cases n with n, { exact _},
+    cases n with n, { have -1 ≤ of_nat 0, from dec_star, apply is_conn_fun_of_le f this},
+    rewrite -of_nat_add_two, exact _
+  end
+
+  definition is_conn_inf.mk_nat {A : Type} (H : Π(n : ℕ), is_conn n A) : is_conn_inf A :=
+  begin
+    intro n,
+    cases n with n, { exact _},
+    cases n with n, { have -1 ≤ of_nat 0, from dec_star, apply is_conn_of_le A this},
+    rewrite -of_nat_add_two, exact _
   end
 
 end is_conn

--- a/hott/homotopy/connectedness.hlean
+++ b/hott/homotopy/connectedness.hlean
@@ -145,6 +145,13 @@ namespace is_conn
       exact is_conn_equiv_closed n (fiber.fiber_star_equiv A) _,
     end
 
+    definition is_conn_fun_to_unit_of_is_conn [H : is_conn n A] :
+      is_conn_fun n (const A unit.star) :=
+    begin
+      intro u, induction u,
+      exact is_conn_equiv_closed n (fiber.fiber_star_equiv A)⁻¹ᵉ _,
+    end
+
     -- now maps from unit
     definition is_conn_of_map_from_unit (a₀ : A) (H : is_conn_fun n (const unit a₀))
       : is_conn n .+1 A :=
@@ -176,7 +183,7 @@ namespace is_conn
       protected definition rec : is_equiv (λs : Πa : A, P a, s (Point A)) :=
       @is_equiv_compose
         (Πa : A, P a) (unit → P (Point A)) (P (Point A))
-        (λs x, s (Point A)) (λf, f unit.star)
+        (λf, f unit.star) (λs x, s (Point A))
         (is_conn_fun.rec n (is_conn_fun_from_unit n A (Point A)) P)
         (to_is_equiv (arrow_unit_left (P (Point A))))
 

--- a/hott/homotopy/cylinder.hlean
+++ b/hott/homotopy/cylinder.hlean
@@ -57,7 +57,7 @@ section
 
   protected definition elim {P : Type} (Pbase : B → P) (Ptop : A → P)
     (Pseg : Π(a : A), Pbase (f a) = Ptop a) (x : cylinder) : P :=
-  rec Pbase Ptop (λa, pathover_of_eq (Pseg a)) x
+  rec Pbase Ptop (λa, pathover_of_eq _ (Pseg a)) x
 
   protected definition elim_on [reducible] {P : Type} (x : cylinder) (Pbase : B → P) (Ptop : A → P)
     (Pseg : Π(a : A), Pbase (f a) = Ptop a) : P :=

--- a/hott/homotopy/default.hlean
+++ b/hott/homotopy/default.hlean
@@ -1,0 +1,8 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+
+-/
+
+import .sphere2 .EM .torus .red_susp .quaternionic_hopf .smash .cellcomplex .interval .cylinder

--- a/hott/homotopy/homotopy.md
+++ b/hott/homotopy/homotopy.md
@@ -23,8 +23,10 @@ folder (sorted such that files only import previous files).
 * [quaternionic_hopf](quaternionic_hopf.hlean) (the quaternionic Hopf fibration)
 * [chain_complex](chain_complex.hlean)
 * [LES_of_homotopy_groups](LES_of_homotopy_groups.hlean)
+* [vankampen](vankampen.hlean) (the Seifert-van Kampen theorem)
 * [homotopy_group](homotopy_group.hlean) (theorems about homotopy groups. The definition and basic facts about homotopy groups is in [algebra/homotopy_group](../algebra/homotopy_group.hlean))
 * [sphere2](sphere2.hlean) (calculation of the homotopy group of spheres)
+
 
 The following files depend on
 [hit.two_quotient](../hit/two_quotient.hlean) which on turn depends on

--- a/hott/homotopy/homotopy_group.hlean
+++ b/hott/homotopy/homotopy_group.hlean
@@ -244,3 +244,25 @@ namespace is_trunc
   end
 
 end is_trunc
+open is_trunc function
+/- applications to infty-connected types and maps -/
+namespace is_conn
+
+  definition is_conn_fun_inf_of_equiv_on_homotopy_groups.{u} {A B : Type.{u}} (f : A → B)
+    [is_equiv (trunc_functor 0 f)]
+    (H1 : Πa k, is_equiv (homotopy_group_functor k (pmap_of_map f a))) : is_conn_fun_inf f :=
+  begin
+    apply is_conn_fun_inf.mk_nat, intro n, apply is_conn_fun_of_equiv_on_homotopy_groups,
+    { intro a k H, exact H1 a k},
+    { intro a, apply is_surjective_of_is_equiv}
+  end
+
+  definition is_equiv_trunc_functor_of_is_conn_fun_inf.{u} (n : ℕ₋₂) {A B : Type.{u}} (f : A → B)
+    [is_conn_fun_inf f] : is_equiv (trunc_functor n f) :=
+  _
+
+  definition is_equiv_homotopy_group_functor_of_is_conn_fun_inf.{u} {A B : pType.{u}} (f : A →* B)
+    [is_conn_fun_inf f] (a : A) (k : ℕ) : is_equiv (homotopy_group_functor k f) :=
+  is_equiv_π_of_is_connected f (le.refl k)
+
+end is_conn

--- a/hott/homotopy/interval.hlean
+++ b/hott/homotopy/interval.hlean
@@ -62,9 +62,11 @@ namespace interval
   definition is_contr_interval [instance] [priority 900] : is_contr interval :=
   is_contr.mk zero (λx, interval.rec_on x idp seg !pathover_eq_r_idp)
 
-  open is_equiv equiv
   definition naive_funext_of_interval : naive_funext :=
   λA P f g p, ap (λ(i : interval) (x : A), interval.elim_on i (f x) (g x) (p x)) seg
+
+  definition funext_of_interval : funext :=
+  funext_from_naive_funext naive_funext_of_interval
 
 end interval open interval
 

--- a/hott/homotopy/interval.hlean
+++ b/hott/homotopy/interval.hlean
@@ -35,7 +35,7 @@ namespace interval
   !rec_merid
 
   protected definition elim {P : Type} (P0 P1 : P) (Ps : P0 = P1) (x : interval) : P :=
-  interval.rec P0 P1 (pathover_of_eq Ps) x
+  interval.rec P0 P1 (pathover_of_eq _ Ps) x
 
   protected definition elim_on [reducible] {P : Type} (x : interval) (P0 P1 : P)
     (Ps : P0 = P1) : P :=

--- a/hott/homotopy/join.hlean
+++ b/hott/homotopy/join.hlean
@@ -39,7 +39,7 @@ namespace join
 
   protected definition elim {P : Type} (Pinl : A → P) (Pinr : B → P)
     (Pglue : Π(x : A)(y : B), Pinl x = Pinr y) (z : join A B) : P :=
-  join.rec Pinl Pinr (λx y, pathover_of_eq (Pglue x y)) z
+  join.rec Pinl Pinr (λx y, pathover_of_eq _ (Pglue x y)) z
 
   protected definition elim_glue {P : Type} (Pinl : A → P) (Pinr : B → P)
     (Pglue : Π(x : A)(y : B), Pinl x = Pinr y) (x : A) (y : B)

--- a/hott/homotopy/sphere2.hlean
+++ b/hott/homotopy/sphere2.hlean
@@ -65,11 +65,11 @@ namespace sphere
         _,
         { rewrite [▸*, LES_of_homotopy_groups_2 _ (n +[ℕ] 2)],
           have H : 1 ≤[ℕ] n + 1, from !one_le_succ,
-          apply trivial_homotopy_group_of_is_trunc _ _ _ H},
+          apply trivial_ghomotopy_group_of_is_trunc _ _ _ H},
         { refine tr_rev (λx, is_contr (ptrunctype._trans_of_to_pType x))
                         (LES_of_homotopy_groups_2 complex_phopf _) _,
           have H : 1 ≤[ℕ] n + 2, from !one_le_succ,
-          apply trivial_homotopy_group_of_is_trunc _ _ _ H},
+          apply trivial_ghomotopy_group_of_is_trunc _ _ _ H},
         { exact homomorphism.struct (homomorphism_LES_of_homotopy_groups_fun _ (n+2, 0))}}},
     { exact homomorphism.struct (homomorphism_LES_of_homotopy_groups_fun _ (n+2, 0))}
   end
@@ -96,7 +96,7 @@ namespace sphere
   theorem not_is_trunc_sphere (n : ℕ) : ¬is_trunc n (S. (succ n)) :=
   begin
     intro H,
-    note H2 := trivial_homotopy_group_of_is_trunc (S. (succ n)) n n !le.refl,
+    note H2 := trivial_ghomotopy_group_of_is_trunc (S. (succ n)) n n !le.refl,
     have H3 : is_contr ℤ, from is_trunc_equiv_closed _ (equiv_of_isomorphism (πnSn n)),
     have H4 : (0 : ℤ) ≠ (1 : ℤ), from dec_star,
     apply H4,

--- a/hott/homotopy/susp.hlean
+++ b/hott/homotopy/susp.hlean
@@ -155,7 +155,7 @@ namespace susp
   variables {A B : Type} (f : A → B)
   include f
 
-  protected definition functor : susp A → susp B :=
+  protected definition functor [unfold 4] : susp A → susp B :=
   begin
     intro x, induction x with a,
     { exact north },
@@ -167,7 +167,7 @@ namespace susp
   include Hf
 
   open is_equiv
-  protected definition is_equiv_functor [instance] : is_equiv (susp.functor f) :=
+  protected definition is_equiv_functor [instance] [constructor] : is_equiv (susp.functor f) :=
   adjointify (susp.functor f) (susp.functor f⁻¹)
   abstract begin
     intro sb, induction sb with b, do 2 reflexivity,
@@ -209,18 +209,18 @@ namespace susp
   open pointed
   variables {X Y Z : Type*}
 
-  definition psusp_functor (f : X →* Y) : psusp X →* psusp Y :=
+  definition psusp_functor [constructor] (f : X →* Y) : psusp X →* psusp Y :=
   begin
     fconstructor,
     { exact susp.functor f },
     { reflexivity }
   end
 
-  definition is_equiv_psusp_functor (f : X →* Y) [Hf : is_equiv f]
+  definition is_equiv_psusp_functor [constructor] (f : X →* Y) [Hf : is_equiv f]
     : is_equiv (psusp_functor f) :=
   susp.is_equiv_functor f
 
-  definition psusp_equiv (f : X ≃* Y) : psusp X ≃* psusp Y :=
+  definition psusp_equiv [constructor] (f : X ≃* Y) : psusp X ≃* psusp Y :=
   pequiv_of_equiv (susp.equiv f) idp
 
   definition psusp_functor_compose (g : Y →* Z) (f : X →* Y)
@@ -231,7 +231,7 @@ namespace susp
       { reflexivity },
       { reflexivity },
       { apply eq_pathover, apply hdeg_square,
-        rewrite [▸*,ap_compose' _ (psusp_functor f),↑psusp_functor],
+        rewrite [▸*,ap_compose' _ (psusp_functor f)],
         krewrite +susp.elim_merid } },
     { reflexivity }
   end
@@ -263,7 +263,6 @@ namespace susp
       rewrite inverse2_right_inv,
       refine _ ⬝ !con.assoc',
       rewrite [ap_con_right_inv],
-      unfold psusp_functor,
       xrewrite [idp_con_idp, -ap_compose (concat idp)]},
   end
 
@@ -315,7 +314,7 @@ namespace susp
     { reflexivity}
   end
 
-  definition susp_adjoint_loop (X Y : Type*) : pointed.mk' (susp X) →* Y ≃ X →* Ω Y :=
+  definition susp_adjoint_loop [constructor] (X Y : Type*) : psusp X →* Y ≃ X →* Ω Y :=
   begin
     fapply equiv.MK,
     { intro f, exact ap1 f ∘* loop_susp_unit X},

--- a/hott/homotopy/susp.hlean
+++ b/hott/homotopy/susp.hlean
@@ -44,7 +44,7 @@ namespace susp
 
   protected definition elim {P : Type} (PN : P) (PS : P) (Pm : A → PN = PS)
     (x : susp A) : P :=
-  susp.rec PN PS (λa, pathover_of_eq (Pm a)) x
+  susp.rec PN PS (λa, pathover_of_eq _ (Pm a)) x
 
   protected definition elim_on [reducible] {P : Type} (x : susp A)
     (PN : P) (PS : P)  (Pm : A → PN = PS) : P :=

--- a/hott/homotopy/vankampen.hlean
+++ b/hott/homotopy/vankampen.hlean
@@ -7,7 +7,7 @@ Authors: Floris van Doorn
 import hit.pushout algebra.category.constructions.pushout algebra.category.constructions.type
        algebra.category.functor.equivalence
 
-open eq pushout category functor sum iso indexed_list set_quotient is_trunc trunc pi quotient
+open eq pushout category functor sum iso paths set_quotient is_trunc trunc pi quotient
      is_equiv
 
 namespace pushout
@@ -18,14 +18,9 @@ namespace pushout
   definition pushout_of_sum [unfold 6] (x : BL + TR) : pushout f g :=
   quotient.class_of _ x
 
-  local notation `C` := Groupoid_pushout (fundamental_groupoid_functor f)
-                                         (fundamental_groupoid_functor g)
-
-  local notation `R` := pushout_prehom_index (fundamental_groupoid_functor f)
-                                             (fundamental_groupoid_functor g)
-
-  local notation `Q` := pushout_hom_rel_index (fundamental_groupoid_functor f)
-                                              (fundamental_groupoid_functor g)
+  local notation `C` := Groupoid_pushout      (fundamental_groupoid BL) (fundamental_groupoid TR) f g
+  local notation `R` := pushout_prehom_index  (fundamental_groupoid BL) (fundamental_groupoid TR) f g
+  local notation `Q` := pushout_hom_rel_index (fundamental_groupoid BL) (fundamental_groupoid TR) f g
 
   protected definition code [unfold 7] (x : BL + TR) (y : pushout f g) : Type.{max u v w} :=
   begin
@@ -61,7 +56,7 @@ namespace pushout
     { exact tr (glue c)⁻¹},
   end
 
-  definition decode_list ⦃x x' : BL + TR⦄ (l : indexed_list R x x') :
+  definition decode_list ⦃x x' : BL + TR⦄ (l : paths R x x') :
     trunc 0 (pushout_of_sum x = pushout_of_sum x') :=
   realize (λa a', trunc 0 (pushout_of_sum a = pushout_of_sum a'))
           decode_reduction_rule
@@ -71,7 +66,7 @@ namespace pushout
   definition decode_list_nil (x : BL + TR) : decode_list (@nil _ _ x) = tidp :=
   idp
 
-  definition decode_list_cons ⦃x₁ x₂ x₃ : BL + TR⦄ (r : R x₂ x₃) (l : indexed_list R x₁ x₂) :
+  definition decode_list_cons ⦃x₁ x₂ x₃ : BL + TR⦄ (r : R x₂ x₃) (l : paths R x₁ x₂) :
     decode_list (r :: l) = tconcat (decode_list l) (decode_reduction_rule r) :=
   idp
 
@@ -83,12 +78,12 @@ namespace pushout
     decode_list [r₂, r₁] = tconcat (decode_reduction_rule r₁) (decode_reduction_rule r₂) :=
   realize_pair (λa b p, tidp_tcon p) r₂ r₁
 
-  definition decode_list_append ⦃x₁ x₂ x₃ : BL + TR⦄ (l₂ : indexed_list R x₂ x₃)
-    (l₁ : indexed_list R x₁ x₂) :
+  definition decode_list_append ⦃x₁ x₂ x₃ : BL + TR⦄ (l₂ : paths R x₂ x₃)
+    (l₁ : paths R x₁ x₂) :
     decode_list (l₂ ++ l₁) = tconcat (decode_list l₁) (decode_list l₂) :=
   realize_append (λa b c d, tassoc) (λa b, tcon_tidp) l₂ l₁
 
-  theorem decode_list_rel ⦃x x' : BL + TR⦄ {l l' : indexed_list R x x'} (H : Q l l') :
+  theorem decode_list_rel ⦃x x' : BL + TR⦄ {l l' : paths R x x'} (H : Q l l') :
     decode_list l = decode_list l' :=
   begin
     induction H,
@@ -199,9 +194,9 @@ namespace pushout
     have is_prop (encode (decode_reduction_rule r) = class_of [r]), from !is_trunc_eq,
     induction r,
     { induction f_1 with p, induction p, symmetry, apply eq_of_rel,
-      apply tr, apply indexed_list_rel_of_Q, apply idD},
+      apply tr, apply paths_rel_of_Q, apply idD},
     { induction g_1 with p, induction p, symmetry, apply eq_of_rel,
-      apply tr, apply indexed_list_rel_of_Q, apply idE},
+      apply tr, apply paths_rel_of_Q, apply idE},
     { refine !elim_type_eq_of_rel ⬝ _, apply eq_of_rel, apply tr, rewrite [append_nil]},
     { refine !elim_type_eq_of_rel_inv' ⬝ _, apply eq_of_rel, apply tr, rewrite [append_nil]}
   end

--- a/hott/homotopy/vankampen.hlean
+++ b/hott/homotopy/vankampen.hlean
@@ -4,32 +4,109 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Floris van Doorn
 -/
 
-import hit.pushout algebra.category.constructions.pushout algebra.category.constructions.type
-       algebra.category.functor.equivalence
+import hit.pushout hit.prop_trunc algebra.category.constructions.pushout
+       algebra.category.constructions.fundamental_groupoid algebra.category.functor.equivalence
 
 open eq pushout category functor sum iso paths set_quotient is_trunc trunc pi quotient
-     is_equiv
+     is_equiv fiber equiv
 
 namespace pushout
   section
   universe variables u v w
-  parameters {TL : Type.{u}} {BL : Type.{v}} {TR : Type.{w}} (f : TL → BL) (g : TL → TR)
-
+  parameters {S TL : Type.{u}} -- do we want to put these in different universe levels?
+             {BL : Type.{v}} {TR : Type.{w}} (k : S → TL) (f : TL → BL) (g : TL → TR)
+             [ksurj : is_surjective k]
+  include ksurj
   definition pushout_of_sum [unfold 6] (x : BL + TR) : pushout f g :=
   quotient.class_of _ x
 
-  local notation `C` := Groupoid_pushout      (fundamental_groupoid BL) (fundamental_groupoid TR) f g
-  local notation `R` := pushout_prehom_index  (fundamental_groupoid BL) (fundamental_groupoid TR) f g
-  local notation `Q` := pushout_hom_rel_index (fundamental_groupoid BL) (fundamental_groupoid TR) f g
+  local notation `F` := fundamental_groupoid_functor f
+  local notation `G` := fundamental_groupoid_functor g
+  local notation `C` := Groupoid_bpushout k F G
+  local notation `R` := bpushout_prehom_index k F G
+  local notation `Q` := bpushout_hom_rel_index k F G
+  local attribute is_trunc_equiv [instance]
 
-  protected definition code [unfold 7] (x : BL + TR) (y : pushout f g) : Type.{max u v w} :=
+  open category.bpushout_prehom_index category.bpushout_hom_rel_index paths.paths_rel
+  protected definition code_equiv_pt (x : BL + TR) {y : TL} {s : S} (p : k s = y) :
+    @hom C _ x (sum.inl (f y)) ≃ @hom C _ x (sum.inr (g y)) :=
+  begin
+    fapply equiv_postcompose,
+    { apply class_of,
+      refine [iE k F G (tap g (tr p)), DE k F G s, iD k F G (tap f (tr p⁻¹))]},
+    refine all_iso _
+  end
+
+  protected definition code_equiv_pt_constant (x : BL + TR) {y : TL} {s s' : S}
+    (p : k s = y) (p' : k s' = y) : code_equiv_pt x p = code_equiv_pt x p' :=
+  begin
+    apply equiv_eq, intro g,
+    apply ap (λx, x ∘ _),
+    induction p',
+    refine eq_of_rel (tr _) ⬝ (eq_of_rel (tr _))⁻¹,
+    { exact [DE k _ _ s']},
+    { refine rtrans (rel [_] (cohDE F G (tr p))) _,
+      refine rtrans (rcons _ (rel [] !DD)) _,
+      refine tr_rev (λx, paths_rel _ [_ , iD k F G (tr x)] _)
+                    (!ap_con⁻¹ ⬝ ap02 f !con.left_inv) _,
+      exact rcons _ (rel [] !idD)},
+    refine rtrans (rel _ !idE) _,
+    exact rcons _ (rel [] !idD)
+  end
+
+  protected definition code_equiv (x : BL + TR) (y : TL) :
+    @hom C _ x (sum.inl (f y)) ≃ @hom C _ x (sum.inr (g y)) :=
+  begin
+    refine @is_prop.elim_set _ _ _ _ _ (ksurj y), { apply @is_trunc_equiv: apply is_set_hom},
+    { intro v, cases v with s p,
+      exact code_equiv_pt x p},
+    intro v v', cases v with s p, cases v' with s' p',
+    exact code_equiv_pt_constant x p p'
+  end
+
+  theorem code_equiv_eq (x : BL + TR) (s : S) :
+    code_equiv x (k s) = @(equiv_postcompose (class_of [DE k F G s])) !all_iso :=
+  begin
+    apply equiv_eq, intro h,
+--    induction h using set_quotient.rec_prop with l,
+    refine @set_quotient.rec_prop _ _ _ _ _ h, {intro l, apply is_trunc_eq, apply is_set_hom},
+    intro l,
+    have ksurj (k s) = tr (fiber.mk s idp), from !is_prop.elim,
+    refine ap (λz, to_fun (@is_prop.elim_set _ _ _ _ _ z) (class_of l)) this ⬝ _,
+    change class_of ([iE k F G (tr idp), DE k F G s, iD k F G (tr idp)] ++ l) =
+           class_of (DE k F G s :: l) :> @hom C _ _ _,
+    refine eq_of_rel (tr _) ⬝ (eq_of_rel (tr _)),
+    { exact DE k F G s :: iD k F G (tr idp) :: l},
+    { change paths_rel Q ([iE k F G (tr idp)] ++ (DE k F G s :: iD k F G (tr idp) :: l))
+                         (nil ++ (DE k F G s :: iD k F G (tr idp) :: l)),
+      apply rel ([DE k F G s, iD k F G (tr idp)] ++ l),
+      apply idE},
+    { apply rcons, rewrite [-nil_append l at {2}, -singleton_append], apply rel l, apply idD}
+  end
+
+  theorem to_fun_code_equiv (x : BL + TR) (s : S) (h : @hom C _ x (sum.inl (f (k s)))) :
+    (to_fun (code_equiv x (k s)) h) = @comp C _ _ _ _ (class_of [DE k F G s]) h :=
+  ap010 to_fun !code_equiv_eq h
+
+  protected definition code [unfold 10] (x : BL + TR) (y : pushout f g) : Type.{max u v w} :=
   begin
     refine quotient.elim_type _ _ y,
     { clear y, intro y, exact @hom C _ x y},
-    { clear y, intro y z r, induction r with y, fapply equiv_postcompose,
-      { apply class_of, exact [pushout_prehom_index.DE _ _ y]},
-      { refine all_iso _}}
+    clear y, intro y z r, induction r with y,
+    exact code_equiv x y
   end
+
+/-
+[iE (ap g p), DE s, iD (ap f p⁻¹)]
+-->
+[DE s', iD (ap f p), iD (ap f p⁻¹)]
+-->
+[DE s', iD (ap f p ∘ ap f p⁻¹)]
+-->
+[DE s']
+<--
+[iE 1, DE s', iD 1]
+-/
 
   definition is_set_code (x : BL + TR) (y : pushout f g) : is_set (code x y) :=
   begin
@@ -46,14 +123,14 @@ namespace pushout
   end
 
   -- decode is harder
-  definition decode_reduction_rule [unfold 8] ⦃x x' : BL + TR⦄ (i : R x x') :
+  definition decode_reduction_rule [unfold 11] ⦃x x' : BL + TR⦄ (i : R x x') :
     trunc 0 (pushout_of_sum x = pushout_of_sum x') :=
   begin
     induction i,
     { exact tap inl f_1},
     { exact tap inr g_1},
-    { exact tr (glue c)},
-    { exact tr (glue c)⁻¹},
+    { exact tr (glue (k s))},
+    { exact tr (glue (k s))⁻¹},
   end
 
   definition decode_list ⦃x x' : BL + TR⦄ (l : paths R x x') :
@@ -92,10 +169,14 @@ namespace pushout
     { rewrite [decode_list_pair, decode_list_nil], exact ap tr !con.right_inv},
     { rewrite [decode_list_pair, decode_list_nil], exact ap tr !con.left_inv},
     { apply decode_list_singleton},
-    { apply decode_list_singleton}
+    { apply decode_list_singleton},
+    { rewrite [+decode_list_pair], induction h with p, apply ap tr, rewrite [-+ap_compose'],
+      exact !ap_con_eq_con_ap⁻¹},
+    { rewrite [+decode_list_pair], induction h with p, apply ap tr, rewrite [-+ap_compose'],
+      apply ap_con_eq_con_ap}
   end
 
-  definition decode_point [unfold 8] {x x' : BL + TR} (c : @hom C _ x x') :
+  definition decode_point [unfold 11] {x x' : BL + TR} (c : @hom C _ x x') :
     trunc 0 (pushout_of_sum x = pushout_of_sum x') :=
   begin
     induction c with l,
@@ -123,7 +204,19 @@ namespace pushout
       revert c, apply @set_quotient.rec_prop, { intro z, apply is_trunc_pathover},
       intro l,
       refine _ ⬝op ap decode_point !quotient.elim_type_eq_of_rel⁻¹,
-      apply decode_coh}
+      change pathover (λ a, trunc 0 (eq (pushout_of_sum x) a))
+    (decode_list l)
+    (eq_of_rel (pushout_rel f g) (pushout_rel.Rmk f g y))
+    (decode_point
+       (code_equiv x y (class_of l))),
+      note z := ksurj y, revert z,
+      apply @image.rec, { intro, apply is_trunc_pathover},
+      intro s p, induction p, rewrite to_fun_code_equiv,
+      refine _ ⬝op (decode_list_cons (DE k F G s) l)⁻¹,
+      esimp, generalize decode_list l,
+      apply @trunc.rec, { intro p, apply is_trunc_pathover},
+      intro p, apply trunc_pathover, apply eq_pathover_constant_left_id_right,
+      apply square_of_eq, exact !idp_con⁻¹}
   end
 
   -- report the failing of esimp in the commented-out proof below
@@ -141,8 +234,7 @@ namespace pushout
 --       change pathover (λ (a : pushout f g), trunc 0 (eq (pushout_of_sum x) a))
 --       (decode_point (class_of l))
 --       (glue y)
---       (decode_point (class_of ((pushout_prehom_index.lr (fundamental_groupoid_functor f)
---         (fundamental_groupoid_functor g) id) :: l))),
+--       (decode_point (class_of ((pushout_prehom_index.lr F G id) :: l))),
 --     esimp, rewrite [▸*, decode_list_cons, ▸*], generalize (decode_list l), clear l,
 --     apply @trunc.rec, { intro z, apply is_trunc_pathover},
 --     intro p, apply trunc_pathover, apply eq_pathover_constant_left_id_right,
@@ -156,6 +248,10 @@ namespace pushout
     induction p with p, induction p, reflexivity
   end
 
+  definition is_surjective.rec {A B : Type} {f : A → B} (Hf : is_surjective f)
+    {P : B → Type} [Πb, is_prop (P b)] (H : Πa, P (f a)) (b : B) : P b :=
+  by induction Hf b; exact p ▸ H a
+
   -- encode-decode is harder
   definition code_comp [unfold 8] {x y : BL + TR} {z : pushout f g}
     (c : code x (pushout_of_sum y)) (d : code y z) : code x z :=
@@ -166,7 +262,9 @@ namespace pushout
       apply arrow_pathover_left, intro d,
       refine !pathover_tr ⬝op _,
       refine !elim_type_eq_of_rel ⬝ _ ⬝ ap _ !elim_type_eq_of_rel⁻¹,
-      apply assoc}
+      note q := ksurj z, revert q, apply @image.rec, { intro, apply is_trunc_eq, apply is_set_code},
+      intro s p, induction p,
+      refine !to_fun_code_equiv ⬝ _ ⬝ ap (λh, h ∘ c) !to_fun_code_equiv⁻¹, apply assoc}
   end
 
   theorem encode_tcon' {x y : BL + TR} {z : pushout f g}
@@ -186,8 +284,7 @@ namespace pushout
     encode (tconcat p q) = encode q ∘ encode p :=
   encode_tcon' p q
 
-  open category.pushout_hom_rel_index
-
+  open category.bpushout_hom_rel_index
   theorem encode_decode_singleton {x y : BL + TR} (r : R x y) :
     encode (decode_reduction_rule r) = class_of [r] :=
   begin
@@ -197,8 +294,8 @@ namespace pushout
       apply tr, apply paths_rel_of_Q, apply idD},
     { induction g_1 with p, induction p, symmetry, apply eq_of_rel,
       apply tr, apply paths_rel_of_Q, apply idE},
-    { refine !elim_type_eq_of_rel ⬝ _, apply eq_of_rel, apply tr, rewrite [append_nil]},
-    { refine !elim_type_eq_of_rel_inv' ⬝ _, apply eq_of_rel, apply tr, rewrite [append_nil]}
+    { refine !elim_type_eq_of_rel ⬝ _, apply to_fun_code_equiv},
+    { refine !elim_type_eq_of_rel_inv' ⬝ _, apply ap010 to_inv !code_equiv_eq}
   end
 
   local attribute pushout [reducible]
@@ -208,7 +305,6 @@ namespace pushout
     induction y using quotient.rec_prop with y,
     revert c, apply @set_quotient.rec_prop, { intro, apply is_trunc_eq}, intro l,
     change encode (decode_list l) = class_of l,
-    -- do induction on l
     induction l,
     { reflexivity},
     { rewrite [decode_list_cons, encode_tcon, encode_decode_singleton, v_0]}

--- a/hott/homotopy/vankampen.hlean
+++ b/hott/homotopy/vankampen.hlean
@@ -1,0 +1,275 @@
+/-
+Copyright (c) 2016 Floris van Doorn. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Floris van Doorn
+-/
+
+import hit.pushout algebra.category.constructions.pushout algebra.category.constructions.type
+       algebra.category.functor.equivalence
+
+open eq pushout category functor sum iso indexed_list set_quotient is_trunc trunc pi quotient
+     is_equiv
+
+namespace pushout
+  section
+  universe variables u v w
+  parameters {TL : Type.{u}} {BL : Type.{v}} {TR : Type.{w}} (f : TL → BL) (g : TL → TR)
+
+  definition pushout_of_sum [unfold 6] (x : BL + TR) : pushout f g :=
+  quotient.class_of _ x
+
+  local notation `C` := Groupoid_pushout (fundamental_groupoid_functor f)
+                                         (fundamental_groupoid_functor g)
+
+  local notation `R` := pushout_prehom_index (fundamental_groupoid_functor f)
+                                             (fundamental_groupoid_functor g)
+
+  local notation `Q` := pushout_hom_rel_index (fundamental_groupoid_functor f)
+                                              (fundamental_groupoid_functor g)
+
+  protected definition code [unfold 7] (x : BL + TR) (y : pushout f g) : Type.{max u v w} :=
+  begin
+    refine quotient.elim_type _ _ y,
+    { clear y, intro y, exact @hom C _ x y},
+    { clear y, intro y z r, induction r with y, fapply equiv_postcompose,
+      { apply class_of, exact [pushout_prehom_index.DE _ _ y]},
+      { refine all_iso _}}
+  end
+
+  definition is_set_code (x : BL + TR) (y : pushout f g) : is_set (code x y) :=
+  begin
+    induction y using pushout.rec_prop, apply is_set_hom, apply is_set_hom,
+  end
+  local attribute is_set_code [instance]
+
+  -- encode is easy
+  definition encode {x : BL + TR} {y : pushout f g} (p : trunc 0 (pushout_of_sum x = y)) :
+    code x y :=
+  begin
+    induction p with p,
+    exact transport (code x) p id
+  end
+
+  -- decode is harder
+  definition decode_reduction_rule [unfold 8] ⦃x x' : BL + TR⦄ (i : R x x') :
+    trunc 0 (pushout_of_sum x = pushout_of_sum x') :=
+  begin
+    induction i,
+    { exact tap inl f_1},
+    { exact tap inr g_1},
+    { exact tr (glue c)},
+    { exact tr (glue c)⁻¹},
+  end
+
+  definition decode_list ⦃x x' : BL + TR⦄ (l : indexed_list R x x') :
+    trunc 0 (pushout_of_sum x = pushout_of_sum x') :=
+  realize (λa a', trunc 0 (pushout_of_sum a = pushout_of_sum a'))
+          decode_reduction_rule
+          (λa, tidp)
+          (λa₁ a₂ a₃, tconcat) l
+
+  definition decode_list_nil (x : BL + TR) : decode_list (@nil _ _ x) = tidp :=
+  idp
+
+  definition decode_list_cons ⦃x₁ x₂ x₃ : BL + TR⦄ (r : R x₂ x₃) (l : indexed_list R x₁ x₂) :
+    decode_list (r :: l) = tconcat (decode_list l) (decode_reduction_rule r) :=
+  idp
+
+  definition decode_list_singleton ⦃x₁ x₂ : BL + TR⦄ (r : R x₁ x₂) :
+    decode_list [r] = decode_reduction_rule r :=
+  realize_singleton (λa b p, tidp_tcon p) r
+
+  definition decode_list_pair ⦃x₁ x₂ x₃ : BL + TR⦄ (r₂ : R x₂ x₃) (r₁ : R x₁ x₂) :
+    decode_list [r₂, r₁] = tconcat (decode_reduction_rule r₁) (decode_reduction_rule r₂) :=
+  realize_pair (λa b p, tidp_tcon p) r₂ r₁
+
+  definition decode_list_append ⦃x₁ x₂ x₃ : BL + TR⦄ (l₂ : indexed_list R x₂ x₃)
+    (l₁ : indexed_list R x₁ x₂) :
+    decode_list (l₂ ++ l₁) = tconcat (decode_list l₁) (decode_list l₂) :=
+  realize_append (λa b c d, tassoc) (λa b, tcon_tidp) l₂ l₁
+
+  theorem decode_list_rel ⦃x x' : BL + TR⦄ {l l' : indexed_list R x x'} (H : Q l l') :
+    decode_list l = decode_list l' :=
+  begin
+    induction H,
+    { rewrite [decode_list_pair, decode_list_singleton], exact !tap_tcon⁻¹},
+    { rewrite [decode_list_pair, decode_list_singleton], exact !tap_tcon⁻¹},
+    { rewrite [decode_list_pair, decode_list_nil], exact ap tr !con.right_inv},
+    { rewrite [decode_list_pair, decode_list_nil], exact ap tr !con.left_inv},
+    { apply decode_list_singleton},
+    { apply decode_list_singleton}
+  end
+
+  definition decode_point [unfold 8] {x x' : BL + TR} (c : @hom C _ x x') :
+    trunc 0 (pushout_of_sum x = pushout_of_sum x') :=
+  begin
+    induction c with l,
+    { exact decode_list l},
+    { induction H with H, refine realize_eq _ _ _ H,
+      { intros, apply tassoc},
+      { intros, apply tcon_tidp},
+      { clear H a a', intros, exact decode_list_rel a}}
+  end
+
+  theorem decode_coh (x : BL + TR) (y : TL) (p : trunc 0 (pushout_of_sum x = inl (f y))) :
+    p =[glue y] tconcat p (tr (glue y)) :=
+  begin
+    induction p with p,
+    apply trunc_pathover, apply eq_pathover_constant_left_id_right,
+    apply square_of_eq, exact !idp_con⁻¹
+  end
+
+  definition decode [unfold 7] {x : BL + TR} {y : pushout f g} (c : code x y) :
+    trunc 0 (pushout_of_sum x = y) :=
+  begin
+    induction y using quotient.rec with y,
+    { exact decode_point c},
+    { induction H with y, apply arrow_pathover_left, intro c,
+      revert c, apply @set_quotient.rec_prop, { intro z, apply is_trunc_pathover},
+      intro l,
+      refine _ ⬝op ap decode_point !quotient.elim_type_eq_of_rel⁻¹,
+      apply decode_coh}
+  end
+
+  -- report the failing of esimp in the commented-out proof below
+--   definition decode [unfold 7] {x : BL + TR} {y : pushout f g} (c : code x y) :
+--     trunc 0 (pushout_of_sum x = y) :=
+--   begin
+--     induction y using quotient.rec with y,
+--     { exact decode_point c},
+--     { induction H with y, apply arrow_pathover_left, intro c,
+--       revert c, apply @set_quotient.rec_prop, { intro z, apply is_trunc_pathover},
+--       intro l,
+--       refine _ ⬝op ap decode_point !quotient.elim_type_eq_of_rel⁻¹,
+-- -- REPORT THIS!!! esimp fails here, but works after this change
+--   --esimp,
+--       change pathover (λ (a : pushout f g), trunc 0 (eq (pushout_of_sum x) a))
+--       (decode_point (class_of l))
+--       (glue y)
+--       (decode_point (class_of ((pushout_prehom_index.lr (fundamental_groupoid_functor f)
+--         (fundamental_groupoid_functor g) id) :: l))),
+--     esimp, rewrite [▸*, decode_list_cons, ▸*], generalize (decode_list l), clear l,
+--     apply @trunc.rec, { intro z, apply is_trunc_pathover},
+--     intro p, apply trunc_pathover, apply eq_pathover_constant_left_id_right,
+--     apply square_of_eq, exact !idp_con⁻¹}
+--   end
+
+  -- decode-encode is easy
+  protected theorem decode_encode {x : BL + TR} {y : pushout f g}
+    (p : trunc 0 (pushout_of_sum x = y)) : decode (encode p) = p :=
+  begin
+    induction p with p, induction p, reflexivity
+  end
+
+  -- encode-decode is harder
+  definition code_comp [unfold 8] {x y : BL + TR} {z : pushout f g}
+    (c : code x (pushout_of_sum y)) (d : code y z) : code x z :=
+  begin
+    induction z using quotient.rec with z,
+    { exact d ∘ c},
+    { induction H with z,
+      apply arrow_pathover_left, intro d,
+      refine !pathover_tr ⬝op _,
+      refine !elim_type_eq_of_rel ⬝ _ ⬝ ap _ !elim_type_eq_of_rel⁻¹,
+      apply assoc}
+  end
+
+  theorem encode_tcon' {x y : BL + TR} {z : pushout f g}
+    (p : trunc 0 (pushout_of_sum x = pushout_of_sum y))
+    (q : trunc 0 (pushout_of_sum y = z)):
+    encode (tconcat p q) = code_comp (encode p) (encode q) :=
+  begin
+    induction q with q,
+    induction q,
+    refine ap encode !tcon_tidp ⬝ _,
+    symmetry, apply id_left
+  end
+
+  theorem encode_tcon {x y z : BL + TR}
+    (p : trunc 0 (pushout_of_sum x = pushout_of_sum y))
+    (q : trunc 0 (pushout_of_sum y = pushout_of_sum z)):
+    encode (tconcat p q) = encode q ∘ encode p :=
+  encode_tcon' p q
+
+  open category.pushout_hom_rel_index
+
+  theorem encode_decode_singleton {x y : BL + TR} (r : R x y) :
+    encode (decode_reduction_rule r) = class_of [r] :=
+  begin
+    have is_prop (encode (decode_reduction_rule r) = class_of [r]), from !is_trunc_eq,
+    induction r,
+    { induction f_1 with p, induction p, symmetry, apply eq_of_rel,
+      apply tr, apply indexed_list_rel_of_Q, apply idD},
+    { induction g_1 with p, induction p, symmetry, apply eq_of_rel,
+      apply tr, apply indexed_list_rel_of_Q, apply idE},
+    { refine !elim_type_eq_of_rel ⬝ _, apply eq_of_rel, apply tr, rewrite [append_nil]},
+    { refine !elim_type_eq_of_rel_inv' ⬝ _, apply eq_of_rel, apply tr, rewrite [append_nil]}
+  end
+
+  local attribute pushout [reducible]
+  protected theorem encode_decode {x : BL + TR} {y : pushout f g} (c : code x y) :
+    encode (decode c) = c :=
+  begin
+    induction y using quotient.rec_prop with y,
+    revert c, apply @set_quotient.rec_prop, { intro, apply is_trunc_eq}, intro l,
+    change encode (decode_list l) = class_of l,
+    -- do induction on l
+    induction l,
+    { reflexivity},
+    { rewrite [decode_list_cons, encode_tcon, encode_decode_singleton, v_0]}
+  end
+
+  definition pushout_teq_equiv [constructor] (x : BL + TR) (y : pushout f g) :
+    trunc 0 (pushout_of_sum x = y) ≃ code x y :=
+  equiv.MK encode
+           decode
+           encode_decode
+           decode_encode
+
+  definition vankampen [constructor] (x y : BL + TR) :
+    trunc 0 (pushout_of_sum x = pushout_of_sum y) ≃ @hom C _ x y :=
+  pushout_teq_equiv x (pushout_of_sum y)
+
+  definition decode_point_comp [unfold 8] {x₁ x₂ x₃ : BL + TR}
+    (c₂ : @hom C _ x₂ x₃) (c₁ : @hom C _ x₁ x₂) :
+    decode_point (c₂ ∘ c₁) = tconcat (decode_point c₁) (decode_point c₂) :=
+  begin
+    induction c₂ using set_quotient.rec_prop with l₂,
+    induction c₁ using set_quotient.rec_prop with l₁,
+    apply decode_list_append
+  end
+
+  definition vankampen_functor [constructor] : C ⇒ fundamental_groupoid (pushout f g) :=
+  begin
+    fconstructor,
+    { exact pushout_of_sum},
+    { intro x y c, exact decode_point c},
+    { intro x, reflexivity},
+    { intro x y z d c, apply decode_point_comp}
+  end
+
+  definition fully_faithful_vankampen_functor : fully_faithful vankampen_functor :=
+  begin
+    intro x x',
+    fapply adjointify,
+    { apply encode},
+    { intro p, apply decode_encode},
+    { intro c, apply encode_decode}
+  end
+
+  definition essentially_surjective_vankampen_functor : essentially_surjective vankampen_functor :=
+  begin
+    intro z, induction z using quotient.rec_prop with x,
+    apply exists.intro x, reflexivity
+  end
+
+  definition is_weak_equivalence_vankampen_functor [constructor] :
+    is_weak_equivalence vankampen_functor :=
+  begin
+    constructor,
+    { exact fully_faithful_vankampen_functor},
+    { exact essentially_surjective_vankampen_functor}
+  end
+
+  end
+end pushout

--- a/hott/hott.md
+++ b/hott/hott.md
@@ -3,11 +3,12 @@ The Lean Homotopy Type Theory Library
 
 The Lean Homotopy Type Theory library consists of the following directories:
 
-* [init](init/init.md) : constants and theorems needed for low-level system operations
+* [init](init/init.md) : basic definitions and theorems. These are imported in each ".hlean" file by default, unless the `prelude` command is used.
 * [types](types/types.md) : concrete datatypes and type constructors
-* [hit](hit/hit.md): higher inductive types
-* [algebra](algebra/algebra.md) : algebraic structures
-* [cubical](cubical/cubical.md): cubical types
+* [algebra](algebra/algebra.md) : algebraic structures, group theory and category theory.
+* [cubical](cubical/cubical.md) : cubical types (e.g. squares in a types, squareovers)
+* [hit](hit/hit.md): higher inductive types. Some higher inductive types which are mostly relevant in homotopy theory are in the [homotopy](homotopy/homotopy.md) folder.
+* [homotopy](homotopy/homotopy.md) : synthetic homotopy theory.
 
 The following files don't fit in any of the subfolders:
 * [prop_trunc](prop_trunc.hlean): in this file we prove that `is_trunc n A` is a mere proposition. We separate this from [types.trunc](types/trunc.hlean) to avoid circularity in imports.

--- a/hott/init/equiv.hlean
+++ b/hott/init/equiv.hlean
@@ -68,7 +68,7 @@ namespace is_equiv
   parameters {A B : Type} (f : A → B) (g : B → A)
             (ret : Πb, f (g b) = b) (sec : Πa, g (f a) = a)
 
-  definition adjointify_left_inv' (a : A) : g (f a) = a :=
+  definition adjointify_left_inv' [unfold_full] (a : A) : g (f a) = a :=
   ap g (ap f (inverse (sec a))) ⬝ ap g (ret (f a)) ⬝ sec a
 
   theorem adjointify_adj' (a : A) : ret (f a) = ap f (adjointify_left_inv' a) :=
@@ -276,6 +276,7 @@ namespace is_equiv
                        = right_inv f (h' c) ⬝ ap h' (right_inv f c)⁻¹ ⬝ (p (f⁻¹ c))⁻¹ :=
   !ap_eq_of_fn_eq_fn'
 
+  -- inv_commute'_fn is in types.equiv
   end
 
   -- This is inv_commute' for A ≡ unit

--- a/hott/init/equiv.hlean
+++ b/hott/init/equiv.hlean
@@ -35,7 +35,7 @@ namespace is_equiv
   postfix [parsing_only] `⁻¹ᶠ`:std.prec.max_plus := inv
 
   section
-  variables {A B C : Type} (f : A → B) (g : B → C) {f' : A → B}
+  variables {A B C : Type} (g : B → C) (f : A → B) {f' : A → B}
 
   -- The variant of mk' where f is explicit.
   protected abbreviation mk [constructor] := @is_equiv.mk' A B f
@@ -134,11 +134,11 @@ namespace is_equiv
   -- The 2-out-of-3 properties
   definition cancel_right (g : B → C) [Hgf : is_equiv (g ∘ f)] : (is_equiv g) :=
   have Hfinv : is_equiv f⁻¹, from is_equiv_inv f,
-  @homotopy_closed _ _ _ _ (is_equiv_compose f⁻¹ (g ∘ f)) (λb, ap g (@right_inv _ _ f _ b))
+  @homotopy_closed _ _ _ _ (is_equiv_compose (g ∘ f) f⁻¹) (λb, ap g (@right_inv _ _ f _ b))
 
   definition cancel_left (g : C → A) [Hgf : is_equiv (f ∘ g)] : (is_equiv g) :=
   have Hfinv : is_equiv f⁻¹, from is_equiv_inv f,
-  @homotopy_closed _ _ _ _ (is_equiv_compose (f ∘ g) f⁻¹) (λa, left_inv f (g a))
+  @homotopy_closed _ _ _ _ (is_equiv_compose f⁻¹ (f ∘ g)) (λa, left_inv f (g a))
 
   definition eq_of_fn_eq_fn' {x y : A} (q : f x = f y) : x = y :=
   (left_inv f x)⁻¹ ⬝ ap f⁻¹ q ⬝ left_inv f y

--- a/hott/init/equiv.hlean
+++ b/hott/init/equiv.hlean
@@ -254,6 +254,10 @@ namespace is_equiv
     (p : x = y) : (is_equiv (transport P p)) :=
   is_equiv.mk _ (transport P p⁻¹) (tr_inv_tr p) (inv_tr_tr p) (tr_inv_tr_lemma p)
 
+  -- a version where the transport is a cast. Note: A and B live in the same universe here.
+  definition is_equiv_cast [constructor] {A B : Type} (H : A = B) : is_equiv (cast H) :=
+  is_equiv_tr (λX, X) H
+
   section
   variables {A : Type} {B C : A → Type} (f : Π{a}, B a → C a) [H : Πa, is_equiv (@f a)]
             {g : A → A} {g' : A → A} (h : Π{a}, B (g' a) → B (g a)) (h' : Π{a}, C (g' a) → C (g a))
@@ -354,6 +358,10 @@ namespace equiv
 
   definition equiv_of_eq [constructor] {A B : Type} (p : A = B) : A ≃ B :=
   equiv.mk (cast p) !is_equiv_tr
+
+  definition equiv_of_eq_refl [reducible] [unfold_full] (A : Type)
+    : equiv_of_eq (refl A) = equiv.refl A :=
+  idp
 
   definition eq_of_fn_eq_fn (f : A ≃ B) {x y : A} (q : f x = f y) : x = y :=
   (left_inv f x)⁻¹ ⬝ ap f⁻¹ q ⬝ left_inv f y

--- a/hott/init/funext.hlean
+++ b/hott/init/funext.hlean
@@ -238,42 +238,65 @@ end funext
 
 open funext
 
-definition eq_equiv_homotopy : (f = g) ≃ (f ~ g) :=
-equiv.mk apd10 _
+namespace eq
+  definition eq_equiv_homotopy : (f = g) ≃ (f ~ g) :=
+  equiv.mk apd10 _
 
-definition eq_of_homotopy [reducible] : f ~ g → f = g :=
-(@apd10 A P f g)⁻¹
+  definition eq_of_homotopy [reducible] : f ~ g → f = g :=
+  (@apd10 A P f g)⁻¹
 
-definition apd10_eq_of_homotopy (p : f ~ g) : apd10 (eq_of_homotopy p) = p :=
-right_inv apd10 p
+  definition apd10_eq_of_homotopy (p : f ~ g) : apd10 (eq_of_homotopy p) = p :=
+  right_inv apd10 p
 
-definition eq_of_homotopy_apd10 (p : f = g) : eq_of_homotopy (apd10 p) = p :=
-left_inv apd10 p
+  definition eq_of_homotopy_apd10 (p : f = g) : eq_of_homotopy (apd10 p) = p :=
+  left_inv apd10 p
 
-definition eq_of_homotopy_idp (f : Π x, P x) : eq_of_homotopy (λx : A, idpath (f x)) = idpath f :=
-is_equiv.left_inv apd10 idp
+  definition eq_of_homotopy_idp (f : Π x, P x) : eq_of_homotopy (λx : A, idpath (f x)) = idpath f :=
+  is_equiv.left_inv apd10 idp
 
-definition naive_funext_of_ua : naive_funext :=
-λ A P f g h, eq_of_homotopy h
+  definition naive_funext_of_ua : naive_funext :=
+  λ A P f g h, eq_of_homotopy h
 
-protected definition homotopy.rec_on [recursor] {Q : (f ~ g) → Type} (p : f ~ g)
-  (H : Π(q : f = g), Q (apd10 q)) : Q p :=
-right_inv apd10 p ▸ H (eq_of_homotopy p)
+  protected definition homotopy.rec_on [recursor] {Q : (f ~ g) → Type} (p : f ~ g)
+    (H : Π(q : f = g), Q (apd10 q)) : Q p :=
+  right_inv apd10 p ▸ H (eq_of_homotopy p)
 
-protected definition homotopy.rec_on_idp [recursor] {Q : Π{g}, (f ~ g) → Type} {g : Π x, P x} (p : f ~ g) (H : Q (homotopy.refl f)) : Q p :=
-homotopy.rec_on p (λq, eq.rec_on q H)
+  protected definition homotopy.rec_on_idp [recursor] {Q : Π{g}, (f ~ g) → Type} {g : Π x, P x}
+    (p : f ~ g) (H : Q (homotopy.refl f)) : Q p :=
+  homotopy.rec_on p (λq, eq.rec_on q H)
 
-definition eq_of_homotopy_inv {f g : Π x, P x} (H : f ~ g)
-  : eq_of_homotopy (λx, (H x)⁻¹) = (eq_of_homotopy H)⁻¹ :=
-begin
-  apply homotopy.rec_on_idp H,
-  rewrite [+eq_of_homotopy_idp]
-end
+  protected definition homotopy.rec_on' {f f' : Πa, P a} {Q : (f ~ f') → (f = f') → Type}
+    (p : f ~ f') (H : Π(q : f = f'), Q (apd10 q) q) : Q p (eq_of_homotopy p) :=
+  begin
+    refine homotopy.rec_on p _,
+    intro q, exact (left_inv (apd10) q)⁻¹ ▸ H q
+  end
 
-definition eq_of_homotopy_con {f g h : Π x, P x} (H1 : f ~ g) (H2 : g ~ h)
-  : eq_of_homotopy (λx, H1 x ⬝ H2 x) = eq_of_homotopy H1 ⬝ eq_of_homotopy H2 :=
-begin
-  apply homotopy.rec_on_idp H1,
-  apply homotopy.rec_on_idp H2,
-  rewrite [+eq_of_homotopy_idp]
-end
+  protected definition homotopy.rec_on_idp' {f : Πa, P a} {Q : Π{g}, (f ~ g) → (f = g) → Type}
+    {g : Πa, P a} (p : f ~ g) (H : Q (homotopy.refl f) idp) : Q p (eq_of_homotopy p) :=
+  begin
+    refine homotopy.rec_on' p _, intro q, induction q, exact H
+  end
+
+  definition eq_of_homotopy_inv {f g : Π x, P x} (H : f ~ g)
+    : eq_of_homotopy (λx, (H x)⁻¹) = (eq_of_homotopy H)⁻¹ :=
+  begin
+    apply homotopy.rec_on_idp H,
+    rewrite [+eq_of_homotopy_idp]
+  end
+
+  definition eq_of_homotopy_con {f g h : Π x, P x} (H1 : f ~ g) (H2 : g ~ h)
+    : eq_of_homotopy (λx, H1 x ⬝ H2 x) = eq_of_homotopy H1 ⬝ eq_of_homotopy H2 :=
+  begin
+    apply homotopy.rec_on_idp H1,
+    apply homotopy.rec_on_idp H2,
+    rewrite [+eq_of_homotopy_idp]
+  end
+
+  definition compose_eq_of_homotopy {A B C : Type} (g : B → C) {f f' : A → B} (H : f ~ f') :
+    ap (λf, g ∘ f) (eq_of_homotopy H) = eq_of_homotopy (hwhisker_left g H) :=
+  begin
+    refine homotopy.rec_on_idp' H _, exact !eq_of_homotopy_idp⁻¹
+  end
+
+end eq

--- a/hott/init/funext.hlean
+++ b/hott/init/funext.hlean
@@ -125,31 +125,28 @@ section
           from (@right_inv _ _ (@equiv_of_eq A B) (univalence A B) w'),
         have invs_eq : (to_fun eq')⁻¹ = (to_fun w')⁻¹,
           from inv_eq eq' w' eqretr,
+        have eqfin1 : Π(p : A = B), (to_fun (equiv_of_eq p)) ∘ ((to_fun (equiv_of_eq p))⁻¹ ∘ x) = x,
+          by intro p; induction p; reflexivity,
         have eqfin : (to_fun eq') ∘ ((to_fun eq')⁻¹ ∘ x) = x,
-          from (λ p,
-            (@eq.rec_on Type.{l} A
-              (λ B' p', Π (x' : C → B'), (to_fun (equiv_of_eq p'))
-                ∘ ((to_fun (equiv_of_eq p'))⁻¹ ∘ x') = x')
-              B p (λ x', idp))
-            ) eqinv x,
+          from eqfin1 eqinv,
         have eqfin' : (to_fun w') ∘ ((to_fun eq')⁻¹ ∘ x) = x,
-          from eqretr ▸ eqfin,
-        have eqfin'' : (to_fun w') ∘ ((to_fun w')⁻¹ ∘ x) = x,
-          from invs_eq ▸ eqfin',
-        eqfin''
+          from ap (λu, u ∘ _) eqretr⁻¹ ⬝ eqfin,
+        show (to_fun w') ∘ ((to_fun w')⁻¹ ∘ x) = x,
+          from ap (λu, _ ∘ (u ∘ _)) invs_eq⁻¹ ⬝ eqfin'
       )
       (λ (x : C → A),
         have eqretr : eq' = w',
           from (@right_inv _ _ (@equiv_of_eq A B) (univalence A B) w'),
         have invs_eq : (to_fun eq')⁻¹ = (to_fun w')⁻¹,
           from inv_eq eq' w' eqretr,
+        have eqfin1 : Π(p : A = B), (to_fun (equiv_of_eq p))⁻¹ ∘ ((to_fun (equiv_of_eq p)) ∘ x) = x,
+          by intro p; induction p; reflexivity,
         have eqfin : (to_fun eq')⁻¹ ∘ ((to_fun eq') ∘ x) = x,
-          from (λ p, eq.rec_on p idp) eqinv,
+          from eqfin1 eqinv,
         have eqfin' : (to_fun eq')⁻¹ ∘ ((to_fun w') ∘ x) = x,
-          from eqretr ▸ eqfin,
-        have eqfin'' : (to_fun w')⁻¹ ∘ ((to_fun w') ∘ x) = x,
-          from invs_eq ▸ eqfin',
-        eqfin''
+          from ap (λu, _ ∘ (u ∘ _)) eqretr⁻¹ ⬝ eqfin,
+        show (to_fun w')⁻¹ ∘ ((to_fun w') ∘ x) = x,
+          from ap (λu, u ∘ _) invs_eq⁻¹ ⬝ eqfin'
       )
 
   -- We are ready to prove functional extensionality,

--- a/hott/init/nat.hlean
+++ b/hott/init/nat.hlean
@@ -16,6 +16,10 @@ namespace nat
                        {C : ℕ → Type} (n : ℕ) (H₁ : C 0) (H₂ : Π (a : ℕ), C a → C (succ a)) : C n :=
   nat.rec H₁ H₂ n
 
+  protected definition cases [reducible] [unfold 4] {M : ℕ → Type} (mz : M zero)
+    (ms : Πn, M (succ n)) : Πn, M n :=
+  nat.rec mz (λn dummy, ms n)
+
   protected definition cases_on [reducible] [recursor] [unfold 2]
                        {C : ℕ → Type} (n : ℕ) (H₁ : C 0) (H₂ : Π (a : ℕ), C (succ a)) : C n :=
   nat.rec H₁ (λ a ih, H₂ a) n

--- a/hott/init/path.hlean
+++ b/hott/init/path.hlean
@@ -483,6 +483,7 @@ namespace eq
 
 
   -- Dependent transport in a doubly dependent type.
+  -- This is a special case of transporto in init.pathover
   definition transportD [unfold 6] {P : A → Type} (Q : Πa, P a → Type)
       {a a' : A} (p : a = a') (b : P a) (z : Q a b) : Q a' (p ▸ b) :=
   by induction p; exact z
@@ -492,6 +493,7 @@ namespace eq
   notation p ` ▸D `:65 x:64 := transportD _ p _ x
 
   -- transporting over 2 one-dimensional paths
+  -- This is a special case of transporto in init.pathover
   definition transport11 {A B : Type} (P : A → B → Type) {a a' : A} {b b' : B}
     (p : a = a') (q : b = b') (z : P a b) : P a' b' :=
   transport (P a') q (p ▸ z)

--- a/hott/init/path.hlean
+++ b/hott/init/path.hlean
@@ -104,11 +104,12 @@ namespace eq
   by induction q; induction p; reflexivity
 
   -- Inverse is an involution.
-  definition inv_inv (p : x = y) : p⁻¹⁻¹ = p :=
+  definition inv_inv [unfold 4] (p : x = y) : p⁻¹⁻¹ = p :=
   by induction p; reflexivity
 
   -- auxiliary definition used by 'cases' tactic
-  definition elim_inv_inv {A : Type} {a b : A} {C : a = b → Type} (H₁ : a = b) (H₂ : C (H₁⁻¹⁻¹)) : C H₁ :=
+  definition elim_inv_inv [unfold 5] {A : Type} {a b : A} {C : a = b → Type}
+    (H₁ : a = b) (H₂ : C (H₁⁻¹⁻¹)) : C H₁ :=
   eq.rec_on (inv_inv H₁) H₂
 
   /- Theorems for moving things around in equations -/
@@ -240,6 +241,14 @@ namespace eq
   protected definition homotopy.trans [trans] [reducible] [unfold_full] {f g h : Πx, P x}
     (H1 : f ~ g) (H2 : g ~ h) : f ~ h :=
   λ x, H1 x ⬝ H2 x
+
+  definition hwhisker_left [unfold_full] (g : B → C) {f f' : A → B} (H : f ~ f') :
+    g ∘ f ~ g ∘ f' :=
+  λa, ap g (H a)
+
+  definition hwhisker_right [unfold_full] (f : A → B) {g g' : B → C} (H : g ~ g') :
+    g ∘ f ~ g' ∘ f :=
+  λa, H (f a)
 
   definition homotopy_of_eq {f g : Πx, P x} (H1 : f = g) : f ~ g :=
   H1 ▸ homotopy.refl f

--- a/hott/init/pathover.hlean
+++ b/hott/init/pathover.hlean
@@ -59,25 +59,25 @@ namespace eq
   end
 
   definition pathover_tr [unfold 5] (p : a = a₂) (b : B a) : b =[p] p ▸ b :=
-  by cases p;constructor
+  by cases p; constructor
 
   definition tr_pathover [unfold 5] (p : a = a₂) (b : B a₂) : p⁻¹ ▸ b =[p] b :=
-  by cases p;constructor
+  by cases p; constructor
 
   definition concato [unfold 12] (r : b =[p] b₂) (r₂ : b₂ =[p₂] b₃) : b =[p ⬝ p₂] b₃ :=
-  pathover.rec_on r₂ r
+  by induction r₂; exact r
 
   definition inverseo [unfold 8] (r : b =[p] b₂) : b₂ =[p⁻¹] b :=
-  pathover.rec_on r idpo
+  by induction r; constructor
 
   definition apd [unfold 6] (f : Πa, B a) (p : a = a₂) : f a =[p] f a₂ :=
-  eq.rec_on p idpo
+  by induction p; constructor
 
   definition concato_eq [unfold 10] (r : b =[p] b₂) (q : b₂ = b₂') : b =[p] b₂' :=
-  eq.rec_on q r
+  by induction q; exact r
 
   definition eq_concato [unfold 9] (q : b = b') (r : b' =[p] b₂) : b =[p] b₂ :=
-  by induction q;exact r
+  by induction q; exact r
 
   definition change_path [unfold 9] (q : p = p') (r : b =[p] b₂) : b =[p'] b₂ :=
   q ▸ r

--- a/hott/init/pathover.hlean
+++ b/hott/init/pathover.hlean
@@ -70,9 +70,6 @@ namespace eq
   definition inverseo [unfold 8] (r : b =[p] b₂) : b₂ =[p⁻¹] b :=
   by induction r; constructor
 
-  definition apd [unfold 6] (f : Πa, B a) (p : a = a₂) : f a =[p] f a₂ :=
-  by induction p; constructor
-
   definition concato_eq [unfold 10] (r : b =[p] b₂) (q : b₂ = b₂') : b =[p] b₂' :=
   by induction q; exact r
 
@@ -126,20 +123,20 @@ namespace eq
   definition eq_of_pathover {a' a₂' : A'} (q : a' =[p] a₂') : a' = a₂' :=
   by cases q;reflexivity
 
-  definition pathover_of_eq [unfold 5 8] {a' a₂' : A'} (q : a' = a₂') : a' =[p] a₂' :=
+  definition pathover_of_eq [unfold 5 8] (p : a = a₂) {a' a₂' : A'} (q : a' = a₂') : a' =[p] a₂' :=
   by cases p;cases q;constructor
 
   definition pathover_constant [constructor] (p : a = a₂) (a' a₂' : A') : a' =[p] a₂' ≃ a' = a₂' :=
   begin
     fapply equiv.MK,
     { exact eq_of_pathover},
-    { exact pathover_of_eq},
+    { exact pathover_of_eq p},
     { intro r, cases p, cases r, reflexivity},
     { intro r, cases r, reflexivity},
   end
 
   definition pathover_of_eq_tr_constant_inv (p : a = a₂) (a' : A')
-    : pathover_of_eq (tr_constant p a')⁻¹ = pathover_tr p a' :=
+    : pathover_of_eq p (tr_constant p a')⁻¹ = pathover_tr p a' :=
   by cases p; constructor
 
   definition eq_of_pathover_idp [unfold 6] {b' : B a} (q : b =[idpath a] b') : b = b' :=
@@ -155,6 +152,9 @@ namespace eq
            (to_right_inv !pathover_equiv_tr_eq)
            (to_left_inv !pathover_equiv_tr_eq)
 
+  definition eq_of_pathover_idp_pathover_of_eq {A X : Type} (x : X) {a a' : A} (p : a = a') :
+    eq_of_pathover_idp (pathover_of_eq (idpath x) p) = p :=
+  by induction p; reflexivity
 
   -- definition pathover_idp (b : B a) (b' : B a) : b =[idpath a] b' ≃ b = b' :=
   -- pathover_equiv_tr_eq idp b b'
@@ -165,7 +165,7 @@ namespace eq
   -- definition pathover_idp_of_eq [reducible] {b' : B a} (q : b = b') : b =[idpath a] b' :=
   -- to_inv !pathover_idp q
 
-  definition idp_rec_on [recursor] {P : Π⦃b₂ : B a⦄, b =[idpath a] b₂ → Type}
+  definition idp_rec_on [recursor] [unfold 7] {P : Π⦃b₂ : B a⦄, b =[idpath a] b₂ → Type}
     {b₂ : B a} (r : b =[idpath a] b₂) (H : P idpo) : P r :=
   have H2 : P (pathover_idp_of_eq (eq_of_pathover_idp r)), from
     eq.rec_on (eq_of_pathover_idp r) H,
@@ -198,17 +198,6 @@ namespace eq
     { intro q, cases q, reflexivity},
   end
 
-  definition apd_con (f : Πa, B a) (p : a = a₂) (q : a₂ = a₃)
-    : apd f (p ⬝ q) = apd f p ⬝o apd f q :=
-  by cases p; cases q; reflexivity
-
-  definition apd_inv (f : Πa, B a) (p : a = a₂) : apd f p⁻¹ = (apd f p)⁻¹ᵒ :=
-  by cases p; reflexivity
-
-  definition apd_eq_pathover_of_eq_ap (f : A → A') (p : a = a₂) :
-    apd f p = pathover_of_eq (ap f p) :=
-  eq.rec_on p idp
-
   definition pathover_of_pathover_tr (q : b =[p ⬝ p₂] p₂ ▸ b₂) : b =[p] b₂ :=
   pathover_cancel_right q !pathover_tr⁻¹ᵒ
 
@@ -232,29 +221,33 @@ namespace eq
   by induction r;exact c
   infix ` ▸o `:75 := transporto _
 
-  definition fn_tro_eq_tro_fn (C' : Π ⦃a : A⦄, B a → Type) (q : b =[p] b₂)
-    (f : Π(b : B a), C b → C' b) (c : C b) : f b (q ▸o c) = (q ▸o (f b c)) :=
-  by induction q;reflexivity
+  definition fn_tro_eq_tro_fn {C' : Π ⦃a : A⦄, B a → Type} (q : b =[p] b₂)
+    (f : Π⦃a : A⦄ (b : B a), C b → C' b) (c : C b) : f b₂ (q ▸o c) = q ▸o (f b c) :=
+  by induction q; reflexivity
   variable {C}
 
-  definition apo {f : A → A'} (g : Πa, B a → B'' (f a))
-    (q : b =[p] b₂) : g a b =[p] g a₂ b₂ :=
+  /- various variants of ap for pathovers -/
+  definition apd [unfold 6] (f : Πa, B a) (p : a = a₂) : f a =[p] f a₂ :=
+  by induction p; constructor
+
+  definition apo [unfold 12] {f : A → A'} (g : Πa, B a → B'' (f a)) (q : b =[p] b₂) :
+    g a b =[p] g a₂ b₂ :=
   by induction q; constructor
 
-  definition apo011 [unfold 10] (f : Πa, B a → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
+  definition apd011 [unfold 10] (f : Πa, B a → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
       : f a b = f a₂ b₂ :=
   by cases Hb; reflexivity
 
-  definition apo0111 (f : Πa b, C b → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
-    (Hc : c =[apo011 C Ha Hb] c₂) : f a b c = f a₂ b₂ c₂ :=
+  definition apd0111 [unfold 13 14] (f : Πa b, C b → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
+    (Hc : c =[apd011 C Ha Hb] c₂) : f a b c = f a₂ b₂ c₂ :=
   by cases Hb; apply (idp_rec_on Hc); apply idp
 
   definition apod11 {f : Πb, C b} {g : Πb₂, C b₂} (r : f =[p] g)
-    {b : B a} {b₂ : B a₂} (q : b =[p] b₂) : f b =[apo011 C p q] g b₂ :=
+    {b : B a} {b₂ : B a₂} (q : b =[p] b₂) : f b =[apd011 C p q] g b₂ :=
   by cases r; apply (idp_rec_on q); constructor
 
   definition apdo10 {f : Πb, C b} {g : Πb₂, C b₂} (r : f =[p] g)
-    (b : B a) : f b =[apo011 C p !pathover_tr] g (p ▸ b) :=
+    (b : B a) : f b =[apd011 C p !pathover_tr] g (p ▸ b) :=
   by cases r; constructor
 
   definition apo10 [unfold 9] {f : B a → B' a} {g : B a₂ → B' a₂} (r : f =[p] g)
@@ -273,6 +266,46 @@ namespace eq
     (q : b =[p] b₂) : f b =[p] g b₂ :=
   by induction q; exact apo10 r b
 
+  definition apdo011 {A : Type} {B : A → Type} {C : Π⦃a⦄, B a → Type}
+    (f : Π⦃a⦄ (b : B a), C b) {a a' : A} (p : a = a') {b : B a} {b' : B a'} (q : b =[p] b')
+      : f b =[apd011 C p q] f b' :=
+  by cases q; constructor
+
+  definition apdo0111 {A : Type} {B : A → Type} {C C' : Π⦃a⦄, B a → Type}
+    (f : Π⦃a⦄ {b : B a}, C b → C' b) {a a' : A} (p : a = a') {b : B a} {b' : B a'} (q : b =[p] b')
+    {c : C b} {c' : C b'} (r : c =[apd011 C p q] c')
+      : f c =[apd011 C' p q] f c' :=
+  begin
+    induction q, esimp at r, induction r using idp_rec_on, constructor
+  end
+
+  definition apo11_constant_right [unfold 12] {f : B a → A'} {g : B a₂ → A'}
+    (q : f =[p] g) (r : b =[p] b₂) : f b = g b₂ :=
+  eq_of_pathover (apo11 q r)
+
+  /- properties about these "ap"s, transporto and pathover_ap -/
+  definition apd_con (f : Πa, B a) (p : a = a₂) (q : a₂ = a₃)
+    : apd f (p ⬝ q) = apd f p ⬝o apd f q :=
+  by cases p; cases q; reflexivity
+
+  definition apd_inv (f : Πa, B a) (p : a = a₂) : apd f p⁻¹ = (apd f p)⁻¹ᵒ :=
+  by cases p; reflexivity
+
+  definition apd_eq_pathover_of_eq_ap (f : A → A') (p : a = a₂) :
+    apd f p = pathover_of_eq p (ap f p) :=
+  eq.rec_on p idp
+
+  definition apo_invo (f : Πa, B a → B' a) {Ha : a = a₂} (Hb : b =[Ha] b₂)
+      : (apo f Hb)⁻¹ᵒ = apo f Hb⁻¹ᵒ :=
+  by induction Hb; reflexivity
+
+  definition apd011_inv (f : Πa, B a → A') (Ha : a = a₂) (Hb : b =[Ha] b₂)
+      : (apd011 f Ha Hb)⁻¹ = (apd011 f Ha⁻¹ Hb⁻¹ᵒ) :=
+  by induction Hb; reflexivity
+
+  definition cast_apd011 (q : b =[p] b₂) (c : C b) : cast (apd011 C p q) c = q ▸o c :=
+  by induction q; reflexivity
+
   definition apd_compose1 (g : Πa, B a → B' a) (f : Πa, B a) (p : a = a₂)
     : apd (g ∘' f) p = apo g (apd f p) :=
   by induction p; reflexivity
@@ -281,25 +314,79 @@ namespace eq
     : apd (λa, g (f a)) p = pathover_of_pathover_ap B'' f (apd g (ap f p)) :=
   by induction p; reflexivity
 
-  definition cono.right_inv_eq (q : b = b')
-    : concato_eq (pathover_idp_of_eq q) q⁻¹ = (idpo : b =[refl a] b) :=
+  definition apo_tro (C : Π⦃a⦄, B' a → Type) (f : Π⦃a⦄, B a → B' a) (q : b =[p] b₂)
+    (c : C (f b)) : apo f q ▸o c = q ▸o c :=
+  by induction q; reflexivity
+
+  definition pathover_ap_tro {B' : A' → Type} (C : Π⦃a'⦄, B' a' → Type) (f : A → A')
+    {b : B' (f a)} {b₂ : B' (f a₂)} (q : b =[p] b₂) (c : C b) : pathover_ap B' f q ▸o c = q ▸o c :=
+  by induction q; reflexivity
+
+  definition pathover_ap_invo_tro {B' : A' → Type} (C : Π⦃a'⦄, B' a' → Type) (f : A → A')
+    {b : B' (f a)} {b₂ : B' (f a₂)} (q : b =[p] b₂) (c : C b₂)
+    : (pathover_ap B' f q)⁻¹ᵒ ▸o c = q⁻¹ᵒ ▸o c :=
+  by induction q; reflexivity
+
+  definition pathover_tro (q : b =[p] b₂) (c : C b) : c =[apd011 C p q] q ▸o c :=
+  by induction q; constructor
+
+  definition pathover_ap_invo {B' : A' → Type} (f : A → A') {p : a = a₂}
+    {b : B' (f a)} {b₂ : B' (f a₂)} (q : b =[p] b₂)
+    : pathover_ap B' f q⁻¹ᵒ =[ap_inv f p] (pathover_ap B' f q)⁻¹ᵒ :=
+  by induction q; exact idpo
+
+  definition tro_invo_tro {A : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} (q : b =[p] b') (c : C b') :
+    q ▸o (q⁻¹ᵒ ▸o c) = c :=
+  by induction q; reflexivity
+
+  definition invo_tro_tro {A : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} (q : b =[p] b') (c : C b) :
+    q⁻¹ᵒ ▸o (q ▸o c) = c :=
+  by induction q; reflexivity
+
+  definition cono_tro {A : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a₁ a₂ a₃ : A} {p₁ : a₁ = a₂} {p₂ : a₂ = a₃} {b₁ : B a₁} {b₂ : B a₂} {b₃ : B a₃}
+    (q₁ : b₁ =[p₁] b₂) (q₂ : b₂ =[p₂] b₃) (c : C b₁) :
+    transporto C (q₁ ⬝o q₂) c = transporto C q₂ (transporto C q₁ c) :=
+  by induction q₂; reflexivity
+
+  definition is_equiv_transporto [constructor] {A : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} (q : b =[p] b') : is_equiv (transporto C q) :=
+  begin
+    fapply adjointify,
+    { exact transporto C q⁻¹ᵒ},
+    { exact tro_invo_tro C q},
+    { exact invo_tro_tro C q}
+  end
+
+  definition equiv_apd011 [constructor] {A : Type} {B : A → Type} (C : Π⦃a⦄, B a → Type)
+    {a a' : A} {p : a = a'} {b : B a} {b' : B a'} (q : b =[p] b') : C b ≃ C b' :=
+  equiv.mk (transporto C q) !is_equiv_transporto
+
+  /- some cancellation laws for concato_eq an variants -/
+
+  definition cono.right_inv_eq (q : b = b') :
+    pathover_idp_of_eq q ⬝op q⁻¹ = (idpo : b =[refl a] b) :=
   by induction q;constructor
 
-  definition cono.right_inv_eq' (q : b = b')
-    : eq_concato q (pathover_idp_of_eq q⁻¹) = (idpo : b =[refl a] b) :=
+  definition cono.right_inv_eq' (q : b = b') :
+    q ⬝po (pathover_idp_of_eq q⁻¹) = (idpo : b =[refl a] b) :=
   by induction q;constructor
 
-  definition cono.left_inv_eq (q : b = b')
-    : concato_eq (pathover_idp_of_eq q⁻¹) q = (idpo : b' =[refl a] b') :=
+  definition cono.left_inv_eq (q : b = b') :
+    pathover_idp_of_eq q⁻¹ ⬝op q = (idpo : b' =[refl a] b') :=
   by induction q;constructor
 
-  definition cono.left_inv_eq' (q : b = b')
-    : eq_concato q⁻¹ (pathover_idp_of_eq q) = (idpo : b' =[refl a] b') :=
+  definition cono.left_inv_eq' (q : b = b') :
+    q⁻¹ ⬝po pathover_idp_of_eq q = (idpo : b' =[refl a] b') :=
   by induction q;constructor
 
   definition pathover_of_fn_pathover_fn (f : Π{a}, B a ≃ B' a) (r : f b =[p] f b₂) : b =[p] b₂ :=
   (left_inv f b)⁻¹ ⬝po apo (λa, f⁻¹ᵉ) r ⬝op left_inv f b₂
 
+  /- a pathover in a pathover type where the only thing which varies is the path is the same as
+    an equality with a change_path -/
   definition change_path_of_pathover (s : p = p') (r : b =[p] b₂) (r' : b =[p'] b₂)
     (q : r =[s] r') : change_path s r = r' :=
   by induction s; eapply idp_rec_on q; reflexivity
@@ -318,6 +405,7 @@ namespace eq
     { intro q, induction s, eapply idp_rec_on q, reflexivity},
   end
 
+  /- variants of inverse2 and concat2 -/
   definition inverseo2 [unfold 10] {r r' : b =[p] b₂} (s : r = r') : r⁻¹ᵒ = r'⁻¹ᵒ :=
   by induction s; reflexivity
 
@@ -327,5 +415,20 @@ namespace eq
 
   infixl ` ◾o `:75 := concato2
   postfix [parsing_only] `⁻²ᵒ`:(max+10) := inverseo2 --this notation is abusive, should we use it?
+
+  -- find a better name for this
+  definition fn_tro_eq_tro_fn2 (q : b =[p] b₂)
+    {k : A → A} {l : Π⦃a⦄, B a → B (k a)} (m : Π⦃a⦄ {b : B a}, C b → C (l b))
+    (c : C b) :
+    m (q ▸o c) = (pathover_ap B k (apo l q)) ▸o (m c) :=
+  by induction q; reflexivity
+
+  definition apd0111_precompose (f  : Π⦃a⦄ {b : B a}, C b → A')
+    {k : A → A} {l : Π⦃a⦄, B a → B (k a)} (m : Π⦃a⦄ {b : B a}, C b → C (l b))
+    {q : b =[p] b₂} (c : C b)
+    : apd0111 (λa b c, f (m c)) p q (pathover_tro q c) ⬝ ap (@f _ _) (fn_tro_eq_tro_fn2 q m c) =
+      apd0111 f (ap k p) (pathover_ap B k (apo l q)) (pathover_tro _ (m c)) :=
+  by induction q; reflexivity
+
 
 end eq

--- a/hott/init/ua.hlean
+++ b/hott/init/ua.hlean
@@ -10,24 +10,6 @@ prelude
 import .equiv
 open eq equiv is_equiv
 
---Ensure that the types compared are in the same universe
-section
-  universe variable l
-  variables {A B : Type.{l}}
-
-  definition is_equiv_cast [constructor] (H : A = B) : is_equiv (cast H) :=
-  is_equiv_tr (λX, X) H
-
-  definition equiv_of_eq [constructor] (H : A = B) : A ≃ B :=
-  equiv.mk _ (is_equiv_cast H)
-
-  definition equiv_of_eq_refl [reducible] [unfold_full] (A : Type)
-    : equiv_of_eq (refl A) = equiv.refl A :=
-  idp
-
-
-end
-
 axiom univalence (A B : Type) : is_equiv (@equiv_of_eq A B)
 
 attribute univalence [instance]

--- a/hott/types/arrow.hlean
+++ b/hott/types/arrow.hlean
@@ -122,16 +122,20 @@ namespace pi
   definition arrow_pathover_constant_right' {B : A → Type} {C : Type}
     {f : B a → C} {g : B a' → C} {p : a = a'}
     (r : Π⦃b : B a⦄ ⦃b' : B a'⦄ (q : b =[p] b'), f b = g b') : f =[p] g :=
-  arrow_pathover (λb b' q, pathover_of_eq (r q))
+  arrow_pathover (λb b' q, pathover_of_eq p (r q))
 
   definition arrow_pathover_constant_right {B : A → Type} {C : Type} {f : B a → C}
     {g : B a' → C} {p : a = a'} (r : Π(b : B a), f b = g (p ▸ b)) : f =[p] g :=
-  arrow_pathover_left (λb, pathover_of_eq (r b))
+  arrow_pathover_left (λb, pathover_of_eq p (r b))
 
-  /- a lemma used for the flattening lemma -/
-  definition apo011_arrow_pathover_constant_right {f : D a → A'} {g : D a' → A'} {p : a = a'}
+  definition arrow_pathover_constant_right_rev {A : Type} {B : A → Type} {C : Type} {a a' : A}
+    {f : B a → C} {g : B a' → C} {p : a = a'} (r : Π(b : B a'), f (p⁻¹ ▸ b) = g b) : f =[p] g :=
+  arrow_pathover_right (λb, pathover_of_eq p (r b))
+
+  /- a lemma used for the flattening lemma, and is also used in the colimits file -/
+  definition apo11_arrow_pathover_constant_right {f : D a → A'} {g : D a' → A'} {p : a = a'}
     {q : d =[p] d'} (r : Π(d : D a), f d = g (p ▸ d))
-    : eq_of_pathover (apo11 (arrow_pathover_constant_right r) q) = r d ⬝ ap g (tr_eq_of_pathover q)
+    : apo11_constant_right (arrow_pathover_constant_right r) q = r d ⬝ ap g (tr_eq_of_pathover q)
       :=
   begin
     induction q, esimp at r,
@@ -139,7 +143,6 @@ namespace pi
     esimp [arrow_pathover_constant_right, arrow_pathover_left],
     rewrite [eq_of_homotopy_idp]
   end
-
 
   /-
      The fact that the arrow type preserves truncation level is a direct consequence

--- a/hott/types/arrow.hlean
+++ b/hott/types/arrow.hlean
@@ -54,8 +54,16 @@ namespace pi
   /- Equivalence if one of the types is contractible -/
 
   variables (A B)
+  -- we prove this separately from pi_equiv_of_is_contr_left,
+  --   because the underlying inverse function is simpler here (no transport needed)
   definition arrow_equiv_of_is_contr_left [constructor] [H : is_contr A] : (A → B) ≃ B :=
-  !pi_equiv_of_is_contr_left
+  begin
+    fapply equiv.MK,
+    { intro f, exact f (center A)},
+    { intro b a, exact b},
+    { intro b, reflexivity},
+    { intro f, apply eq_of_homotopy, intro a, exact ap f !is_prop.elim}
+  end
 
   definition arrow_equiv_of_is_contr_right [constructor] [H : is_contr B] : (A → B) ≃ unit :=
   !pi_equiv_of_is_contr_right

--- a/hott/types/arrow_2.hlean
+++ b/hott/types/arrow_2.hlean
@@ -171,11 +171,9 @@ namespace arrow
     : is_equiv (inv_commute_of_commute f f' α β) :=
   begin
     unfold inv_commute_of_commute,
-    apply @is_equiv_compose _ _ _
-      (homotopy.symm ∘ (inv_homotopy_of_homotopy_pre f (f' ∘ α) β))
-      (inv_homotopy_of_homotopy_post f' (α ∘ f⁻¹) β),
-    { apply @is_equiv_compose _ _ _
-            (inv_homotopy_of_homotopy_pre f (f' ∘ α) β) homotopy.symm,
+    apply @is_equiv_compose _ _ _ (inv_homotopy_of_homotopy_post f' (α ∘ f⁻¹) β)
+      (homotopy.symm ∘ (inv_homotopy_of_homotopy_pre f (f' ∘ α) β)),
+    { apply @is_equiv_compose _ _ _ homotopy.symm (inv_homotopy_of_homotopy_pre f (f' ∘ α) β),
       { apply inv_homotopy_of_homotopy_pre.is_equiv },
       { apply pi.is_equiv_homotopy_symm }
     },

--- a/hott/types/default.hlean
+++ b/hott/types/default.hlean
@@ -6,4 +6,4 @@ Authors: Floris van Doorn
 
 import .bool .unit .prod .sigma .pi .arrow .pointed .fiber
 import .nat .int
-import .eq .equiv .trunc
+import .eq .equiv .trunc .univ .W .type_functor

--- a/hott/types/eq.hlean
+++ b/hott/types/eq.hlean
@@ -494,5 +494,4 @@ namespace eq
     { reflexivity}
   end
 
-
 end eq

--- a/hott/types/eq.hlean
+++ b/hott/types/eq.hlean
@@ -61,8 +61,9 @@ namespace eq
     : whisker_right r⁻¹ q = (whisker_right r q)⁻¹ :=
   by induction r; reflexivity
 
-  theorem ap_eq_ap10 {f g : A → B} (p : f = g) (a : A) : ap (λh, h a) p = ap10 p a :=
-  by induction p;reflexivity
+  theorem ap_eq_apd10 {B : A → Type} {f g : Πa, B a} (p : f = g) (a : A) :
+    ap (λh, h a) p = apd10 p a :=
+  by induction p; reflexivity
 
   theorem inverse2_right_inv (r : p = p') : r ◾ inverse2 r ⬝ con.right_inv p' = con.right_inv p :=
   by induction r;induction p;reflexivity

--- a/hott/types/eq.hlean
+++ b/hott/types/eq.hlean
@@ -213,7 +213,7 @@ namespace eq
 
   /- Equivalences between path spaces -/
 
-  /- [ap_closed] is in init.equiv  -/
+  /- [is_equiv_ap] is in init.equiv  -/
 
   definition equiv_ap (f : A → B) [H : is_equiv f] (a₁ a₂ : A)
     : (a₁ = a₂) ≃ (f a₁ = f a₂) :=

--- a/hott/types/equiv.hlean
+++ b/hott/types/equiv.hlean
@@ -81,7 +81,7 @@ namespace is_equiv
 
   definition inv_eq_inv {A B : Type} {f f' : A → B} {Hf : is_equiv f} {Hf' : is_equiv f'}
     (p : f = f') : f⁻¹ = f'⁻¹ :=
-  apd011 inv p !is_prop.elim
+  apd011 inv p !is_prop.elimo
 
   /- contractible fibers -/
   definition is_contr_fun_of_is_equiv [H : is_equiv f] : is_contr_fun f :=
@@ -99,6 +99,20 @@ namespace is_equiv
 
   definition is_equiv_equiv_is_contr_fun : is_equiv f ≃ is_contr_fun f :=
   equiv_of_is_prop _ (λH, !is_equiv_of_is_contr_fun)
+
+  theorem inv_commute'_fn {A : Type} {B C : A → Type} (f : Π{a}, B a → C a) [H : Πa, is_equiv (@f a)]
+    {g : A → A} (h : Π{a}, B a → B (g a)) (h' : Π{a}, C a → C (g a))
+    (p : Π⦃a : A⦄ (b : B a), f (h b) = h' (f b)) {a : A} (b : B a) :
+    inv_commute' @f @h @h' p (f b)
+      = (ap f⁻¹ (p b))⁻¹ ⬝ left_inv f (h b) ⬝ (ap h (left_inv f b))⁻¹ :=
+  begin
+    rewrite [↑[inv_commute',eq_of_fn_eq_fn'],+ap_con,-adj_inv f,+con.assoc,inv_con_cancel_left,
+       adj f,+ap_inv,-+ap_compose,
+       eq_bot_of_square (natural_square (λb, (left_inv f (h b))⁻¹ ⬝ ap f⁻¹ (p b)) (left_inv f b))⁻¹ʰ,
+       con_inv,inv_inv,+con.assoc],
+    do 3 apply whisker_left,
+    rewrite [con_inv_cancel_left,con.left_inv]
+  end
 
 end is_equiv
 
@@ -206,7 +220,7 @@ namespace equiv
 
   definition equiv_mk_eq {f f' : A → B} [H : is_equiv f] [H' : is_equiv f'] (p : f = f')
       : equiv.mk f H = equiv.mk f' H' :=
-  apd011 equiv.mk p !is_prop.elim
+  apd011 equiv.mk p !is_prop.elimo
 
   definition equiv_eq' {f f' : A ≃ B} (p : to_fun f = to_fun f') : f = f' :=
   by (cases f; cases f'; apply (equiv_mk_eq p))

--- a/hott/types/fin.hlean
+++ b/hott/types/fin.hlean
@@ -122,7 +122,7 @@ definition mk_mod [reducible] (n i : nat) : fin (succ n) :=
 mk (i % (succ n)) (mod_lt _ !zero_lt_succ)
 
 theorem mk_mod_zero_eq (n : nat) : mk_mod n 0 = 0 :=
-apd011 fin.mk rfl !is_prop.elim
+apd011 fin.mk rfl !is_prop.elimo
 
 variable {n : nat}
 

--- a/hott/types/int/hott.hlean
+++ b/hott/types/int/hott.hlean
@@ -18,6 +18,10 @@ namespace int
   Group.mk ℤ (group_of_add_group _)
 
   notation `gℤ` := group_integers
+
+  definition CommGroup_int [constructor] : CommGroup :=
+  CommGroup.mk ℤ ⦃comm_group, group_of_add_group ℤ, mul_comm := add.comm⦄
+  notation `agℤ` := CommGroup_int
   end
 
   definition is_equiv_succ [instance] : is_equiv succ :=

--- a/hott/types/list.hlean
+++ b/hott/types/list.hlean
@@ -137,7 +137,7 @@ rfl
 
 theorem last_congr {l₁ l₂ : list T} (h₁ : l₁ ≠ []) (h₂ : l₂ ≠ []) (h₃ : l₁ = l₂)
   : last l₁ h₁ = last l₂ h₂ :=
-apd011 last h₃ !is_prop.elim
+apd011 last h₃ !is_prop.elimo
 
 theorem last_concat {x : T} : ∀ {l : list T} (h : concat x l ≠ []), last (concat x l) h = x
 | []          h := rfl

--- a/hott/types/pi.hlean
+++ b/hott/types/pi.hlean
@@ -243,7 +243,7 @@ namespace pi
   begin
     fapply equiv.MK,
     { intro f, exact f (center A)},
-    { intro b a, exact (center_eq a) ▸ b},
+    { intro b a, exact center_eq a ▸ b},
     { intro b, rewrite [prop_eq_of_is_contr (center_eq (center A)) idp]},
     { intro f, apply eq_of_homotopy, intro a, induction (center_eq a),
       rewrite [prop_eq_of_is_contr (center_eq (center A)) idp]}

--- a/hott/types/pointed.hlean
+++ b/hott/types/pointed.hlean
@@ -29,6 +29,13 @@ namespace pointed
   notation `Ω` := ploop_space
   notation `Ω[`:95 n:0 `] `:0 A:95 := iterated_ploop_space n A
 
+  namespace ops
+    -- this is in a separate namespace because it caused type class inference to loop in some places
+    definition is_trunc_pointed_MK [instance] [priority 1100] (n : ℕ₋₂) {A : Type} (a : A)
+      [H : is_trunc n A] : is_trunc n (pointed.MK A a) :=
+    H
+  end ops
+
   definition is_trunc_loop [instance] [priority 1100] (A : Type*)
     (n : ℕ₋₂) [H : is_trunc (n.+1) A] : is_trunc n (Ω A) :=
   !is_trunc_eq
@@ -775,6 +782,21 @@ namespace pointed
   definition pequiv_of_eq_pt [constructor] {A : Type} {a a' : A} (p : a = a') :
     pointed.MK A a ≃* pointed.MK A a' :=
   pequiv_of_pmap (pmap_of_eq_pt p) !is_equiv_id
+
+  definition pointed_eta_pequiv [constructor] (A : Type*) : A ≃* pointed.MK A pt :=
+  pequiv.mk id !is_equiv_id idp
+
+  /- every pointed map is homotopic to one of the form `pmap_of_map _ _`, up to some
+     pointed equivalences -/
+  definition phomotopy_pmap_of_map {A B : Type*} (f : A →* B) :
+    (pointed_eta_pequiv B ⬝e* (pequiv_of_eq_pt (respect_pt f))⁻¹ᵉ*) ∘* f ∘*
+      (pointed_eta_pequiv A)⁻¹ᵉ* ~* pmap_of_map f pt :=
+  begin
+    fapply phomotopy.mk,
+    { reflexivity},
+    { esimp [pequiv.trans, pequiv.symm],
+      exact !con.right_inv⁻¹ ⬝ ((!idp_con⁻¹ ⬝ !ap_id⁻¹) ◾ (!ap_id⁻¹⁻² ⬝ !idp_con⁻¹)), }
+  end
 
 /- -- TODO
   definition pmap_pequiv_pmap {A A' B B' : Type*} (f : A ≃* A') (g : B ≃* B') :

--- a/hott/types/pointed.hlean
+++ b/hott/types/pointed.hlean
@@ -52,9 +52,9 @@ namespace pointed
   definition pType_eq {A B : Type*} (f : A ≃ B) (p : f pt = pt) : A = B :=
   begin
     cases A with A a, cases B with B b, esimp at *,
-    fapply apd011 @pType.mk,
+    fapply apdt011 @pType.mk,
     { apply ua f},
-    { rewrite [cast_ua,p]},
+    { rewrite [cast_ua, p]},
   end
 
   definition pType_eq_elim {A B : Type*} (p : A = B :> Type*)
@@ -193,10 +193,10 @@ namespace pointed
   begin
     cases f with f p, cases g with g q,
     esimp at *,
-    fapply apo011 pmap.mk,
+    fapply apd011 pmap.mk,
     { exact eq_of_homotopy r},
     { apply concato_eq, apply pathover_eq_Fl, apply inv_con_eq_of_eq_con,
-      rewrite [ap_eq_ap10,↑ap10,apd10_eq_of_homotopy,s]}
+      rewrite [ap_eq_apd10, apd10_eq_of_homotopy, s]}
   end
 
   definition pmap_equiv_left (A : Type) (B : Type*) : A₊ →* B ≃ (A → B) :=
@@ -554,7 +554,7 @@ namespace pointed
     (gf : g ∘* f ~* !pid) (fg : f ∘* g ~* !pid) : to_pinv (pequiv.MK2 f g gf fg) ~* g :=
   phomotopy.mk (λb, idp)
     abstract [irreducible] begin
-      esimp, unfold [adjointify_left_inv'],
+      esimp,
       note H := to_homotopy_pt gf, note H2 := to_homotopy_pt fg,
       note H3 := eq_top_of_square (natural_square_tr (to_homotopy fg) (respect_pt f)),
       rewrite [▸* at *, H, H3, H2, ap_id, - +con.assoc, ap_compose' f g, con_inv,
@@ -614,7 +614,7 @@ namespace pointed
   definition pequiv_eq {p q : A ≃* B} (H : p = q :> (A →* B)) : p = q :=
   begin
     cases p with f Hf, cases q with g Hg, esimp at *,
-    exact apd011 pequiv_of_pmap H !is_prop.elim
+    exact apd011 pequiv_of_pmap H !is_prop.elimo
   end
 
   infix ` ⬝e*p `:75 := peconcat_eq

--- a/hott/types/prod.hlean
+++ b/hott/types/prod.hlean
@@ -212,7 +212,7 @@ namespace prod
   definition equiv_prod_rec [constructor] (P : A × B → Type) : (Πa b, P (a, b)) ≃ (Πu, P u) :=
   equiv.mk prod.rec _
 
-  definition imp_imp_equiv_prod_imp (A B C : Type) : (A → B → C) ≃ (A × B → C) :=
+  definition imp_imp_equiv_prod_imp [constructor] (A B C : Type) : (A → B → C) ≃ (A × B → C) :=
   !equiv_prod_rec
 
   definition prod_corec_unc [unfold 4] {P Q : A → Type} (u : (Πa, P a) × (Πa, Q a)) (a : A)

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -30,7 +30,7 @@ namespace sigma
   | eta3 ⟨u₁, u₂, u₃, u₄⟩ := idp
 
   definition dpair_eq_dpair [unfold 8] (p : a = a') (q : b =[p] b') : ⟨a, b⟩ = ⟨a', b'⟩ :=
-  apo011 sigma.mk p q
+  apd011 sigma.mk p q
 
   definition sigma_eq [unfold 3 4] (p : u.1 = v.1) (q : u.2 =[p] v.2) : u = v :=
   by induction u; induction v; exact (dpair_eq_dpair p q)
@@ -159,7 +159,7 @@ namespace sigma
   destruct rs sigma_eq2
 
   definition ap_dpair_eq_dpair (f : Πa, B a → A') (p : a = a') (q : b =[p] b')
-    : ap (sigma.rec f) (dpair_eq_dpair p q) = apo011 f p q :=
+    : ap (sigma.rec f) (dpair_eq_dpair p q) = apd011 f p q :=
   by induction q; reflexivity
 
   /- Transport -/
@@ -192,10 +192,10 @@ namespace sigma
   by induction p; induction bc; apply idpo
 
   definition sigma_pathover (p : a = a') (u : Σ(b : B a), C a b) (v : Σ(b : B a'), C a' b)
-    (r : u.1 =[p] v.1) (s : u.2 =[apo011 C p r] v.2) : u =[p] v :=
+    (r : u.1 =[p] v.1) (s : u.2 =[apd011 C p r] v.2) : u =[p] v :=
   begin
     induction u, induction v, esimp at *, induction r,
-    esimp [apo011] at s, induction s using idp_rec_on, apply idpo
+    esimp [apd011] at s, induction s using idp_rec_on, apply idpo
   end
 
   /-
@@ -203,6 +203,7 @@ namespace sigma
     * define the projections from the type u =[p] v
     * show that the uncurried version of sigma_pathover is an equivalence
   -/
+  /- Squares in a sigma type are characterized in cubical.squareover (to avoid circular imports) -/
 
   /- Functorial action -/
   variables (f : A → A') (g : Πa, B a → B' (f a))

--- a/hott/types/sigma.hlean
+++ b/hott/types/sigma.hlean
@@ -331,10 +331,8 @@ namespace sigma
   definition sigma_assoc_comm_equiv {A : Type} (B C : A → Type)
     : (Σ(v : Σa, B a), C v.1) ≃ (Σ(u : Σa, C a), B u.1) :=
   calc    (Σ(v : Σa, B a), C v.1)
-        ≃ (Σa (b : B a), C a)     : !sigma_assoc_equiv⁻¹ᵉ
-    ... ≃ (Σa, B a × C a)         : sigma_equiv_sigma_right (λa, !equiv_prod)
-    ... ≃ (Σa, C a × B a)         : sigma_equiv_sigma_right (λa, !prod_comm_equiv)
-    ... ≃ (Σa (c : C a), B a)     : sigma_equiv_sigma_right (λa, !equiv_prod)
+        ≃ (Σa (b : B a), C a)     : sigma_assoc_equiv
+    ... ≃ (Σa (c : C a), B a)     : sigma_equiv_sigma_right (λa, !comm_equiv_nondep)
     ... ≃ (Σ(u : Σa, C a), B u.1) : sigma_assoc_equiv
 
   /- Interaction with other type constructors -/

--- a/hott/types/trunc.hlean
+++ b/hott/types/trunc.hlean
@@ -182,6 +182,9 @@ namespace trunc_index
   definition sub_two_succ_succ (n : ℕ) : n.-2.+1.+1 = n := rfl
   definition succ_sub_two_succ (n : ℕ) : (nat.succ n).-2.+1 = n := rfl
 
+  definition of_nat_add_two (n : ℕ₋₂) : of_nat (add_two n) = n.+2 :=
+  begin induction n with n IH, reflexivity, exact ap succ IH end
+
   definition of_nat_le_of_nat {n m : ℕ} (H : n ≤ m) : (of_nat n ≤ of_nat m) :=
   begin
     induction H with m H IH,
@@ -222,6 +225,17 @@ namespace trunc_index
     { cases H2 with n' H2',
       { exfalso, exact H !le.refl},
       { exact succ_le_succ H2'}}
+  end
+
+  definition trunc_index.decidable_le [instance] : Π(n m : ℕ₋₂), decidable (n ≤ m) :=
+  begin
+    intro n, induction n with n IH: intro m,
+    { left, apply minus_two_le},
+    cases m with m,
+    { right, apply not_succ_le_minus_two},
+    cases IH m with H H,
+    { left, apply succ_le_succ H},
+    right, intro H2, apply H, exact le_of_succ_le_succ H2
   end
 
 end trunc_index open trunc_index
@@ -401,6 +415,7 @@ namespace is_trunc
     is_trunc (n.+1) A ↔ Π(a : A), is_trunc n (a = a) :=
   iff.intro _ (is_trunc_succ_of_is_trunc_loop Hn)
 
+  -- use loopn in name
   theorem is_trunc_iff_is_contr_loop_succ (n : ℕ) (A : Type)
     : is_trunc n A ↔ Π(a : A), is_contr (Ω[succ n](pointed.Mk a)) :=
   begin
@@ -417,6 +432,7 @@ namespace is_trunc
       apply imp_iff, reflexivity}
   end
 
+  -- use loopn in name
   theorem is_trunc_iff_is_contr_loop (n : ℕ) (A : Type)
     : is_trunc (n.-2.+1) A ↔ (Π(a : A), is_contr (Ω[n](pointed.Mk a))) :=
   begin
@@ -427,6 +443,7 @@ namespace is_trunc
     { apply is_trunc_iff_is_contr_loop_succ},
   end
 
+  -- rename to is_contr_loopn_of_is_trunc
   theorem is_contr_loop_of_is_trunc (n : ℕ) (A : Type*) [H : is_trunc (n.-2.+1) A] :
     is_contr (Ω[n] A) :=
   begin
@@ -434,6 +451,7 @@ namespace is_trunc
     apply iff.mp !is_trunc_iff_is_contr_loop H
   end
 
+  -- rename to is_trunc_loopn_of_is_trunc
   theorem is_trunc_loop_of_is_trunc (n : ℕ₋₂) (k : ℕ) (A : Type*) [H : is_trunc n A] :
     is_trunc n (Ω[k] A) :=
   begin
@@ -441,6 +459,17 @@ namespace is_trunc
     { exact H},
     { apply is_trunc_eq}
   end
+
+  definition is_trunc_loopn (k : ℕ₋₂) (n : ℕ) (A : Type*) [H : is_trunc (k+n) A]
+    : is_trunc k (Ω[n] A) :=
+  begin
+    revert k H, induction n with n IH: intro k H, exact _,
+    apply is_trunc_eq, apply IH, rewrite [succ_add_nat, add_nat_succ at H], exact H
+  end
+
+  definition is_set_loopn (n : ℕ) (A : Type*) [is_trunc n A] : is_set (Ω[n] A) :=
+  have is_trunc (0+[ℕ₋₂]n) A, by rewrite [trunc_index.zero_add]; exact _,
+  is_trunc_loopn 0 n A
 
 end is_trunc open is_trunc
 
@@ -496,7 +525,8 @@ namespace trunc
     intro p, induction p, induction aa with a, esimp, exact (tr idp)
   end
 
-  protected definition decode {n : ℕ₋₂} (aa aa' : trunc n.+1 A) : trunc.code n aa aa' → aa = aa' :=
+  protected definition decode [unfold 3 4 5] {n : ℕ₋₂} (aa aa' : trunc n.+1 A) :
+    trunc.code n aa aa' → aa = aa' :=
   begin
     induction aa' with a', induction aa with a,
     esimp [trunc.code, trunc.rec_on], intro x,

--- a/hott/types/types.md
+++ b/hott/types/types.md
@@ -30,3 +30,4 @@ Types in HoTT:
 * [trunc](trunc.hlean): truncation levels, n-types, truncation
 * [pullback](pullback.hlean)
 * [univ](univ.hlean)
+* [type_functor](type_functor.hlean)

--- a/hott/types/unit.hlean
+++ b/hott/types/unit.hlean
@@ -6,7 +6,7 @@ Authors: Floris van Doorn
 Theorems about the unit type
 -/
 
-open equiv option eq pointed is_trunc
+open is_equiv equiv option eq pointed is_trunc function
 
 namespace unit
 
@@ -31,6 +31,20 @@ namespace unit
   pSet.mk' unit
 
   notation `unit*` := punit
+
+  definition unit_arrow_eq {X : Type} (f : unit → X) : (λx, f ⋆) = f :=
+  by apply eq_of_homotopy; intro u; induction u; reflexivity
+
+  open funext
+  definition unit_arrow_eq_compose {X Y : Type} (g : X → Y) (f : unit → X) :
+    unit_arrow_eq (g ∘ f) = ap (λf, g ∘ f) (unit_arrow_eq f) :=
+  begin
+    apply eq_of_fn_eq_fn' apd10,
+    refine right_inv apd10 _ ⬝ _,
+    refine _ ⬝ ap apd10 (!compose_eq_of_homotopy)⁻¹,
+    refine _ ⬝ (right_inv apd10 _)⁻¹,
+    apply eq_of_homotopy, intro u, induction u, reflexivity
+  end
 
 end unit
 

--- a/hott/types/univ.hlean
+++ b/hott/types/univ.hlean
@@ -83,7 +83,7 @@ namespace univ
     (b : B) : Type.{max u v} :=
   by induction p with A f; exact fiber f b
 
-  definition characteristic_map_inv [unfold 2] {B : Type.{u}} (P : B → Type.{max u v}) :
+  definition characteristic_map_inv [constructor] {B : Type.{u}} (P : B → Type.{max u v}) :
     Σ(A : Type.{max u v}), A → B :=
   ⟨(Σb, P b), pr1⟩
 

--- a/tests/lean/extra/616b.hlean
+++ b/tests/lean/extra/616b.hlean
@@ -5,5 +5,5 @@ definition my_elim {A P : Type} {R : A → A → Type} (Pc : A → P)
 begin
   induction x,
     exact (Pc a),
-    refine (pathover_of_eq (Pp H))
+    refine (pathover_of_eq _ (Pp H))
 end

--- a/tests/lean/extra/616c.hlean
+++ b/tests/lean/extra/616c.hlean
@@ -4,5 +4,5 @@ definition my_elim {A P : Type} {R : A → A → Type} (Pc : A → P)
 begin
   induction x,
     exact (Pc a),
-    refine (pathover_of_eq (Pp H))
+    refine (pathover_of_eq _ (Pp H))
 end

--- a/tests/lean/extra/755.hlean
+++ b/tests/lean/extra/755.hlean
@@ -27,7 +27,7 @@ section
 
   protected definition elim {P : Type} (Pt : A → P)
     (Pe : Π(a a' : A), Pt a = Pt a') (x : one_step_tr) : P :=
-  rec Pt (λa a', pathover_of_eq (Pe a a')) x
+  rec Pt (λa a', pathover_of_eq _ (Pe a a')) x
 
   theorem rec_tr_eq {P : one_step_tr → Type} (Pt : Π(a : A), P (tr a))
     (Pe : Π(a a' : A), Pt a =[tr_eq a a'] Pt a') (a a' : A)

--- a/tests/lean/hott/ind_tac1.hlean
+++ b/tests/lean/hott/ind_tac1.hlean
@@ -1,3 +1,4 @@
+open eq
 set_option pp.universes true
 
 check @homotopy.rec_on


### PR DESCRIPTION
- Many small changes in the HoTT library. Most notably I've proven the Seifert-van Kampen Theorem (the full version with a type of basepoints).
- Changes which are most likely to break proofs: `pathover_of_eq` now has a second explicit argument, and I've renamed `apo011[1] -> apd011[1]` and `apd011[1...] -> apdt011[1...]`
- The commits 05f8777 and 65eae47 are changes in the `extras` folder and are also useful for the `lean3` branch.
