### PR TITLE
fix(library/tactic/simplifier/util): fix deserialization of flat macros

### DIFF
--- a/src/library/tactic/simplifier/util.cpp
+++ b/src/library/tactic/simplifier/util.cpp
@@ -308,7 +308,7 @@ void initialize_simp_util() {
     g_flat_opcode     = new std::string("FLAT");
     register_macro_deserializer(*g_flat_opcode,
                                 [](deserializer & /* d */, unsigned num, expr const * args) {
-                                    if (num != 3)
+                                    if (num != 2)
                                         throw corrupted_stream_exception();
                                     return mk_flat_macro(num, args);
                                 });


### PR DESCRIPTION
I'm not sure this actually fixes the deserialization, but at least it makes it possible to import modules containing proofs that were obtained with the simplifier.  (Otherwise you get "corrupt binary file".)
