### PR TITLE
small additions

### DIFF
--- a/library/init/default.lean
+++ b/library/init/default.lean
@@ -9,6 +9,7 @@ import init.relation init.nat init.prod init.sum init.combinator
 import init.bool init.unit init.num init.sigma init.setoid init.quot
 import init.funext init.function init.subtype init.classical
 import init.monad init.option init.state init.fin init.list init.char init.string init.to_string
+import init.monad_combinators
 import init.timeit init.trace init.unsigned init.ordering init.list_classes init.coe
 import init.wf init.nat_div init.meta init.instances
 import init.wf_k init.sigma_lex init.sizeof

--- a/library/init/meta/rb_map.lean
+++ b/library/init/meta/rb_map.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Leonardo de Moura
+Authors: Leonardo de Moura, Jeremy Avigad
 -/
 prelude
 import init.ordering init.meta.name init.meta.format
@@ -74,3 +74,35 @@ meta_definition rb_map_has_to_string : has_to_string (rb_map key data) :=
 has_to_string.mk (λ m,
   "⟨" ++ (pr₁ (fold m ("", tt) (λ k d p, (pr₁ p ++ key_data_to_string k d (pr₂ p), ff)))) ++ "⟩")
 end
+
+/- a variant of rb_maps that stores a list of elements for each key.
+   "find" returns the list of elements in the opposite order that they were inserted. -/
+
+meta_definition rb_lmap (key : Type) (data : Type) : Type := rb_map key (list data)
+
+namespace rb_lmap
+
+protected meta_definition mk (key : Type) [has_ordering key] (data : Type) : rb_lmap key data :=
+rb_map.mk key (list data)
+
+meta_definition insert {key : Type} {data : Type} (rbl : rb_lmap key data) (k : key) (d : data) :
+  rb_lmap key data :=
+match (rb_map.find rbl k) with
+| none     := rb_map.insert rbl k [d]
+| (some l) := rb_map.insert (rb_map.erase rbl k) k (d :: l)
+end
+
+meta_definition erase {key : Type} {data : Type} (rbl : rb_lmap key data) (k : key) :
+  rb_lmap key data :=
+rb_map.erase rbl k
+
+meta_definition contains {key : Type} {data : Type} (rbl : rb_lmap key data) (k : key) : bool :=
+rb_map.contains rbl k
+
+meta_definition find {key : Type} {data : Type} (rbl : rb_lmap key data) (k : key) : list data :=
+match (rb_map.find rbl k) with
+| none     := []
+| (some l) := l
+end
+
+end rb_lmap

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -17,7 +17,7 @@ meta_constant simp_lemmas : Type₁
    computed with respect to the given transparency setting. -/
 meta_constant mk_simp_lemmas_core     : transparency → list name → list name → tactic simp_lemmas
 /- Create an empty simp_lemmas. That is, it ignores the lemmas marked with the [simp] attribute.  -/
-meta_constant mk_empy_simp_lemmas     : tactic simp_lemmas
+meta_constant mk_empty_simp_lemmas     : tactic simp_lemmas
 /- (simp_lemmas_insert_core m lemmas id lemma priority) adds the given lemma to the set simp_lemmas. -/
 meta_constant simp_lemmas_insert_core : transparency → simp_lemmas → expr → tactic simp_lemmas
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -448,7 +448,7 @@ rotate_left
 
 /- first [t_1, ..., t_n] applies the first tactic that doesn't fail.
    The tactic fails if all t_i's fail. -/
-meta_definition first : list (tactic unit) → tactic unit
+meta_definition first {A : Type} : list (tactic A) → tactic A
 | []      := fail "first tactic failed, no more alternatives"
 | (t::ts) := t <|> first ts
 

