### PR TITLE
Make sure all intro rule names are atomic

### DIFF
--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -256,7 +256,7 @@ class inductive_cmd_fn {
             m_p.next();
             while (true) {
                 m_pos = m_p.pos();
-                name ir_name = mlocal_name(ind) + m_p.check_decl_id_next("invalid introduction rule, identifier expected");
+                name ir_name = mlocal_name(ind) + m_p.check_atomic_id_next("invalid introduction rule, atomic identifier expected");
                 if (prepend_ns)
                     ir_name = get_namespace(m_env) + ir_name;
                 m_implicit_infer_map.insert(ir_name, parse_implicit_infer_modifier(m_p));

--- a/src/library/inductive_compiler/mutual.cpp
+++ b/src/library/inductive_compiler/mutual.cpp
@@ -231,7 +231,7 @@ class add_mutual_inductive_decl_fn {
     }
 
     expr translate_ir(unsigned ind_idx, expr const & ir) {
-        name ir_name = mlocal_name(m_mut_decl.get_ind(ind_idx)) + mlocal_name(ir).replace_prefix(m_basic_prefix, name());
+        name ir_name = m_basic_ind_name + name(mlocal_name(ir).get_string()).append_after(ind_idx);
         buffer<expr> locals;
         expr ty = m_tctx.whnf(mlocal_type(ir));
         while (is_pi(ty)) {

--- a/src/library/inductive_compiler/nested.cpp
+++ b/src/library/inductive_compiler/nested.cpp
@@ -197,6 +197,10 @@ class add_nested_inductive_decl_fn {
     name mk_inner_name(name const & n) {
         if (m_nested_decl.is_ind_name(n) || m_nested_decl.is_ir_name(n)) {
             return nest(n);
+        } else if (!n.is_atomic()) {
+            // We want the atomic introduction rule name to stay at the end, but we don't want to introduce
+            // a new "nest_" in the beginning.
+            return nest(n.get_prefix() + mlocal_name(m_nested_decl.get_ind(0)) + name(n.get_string()));
         } else {
             // We append the ind name at the end so that we don't put the "nest_" in the beginning
             return nest(n + mlocal_name(m_nested_decl.get_ind(0)));


### PR DESCRIPTION
Some parts of the code assume that every introduction rule name has the form `<ind_name>.<atomic>`. 

Example:
https://github.com/leanprover/lean/blob/lean3/library/init/meta/contradiction_tactic.lean#L67-L68

We were not enforcing this restriction in the inductive command, and more importantly, the inductive compiler was generating names for basic intro rules that do not adhere to this invariant. 
