### PR TITLE
Improve autocompletion reliability

### DIFF
--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2063,7 +2063,6 @@ void parser::parse_imports() {
     buffer<module_name> olean_files;
     bool prelude     = false;
     std::string base = m_base_dir ? *m_base_dir : dirname(get_stream_name().c_str());
-    bool imported    = false;
     unsigned fingerprint = 0;
     if (curr_is_token(get_prelude_tk())) {
         next();
@@ -2085,7 +2084,6 @@ void parser::parse_imports() {
         import_olean(optional<unsigned>(), "init");
     }
     while (curr_is_token(get_import_tk())) {
-        imported       = true;
         m_last_cmd_pos = pos();
         next();
         while (true) {
@@ -2128,7 +2126,7 @@ void parser::parse_imports() {
     m_env = replay_export_decls_core(m_env, m_ios);
     check_modules_up_to_date();
     m_imports_parsed = true;
-    if (imported)
+    if (olean_files.size())
         save_snapshot();
 }
 

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -174,7 +174,7 @@ json server::handle_check(json const &) {
 }
 
 snapshot const * server::get_closest_snapshot(unsigned line) {
-    snapshot const * ret = nullptr;
+    snapshot const * ret = m_snapshots.size() ? &m_snapshots.front() : nullptr;
     for (snapshot const & snap : m_snapshots) {
         if (snap.m_pos.first <= line)
             ret = &snap;
@@ -271,6 +271,10 @@ json server::handle_complete(json const & req) {
     std::string pattern = req["pattern"];
     unsigned line = req["line"];
     std::vector<json> completions;
+
+    if (!m_snapshots.size()) { // should only happen when imports have been touched
+        handle_check({});
+    }
 
     if (snapshot const * snap = get_closest_snapshot(line)) {
         environment const & env = snap->m_env;


### PR DESCRIPTION
With these changes, `complete` should always offer prelude definitions (except if there are erroneous `import` statements).