--- a/library/init/monad_combinators.lean
+++ b/library/init/monad_combinators.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jeremy Avigad
+
+Monad combinators, as in Haskell's Control.Monad.
+-/
+prelude
+import init.monad init.list
+
+namespace monad
+
+definition mapM {m : Type → Type} [monad m] {A B : Type} (f : A → m B) : list A → m (list B)
+| []       := return []
+| (h :: t) := do h' ← f h, t' ← mapM t, return (h' :: t')
+
+definition mapM' {m : Type₁ → Type₁} [monad m] {A B : Type₁} (f : A → m B) : list A → m unit
+| []       := return ()
+| (h :: t) := f h >> mapM' t
+
+definition forM {m : Type → Type} [monad m] {A B : Type} (l : list A) (f : A → m B) : m (list B) :=
+mapM f l
+
+definition forM' {m : Type₁ → Type₁} [monad m] {A B : Type₁} (l : list A) (f : A → m B) : m unit :=
+mapM' f l
+
+definition sequence {m : Type → Type} [monad m] {A : Type} : list (m A) → m (list A)
+| []       := return []
+| (h :: t) := do h' ← h, t' ← sequence t, return (h' :: t')
+
+definition sequence' {m : Type₁ → Type₁} [monad m] {A : Type₁} : list (m A) → m unit
+| []       := return ()
+| (h :: t) := h >> sequence' t
+
+infix ` =<< `:2 := λ u v, v >>= u
+
+infix ` >=> `:2 := λ s t a, s a >>= t
+
+infix ` <=< `:2 := λ t s a, s a >>= t
+
+definition join {m : Type → Type} [monad m] {A : Type} (a : m (m A)) : m A :=
+bind a id
+
+definition filterM {m : Type₁ → Type₁} [monad m] {A : Type₁} (f : A → m bool) : list A → m (list A)
+| []       := return []
+| (h :: t) := do b ← f h, t' ← filterM t, bool.cond b (return (h :: t')) (return t')
+
+definition whenb {m : Type₁ → Type₁} [monad m] (b : bool) (t : m unit) : m unit :=
+bool.cond b t (return ())
+
+definition unlessb {m : Type₁ → Type₁} [monad m] (b : bool) (t : m unit) : m unit :=
+bool.cond b (return ()) t
+
+definition condM {m : Type₁ → Type₁} [monad m] {A : Type₁} (mbool : m bool)
+  (tm fm : m A) : m A :=
+do b ← mbool, bool.cond b tm fm
+
+definition liftM {m : Type → Type} [monad m] {A R : Type} (f : A → R) (ma : m A) : m R :=
+do a ← ma, return (f a)
+
+definition liftM₂ {m : Type → Type} [monad m] {A R : Type} (f : A → A → R) (ma₁ ma₂: m A) : m R :=
+do a₁ ← ma₁, a₂ ← ma₂, return (f a₁ a₂)
+
+definition liftM₃ {m : Type → Type} [monad m] {A R : Type} (f : A → A → A → R)
+  (ma₁ ma₂ ma₃ : m A) : m R :=
+do a₁ ← ma₁, a₂ ← ma₂, a₃ ← ma₃, return (f a₁ a₂ a₃)
+
+definition liftM₄ {m : Type → Type} [monad m] {A R : Type} (f : A → A → A → A → R)
+  (ma₁ ma₂ ma₃ ma₄ : m A) : m R :=
+do a₁ ← ma₁, a₂ ← ma₂, a₃ ← ma₃, a₄ ← ma₄, return (f a₁ a₂ a₃ a₄)
+
+definition liftM₅ {m : Type → Type} [monad m] {A R : Type} (f : A → A → A → A → A → R)
+  (ma₁ ma₂ ma₃ ma₄ ma₅ : m A) : m R :=
+do a₁ ← ma₁, a₂ ← ma₂, a₃ ← ma₃, a₄ ← ma₄, a₅ ← ma₅, return (f a₁ a₂ a₃ a₄ a₅)
+
+end monad


### PR DESCRIPTION
This includes some small additions related to the development of a tableau prover written in Lean itself. 

The tableau prover is here: https://github.com/avigad/scratch/tree/master/lean. We are planning to create a new leanprover repository `library_dev` for work in progress and experiments with the new library. The idea is to allow some tentative work to proceed on the new library without impeding development of Lean 3. Specifically, Lean 3 developers will not have to worry about things breaking there as the code base changes. We will move things to the `lean` repo only when we are committed to maintaining them with every change.

I added a file of monad combinators, following Haskell. This could be moved in various places:
- we can merge it with init/monad (it induces a dependency on list)
- we can leave it where it is
- we can take it outside the init folder.
  A few of the combinators (`filterM`, `condM`, and `mapM`) were useful for the tableau prover.
