### PR TITLE
Delegate parameter parsing and printing to the `attribute` class

### DIFF
--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -17,12 +17,10 @@ decl_attributes::decl_attributes(bool is_abbrev, bool persistent) {
     m_persistent             = persistent;
     m_parsing_only           = false;
     if (is_abbrev)
-        m_entries = to_list(entry("reducible"));
+        m_entries = to_list(entry {&get_attribute("reducible"), attr_data_ptr(new attr_data)});
 }
 
 void decl_attributes::parse(parser & p) {
-    buffer<char const *> attr_tokens;
-    get_attribute_tokens(attr_tokens);
     while (true) {
         auto pos   = p.pos();
         if (auto it = parse_priority(p)) {
@@ -33,34 +31,23 @@ void decl_attributes::parse(parser & p) {
                                    "marked as '[parsing_only]'", pos);
             m_parsing_only = true;
             p.next();
-        } else {
-            bool found = false;
-            for (char const * tk : attr_tokens) {
-                if (p.curr_is_token(tk)) {
-                    p.next();
-                    char const * attr = get_attribute_from_token(tk);
-                    for (auto const & entry : m_entries) {
-                        if (are_incompatible(entry.m_attr.c_str(), attr)) {
-                            throw parser_error(sstream() << "invalid attribute [" << attr
-                                               << "], declaration was already marked with [" << entry.m_attr << "]", pos);
-                        }
-                    }
-                    buffer<unsigned> vs;
-                    while (!p.curr_is_token(get_rbracket_tk())) {
-                        unsigned v = p.parse_small_nat();
-                        if (v == 0)
-                            throw parser_error("invalid attribute parameter, value must be positive", pos);
-                        vs.push_back(v-1);
-                    }
-                    p.next();
-                    m_entries = cons(entry(attr, to_list(vs)), m_entries);
-                    found = true;
-                    break;
-                }
-            }
-            if (!found)
-                break;
-        }
+        } else if (p.curr_is_command()) {
+           if (auto attr = get_attribute_from_token(p.get_token_info().token().get_string())) {
+               p.next();
+               for (auto const & entry : m_entries) {
+                   if (are_incompatible(entry.m_attr, attr)) {
+                       throw parser_error(sstream() << "invalid attribute [" << attr
+                                                    << "], declaration was already marked with [" << entry.m_attr
+                                                    << "]", pos);
+                   }
+               }
+               auto data = attr->parse_data(p);
+               p.check_token_next(get_rbracket_tk(), "invalid attribute declaration, ']' expected");
+               m_entries = cons({attr, data}, m_entries);
+           } else
+               break;
+        } else
+            break;
     }
 }
 
@@ -71,41 +58,12 @@ environment decl_attributes::apply(environment env, io_state const & ios, name c
     while (i > 0) {
         --i;
         auto const & entry = entries[i];
-        char const * attr = entry.m_attr.c_str();
-        unsigned prio = m_prio ? *m_prio : LEAN_DEFAULT_PRIORITY;
-        env = set_attribute(env, ios, attr, d, prio, entry.m_params, m_persistent);
+        if (auto prio_attr = dynamic_cast<prio_attribute const *>(entry.m_attr)) {
+            unsigned prio = m_prio ? *m_prio : LEAN_DEFAULT_PRIORITY;
+            env = prio_attr->set(env, ios, d, prio, m_persistent);
+        } else
+            env = entry.m_attr->set_untyped(env, ios, d, entry.m_params, m_persistent);
     }
     return env;
-}
-
-serializer & operator<<(serializer & s, decl_attributes::entry const & e) {
-    s << e.m_attr;
-    write_list(s, e.m_params);
-    return s;
-}
-
-deserializer & operator>>(deserializer & d, decl_attributes::entry & e) {
-    d >> e.m_attr;
-    e.m_params = read_list<unsigned>(d);
-    return d;
-}
-
-void decl_attributes::write(serializer & s) const {
-    s << m_is_abbrev << m_persistent << m_prio << m_parsing_only;
-    write_list(s, m_entries);
-}
-
-void decl_attributes::read(deserializer & d) {
-    d >> m_is_abbrev >> m_persistent >> m_prio >> m_parsing_only;
-    m_entries = read_list<decl_attributes::entry>(d);
-}
-
-bool operator==(decl_attributes const & d1, decl_attributes const & d2) {
-    return
-        d1.m_is_abbrev    == d2.m_is_abbrev ||
-        d1.m_persistent   == d2.m_persistent ||
-        d1.m_parsing_only == d2.m_parsing_only ||
-        d1.m_entries      == d2.m_entries ||
-        d1.m_prio         == d2.m_prio;
 }
 }

--- a/src/frontends/lean/decl_attributes.h
+++ b/src/frontends/lean/decl_attributes.h
@@ -7,22 +7,17 @@ Author: Leonardo de Moura
 #pragma once
 #include <string>
 #include "kernel/environment.h"
