### PR TITLE
Make local_context::get_unused_name O(log(n)) and use it in the intro tactic

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -231,6 +231,7 @@ meta_constant infer_type    : expr → tactic expr
 meta_constant get_local     : name → tactic expr
 /- Return the hypothesis in the main goal. Fail if tactic_state does not have any goal left. -/
 meta_constant local_context : tactic (list expr)
+meta_constant get_unused_name : name → option nat → tactic name
 /-  Helper tactic for creating simple applications where some arguments are inferred using
     type inference.
 

--- a/src/library/local_context.h
+++ b/src/library/local_context.h
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #pragma once
 #include "util/name_map.h"
 #include "util/name_set.h"
+#include "util/subscripted_name_set.h"
 #include "kernel/expr.h"
 
 namespace lean {
@@ -73,13 +74,18 @@ class metavar_context;
 
 class local_context {
     typedef rb_map<unsigned, local_decl, unsigned_cmp> idx2local_decl;
-    unsigned              m_next_idx;
-    name_map<local_decl>  m_name2local_decl;
-    idx2local_decl        m_idx2local_decl;
-    optional<unsigned>    m_instance_fingerprint;
+    unsigned                   m_next_idx;
+    name_map<local_decl>       m_name2local_decl;
+    subscripted_name_set  m_user_names;
+    name_map<list<local_decl>> m_user_name2local_decls;
+    idx2local_decl             m_idx2local_decl;
+    optional<unsigned>         m_instance_fingerprint;
     friend class type_context;
     /* Return the instance fingerprint for empty local_contexts */
     static unsigned get_empty_instance_fingerprint() { return 31; }
+
+    void insert_user_name(local_decl const &d);
+    void erase_user_name(local_decl const &d);
 
     local_context remove(buffer<expr> const & locals) const;
     expr mk_local_decl(name const & n, name const & ppn, expr const & type,

--- a/src/library/tactic/intro_tactic.cpp
+++ b/src/library/tactic/intro_tactic.cpp
@@ -135,7 +135,7 @@ vm_obj intro(name const & n, tactic_state const & s) {
     local_context lctx   = g->get_context();
     metavar_context mctx = ctx.mctx();
     if (is_pi(type)) {
-        name n1              = n == "_" ? binding_name(type) : n;
+        name n1              = n == "_" ? lctx.get_unused_name(binding_name(type)) : n;
         expr H               = lctx.mk_local_decl(n1, head_beta_reduce(binding_domain(type)), binding_info(type));
         expr new_type        = instantiate(binding_body(type), H);
         expr new_M           = mctx.mk_metavar_decl(lctx, new_type);
@@ -145,7 +145,7 @@ vm_obj intro(name const & n, tactic_state const & s) {
         return mk_tactic_success(to_obj(H), set_mctx_goals(s, mctx, new_gs));
     } else {
         lean_assert(is_let(type));
-        name n1              = n == "_" ? let_name(type) : n;
+        name n1              = n == "_" ? lctx.get_unused_name(let_name(type)) : n;
         expr H               = lctx.mk_local_decl(n1, head_beta_reduce(let_type(type)), let_value(type));
         expr new_type        = instantiate(let_body(type), H);
         expr new_M           = mctx.mk_metavar_decl(lctx, new_type);

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -24,6 +24,7 @@ Author: Leonardo de Moura
 #include "library/vm/vm_declaration.h"
 #include "library/vm/vm_expr.h"
 #include "library/vm/vm_list.h"
+#include "library/vm/vm_option.h"
 #include "library/tactic/tactic_state.h"
 
 #ifndef LEAN_DEFAULT_PP_INSTANTIATE_GOAL_MVARS
@@ -432,6 +433,20 @@ vm_obj tactic_local_context(vm_obj const & s0) {
     return mk_tactic_success(to_obj(to_list(r)), s);
 }
 
+vm_obj tactic_get_unused_name(vm_obj const & n, vm_obj const & vm_i, vm_obj const & s0) {
+    tactic_state const & s   = to_tactic_state(s0);
+    optional<metavar_decl> g = s.get_main_goal_decl();
+    if (!g) return mk_no_goals_exception(s);
+    name unused_name;
+    if (is_none(vm_i)) {
+        unused_name = g->get_context().get_unused_name(to_name(n));
+    } else {
+        unsigned i  = force_to_unsigned(get_some_value(vm_i), 0);
+        unused_name = g->get_context().get_unused_name(to_name(n), i);
+    }
+    return mk_tactic_success(to_obj(unused_name), s);
+}
+
 vm_obj rotate_left(unsigned n, tactic_state const & s) {
     buffer<expr> gs;
     to_buffer(s.goals(), gs);
@@ -562,6 +577,7 @@ void initialize_tactic_state() {
     DECLARE_VM_BUILTIN(name({"tactic", "unify_core"}),           tactic_unify_core);
     DECLARE_VM_BUILTIN(name({"tactic", "get_local"}),            tactic_get_local);
     DECLARE_VM_BUILTIN(name({"tactic", "local_context"}),        tactic_local_context);
+    DECLARE_VM_BUILTIN(name({"tactic", "get_unused_name"}),      tactic_get_unused_name);
     DECLARE_VM_BUILTIN(name({"tactic", "rotate_left"}),          tactic_rotate_left);
     DECLARE_VM_BUILTIN(name({"tactic", "get_goals"}),            tactic_get_goals);
     DECLARE_VM_BUILTIN(name({"tactic", "set_goals"}),            tactic_set_goals);

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -4,4 +4,4 @@ add_library(util OBJECT debug.cpp name.cpp name_set.cpp fresh_name.cpp
   stackinfo.cpp lean_path.cpp serializer.cpp lbool.cpp
   bitap_fuzzy_search.cpp init_module.cpp thread.cpp memory_pool.cpp
   utf8.cpp name_map.cpp list_fn.cpp null_ostream.cpp file_lock.cpp
-  small_object_allocator.cpp)
+  small_object_allocator.cpp subscripted_name_set.cpp)

--- a/src/util/name.h
+++ b/src/util/name.h
@@ -146,12 +146,25 @@ public:
            If a_k is a numeral, return a_1.a_2. ... .a_k.s
     */
     name append_after(char const * s) const;
+
     /**
         \brief Given a name of the form a_1.a_2. ... .a_k,
            If a_k is a string,  return a_1.a_2. ... .a_k', where a_k' is the string a_k concatenated with _i.
-           If a_k is a numeral, return a_1.a_2. ... .a_k.i
+           Otherwise add _i as the last component.
     */
     name append_after(unsigned i) const;
+
+    /**
+        \brief Given a name of the form a_1.a_2. ... .a_k,
+           If a_k is a string, return the name itself.
+           Otherwise add the empty string as the last component.
+    */
+    name get_subscript_base() const;
+
+    /**
+        \brief Given a name of the form a_1.a_2. ... .a_k, determine whether it was produced by append_after(unsigned).
+    */
+    optional<pair<name, unsigned>> is_subscripted() const;
 
     /**
         \brief If prefix is a prefix of this name, then return a new name where the prefix is replaced with new_prefix.

--- a/src/util/rb_tree.h
+++ b/src/util/rb_tree.h
@@ -280,6 +280,27 @@ class rb_tree : private CMP {
         }
     }
 
+    T const * find_next_greater_or_equal(T const & v, node_cell const * n) const {
+        if (n) {
+            int c = cmp(v, n->m_value);
+            if (c == 0) {
+                return &n->m_value;
+            } else if (c > 0) {
+                // v > n->m_value
+                return find_next_greater_or_equal(v, n->m_right.m_ptr);
+            } else {
+                // v < n->m_value
+                if (auto on_left = find_next_greater_or_equal(v, n->m_left.m_ptr)) {
+                    return on_left;
+                } else {
+                    return &n->m_value;
+                }
+            }
+        } else {
+            return nullptr;
+        }
+    }
+
     static void display(std::ostream & out, node_cell const * n) {
         if (n) {
             out << "(";
@@ -410,6 +431,10 @@ public:
     template<typename F>
     void for_each_greater(T const & v, F && f) const {
         for_each_greater(v, f, m_root.m_ptr);
+    }
+
+    T const * find_next_greater_or_equal(T const & v) const {
+        return find_next_greater_or_equal(v, m_root.m_ptr);
     }
 
     // For debugging purposes

--- a/src/util/subscripted_name_set.cpp
+++ b/src/util/subscripted_name_set.cpp
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Gabriel Ebner
+*/
+#include <limits>
+#include <iostream>
+#include "util/subscripted_name_set.h"
+namespace lean {
+void subscripted_name_set::check_invariants() const {
+    m_names.for_each([&] (name const & n) {
+       if (auto is_subscripted = n.is_subscripted()) {
+           auto subscripts = m_prefixes.find(is_subscripted->first);
+           lean_assert(subscripts);
+           auto free_region = subscripts->find_next_greater_or_equal(closed_ival(is_subscripted->second));
+           lean_assert(free_region);
+           lean_assert(!free_region->contains(is_subscripted->second));
+       }
+    });
+    m_prefixes.for_each([&] (name const &, free_subscript_set const & subscripts) {
+        unsigned last_end = 0;
+        subscripts.for_each([&] (closed_ival const & region) {
+            lean_assert(last_end < region.begin);
+            lean_assert(region.begin <= region.end);
+            last_end = region.end;
+        });
+        lean_assert(last_end == std::numeric_limits<unsigned>::max());
+    });
+}
+
+void subscripted_name_set::insert(name const & n) {
+    if (contains(n)) return;
+    m_names.insert(n);
+    if (auto is_subscripted = n.is_subscripted()) {
+        free_subscript_set subscripts;
+        if (auto entry = m_prefixes.find(is_subscripted->first)) {
+            subscripts = *entry;
+        } else {
+            subscripts.insert(closed_ival());
+        }
+        unsigned idx = is_subscripted->second;
+        closed_ival free_region = *subscripts.find_next_greater_or_equal(closed_ival(idx));
+        if (free_region.contains(idx)) {
+            subscripts.erase(free_region);
+            if (free_region.begin < idx)
+                subscripts.insert(closed_ival(free_region.begin, idx - 1));
+            if (idx < free_region.end)
+                subscripts.insert(closed_ival(idx + 1, free_region.end));
+        }
+        m_prefixes.insert(is_subscripted->first, subscripts);
+    }
+    DEBUG_CODE(check_invariants());
+}
+
+void subscripted_name_set::erase(name const & n) {
+    if (!contains(n)) return;
+    m_names.erase(n);
+    if (auto is_subscripted = n.is_subscripted()) {
+        unsigned idx = is_subscripted->second;
+        free_subscript_set subscripts = *m_prefixes.find(is_subscripted->first);
+        auto prev_free_region = *subscripts.find_next_greater_or_equal(closed_ival(idx - 1));
+        auto next_free_region = *subscripts.find_next_greater_or_equal(closed_ival(idx));
+
+        if (prev_free_region.end == next_free_region.end) {
+            if (next_free_region.begin == idx + 1) {
+                subscripts.insert(closed_ival(idx, next_free_region.end));  // replaces next_free_region
+            } else {
+                lean_assert(next_free_region.begin > idx + 1);
+                subscripts.insert(closed_ival(idx));
+            }
+        } else {
+            lean_assert(prev_free_region.end == idx - 1);
+            if (next_free_region.begin == idx + 1) {
+                subscripts.erase(prev_free_region);
+                subscripts.insert(closed_ival(prev_free_region.begin, next_free_region.end)); // replaces next_free_region
+            } else {
+                lean_assert(next_free_region.begin > idx + 1);
+                subscripts.erase(prev_free_region);
+                subscripts.insert(closed_ival(prev_free_region.begin, idx));
+            }
+        }
+
+        m_prefixes.insert(is_subscripted->first, subscripts);
+    }
+    DEBUG_CODE(check_invariants());
+}
+
+name subscripted_name_set::get_unused_name(name const & prefix, unsigned idx) const {
+    if (auto free_subscripts = m_prefixes.find(prefix.get_subscript_base())) {
+        auto free_region = free_subscripts->find_next_greater_or_equal(closed_ival(idx));
+        if (free_region->begin >= idx)
+            idx = free_region->begin;
+    }
+    name n = prefix.append_after(idx);
+    if (contains(n)) { lean_unreachable(); }
+    return n;
+}
+
+name subscripted_name_set::get_unused_name(name const & suggestion) const {
+    if (!contains(suggestion))
+        return suggestion;
+    return get_unused_name(suggestion, 1);
+}
+}

--- a/src/util/subscripted_name_set.h
+++ b/src/util/subscripted_name_set.h
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Gabriel Ebner
+*/
+#pragma once
+#include <limits>
+#include "util/name_map.h"
+#include "util/name_set.h"
+#include "util/name.h"
+namespace lean {
+/**
+ * \brief Set of names with an efficient operation to get unused names.
+ */
+class subscripted_name_set {
+    name_set m_names;
+
+    // For each subscripted name of the form prefix.append_after(idx), we keep track of
+    // the indices that are not yet used.  The unused indices form a subset of the positive
+    // natural numbers, this subset is stored as an rb_tree of intervals.
+    struct closed_ival {
+        unsigned begin, end;
+        closed_ival() : begin(1), end(std::numeric_limits<unsigned>::max()) {}
+        closed_ival(unsigned singleton) : begin(singleton), end(singleton) {}
+        closed_ival(unsigned begin, unsigned end) : begin(begin), end(end) {}
+        bool contains(unsigned i) const { return begin <= i && i <= end; }
+    };
+    struct closed_ival_cmp {
+        int operator()(closed_ival const & i1, closed_ival const & i2) const {
+            return unsigned_cmp()(i1.end, i2.end);
+        }
+    };
+    typedef rb_tree<closed_ival, closed_ival_cmp> free_subscript_set;
+    name_map<free_subscript_set> m_prefixes;
+
+    void check_invariants() const;
+
+public:
+    subscripted_name_set() : m_names(), m_prefixes() {}
+
+    bool contains(name const & n) const { return m_names.contains(n); }
+    void insert(name const & n);
+    void erase(name const & n);
+
+    name get_unused_name(name const & suggestion) const;
+    name get_unused_name(name const & prefix, unsigned idx) const;
+};
+}

--- a/tests/lean/by_contradiction.lean.expected.out
+++ b/tests/lean/by_contradiction.lean.expected.out
@@ -1,10 +1,10 @@
 a b : ℕ,
-a : a ≠ b,
+a_1 : a ≠ b,
 H : a = b
 ⊢ false
 -------
 a b : ℕ,
-a : ¬¬a = b,
+a_1 : ¬¬a = b,
 H : ¬a = b
 ⊢ false
 -------

--- a/tests/lean/combinators1.lean.expected.out
+++ b/tests/lean/combinators1.lean.expected.out
@@ -1,22 +1,22 @@
 first goal
 p q : Prop,
 a : p,
-a : q
+a_1 : q
 ⊢ p ∧ p
 --- Second goal: 
 p q : Prop,
 a : p,
-a : q
+a_1 : q
 ⊢ q
 --- After
 p q : Prop,
 a : p,
-a : q
+a_1 : q
 ⊢ p
 
 p q : Prop,
 a : p,
-a : q
+a_1 : q
 ⊢ p
 should not work
 should not work


### PR DESCRIPTION
Right now, calling the `intro` tactic on two binders with the same name `a` results in two local constants `a` and `a` with the same (user-facing) name.  This is unsatisfactory, as it is now not only unclear what `a` resolves to (it refers to the one introduced last), it also makes it impossible to refer to one of the `a`s at all.

This PR resolves this by using the existing `local_context::get_unused_name` function to obtain a name that is not yet used in the current goal, i.e. we now get the hypotheses `a` and `a_1`.  As discussed on slack, I have also implemented an asymptotically faster version of `get_unused_name`, it should now be O(log(n)) instead of O(n^2).

The function `get_unused_name` now has the following specification: given a name `foo` it returns the first name out of the following list that is not yet used as a user-facing name in a hypothesis: `foo`, `foo_1`, `foo_2`, ...
