### PR TITLE
refactor(inductive_compiler): keep simulated inductive types semiredu…

### DIFF
--- a/src/library/inductive_compiler/mutual.cpp
+++ b/src/library/inductive_compiler/mutual.cpp
@@ -281,15 +281,7 @@ class add_mutual_inductive_decl_fn {
             lean_assert(!has_local(new_ind_type));
             lean_assert(!has_local(new_ind_val));
             m_env = module::add(m_env, check(m_env, mk_definition_inferring_trusted(m_env, mlocal_name(ind), to_list(m_mut_decl.get_lp_names()), new_ind_type, new_ind_val, true)));
-            m_env = set_reducible(m_env, mlocal_name(ind), reducible_status::Irreducible, true);
             m_tctx.set_env(m_env);
-        }
-    }
-
-    void make_ind_types_reducible() {
-        for (unsigned ind_idx = 0; ind_idx < m_mut_decl.get_inds().size(); ++ind_idx) {
-            expr const & ind = m_mut_decl.get_ind(ind_idx);
-            m_env = set_reducible(m_env, mlocal_name(ind), reducible_status::Reducible, true);
         }
     }
 
@@ -765,7 +757,6 @@ public:
         define_sizeofs();
 
         define_recursors();
-        make_ind_types_reducible();
         return m_env;
     }
 };

--- a/src/library/reducible.h
+++ b/src/library/reducible.h
@@ -25,6 +25,7 @@ environment set_reducible(environment const & env, name const & n, reducible_sta
 reducible_status get_reducible_status(environment const & env, name const & n);
 
 inline bool is_reducible(environment const & env, name const & n) { return get_reducible_status(env, n) == reducible_status::Reducible; }
+inline bool is_semireducible(environment const & env, name const & n) { return get_reducible_status(env, n) == reducible_status::Semireducible; }
 
 /* \brief Execute the given function for each declaration explicitly marked with a reducibility annotation */
 void for_each_reducible(environment const & env, std::function<void(name const &, reducible_status)> const & fn);

--- a/src/library/tactic/simplifier/simplifier.cpp
+++ b/src/library/tactic/simplifier/simplifier.cpp
@@ -164,7 +164,7 @@ static bool get_simplify_canonize_subsingletons(options const & o) {
 /* Main simplifier class */
 
 class simplifier {
-    type_context              m_tctx;
+    type_context              m_tctx, m_tctx_whnf;
     theory_simplifier         m_theory_simplifier;
 
     name                      m_rel;
@@ -709,8 +709,8 @@ class simplifier {
     expr whnf_eta(expr const & e);
 
 public:
-    simplifier(type_context & tctx, name const & rel, simp_lemmas const & slss, optional<vm_obj> const & prove_fn):
-        m_tctx(tctx), m_theory_simplifier(tctx), m_rel(rel), m_slss(slss), m_prove_fn(prove_fn),
+    simplifier(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & slss, optional<vm_obj> const & prove_fn):
+        m_tctx(tctx), m_tctx_whnf(tctx_whnf), m_theory_simplifier(tctx), m_rel(rel), m_slss(slss), m_prove_fn(prove_fn),
         /* Options */
         m_max_steps(get_simplify_max_steps(tctx.get_options())),
         m_nary_assoc(get_simplify_nary_assoc(tctx.get_options())),
@@ -772,7 +772,7 @@ simp_result simplifier::lift_from_eq(expr const & old_e, simp_result const & r_e
 
 /* Whnf + Eta */
 expr simplifier::whnf_eta(expr const & e) {
-    return try_eta(m_tctx.whnf(e));
+    return try_eta(m_tctx_whnf.whnf(e));
 }
 
 simp_result simplifier::simplify_subterms_lambda(expr const & old_e) {
@@ -1430,12 +1430,19 @@ void finalize_simplifier() {
 }
 
 /* Entry point */
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e) {
-    return simplifier(ctx, rel, simp_lemmas, optional<vm_obj>(prove_fn))(e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e) {
+    return simplifier(tctx, tctx, rel, simp_lemmas, optional<vm_obj>(prove_fn))(e);
 }
 
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e) {
-    return simplifier(ctx, rel, simp_lemmas, optional<vm_obj>())(e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e) {
+    return simplifier(tctx, tctx, rel, simp_lemmas, optional<vm_obj>())(e);
 }
 
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e) {
+    return simplifier(tctx, tctx_whnf, rel, simp_lemmas, optional<vm_obj>(prove_fn))(e);
+}
+
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, expr const & e) {
+    return simplifier(tctx, tctx_whnf, rel, simp_lemmas, optional<vm_obj>())(e);
+}
 }

--- a/src/library/tactic/simplifier/simplifier.h
+++ b/src/library/tactic/simplifier/simplifier.h
@@ -12,8 +12,11 @@ Author: Daniel Selsam
 
 namespace lean {
 
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e);
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e);
+
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e);
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, expr const & e);
 
 name get_simplify_prefix_name();
 name get_simplify_max_steps_name();


### PR DESCRIPTION
…cible

This does not fix all issues related to the reducibility of simulated inductive types, but for sure the existing workaround that makes them all reducible is untenable. In order to make them `semireducible`, we do the following: we make all the `pack`/`unpack` functions `irreducible`, and we allow the simplifier to take an extra `type_context` for `whnf` (so that the simplifier can be more lenient during `is_def_eq` than `whnf`).