+#include "library/attribute_manager.h"
 #include "library/io_state.h"
 namespace lean {
 class parser;
 class decl_attributes {
-public:
-    struct entry {
-        std::string    m_attr;
-        list<unsigned> m_params;
-        entry() {}
-        entry(char const * attr):m_attr(attr) {}
-        entry(char const * attr, unsigned p):m_attr(attr), m_params(to_list(p)) {}
-        entry(char const * attr, list<unsigned> const & ps):m_attr(attr), m_params(ps) {}
-        bool operator==(entry const & e) const { return m_attr == e.m_attr && m_params == e.m_params; }
-        bool operator!=(entry const & e) const { return !operator==(e); }
-    };
 private:
+    struct entry {
+        attribute const * m_attr;
+        attr_data_ptr     m_params;
+    };
+
     bool               m_is_abbrev; // if true only abbreviation attributes are allowed
     bool               m_persistent;
     bool               m_parsing_only;
@@ -33,9 +28,5 @@ public:
     void parse(parser & p);
     environment apply(environment env, io_state const & ios, name const & d) const;
     bool is_parsing_only() const { return m_parsing_only; }
-    void write(serializer & s) const;
-    void read(deserializer & d);
-    friend bool operator==(decl_attributes const & d1, decl_attributes const & d2);
 };
-bool operator==(decl_attributes const & d1, decl_attributes const & d2);
 }

--- a/src/library/abstract_parser.h
+++ b/src/library/abstract_parser.h
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Sebastian Ullrich
+*/
+#pragma once
+#include "kernel/pos_info_provider.h"
+
+namespace lean {
+/** \brief Exception used to track parsing erros, it does not leak outside of this class. */
+struct parser_error : public exception {
+    pos_info m_pos;
+    parser_error(char const * msg, pos_info const & p):exception(msg), m_pos(p) {}
+    parser_error(sstream const & msg, pos_info const & p):exception(msg), m_pos(p) {}
+    virtual throwable * clone() const { return new parser_error(m_msg.c_str(), m_pos); }
+    virtual void rethrow() const { throw *this; }
+};
+
+/** \brief Base class for frontend parsers with basic functions */
+class abstract_parser : public pos_info_provider {
+public:
+    /** \brief Return the current position information */
+    virtual pos_info pos() const = 0;
+
+    /** \brief Return true iff the current token is a keyword (or command keyword) named \c tk */
+    virtual bool curr_is_token(name const & tk) const = 0;
+
+    virtual unsigned parse_small_nat() = 0;
+};
+}

--- a/src/library/normalize.cpp
+++ b/src/library/normalize.cpp
@@ -49,7 +49,7 @@ bool has_constructor_hint(environment const & env, name const & d) {
 }
 
 void initialize_normalize() {
-    register_attribute(unsigned_params_attribute("unfold", "unfold definition when the given positions are constructors"));
+    register_attribute(indices_attribute("unfold", "unfold definition when the given positions are constructors"));
     register_attribute(basic_attribute("unfold_full", "instructs normalizer (and simplifier) that function application (f a_1 ... a_n) should be unfolded when it is fully applied"));
     register_attribute(basic_attribute("constructor", "instructs normalizer (and simplifier) that function application (f ...) should be unfolded when it is the major premise of a constructor like operator"));
 }

--- a/src/library/reducible.cpp
+++ b/src/library/reducible.cpp
@@ -42,7 +42,10 @@ static reducibility_attribute const & get_reducibility_attribute() {
 class proxy_attribute : public basic_attribute {
 private:
     reducible_status m_status;
-protected:
+public:
+    proxy_attribute(char const * id, char const * descr, reducible_status m_status) : basic_attribute(id, descr),
+                                                                                      m_status(m_status) {}
+
     virtual attr_data_ptr get(environment const & env, name const & n) const override {
         if (auto data = get_reducibility_attribute().get_data(env, n)) {
             if (data->m_status == m_status)
@@ -50,10 +53,6 @@ protected:
         }
         return {};
     }
-public:
-    proxy_attribute(char const * id, char const * descr, reducible_status m_status) : basic_attribute(id, descr),
-                                                                                      m_status(m_status) {}
-
     virtual environment set(environment const & env, io_state const & ios, name const & n, bool persistent) const override {
         declaration const & d = env.get(n);
         if (!d.is_definition())

--- a/src/library/user_recursors.cpp
+++ b/src/library/user_recursors.cpp
@@ -344,10 +344,10 @@ has_recursors_pred::has_recursors_pred(environment const & env):
 void initialize_user_recursors() {
     g_key        = new std::string("UREC");
     recursor_ext::initialize();
-    register_attribute(unsigned_params_attribute("recursor", "user defined recursor", [](environment const & env, io_state const &, name const & n, unsigned_params_attribute_data const & data, bool persistent) {
-          if (data.m_params && tail(data.m_params))
+    register_attribute(indices_attribute("recursor", "user defined recursor", [](environment const & env, io_state const &, name const & n, indices_attribute_data const & data, bool persistent) {
+          if (data.m_idxs && tail(data.m_idxs))
             throw exception(sstream() << "invalid [recursor] declaration, expected at most one parameter");
-          return add_user_recursor(env, n, head_opt(data.m_params), persistent);
+          return add_user_recursor(env, n, head_opt(data.m_idxs), persistent);
         }));
 }
 


### PR DESCRIPTION
@jroesch With this, it should be easy to implement some `extern` attribute with parameters.

The only attribute still special-cased is `prio_attribute`, since the priority is not actually a parameter of the attribute. What would you think of a syntax like `[simp:nat.prio]`, in analogy to the notation prio syntax? Alternatively, [this comment](https://github.com/Kha/lean/blob/attrs/library/init/nat.lean#L25) suggests that maybe all attributes should be able to take a priority?
