### PR TITLE
fix(meta/mk_dec_eq_instance): handle indices

### DIFF
--- a/library/init/list.lean
+++ b/library/init/list.lean
@@ -111,4 +111,17 @@ def dropn : ℕ → list A → list A
 | (succ n) [] := []
 | (succ n) (x::r) := dropn n r
 
+def zip : list A → list B → list (prod A B)
+| []      _       := []
+| _       []      := []
+| (x::xs) (y::ys) := (prod.mk x y) :: zip xs ys
+
+def repeat (a : A) : ℕ → list A
+| 0 := []
+| (succ n) := a :: repeat n
+
+def iota : ℕ → list ℕ
+| 0 := []
+| (succ n) := iota n ++ [succ n]
+
 end list

--- a/library/init/meta/mk_dec_eq_instance.lean
+++ b/library/init/meta/mk_dec_eq_instance.lean
@@ -98,11 +98,15 @@ do I_name ← get_dec_eq_type_name,
    env ← get_env,
    v_name ← return `_v,
    F_name ← return `_F,
+   num_indices ← return $ inductive_num_indices env I_name,
+   idx_names ← return $ list.map (λ (p : name × nat), mk_num_name p~>fst p~>snd) (list.zip (list.repeat `idx num_indices) (list.iota num_indices)),
+
    -- Use brec_on if type is recursive.
    -- We store the functional in the variable F.
    if is_recursive env I_name
-   then intro1 >>= (λ x, induction_core semireducible x (I_name <.> "brec_on") [v_name, F_name])
+   then intro1 >>= (λ x, induction_core semireducible x (I_name <.> "brec_on") (idx_names ++ [v_name, F_name]))
    else intro v_name >> return (),
+
    -- Apply cases to first element of type (I ...)
    get_local v_name >>= cases,
    all_goals (dec_eq_case_1 I_name F_name)

--- a/tests/lean/run/mk_dec_eq_instance_indices.lean
+++ b/tests/lean/run/mk_dec_eq_instance_indices.lean
@@ -1,0 +1,33 @@
+open tactic
+
+namespace X1
+
+inductive Foo : unit -> Type
+| mk : Foo () -> Foo ()
+
+instance (u : unit) : decidable_eq (Foo u) := by mk_dec_eq_instance
+
+end X1
+
+namespace X2
+
+inductive Foo : bool -> bool -> Type
+| mk₁ : Foo tt tt
+| mk₂ : Foo ff ff -> Foo tt ff
+
+instance (idx₁ idx₂ : bool) : decidable_eq (Foo idx₁ idx₂) := by mk_dec_eq_instance
+
+end X2
+
+namespace X3
+
+constants (C : nat -> Type)
+constants (c : Pi (n : nat), C n)
+
+inductive Foo : Pi (n : nat), C n -> Type
+| mk₁ : Pi (n : nat), Foo n (c n) -> Foo (n+1) (c (n+1))
+| mk₂ : Foo 0 (c 0)
+
+noncomputable instance (n : nat) (c : C n) : decidable_eq (Foo n c) := by mk_dec_eq_instance
+
+end X3


### PR DESCRIPTION
Note that `mk_dec_eq_instance` still does not handle nested inductive types, for several reasons. One issue is that the `cases_on` and `brec_on` are currently only defined on the unfolded "basic" inductive type, and yet the induction tactic with `brec_on` won't support non-variable indices.
