### PR TITLE
[WIP] try to improve elab error message

### DIFF
--- a/src/frontends/lean/elaborator.h
+++ b/src/frontends/lean/elaborator.h
@@ -159,6 +159,9 @@ private:
     expr ensure_function(expr const & e);
     expr visit_function(expr const & fn, bool has_args, expr const & ref);
     format mk_app_type_mismatch_error(expr const & t, expr const & arg, expr const & arg_type, expr const & expected_type);
+    format mk_app_arg_mismatch_error(expr const & t, expr const & arg, expr const & arg_type,
+                                     expr const & expected_mvar, expr const & expected_type);
+
     format mk_too_many_args_error(expr const & fn_type);
     [[ noreturn ]]
     void throw_app_type_mismatch(expr const & t, expr const & arg, expr const & arg_type, expr const & expected_type,


### PR DESCRIPTION
``` Lean
inductive Foo : Type → Type*
| fixed : bool -> Foo bool
| flex  : Pi (X : Type), X -> Foo X

set_option pp.all true

def rig : Pi (X : Type), decidable_eq X → Foo X → X
| .bool _ (Foo.fixed b) := b
| .X    _ (Foo.flex X x) := x
```

was giving the following annoying error message:

```
/home/dselsam/projects/lean/gdb/gdb.lean:21:11: error: type mismatch at application
  Foo.flex X
term
  X
has type
  Type
but is expected to have type
  Type
```

This (not-polished) commit changes it to the following:

```
/home/dselsam/projects/lean/gdb/gdb.lean:21:11: error: type mismatch at application
  Foo.flex X
unable to unify actual argument
  X : Type
with argument placeholder
  ?m_1 : Type
```

Note: I have yet to figure out why the example doesn't work or whether there is a workaround.
