### PR TITLE
Mk dec eq instance indices and ginductives

### DIFF
--- a/library/init/list.lean
+++ b/library/init/list.lean
@@ -111,4 +111,17 @@ def dropn : ℕ → list A → list A
 | (succ n) [] := []
 | (succ n) (x::r) := dropn n r
 
+def zip : list A → list B → list (prod A B)
+| []      _       := []
+| _       []      := []
+| (x::xs) (y::ys) := (prod.mk x y) :: zip xs ys
+
+def repeat (a : A) : ℕ → list A
+| 0 := []
+| (succ n) := a :: repeat n
+
+def iota : ℕ → list ℕ
+| 0 := []
+| (succ n) := iota n ++ [succ n]
+
 end list

--- a/library/init/meta/environment.lean
+++ b/library/init/meta/environment.lean
@@ -46,6 +46,8 @@ meta constant inductive_num_params : environment → name → nat
 meta constant inductive_num_indices : environment → name → nat
 /- Return tt iff the inductive datatype recursor supports dependent elimination -/
 meta constant inductive_dep_elim : environment → name → bool
+/- Return tt iff the given name is a generalized inductive datatype -/
+meta constant is_ginductive : environment → name → bool
 /- Fold over declarations in the environment -/
 meta constant fold {A :Type} : environment → A → (declaration → A → A) → A
 /- (relation_info env n) returns some value if n is marked as a relation in the given environment.

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -256,7 +256,7 @@ class inductive_cmd_fn {
             m_p.next();
             while (true) {
                 m_pos = m_p.pos();
-                name ir_name = mlocal_name(ind) + m_p.check_decl_id_next("invalid introduction rule, identifier expected");
+                name ir_name = mlocal_name(ind) + m_p.check_atomic_id_next("invalid introduction rule, atomic identifier expected");
                 if (prepend_ns)
                     ir_name = get_namespace(m_env) + ir_name;
                 m_implicit_infer_map.insert(ir_name, parse_implicit_infer_modifier(m_p));

--- a/src/library/inductive_compiler/mutual.cpp
+++ b/src/library/inductive_compiler/mutual.cpp
@@ -281,15 +281,7 @@ class add_mutual_inductive_decl_fn {
             lean_assert(!has_local(new_ind_type));
             lean_assert(!has_local(new_ind_val));
             m_env = module::add(m_env, check(m_env, mk_definition_inferring_trusted(m_env, mlocal_name(ind), to_list(m_mut_decl.get_lp_names()), new_ind_type, new_ind_val, true)));
-            m_env = set_reducible(m_env, mlocal_name(ind), reducible_status::Irreducible, true);
             m_tctx.set_env(m_env);
-        }
-    }
-
-    void make_ind_types_reducible() {
-        for (unsigned ind_idx = 0; ind_idx < m_mut_decl.get_inds().size(); ++ind_idx) {
-            expr const & ind = m_mut_decl.get_ind(ind_idx);
-            m_env = set_reducible(m_env, mlocal_name(ind), reducible_status::Reducible, true);
         }
     }
 
@@ -765,7 +757,6 @@ public:
         define_sizeofs();
 
         define_recursors();
-        make_ind_types_reducible();
         return m_env;
     }
 };

