### PR TITLE
doc(make): change g++-4.9 to g++

### DIFF
--- a/doc/make/osx-10.9.md
+++ b/doc/make/osx-10.9.md
@@ -31,7 +31,7 @@ need to use `-DCMAKE_CXX_COMPILER` option to specify the compiler
 that you want to use when you run `cmake`. For example, do the
 following to use `g++`.
 
-    cmake -DCMAKE_CXX_COMPILER=g++-4.9 ...
+    cmake -DCMAKE_CXX_COMPILER=g++ ...
 
 
 Required Packages: CMake, GMP, MPFR, LUA


### PR DESCRIPTION
now if use `g++4.9` as compiler flag on OSX, it will produce error message
that

```
CMake Error at CMakeLists.txt:2 (project):
  The CMAKE_CXX_COMPILER:

    g++-4.9

  is not a full path and was not found in the PATH.

  Tell CMake where to find the compiler by setting
  either the environment variable "CXX" or the CMake cache entry
  CMAKE_CXX_COMPILER to the full path to the compiler, or to the
  compiler name if it is in the PATH.
```

so just use `g++` is cool enough, i can build Lean use this flag.
