### PR TITLE
Type check examples

### DIFF
--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -466,6 +466,9 @@ static environment definition_cmd_ex(parser & p, decl_attributes const & attribu
     } else if (p.curr_is_token_or_id(get_theorem_tk())) {
         p.next();
         kind = Theorem;
+    } else if (p.curr_is_token_or_id(get_example_tk())) {
+        p.next();
+        kind = Example;
     } else if (!modifiers.m_is_private && !modifiers.m_is_protected && p.curr_is_token_or_id(get_instance_tk())) {
         p.next();
         modifiers.m_is_protected = true;
@@ -479,11 +482,6 @@ static environment definition_cmd_ex(parser & p, decl_attributes const & attribu
 
 static environment definition_cmd(parser & p) {
     return definition_cmd_ex(p, {});
-}
-
-static environment example_cmd(parser & p) {
-    definition_cmd_core(p, Example, {}, {});
-    return p.env();
 }
 
 static environment attribute_cmd_core(parser & p, bool persistent) {
@@ -594,7 +592,7 @@ void register_decl_cmds(cmd_table & r) {
     add_cmd(r, cmd_info("protected",       "add new protected definition/theorem/variable", definition_cmd, false));
     add_cmd(r, cmd_info("theorem",         "add new theorem", definition_cmd, false));
     add_cmd(r, cmd_info("instance",        "add new instance", definition_cmd, false));
-    add_cmd(r, cmd_info("example",         "add new example", example_cmd));
+    add_cmd(r, cmd_info("example",         "add new example", definition_cmd, false));
     add_cmd(r, cmd_info("reveal",          "reveal given theorems", reveal_cmd));
     add_cmd(r, cmd_info("include",         "force section parameter/variable to be included", include_cmd));
     add_cmd(r, cmd_info("attribute",       "set declaration attributes", attribute_cmd));

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -327,6 +327,9 @@ declare_definition(parser & p, environment const & env, def_cmd_kind kind, buffe
 
     check_noncomputable(p, new_env, c_name, c_real_name, modifiers.m_is_noncomputable);
 
+    if (kind == Example)
+        return mk_pair(env, c_real_name);
+
     if (modifiers.m_is_protected)
         new_env = add_protected(new_env, c_real_name);
 
@@ -402,9 +405,9 @@ environment single_definition_cmd_core(parser & p, def_cmd_kind kind, decl_modif
             val = get_equations_result(val, 0);
         }
         finalize_definition(elab, new_params, type, val, lp_names);
-        if (kind == Example) return p.env();
         name c_name = mlocal_name(fn);
         auto env_n  = declare_definition(p, elab.env(), kind, lp_names, c_name, type, val, modifiers, attrs, header_pos);
+        if (kind == Example) return p.env();
         environment new_env = env_n.first;
         name c_real_name    = env_n.second;
         return add_local_ref(p, new_env, c_name, c_real_name, lp_names, params);

--- a/src/frontends/lean/tokens.cpp
+++ b/src/frontends/lean/tokens.cpp
@@ -84,6 +84,7 @@ static name const * g_definition_tk = nullptr;
 static name const * g_meta_tk = nullptr;
 static name const * g_mutual_tk = nullptr;
 static name const * g_theorem_tk = nullptr;
+static name const * g_example_tk = nullptr;
 static name const * g_axiom_tk = nullptr;
 static name const * g_axioms_tk = nullptr;
 static name const * g_constant_tk = nullptr;
@@ -200,6 +201,7 @@ void initialize_tokens() {
     g_meta_tk = new name{"meta"};
     g_mutual_tk = new name{"mutual"};
     g_theorem_tk = new name{"theorem"};
+    g_example_tk = new name{"example"};
     g_axiom_tk = new name{"axiom"};
     g_axioms_tk = new name{"axioms"};
     g_constant_tk = new name{"constant"};
@@ -317,6 +319,7 @@ void finalize_tokens() {
     delete g_meta_tk;
     delete g_mutual_tk;
     delete g_theorem_tk;
+    delete g_example_tk;
     delete g_axiom_tk;
     delete g_axioms_tk;
     delete g_constant_tk;
@@ -433,6 +436,7 @@ name const & get_definition_tk() { return *g_definition_tk; }
 name const & get_meta_tk() { return *g_meta_tk; }
 name const & get_mutual_tk() { return *g_mutual_tk; }
 name const & get_theorem_tk() { return *g_theorem_tk; }
+name const & get_example_tk() { return *g_example_tk; }
 name const & get_axiom_tk() { return *g_axiom_tk; }
 name const & get_axioms_tk() { return *g_axioms_tk; }
 name const & get_constant_tk() { return *g_constant_tk; }

--- a/src/frontends/lean/tokens.h
+++ b/src/frontends/lean/tokens.h
@@ -86,6 +86,7 @@ name const & get_definition_tk();
 name const & get_meta_tk();
 name const & get_mutual_tk();
 name const & get_theorem_tk();
+name const & get_example_tk();
 name const & get_axiom_tk();
 name const & get_axioms_tk();
 name const & get_constant_tk();

--- a/tests/lean/example_false.lean
+++ b/tests/lean/example_false.lean
@@ -1,0 +1,5 @@
+open expr tactic
+
+example : false := by do
+n ← mk_fresh_name,
+apply (local_const n n binder_info.default (const ``false []))

--- a/tests/lean/example_false.lean.expected.out
+++ b/tests/lean/example_false.lean.expected.out
@@ -1,0 +1,1 @@
+example_false.lean:3:0: error: failed to add declaration to environment, it contains local constants

--- a/tests/lean/run/noncomputable_example.lean
+++ b/tests/lean/run/noncomputable_example.lean
@@ -1,0 +1,7 @@
+open classical sum
+
+noncomputable example (A : Type _) (h : (A → false) → false) : A :=
+match type_decidable A with
+| (inl ha) := ha
+| (inr hna) := false.rec _ (h hna)
+end

--- a/tests/lean/run/untrusted_examples.lean
+++ b/tests/lean/run/untrusted_examples.lean
@@ -2,7 +2,7 @@ open tactic
 
 set_option pp.all true
 
-example (m1 : tactic nat) (m2 : nat → tactic bool) : true :=
+meta example (m1 : tactic nat) (m2 : nat → tactic bool) : true :=
 by do
   m1 ← get_local `m1,
   m2 ← get_local `m2,


### PR DESCRIPTION
Right now, `example : T := ...` behaves differently from `lemma foo : T := ...` in a surprising way: the example declaration is not type-checked.  For example, we can give an example that proves false, without any warning:

``` lean
open expr tactic

example : false := by do
n ← mk_fresh_name,
apply (local_const n n binder_info.default (const ``false [])) 
```

This PR parses and type-checks example declarations in the same way definitions and theorems are parsed, up until the point where they would be added to the environment--this is skipped for the examples.  As a side-effect, examples now indicate whether they use untrusted definitions or are noncomputable: the syntax is `meta example` and `noncomputable example`, respectively.
