### PR TITLE
feat(frontends/lean): support binary, octal and hex literals

### DIFF
--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -67,6 +67,7 @@ protected:
     void next_utf(buffer<char> & cs);
 
     optional<unsigned> try_hex_to_unsigned(char c);
+    optional<unsigned> try_digit_to_unsigned(int base, char c);
     unsigned hex_to_unsigned(char c);
     char read_quoted_char(char const * error_msg);
     token_kind read_string();


### PR DESCRIPTION
Scanner will interpret numeric literals prefixed with `0b`, `0o`, and `0x` as binary, octal, and hex decimal values respectively.

The prefix character (`b`, `o`, `x`) may be upper or lower case.
