### PR TITLE
Redirect all diagnostic output from commands to flycheck

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -174,6 +174,8 @@ expr elaborator::mk_type_metavar(expr const & ref) {
 }
 
 expr elaborator::mk_instance_core(local_context const & lctx, expr const & C, expr const & ref) {
+    flycheck_output_scope flycheck(get_pos_info_provider(), ref);
+
     optional<expr> inst = m_ctx.mk_class_instance_at(lctx, C);
     if (!inst) {
         metavar_context mctx   = m_ctx.mctx();

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2067,6 +2067,7 @@ void parser::parse_command() {
         lazy_type_context tc(m_env, get_options());
         scope_global_ios scope1(m_ios);
         scope_trace_env  scope2(m_env, m_ios.get_options(), tc);
+        flycheck_output_scope flycheck(get_file_name(), pos());
         if (is_notation_cmd(cmd_name)) {
             in_notation_ctx ctx(*this);
             if (it->get_skip_token())

--- a/src/library/flycheck.cpp
+++ b/src/library/flycheck.cpp
@@ -24,14 +24,12 @@ flycheck_output_scope::flycheck_output_scope(io_state const & ios, char const * 
     if (ios.get_options().get_bool("flycheck", false)) {
         m_buffer = std::shared_ptr<string_output_channel>(new string_output_channel);
         m_redirected_ios.set_diagnostic_channel(m_buffer);
-        m_redirected_ios.set_regular_channel(m_buffer);
         m_scoped_ios = std::unique_ptr<scope_global_ios>(new scope_global_ios(m_redirected_ios));
         lean_assert(enabled());
     }
 }
 flycheck_output_scope::flycheck_output_scope(pos_info_provider const * provider, expr const & ref) :
-    flycheck_output_scope(get_global_ios(),
-                          provider ? provider->get_file_name() : "unknown",
+    flycheck_output_scope(provider ? provider->get_file_name() : "unknown",
                           provider ? provider->get_pos_info_or_some(ref) : pos_info(0, 0)) {}
 flycheck_output_scope::~flycheck_output_scope() {
     if (enabled()) {

--- a/src/library/flycheck.h
+++ b/src/library/flycheck.h
@@ -23,7 +23,7 @@ public:
     bool enabled() const { return m_flycheck; }
 };
 
-/** Redirects regular and diagnostic output streams of the global ios as flycheck informations. */
+/** Redirects the diagnostic output stream of the global ios as a flycheck information. */
 class flycheck_output_scope {
     char const *                           m_stream_name;
     pos_info                               m_pos;
@@ -33,6 +33,8 @@ class flycheck_output_scope {
     std::shared_ptr<string_output_channel> m_buffer;
 public:
     flycheck_output_scope(io_state const & ios, char const * stream_name, pos_info const & pos);
+    flycheck_output_scope(char const * stream_name, pos_info const & pos) :
+        flycheck_output_scope(get_global_ios(), stream_name, pos) {}
     flycheck_output_scope(pos_info_provider const * provider, expr const & ref);
     ~flycheck_output_scope();
     bool enabled() const { return static_cast<bool>(m_scoped_ios); }


### PR DESCRIPTION
Right now, only diagnostic output produced during tactic evaluation is shown as flycheck information.  This not only applies to output produced via the `trace`-tactic, but also trace output produced by the app-builder or the type-class inference.

This output is also valuable outside of tactic evaluation.  For instance, I have found it useful to have `trace.class_instances` output available when trying to figure out how type-class inference works.

This PR adds nested usage of `flycheck_output_scope`, the innermost scope determines the position an information is shown at in emacs.  Type-class instance trace output is shown at the point in the expression where we infer the instance (this is amazingly useful), tactic traces are shown at the tactic, and as a fall-back everything else is shown at the position of the command.

The combination, i.e output from the `mk_instance` tactic is unfortunately not shown together with the other tactic trace output; it appears at the precise point in the tactic where the instance is inferred.
