### PR TITLE
refactor(library/attribute_manager): remove weakly-typed API

### DIFF
--- a/src/frontends/lean/print_cmd.cpp
+++ b/src/frontends/lean/print_cmd.cpp
@@ -256,7 +256,7 @@ static void print_attributes(parser const & p, name const & n) {
     for (auto attr : attrs) {
         if (attr->get_name() == "reducibility")
             continue;
-        if (auto data = attr->get(env, n)) {
+        if (auto data = attr->get_untyped(env, n)) {
             if (first) {
                 out << "attribute [";
                 first = false;

--- a/src/library/abbreviation.cpp
+++ b/src/library/abbreviation.cpp
@@ -14,6 +14,7 @@ Author: Leonardo de Moura
 #include "library/expr_lt.h"
 #include "library/util.h"
 #include "library/normalize.h"
+#include "library/reducible.h"
 
 namespace lean {
 typedef pair<name, bool> abbrev_entry;
@@ -76,7 +77,7 @@ typedef scoped_ext<abbrev_config> abbrev_ext;
 
 environment add_abbreviation(environment const & env, name const & n, bool parsing_only, bool persistent) {
     auto env2 = abbrev_ext::add_entry(env, get_dummy_ios(), abbrev_entry(n, parsing_only), persistent);
-    return set_attribute(env2, get_dummy_ios(), "reducible", n, persistent);
+    return set_reducible(env2, n, reducible_status::Reducible, persistent);
 }
 
 bool is_abbreviation(environment const & env, name const & n) {

--- a/src/library/attribute_manager.h
+++ b/src/library/attribute_manager.h
@@ -48,9 +48,13 @@ public:
     name const & get_name() const { return m_id; }
     std::string const & get_description() const { return m_descr; }
 
-    virtual attr_data_ptr get(environment const &, name const &) const;
+    virtual attr_data_ptr get_untyped(environment const &, name const &) const;
+    bool is_instance(environment const & env, name const &n ) const {
+        return static_cast<bool>(get_untyped(env, n));
+    }
     unsigned get_prio(environment const &, name const &) const;
     virtual void get_instances(environment const &, buffer<name> &) const;
+    priority_queue<name, name_quick_cmp> get_instances_by_prio(environment const &) const;
     virtual attr_data_ptr parse_data(abstract_parser &) const;
 };
 
@@ -117,8 +121,8 @@ public:
             env2 = m_on_set(env2, ios, n, prio, data, persistent);
         return env2;
     }
-    std::shared_ptr<Data> get_data(environment const & env, name const & n) const {
-        auto data = get(env, n);
+    std::shared_ptr<Data> get(environment const & env, name const & n) const {
+        auto data = get_untyped(env, n);
         if (!data)
             return {};
         lean_assert(std::dynamic_pointer_cast<Data>(data));
@@ -179,20 +183,7 @@ attribute const & get_attribute(environment const & env, name const & attr);
 attribute const & get_system_attribute(name const & attr);
 void get_attributes(environment const & env, buffer<attribute const *> &);
 
-// TODO(sullrich): all of these should become members of/return attribute or a subclass
-environment set_attribute(environment const & env, io_state const & ios, char const * attr,
-                          name const & d, unsigned prio, list<unsigned> const & params, bool persistent);
-environment set_attribute(environment const & env, io_state const & ios, char const * attr,
-                          name const & d, unsigned prio, bool persistent);
-environment set_attribute(environment const & env, io_state const & ios, char const * attr,
-                          name const & d, bool persistent);
-
-bool has_attribute(environment const & env, char const * attr, name const & d);
-void get_attribute_instances(environment const & env, char const * attr, buffer<name> &);
-priority_queue<name, name_quick_cmp> get_attribute_instances_by_prio(environment const & env, name const & attr);
-
-unsigned get_attribute_prio(environment const & env, name const & attr, name const & d);
-list<unsigned> get_attribute_params(environment const & env, name const & attr, name const & d);
+bool has_attribute(environment const & env, name const & attr, name const & d);
 
 bool are_incompatible(attribute const & attr1, attribute const & attr2);
 

--- a/src/library/normalize.cpp
+++ b/src/library/normalize.cpp
@@ -30,12 +30,15 @@ namespace lean {
    - constructor (f ...) should be unfolded when it is the major premise of a recursor-like operator
 */
 
+static indices_attribute const & get_unfold_attribute() {
+    return static_cast<indices_attribute const &>(get_system_attribute("unfold"));
+}
 environment add_unfold_hint(environment const & env, name const & n, list<unsigned> const & idxs, bool persistent) {
-    return set_attribute(env, get_dummy_ios(), "unfold", n, LEAN_DEFAULT_PRIORITY, idxs, persistent);
+    return get_unfold_attribute().set(env, get_dummy_ios(), n, LEAN_DEFAULT_PRIORITY, idxs, persistent);
 }
 list<unsigned> has_unfold_hint(environment const & env, name const & d) {
-    if (has_attribute(env, "unfold", d))
-        return get_attribute_params(env, "unfold", d);
+    if (auto data = get_unfold_attribute().get(env, d))
+        return data->m_idxs;
     else
         return list<unsigned>();
 }

--- a/src/library/reducible.cpp
+++ b/src/library/reducible.cpp
@@ -46,8 +46,8 @@ public:
     proxy_attribute(char const * id, char const * descr, reducible_status m_status) : basic_attribute(id, descr),
                                                                                       m_status(m_status) {}
 
-    virtual attr_data_ptr get(environment const & env, name const & n) const override {
-        if (auto data = get_reducibility_attribute().get_data(env, n)) {
+    virtual attr_data_ptr get_untyped(environment const & env, name const & n) const override {
+        if (auto data = get_reducibility_attribute().get(env, n)) {
             if (data->m_status == m_status)
                 return attr_data_ptr(new attr_data);
         }
@@ -64,7 +64,7 @@ public:
         buffer<name> tmp;
         get_reducibility_attribute().get_instances(env, tmp);
         for (name const & n : tmp)
-            if (get(env, n))
+            if (is_instance(env, n))
                 r.push_back(n);
     }
 };
@@ -89,7 +89,7 @@ environment set_reducible(environment const & env, name const & n, reducible_sta
 }
 
 reducible_status get_reducible_status(environment const & env, name const & n) {
-    auto data = get_reducibility_attribute().get_data(env, n);
+    auto data = get_reducibility_attribute().get(env, n);
     if (data)
         return data->m_status;
     return reducible_status::Semireducible;
@@ -97,13 +97,13 @@ reducible_status get_reducible_status(environment const & env, name const & n) {
 
 name_predicate mk_not_reducible_pred(environment const & env) {
     return [=](name const & n) { // NOLINT
-        return !has_attribute(env, "reducible", n);
+        return get_reducible_status(env, n) != reducible_status::Reducible;
     };
 }
 
 name_predicate mk_irreducible_pred(environment const & env) {
     return [=](name const & n) { // NOLINT
-        return has_attribute(env, "irreducible", n);
+        return get_reducible_status(env, n) == reducible_status::Irreducible;
     };
 }
 

--- a/src/library/tactic/backward/backward_lemmas.cpp
+++ b/src/library/tactic/backward/backward_lemmas.cpp
@@ -72,12 +72,16 @@ struct intro_attr_data : public attr_data {
 template class typed_attribute<intro_attr_data>;
 typedef typed_attribute<intro_attr_data> intro_attribute;
 
+static intro_attribute const & get_intro_attribute() {
+    return static_cast<intro_attribute const &>(get_system_attribute("intro"));
+}
+
 bool is_backward_lemma(environment const & env, name const & c) {
-    return has_attribute(env, "intro", c);
+    return get_intro_attribute().is_instance(env, c);
 }
 
 void get_backward_lemmas(environment const & env, buffer<name> & r) {
-    return get_attribute_instances(env, "intro", r);
+    return get_intro_attribute().get_instances(env, r);
 }
 
 unsigned backward_lemma_prio_fn::operator()(backward_lemma const & r) const {
@@ -90,9 +94,9 @@ unsigned backward_lemma_prio_fn::operator()(backward_lemma const & r) const {
 }
 
 backward_lemma_index::backward_lemma_index(type_context & ctx):
-    m_index(get_attribute_instances_by_prio(ctx.env(), "intro")) {
+    m_index(get_intro_attribute().get_instances_by_prio(ctx.env())) {
     buffer<name> lemmas;
-    get_attribute_instances(ctx.env(), "intro", lemmas);
+    get_intro_attribute().get_instances(ctx.env(), lemmas);
     unsigned i = lemmas.size();
     while (i > 0) {
         --i;

--- a/src/library/tactic/simplifier/simp_lemmas.cpp
+++ b/src/library/tactic/simplifier/simp_lemmas.cpp
@@ -571,15 +571,16 @@ simp_lemmas get_simp_lemmas_for_attr(simp_lemma_cache & sl_cache, type_context &
     if (it != sl_cache.simp_cache().end())
         return it->second;
 
+    auto const & attr = get_attribute(tctx.env(), simp_attr);
     simp_lemmas r;
     buffer<name> simp_lemmas;
-    get_attribute_instances(tctx.env(), simp_attr.get_string(), simp_lemmas);
+    attr.get_instances(tctx.env(), simp_lemmas);
     unsigned i = simp_lemmas.size();
     while (i > 0) {
         i--;
         name const & id = simp_lemmas[i];
         tmp_type_context tmp_tctx(tctx);
-        r = add_core(tmp_tctx, r, id, get_attribute_prio(tctx.env(), simp_attr.get_string(), id));
+        r = add_core(tmp_tctx, r, id, attr.get_prio(tctx.env(), id));
     }
     sl_cache.simp_cache().insert({simp_attr, r});
     return r;
@@ -590,15 +591,16 @@ simp_lemmas get_congr_lemmas_for_attr(simp_lemma_cache & sl_cache, type_context 
     if (it != sl_cache.congr_cache().end())
         return it->second;
 
+    auto const & attr = get_attribute(tctx.env(), congr_attr);
     simp_lemmas r;
     buffer<name> congr_lemmas;
-    get_attribute_instances(tctx.env(), congr_attr.get_string(), congr_lemmas);
+    attr.get_instances(tctx.env(), congr_lemmas);
     unsigned i = congr_lemmas.size();
     while (i > 0) {
         i--;
         name const & id = congr_lemmas[i];
         tmp_type_context tmp_tctx(tctx);
-        r = add_congr_core(tmp_tctx, r, id, get_attribute_prio(tctx.env(), congr_attr.get_string(), id));
+        r = add_congr_core(tmp_tctx, r, id, attr.get_prio(tctx.env(), id));
     }
     sl_cache.congr_cache().insert({congr_attr, r});
     return r;


### PR DESCRIPTION
Also reduces number of attribute name literals
