### PR TITLE
abstract_type_context in ac_tactics

### DIFF
--- a/src/library/old_util.cpp
+++ b/src/library/old_util.cpp
@@ -89,24 +89,24 @@ expr mk_eq(old_type_checker & ctx, expr const & lhs, expr const & rhs) {
 }
 
 expr mk_refl(old_type_checker & ctx, expr const & a) {
-    return mk_refl(ctx.get_type_context(), a);
+    return mk_eq_refl(ctx.get_type_context(), a);
 }
 
 expr mk_symm(old_type_checker & ctx, expr const & H) {
-    return mk_symm(ctx.get_type_context(), H);
+    return mk_eq_symm(ctx.get_type_context(), H);
 }
 
 expr mk_trans(old_type_checker & ctx, expr const & H1, expr const & H2) {
-    return mk_trans(ctx.get_type_context(), H1, H2);
+    return mk_eq_trans(ctx.get_type_context(), H1, H2);
 }
 
 expr mk_subst(old_type_checker & ctx, expr const & motive,
               expr const & x, expr const & y, expr const & xeqy, expr const & h) {
-    return mk_subst(ctx.get_type_context(), motive, x, y, xeqy, h);
+    return mk_eq_subst(ctx.get_type_context(), motive, x, y, xeqy, h);
 }
 
 expr mk_subst(old_type_checker & ctx, expr const & motive, expr const & xeqy, expr const & h) {
-    return mk_subst(ctx.get_type_context(), motive, xeqy, h);
+    return mk_eq_subst(ctx.get_type_context(), motive, xeqy, h);
 }
 
 expr mk_subsingleton_elim(old_type_checker & ctx, expr const & h, expr const & x, expr const & y) {

--- a/src/library/tactic/ac_tactics.cpp
+++ b/src/library/tactic/ac_tactics.cpp
@@ -5,17 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include "library/trace.h"
-#include "library/app_builder.h"
+#include "library/util.h"
 #include "library/vm/vm_expr.h"
 #include "library/tactic/tactic_state.h"
 
 namespace lean {
 struct flat_assoc_fn {
-    type_context & m_ctx;
-    expr           m_op;
-    expr           m_assoc;
+    abstract_type_context & m_ctx;
+    expr                    m_op;
+    expr                    m_assoc;
 
-    flat_assoc_fn(type_context & ctx, expr const & op, expr const & assoc):
+    flat_assoc_fn(abstract_type_context & ctx, expr const & op, expr const & assoc):
         m_ctx(ctx), m_op(op), m_assoc(assoc) {}
 
     bool is_op_app(expr const & e, expr & lhs, expr & rhs) {
@@ -146,7 +146,7 @@ struct perm_ac_fn : public flat_assoc_fn {
     expr           m_comm;
     optional<expr> m_left_comm;
 
-    perm_ac_fn(type_context & ctx, expr const & op, expr const & assoc, expr const & comm):
+    perm_ac_fn(abstract_type_context & ctx, expr const & op, expr const & assoc, expr const & comm):
         flat_assoc_fn(ctx, op, assoc), m_comm(comm) {
     }
 
@@ -257,11 +257,11 @@ struct perm_ac_fn : public flat_assoc_fn {
 };
 
 
-pair<expr, optional<expr>> flat_assoc(type_context & ctx, expr const & op, expr const & assoc, expr const & e) {
+pair<expr, optional<expr>> flat_assoc(abstract_type_context & ctx, expr const & op, expr const & assoc, expr const & e) {
     return flat_assoc_fn(ctx, op, assoc).flat_core(e);
 }
 
-expr perm_ac(type_context & ctx, expr const & op, expr const & assoc, expr const & comm, expr const & e1, expr const & e2) {
+expr perm_ac(abstract_type_context & ctx, expr const & op, expr const & assoc, expr const & comm, expr const & e1, expr const & e2) {
     return perm_ac_fn(ctx, op, assoc, comm).perm(e1, e2);
 }
 

--- a/src/library/tactic/ac_tactics.h
+++ b/src/library/tactic/ac_tactics.h
@@ -8,10 +8,10 @@ Author: Leonardo de Moura
 #include "library/type_context.h"
 
 namespace lean {
-pair<expr, optional<expr>> flat_assoc(type_context & ctx, expr const & op, expr const & assoc, expr const & e);
+pair<expr, optional<expr>> flat_assoc(abstract_type_context & ctx, expr const & op, expr const & assoc, expr const & e);
 /* Construct a proof that e1 = e2 modulo AC for the operator op. The proof uses the lemmas \c assoc and \c comm.
    It throws an exception if they are not equal modulo AC. */
-expr perm_ac(type_context & ctx, expr const & op, expr const & assoc, expr const & comm, expr const & e1, expr const & e2);
+expr perm_ac(abstract_type_context & ctx, expr const & op, expr const & assoc, expr const & comm, expr const & e1, expr const & e2);
 
 void initialize_ac_tactics();
 void finalize_ac_tactics();

--- a/src/library/util.cpp
+++ b/src/library/util.cpp
@@ -22,6 +22,14 @@ Author: Leonardo de Moura
 #include "library/old_type_checker.h"
 
 namespace lean {
+
+level get_level(abstract_type_context & ctx, expr const & A) {
+    expr S = ctx.whnf(ctx.infer(A));
+    if (!is_sort(S))
+        throw exception("invalid expression, sort expected");
+    return sort_level(S);
+}
+
 bool occurs(expr const & n, expr const & m) {
     return static_cast<bool>(find(m, [&](expr const & e, unsigned) { return n == e; }));
 }
@@ -335,13 +343,6 @@ expr to_telescope(type_checker & ctx, expr type, buffer<expr> & telescope, optio
         new_type = ctx.whnf(type);
     }
     return type;
-}
-
-static level get_level(abstract_type_context & ctx, expr const & A) {
-    expr S = ctx.whnf(ctx.infer(A));
-    if (!is_sort(S))
-        throw exception("invalid expression, sort expected");
-    return sort_level(S);
 }
 
 void mk_telescopic_eq(type_checker & tc, buffer<expr> const & t, buffer<expr> const & s, buffer<expr> & eqs) {

--- a/src/library/util.cpp
+++ b/src/library/util.cpp
@@ -574,13 +574,13 @@ expr mk_eq(abstract_type_context & ctx, expr const & lhs, expr const & rhs) {
     return mk_app(mk_constant(get_eq_name(), {lvl}), A, lhs, rhs);
 }
 
-expr mk_refl(abstract_type_context & ctx, expr const & a) {
+expr mk_eq_refl(abstract_type_context & ctx, expr const & a) {
     expr A    = ctx.whnf(ctx.infer(a));
     level lvl = get_level(ctx, A);
     return mk_app(mk_constant(get_eq_refl_name(), {lvl}), A, a);
 }
 
-expr mk_symm(abstract_type_context & ctx, expr const & H) {
+expr mk_eq_symm(abstract_type_context & ctx, expr const & H) {
     expr p    = ctx.whnf(ctx.infer(H));
     lean_assert(is_eq(p));
     expr lhs  = app_arg(app_fn(p));
@@ -590,7 +590,7 @@ expr mk_symm(abstract_type_context & ctx, expr const & H) {
     return mk_app(mk_constant(get_eq_symm_name(), {lvl}), A, lhs, rhs, H);
 }
 
-expr mk_trans(abstract_type_context & ctx, expr const & H1, expr const & H2) {
+expr mk_eq_trans(abstract_type_context & ctx, expr const & H1, expr const & H2) {
     expr p1    = ctx.whnf(ctx.infer(H1));
     expr p2    = ctx.whnf(ctx.infer(H2));
     lean_assert(is_eq(p1) && is_eq(p2));
@@ -602,8 +602,8 @@ expr mk_trans(abstract_type_context & ctx, expr const & H1, expr const & H2) {
     return mk_app({mk_constant(get_eq_trans_name(), {lvl}), A, lhs1, rhs1, rhs2, H1, H2});
 }
 
-expr mk_subst(abstract_type_context & ctx, expr const & motive,
-              expr const & x, expr const & y, expr const & xeqy, expr const & h) {
+expr mk_eq_subst(abstract_type_context & ctx, expr const & motive,
+                 expr const & x, expr const & y, expr const & xeqy, expr const & h) {
     expr A    = ctx.infer(x);
     level l1  = get_level(ctx, A);
     expr r;
@@ -616,9 +616,21 @@ expr mk_subst(abstract_type_context & ctx, expr const & motive,
     return mk_app({r, A, x, y, motive, xeqy, h});
 }
 
-expr mk_subst(abstract_type_context & ctx, expr const & motive, expr const & xeqy, expr const & h) {
+expr mk_eq_subst(abstract_type_context & ctx, expr const & motive, expr const & xeqy, expr const & h) {
     expr xeqy_type = ctx.whnf(ctx.infer(xeqy));
-    return mk_subst(ctx, motive, app_arg(app_fn(xeqy_type)), app_arg(xeqy_type), xeqy, h);
+    return mk_eq_subst(ctx, motive, app_arg(app_fn(xeqy_type)), app_arg(xeqy_type), xeqy, h);
+}
+
+expr mk_congr_arg(abstract_type_context & ctx, expr const & f, expr const & H) {
+    expr eq = ctx.relaxed_whnf(ctx.infer(H));
+    expr pi = ctx.relaxed_whnf(ctx.infer(f));
+    expr A, B, lhs, rhs;
+    lean_verify(is_eq(eq, A, lhs, rhs));
+    lean_assert(is_arrow(pi));
+    B = binding_body(pi);
+    level lvl_1  = get_level(ctx, A);
+    level lvl_2  = get_level(ctx, B);
+    return ::lean::mk_app({mk_constant(get_congr_arg_name(), {lvl_1, lvl_2}), A, B, lhs, rhs, f, H});
 }
 
 expr mk_subsingleton_elim(abstract_type_context & ctx, expr const & h, expr const & x, expr const & y) {

--- a/src/library/util.h
+++ b/src/library/util.h
@@ -8,6 +8,12 @@ Author: Leonardo de Moura
 #include "kernel/environment.h"
 
 namespace lean {
+
+/** \brief Return the universe level of the type of \c A.
+    Throws an exception if the (relaxed) whnf of the type
+    of A is not a sort. */
+level get_level(abstract_type_context & ctx, expr const & A);
+
 /** \brief Return true iff \c n occurs in \c m */
 bool occurs(expr const & n, expr const & m);
 /** \brief Return true iff there is a constant named \c n in \c m. */

--- a/src/library/util.h
+++ b/src/library/util.h
@@ -165,12 +165,15 @@ expr mk_iff_refl(expr const & a);
 expr apply_propext(expr const & iff_pr, expr const & iff_term);
 
 expr mk_eq(abstract_type_context & ctx, expr const & lhs, expr const & rhs);
-expr mk_refl(abstract_type_context & ctx, expr const & a);
-expr mk_symm(abstract_type_context & ctx, expr const & H);
-expr mk_trans(abstract_type_context & ctx, expr const & H1, expr const & H2);
-expr mk_subst(abstract_type_context & ctx, expr const & motive,
-              expr const & x, expr const & y, expr const & xeqy, expr const & h);
-expr mk_subst(abstract_type_context & ctx, expr const & motive, expr const & xeqy, expr const & h);
+expr mk_eq_refl(abstract_type_context & ctx, expr const & a);
+expr mk_eq_symm(abstract_type_context & ctx, expr const & H);
+expr mk_eq_trans(abstract_type_context & ctx, expr const & H1, expr const & H2);
+expr mk_eq_subst(abstract_type_context & ctx, expr const & motive,
+                 expr const & x, expr const & y, expr const & xeqy, expr const & h);
+expr mk_eq_subst(abstract_type_context & ctx, expr const & motive, expr const & xeqy, expr const & h);
+
+expr mk_congr_arg(abstract_type_context & ctx, expr const & f, expr const & H);
+
 /** \brief Create an proof for x = y using subsingleton.elim (in standard mode) and is_trunc.is_prop.elim (in HoTT mode) */
 expr mk_subsingleton_elim(abstract_type_context & ctx, expr const & h, expr const & x, expr const & y);
 


### PR DESCRIPTION
Note: there is a lot of duplication in the library. There are many methods in `app_builder` that only require an `abstract_type_context` and not a `type_context`, that are duplicated with `abstract_type_context`s in `util`. My suggestion: refactor `app_builder` so that all things that only require an `abstract_type_context` only receive one, delete all the makers in `util`, and only create an `app_builder` object (with its cache) when needed. I will do this refactor if you give me the green light.
