### PR TITLE
Attribute removal

### DIFF
--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -22,8 +22,11 @@ void decl_attributes::parse(parser & p) {
     while (true) {
         auto pos = p.pos();
         bool deleted = p.curr_is_token_or_id(get_sub_tk());
-        if (deleted)
+        if (deleted) {
+            if (m_persistent)
+                throw parser_error("cannot remove attribute globally (solution: use 'local attribute')", pos);
             p.next();
+        }
         auto name = p.check_id_next("invalid attribute declaration, identifier expected");
         if (name == "priority") {
             if (deleted)

--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -21,8 +21,13 @@ void decl_attributes::parse(parser & p) {
     p.next();
     while (true) {
         auto pos = p.pos();
+        bool deleted = p.curr_is_token_or_id(get_sub_tk());
+        if (deleted)
+            p.next();
         auto name = p.check_id_next("invalid attribute declaration, identifier expected");
         if (name == "priority") {
+            if (deleted)
+                throw parser_error("cannot remove priority attribute", pos);
             auto pos = p.pos();
             expr pre_val = p.parse_expr();
             pre_val = mk_typed_expr(mk_constant(get_num_name()), pre_val);
@@ -40,14 +45,17 @@ void decl_attributes::parse(parser & p) {
                 throw parser_error(sstream() << "unknown attribute [" << name << "]", pos);
 
             auto const & attr = get_attribute(p.env(), name);
-            for (auto const & entry : m_entries) {
-                if (are_incompatible(*entry.m_attr, attr)) {
-                    throw parser_error(sstream() << "invalid attribute [" << name
-                                                 << "], declaration was already marked with [" << entry.m_attr->get_name()
-                                                 << "]", pos);
+            if (!deleted) {
+                for (auto const & entry : m_entries) {
+                    if (!entry.deleted() && are_incompatible(*entry.m_attr, attr)) {
+                        throw parser_error(sstream() << "invalid attribute [" << name
+                                                     << "], declaration was already marked with ["
+                                                     << entry.m_attr->get_name()
+                                                     << "]", pos);
+                    }
                 }
             }
-            auto data = attr.parse_data(p);
+            auto data = deleted ? attr_data_ptr() : attr.parse_data(p);
             m_entries = cons({&attr, data}, m_entries);
             if (name == "parsing_only")
                 m_parsing_only = true;
@@ -71,22 +79,29 @@ environment decl_attributes::apply(environment env, io_state const & ios, name c
     while (i > 0) {
         --i;
         auto const & entry = entries[i];
-        unsigned prio = m_prio ? *m_prio : LEAN_DEFAULT_PRIORITY;
-        env = entry.m_attr->set_untyped(env, ios, d, prio, entry.m_params, m_persistent);
+        if (entry.deleted()) {
+            if (!entry.m_attr->is_instance(env, d))
+                throw exception(sstream() << "cannot remove attribute [" << entry.m_attr->get_name()
+                                          << "]: no prior declaration on " << d);
+            env = entry.m_attr->unset(env, ios, d, m_persistent);
+        } else {
+            unsigned prio = m_prio ? *m_prio : LEAN_DEFAULT_PRIORITY;
+            env = entry.m_attr->set_untyped(env, ios, d, prio, entry.m_params, m_persistent);
+        }
     }
     return env;
 }
 
 bool decl_attributes::ok_for_inductive_type() const {
     for (entry const & e : m_entries)
-        if (e.m_attr->get_name() != "class")
+        if (e.m_attr->get_name() != "class" || e.deleted())
             return false;
     return true;
 }
 
 bool decl_attributes::has_class() const {
     for (entry const & e : m_entries)
-        if (e.m_attr->get_name() == "class")
+        if (e.m_attr->get_name() == "class" && !e.deleted())
             return true;
     return false;
 }

--- a/src/frontends/lean/decl_attributes.h
+++ b/src/frontends/lean/decl_attributes.h
@@ -16,6 +16,10 @@ public:
     struct entry {
         attribute const * m_attr;
         attr_data_ptr     m_params;
+
+        bool deleted() const {
+            return !static_cast<bool>(m_params);
+        }
     };
 private:
     bool               m_persistent;

--- a/src/library/attribute_manager.cpp
+++ b/src/library/attribute_manager.cpp
@@ -230,45 +230,6 @@ void get_attributes(environment const & env, buffer<attribute const *> & r) {
     });
 }
 
-bool has_attribute(environment const & env, char const * attr, name const & d) {
-    return static_cast<bool>(get_attribute(env, attr).get_untyped(env, d));
-}
-
-void get_attribute_instances(environment const & env, char const * attr, buffer<name> & r) {
-    return get_attribute(env, attr).get_instances(env, r);
-}
-
-environment set_attribute(environment const & env, io_state const & ios, char const * name,
-                          lean::name const & d, unsigned prio, list<unsigned> const & params, bool persistent) {
-    auto const & attr = get_attribute(env, name);
-    lean_assert(dynamic_cast<indices_attribute const *>(&attr));
-    return static_cast<indices_attribute const &>(attr).set(env, ios, d, prio, {params}, persistent);
-}
-
-environment set_attribute(environment const & env, io_state const & ios, char const * name, lean::name const & d,
-                          unsigned prio, bool persistent) {
-    auto const & attr = get_attribute(env, name);
-    lean_assert(dynamic_cast<basic_attribute const *>(&attr));
-    return static_cast<basic_attribute const &>(attr).set(env, ios, d, prio, persistent);
-}
-environment set_attribute(environment const & env, io_state const & ios, char const * attr,
-                          name const & d, bool persistent) {
-    return set_attribute(env, ios, attr, d, LEAN_DEFAULT_PRIORITY, persistent);
-}
-
-unsigned get_attribute_prio(environment const & env, name const & attr, name const & d) {
-    return get_attribute(env, attr).get_prio(env, d);
-}
-
-list<unsigned> get_attribute_params(environment const & env, name const & attr, name const & d) {
-    if (auto attribute = dynamic_cast<indices_attribute const *>(&get_attribute(env, attr))) {
-        auto data = attribute->get(env, d);
-        lean_assert(data);
-        return data->m_idxs;
-    }
-    return list<unsigned>();
-}
-
 bool has_attribute(environment const & env, name const & attr, name const & d) {
     return get_attribute(env, attr).is_instance(env, d);
 }

--- a/src/library/reducible.cpp
+++ b/src/library/reducible.cpp
@@ -60,6 +60,9 @@ public:
             throw exception(sstream() << "invalid reducible command, '" << n << "' is not a definition");
         return get_reducibility_attribute().set(env, ios, n, prio, {m_status}, persistent);
     }
+    virtual environment unset(environment, io_state const &, name const &, bool) const override {
+        throw exception(sstream() << "cannot remove attribute [" << get_name() << "]");
+    }
 
     virtual void get_instances(environment const & env, buffer<name> & r) const override {
         buffer<name> tmp;

--- a/src/library/tactic/backward/backward_lemmas.cpp
+++ b/src/library/tactic/backward/backward_lemmas.cpp
@@ -169,7 +169,8 @@ void initialize_backward_lemmas() {
     register_trace_class(name{"tactic", "back_chaining"});
     register_system_attribute(intro_attribute("intro", "introduction rule for backward chaining",
                                               [](environment const & env, io_state const & ios, name const & c,
-                                                 unsigned, intro_attr_data data, bool) {
+                                                 unsigned, bool) {
+                                                  auto const & data = *get_intro_attribute().get(env, c);
                                                   if (data.m_eager)
                                                       return env; // FIXME: support old blast attributes
                                                   aux_type_context ctx(env, ios.get_options());

--- a/src/library/user_recursors.cpp
+++ b/src/library/user_recursors.cpp
@@ -359,12 +359,17 @@ bool is_user_defined_recursor(environment const & env, name const & r) {
 has_recursors_pred::has_recursors_pred(environment const & env):
     m_type2recursors(recursor_ext::get_state(env).m_type2recursors) {}
 
+static indices_attribute const & get_recursor_attribute() {
+    return static_cast<indices_attribute const &>(get_system_attribute("recursor"));
+}
+
 void initialize_user_recursors() {
     g_key        = new std::string("UREC");
     recursor_ext::initialize();
     register_system_attribute(indices_attribute("recursor", "user defined recursor",
                                                 [](environment const & env, io_state const &, name const & n, unsigned,
-                                                   indices_attribute_data const & data, bool persistent) {
+                                                   bool persistent) {
+                                                    auto const & data = *get_recursor_attribute().get(env, n);
                                                     if (data.m_idxs && tail(data.m_idxs))
                                                         throw exception(sstream()
                                                                                 << "invalid [recursor] declaration, expected at most one parameter");

--- a/tests/lean/attributes.lean
+++ b/tests/lean/attributes.lean
@@ -1,0 +1,29 @@
+definition foo (A : Type) := A
+
+attribute [-unfold] foo
+
+attribute [unfold 1] foo
+
+section
+  local attribute [-unfold] foo
+  print foo
+end
+print foo
+
+attribute [-unfold] foo
+print foo
+
+attribute [-unfold] foo
+
+attribute [unfold] foo
+print foo
+
+--
+
+attribute [reducible] foo
+attribute [-reducible] foo -- use [semireducible] instead
+print foo
+
+--
+
+attribute [-instance] nat_has_one

--- a/tests/lean/attributes.lean
+++ b/tests/lean/attributes.lean
@@ -1,8 +1,10 @@
 definition foo (A : Type) := A
 
-attribute [-unfold] foo
+local attribute [-unfold] foo
 
-attribute [unfold 1] foo
+local attribute [unfold 1] foo
+
+attribute [-unfold]
 
 section
   local attribute [-unfold] foo
@@ -10,20 +12,19 @@ section
 end
 print foo
 
-attribute [-unfold] foo
+local attribute [-unfold] foo
 print foo
 
-attribute [-unfold] foo
+local attribute [-unfold] foo
 
-attribute [unfold] foo
-print foo
-
---
-
-attribute [reducible] foo
-attribute [-reducible] foo -- use [semireducible] instead
+local attribute [unfold] foo
 print foo
 
 --
 
-attribute [-instance] nat_has_one
+local attribute [reducible] foo
+local attribute [-reducible] foo -- use [semireducible] instead
+
+--
+
+local attribute [-instance] nat_has_one

--- a/tests/lean/attributes.lean.expected.out
+++ b/tests/lean/attributes.lean.expected.out
@@ -1,0 +1,17 @@
+attributes.lean:3:0: error: cannot remove attribute [unfold]: no prior declaration on foo
+definition foo : Type → Type :=
+λ A, A
+attribute [unfold 1]
+definition foo : Type → Type :=
+λ A, A
+definition foo : Type → Type :=
+λ A, A
+attributes.lean:16:0: error: cannot remove attribute [unfold]: no prior declaration on foo
+attribute [unfold]
+definition foo : Type → Type :=
+λ A, A
+attributes.lean:24:0: error: cannot remove attribute [reducible]
+attribute [reducible, unfold]
+definition foo : Type → Type :=
+λ A, A
+attributes.lean:29:0: error: cannot remove attribute [instance]

--- a/tests/lean/attributes.lean.expected.out
+++ b/tests/lean/attributes.lean.expected.out
@@ -1,4 +1,5 @@
 attributes.lean:3:0: error: cannot remove attribute [unfold]: no prior declaration on foo
+attributes.lean:7:11: error: cannot remove attribute globally (solution: use 'local attribute')
 definition foo : Type → Type :=
 λ A, A
 attribute [unfold 1]
@@ -6,12 +7,9 @@ definition foo : Type → Type :=
 λ A, A
 definition foo : Type → Type :=
 λ A, A
-attributes.lean:16:0: error: cannot remove attribute [unfold]: no prior declaration on foo
+attributes.lean:18:0: error: cannot remove attribute [unfold]: no prior declaration on foo
 attribute [unfold]
 definition foo : Type → Type :=
 λ A, A
-attributes.lean:24:0: error: cannot remove attribute [reducible]
-attribute [reducible, unfold]
-definition foo : Type → Type :=
-λ A, A
-attributes.lean:29:0: error: cannot remove attribute [instance]
+attributes.lean:26:0: error: cannot remove attribute [reducible]
+attributes.lean:30:0: error: cannot remove attribute [instance]


### PR DESCRIPTION
Adds the syntax `[-simp]` for removing attributes.

Existing system attributes that register a callback for setting but not for unsetting cannot be removed. I assume that this is the expected behavior for a few attributes like `instance`.

@leodemoura I haven't disallowed persistent attributes removal so far since it seems to work out of the box.
