### PR TITLE
feat(type_context): don't unfold two identical constants

### DIFF
--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -1968,11 +1968,11 @@ lbool type_context::is_def_eq_lazy_delta(expr & t, expr & s) {
             /* both t and s can be delta reduced */
             if (is_eqp(*d_t, *d_s)) {
                 /* Same constant */
-                if (is_app(t) && is_app(s)) {
+                {
                     /* Heuristic: try so solve (f a =?= f b), by solving (a =?= b) */
                     scope S(*this);
-                    if (is_def_eq_args(t, s) &&
-                        is_def_eq(const_levels(get_app_fn(t)), const_levels(get_app_fn(s)))) {
+                    if (((is_app(t) && is_app(s) && is_def_eq_args(t, s)) || (!is_app(t) && !is_app(s)))
+                         && is_def_eq(const_levels(get_app_fn(t)), const_levels(get_app_fn(s)))) {
                         S.commit();
                         return l_true;
                     }


### PR DESCRIPTION
This is minor, but it seems weird that the type context will unfold both sides in a call to `is_def_eq(x, x)` when `x` is a constant. You may not like the `{ ... }` style. If you agree with the change, write it how you like it.