--- a/src/library/inductive_compiler/mutual.cpp
+++ b/src/library/inductive_compiler/mutual.cpp
@@ -231,7 +231,7 @@ class add_mutual_inductive_decl_fn {
     }
 
     expr translate_ir(unsigned ind_idx, expr const & ir) {
-        name ir_name = mlocal_name(m_mut_decl.get_ind(ind_idx)) + mlocal_name(ir).replace_prefix(m_basic_prefix, name());
+        name ir_name = m_basic_ind_name + name(mlocal_name(ir).get_string()).append_after(ind_idx);
         buffer<expr> locals;
         expr ty = m_tctx.whnf(mlocal_type(ir));
         while (is_pi(ty)) {

--- a/src/library/inductive_compiler/nested.cpp
+++ b/src/library/inductive_compiler/nested.cpp
@@ -197,6 +197,10 @@ class add_nested_inductive_decl_fn {
     name mk_inner_name(name const & n) {
         if (m_nested_decl.is_ind_name(n) || m_nested_decl.is_ir_name(n)) {
             return nest(n);
+        } else if (!n.is_atomic()) {
+            // We want the atomic introduction rule name to stay at the end, but we don't want to introduce
+            // a new "nest_" in the beginning.
+            return nest(n.get_prefix() + mlocal_name(m_nested_decl.get_ind(0)) + name(n.get_string()));
         } else {
             // We append the ind name at the end so that we don't put the "nest_" in the beginning
             return nest(n + mlocal_name(m_nested_decl.get_ind(0)));

--- a/src/library/reducible.h
+++ b/src/library/reducible.h
@@ -25,6 +25,7 @@ environment set_reducible(environment const & env, name const & n, reducible_sta
 reducible_status get_reducible_status(environment const & env, name const & n);
 
 inline bool is_reducible(environment const & env, name const & n) { return get_reducible_status(env, n) == reducible_status::Reducible; }
+inline bool is_semireducible(environment const & env, name const & n) { return get_reducible_status(env, n) == reducible_status::Semireducible; }
 
 /* \brief Execute the given function for each declaration explicitly marked with a reducibility annotation */
 void for_each_reducible(environment const & env, std::function<void(name const &, reducible_status)> const & fn);

--- a/src/library/tactic/simplifier/simplifier.cpp
+++ b/src/library/tactic/simplifier/simplifier.cpp
@@ -164,7 +164,7 @@ static bool get_simplify_canonize_subsingletons(options const & o) {
 /* Main simplifier class */
 
 class simplifier {
-    type_context              m_tctx;
+    type_context              m_tctx, m_tctx_whnf;
     theory_simplifier         m_theory_simplifier;
 
     name                      m_rel;
@@ -709,8 +709,8 @@ class simplifier {
     expr whnf_eta(expr const & e);
 
 public:
-    simplifier(type_context & tctx, name const & rel, simp_lemmas const & slss, optional<vm_obj> const & prove_fn):
-        m_tctx(tctx), m_theory_simplifier(tctx), m_rel(rel), m_slss(slss), m_prove_fn(prove_fn),
+    simplifier(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & slss, optional<vm_obj> const & prove_fn):
+        m_tctx(tctx), m_tctx_whnf(tctx_whnf), m_theory_simplifier(tctx), m_rel(rel), m_slss(slss), m_prove_fn(prove_fn),
         /* Options */
         m_max_steps(get_simplify_max_steps(tctx.get_options())),
         m_nary_assoc(get_simplify_nary_assoc(tctx.get_options())),
@@ -772,7 +772,7 @@ simp_result simplifier::lift_from_eq(expr const & old_e, simp_result const & r_e
 
 /* Whnf + Eta */
 expr simplifier::whnf_eta(expr const & e) {
-    return try_eta(m_tctx.whnf(e));
+    return try_eta(m_tctx_whnf.whnf(e));
 }
 
 simp_result simplifier::simplify_subterms_lambda(expr const & old_e) {
@@ -1430,12 +1430,19 @@ void finalize_simplifier() {
 }
 
 /* Entry point */
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e) {
-    return simplifier(ctx, rel, simp_lemmas, optional<vm_obj>(prove_fn))(e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e) {
+    return simplifier(tctx, tctx, rel, simp_lemmas, optional<vm_obj>(prove_fn))(e);
 }
 
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e) {
-    return simplifier(ctx, rel, simp_lemmas, optional<vm_obj>())(e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e) {
+    return simplifier(tctx, tctx, rel, simp_lemmas, optional<vm_obj>())(e);
 }
 
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e) {
+    return simplifier(tctx, tctx_whnf, rel, simp_lemmas, optional<vm_obj>(prove_fn))(e);
+}
+
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, expr const & e) {
+    return simplifier(tctx, tctx_whnf, rel, simp_lemmas, optional<vm_obj>())(e);
+}
 }

--- a/src/library/tactic/simplifier/simplifier.h
+++ b/src/library/tactic/simplifier/simplifier.h
@@ -12,8 +12,11 @@ Author: Daniel Selsam
 
 namespace lean {
 
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e);
-simp_result simplify(type_context & ctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e);
+simp_result simplify(type_context & tctx, name const & rel, simp_lemmas const & simp_lemmas, expr const & e);
+
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, vm_obj const & prove_fn, expr const & e);
+simp_result simplify(type_context & tctx, type_context & tctx_whnf, name const & rel, simp_lemmas const & simp_lemmas, expr const & e);
 
 name get_simplify_prefix_name();
 name get_simplify_max_steps_name();

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 */
 #include "kernel/type_checker.h"
 #include "kernel/inductive/inductive.h"
+#include "library/inductive_compiler/ginductive.h"
 #include "library/standard_kernel.h"
 #include "library/module.h"
 #include "library/util.h"
@@ -140,6 +141,10 @@ vm_obj environment_inductive_dep_elim(vm_obj const & env, vm_obj const & n) {
     return mk_vm_bool(inductive::has_dep_elim(to_env(env), to_name(n)));
 }
 
+vm_obj environment_is_ginductive(vm_obj const & env, vm_obj const & n) {
+    return mk_vm_bool(static_cast<bool>(is_ginductive(to_env(env), to_name(n))));
+}
+
 vm_obj environment_fold(vm_obj const &, vm_obj const & env, vm_obj const & a, vm_obj const & fn) {
     vm_obj r = a;
     to_env(env).for_each_declaration([&](declaration const & d) {
@@ -198,6 +203,7 @@ void initialize_vm_environment() {
     DECLARE_VM_BUILTIN(name({"environment", "inductive_num_params"}),  environment_inductive_num_params);
     DECLARE_VM_BUILTIN(name({"environment", "inductive_num_indices"}), environment_inductive_num_indices);
     DECLARE_VM_BUILTIN(name({"environment", "inductive_dep_elim"}),    environment_inductive_dep_elim);
+    DECLARE_VM_BUILTIN(name({"environment", "is_ginductive"}),         environment_is_ginductive);
     DECLARE_VM_BUILTIN(name({"environment", "relation_info"}),         environment_relation_info);
     DECLARE_VM_BUILTIN(name({"environment", "refl_for"}),              environment_refl_for);
     DECLARE_VM_BUILTIN(name({"environment", "symm_for"}),              environment_symm_for);

--- a/tests/lean/run/mk_dec_eq_instance_indices.lean
+++ b/tests/lean/run/mk_dec_eq_instance_indices.lean
@@ -1,0 +1,33 @@
+open tactic
+
+namespace X1
+
+inductive Foo : unit -> Type
+| mk : Foo () -> Foo ()
+
+instance (u : unit) : decidable_eq (Foo u) := by mk_dec_eq_instance
+
+end X1
+
+namespace X2
+
+inductive Foo : bool -> bool -> Type
+| mk₁ : Foo tt tt
+| mk₂ : Foo ff ff -> Foo tt ff
+
+instance (idx₁ idx₂ : bool) : decidable_eq (Foo idx₁ idx₂) := by mk_dec_eq_instance
+
+end X2
+
+namespace X3
+
+constants (C : nat -> Type)
+constants (c : Pi (n : nat), C n)
+
+inductive Foo : Pi (n : nat), C n -> Type
+| mk₁ : Pi (n : nat), Foo n (c n) -> Foo (n+1) (c (n+1))
+| mk₂ : Foo 0 (c 0)
+
+noncomputable instance (n : nat) (c : C n) : decidable_eq (Foo n c) := by mk_dec_eq_instance
+
+end X3

--- a/tests/lean/run/mk_dec_eq_instance_nested.lean
+++ b/tests/lean/run/mk_dec_eq_instance_nested.lean
@@ -1,0 +1,31 @@
+open tactic
+
+namespace X1
+
+inductive Wrap (A : Type) : Type
+| mk : A -> Wrap
+
+inductive Foo : Type
+| mk : Wrap Foo -> Foo
+
+instance : decidable_eq Foo := by mk_dec_eq_instance
+
+end X1
+
+namespace X2
+
+inductive Foo : Type
+| mk : list Foo -> Foo
+
+instance : decidable_eq Foo := by mk_dec_eq_instance
+
+end X2
+
+namespace X3
+
+inductive Foo : bool -> Type
+| mk : list (list (Foo tt)) -> Foo ff
+
+instance (b : bool) : decidable_eq (Foo b) := by mk_dec_eq_instance
+
+end X3

--- a/tests/lean/run/nested_inductive.lean
+++ b/tests/lean/run/nested_inductive.lean
@@ -125,3 +125,11 @@ inductive foo (A : Type*)
 | mk : A -> wrap' (list' foo) -> foo
 
 end X13
+
+namespace X14
+print "with indices in original"
+
+inductive Foo : bool -> Type
+| mk : list (Foo ff) -> Foo tt
+
+end X14


### PR DESCRIPTION
This PR combines three previous ones and adds a new feature.
1. All simulated inductive types are `semireducible` instead of `reducible`.
2. All intro rule names must be atomic identitiers, and have the form `<ind_name>.<atomic>`.
3. `mk_dec_eq_instance` now supports indexed families.
4. `mk_dec_eq_instance` now supports generalized inductive types.
