### PR TITLE
Emacs info buffer

### DIFF
--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -8,6 +8,7 @@
 (require 'flycheck)
 (require 'lean-settings)
 (require 'lean-server)
+(require 'lean-info)
 
 (defun lean-toggle-flycheck-mode ()
   "Toggle flycheck-mode"

--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -119,14 +119,13 @@
                      (e (get-char-property pos 'flycheck-error)))
               (setq errors (list e))))
 
-      (when errors
-        (with-output-to-lean-info
-         (dolist (e errors)
-           (princ (format "%d:%d: " (flycheck-error-line e) (flycheck-error-column e)))
-           (princ (flycheck-error-message e))
-           (princ "\n\n"))
-         (when flycheck-current-errors
-           (princ (format "(%d more messages above...)" (length flycheck-current-errors)))))))))
+      (with-output-to-lean-info
+       (dolist (e errors)
+         (princ (format "%d:%d: " (flycheck-error-line e) (flycheck-error-column e)))
+         (princ (flycheck-error-message e))
+         (princ "\n\n"))
+       (when flycheck-current-errors
+         (princ (format "(%d more messages above...)" (length flycheck-current-errors))))))))
 
 (define-minor-mode lean-next-error-mode
   "Toggle lean-next-error-mode on and off.

--- a/src/emacs/lean-info.el
+++ b/src/emacs/lean-info.el
@@ -1,0 +1,44 @@
+;; -*- lexical-binding: t -*-
+;;
+;;; lean-info.el --- Emacs mode for Lean theorem prover
+;;
+;; Copyright (c) 2016 Gabriel Ebner. All rights reserved.
+;;
+;; Author: Gabriel Ebner <gebner@gebner.org>
+;; Maintainer: Gabriel Ebner <gebner@gebner.org>
+;; Created: Oct 29, 2016
+;; Keywords: languages
+;; Version: 0.1
+;; URL: https://github.com/leanprover/lean/blob/master/src/emacs
+;;
+;; Released under Apache 2.0 license as described in the file LICENSE.
+;;
+
+;; Lean Info Mode (for "*lean-info*" buffer)
+;; Automode List
+;;;###autoload
+(define-derived-mode lean-info-mode prog-mode "Lean-Info"
+  "Major mode for Lean Info Buffer"
+  :syntax-table lean-syntax-table
+  :group 'lean
+  (set (make-local-variable 'font-lock-defaults) lean-info-font-lock-defaults)
+  (set (make-local-variable 'indent-tabs-mode) nil)
+  (set 'compilation-mode-font-lock-keywords '())
+  (set-input-method "Lean")
+  (set (make-local-variable 'lisp-indent-function)
+       'common-lisp-indent-function))
+
+(defconst lean-info-buffer-name "*lean-info*")
+
+(defmacro with-output-to-lean-info (&rest body)
+  `(let ((lean-info-buffer (get-buffer lean-info-buffer-name)))
+     (if (and lean-info-buffer (get-buffer-window lean-info-buffer))
+         (with-current-buffer lean-info-buffer
+           (setq buffer-read-only nil)
+           (erase-buffer)
+           (setq standard-output lean-info-buffer)
+           . ,body)
+       (let ((temp-buffer-setup-hook #'lean-info-mode))
+         (with-output-to-temp-buffer lean-info-buffer-name . ,body)))))
+
+(provide 'lean-info)

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -61,7 +61,11 @@
    (cl-function
     (lambda (&key state)
       (let* ((temp-buffer-setup-hook #'lean-info-mode))
-        (with-output-to-temp-buffer "*lean-info*" (princ state)))))))
+        (with-output-to-temp-buffer "*lean-info*" (princ state)))))
+   (cl-function
+    (lambda (&key message)
+      (let* ((temp-buffer-setup-hook #'lean-info-mode))
+        (with-output-to-temp-buffer "*lean-info*" (princ message)))))))
 
 (defun lean-std-exe ()
   (interactive)

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -21,12 +21,13 @@
 (require 'eri)
 (require 'lean-util)
 (require 'lean-settings)
-(require 'lean-flycheck)
 (require 'lean-input)
 (require 'lean-syntax)
 (require 'lean-project)
 (require 'lean-company)
 (require 'lean-server)
+(require 'lean-flycheck)
+(require 'lean-info)
 
 (defun lean-compile-string (exe-name args file-name)
   "Concatenate exe-name, args, and file-name"
@@ -49,12 +50,6 @@
               (shell-quote-argument (f-full (lean-get-executable lean-executable-name)))
               (or arg "")
               (shell-quote-argument (f-full target-file-name))))))
-
-(defconst lean-info-buffer-name "*lean-info*")
-
-(defmacro with-output-to-lean-info (&rest body)
-  `(let* ((temp-buffer-setup-hook #'lean-info-mode))
-     (with-output-to-temp-buffer lean-info-buffer-name . ,body)))
 
 (defun lean-show-goal-at-pos ()
   "Show goal at the current point."
@@ -237,20 +232,6 @@ Invokes `lean-mode-hook'.
   (require 'flycheck)
   (eval-after-load 'flycheck
     '(lean-flycheck-init)))
-
-;; Lean Info Mode (for "*lean-info*" buffer)
-;; Automode List
-;;;###autoload
-(define-derived-mode lean-info-mode prog-mode "Lean-Info"
-  "Major mode for Lean Info Buffer"
-  :syntax-table lean-syntax-table
-  :group 'lean
-  (set (make-local-variable 'font-lock-defaults) lean-info-font-lock-defaults)
-  (set (make-local-variable 'indent-tabs-mode) nil)
-  (set 'compilation-mode-font-lock-keywords '())
-  (set-input-method "Lean")
-  (set (make-local-variable 'lisp-indent-function)
-       'common-lisp-indent-function))
 
 (provide 'lean-mode)
 ;;; lean-mode.el ends here

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -50,6 +50,12 @@
               (or arg "")
               (shell-quote-argument (f-full target-file-name))))))
 
+(defconst lean-info-buffer-name "*lean-info*")
+
+(defmacro with-output-to-lean-info (&rest body)
+  `(let* ((temp-buffer-setup-hook #'lean-info-mode))
+     (with-output-to-temp-buffer lean-info-buffer-name . ,body)))
+
 (defun lean-show-goal-at-pos ()
   "Show goal at the current point."
   (interactive)
@@ -59,13 +65,9 @@
          :line (line-number-at-pos)
          :col (current-column))
    (cl-function
-    (lambda (&key state)
-      (let* ((temp-buffer-setup-hook #'lean-info-mode))
-        (with-output-to-temp-buffer "*lean-info*" (princ state)))))
+    (lambda (&key state) (with-output-to-lean-info (princ state))))
    (cl-function
-    (lambda (&key message)
-      (let* ((temp-buffer-setup-hook #'lean-info-mode))
-        (with-output-to-temp-buffer "*lean-info*" (princ message)))))))
+    (lambda (&key message) (with-output-to-lean-info (princ message))))))
 
 (defun lean-std-exe ()
   (interactive)

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -43,6 +43,7 @@ typedef pair<std::string, std::function<void(environment const &, serializer &)>
 
 struct module_metadata {
     module_metadata() : m_mname(name()), m_lean_mod_time(-1), m_olean_mod_time(-2) {}
+    std::string m_base;
     module_name m_mname;
     time_t m_lean_mod_time;
     time_t m_olean_mod_time;
@@ -106,12 +107,11 @@ static time_t get_mtime(std::string const & fname) {
 
 bool imports_have_changed(environment const & env) {
     module_ext const & ext   = get_extension(env);
-    std::string const & base = ext.m_base;
     bool any_changed = false;
     ext.m_imported.for_each([&] (name const &, module_metadata const & metadata) {
         if (!any_changed) {
-            time_t lean_mtime = get_mtime(find_lean_file(base, metadata.m_mname));
-            time_t olean_mtime = get_mtime(find_olean_file(base, metadata.m_mname));
+            time_t lean_mtime = get_mtime(find_lean_file(metadata.m_base, metadata.m_mname));
+            time_t olean_mtime = get_mtime(find_olean_file(metadata.m_base, metadata.m_mname));
             if (lean_mtime != metadata.m_lean_mod_time || olean_mtime != metadata.m_olean_mod_time) {
                 any_changed = true;
             }
@@ -355,6 +355,7 @@ struct import_modules_fn {
         m_visited.insert(fname);
         try {
             module_metadata metadata;
+            metadata.m_base = base;
             metadata.m_mname = mname;
             try {
                 std::string fname_lean = find_lean_file(base, mname);

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -141,8 +141,12 @@ json server::handle_sync(json const & req) {
 }
 
 json server::handle_check(json const &) {
-    if (imports_have_changed(m_checked_env))
+    try {
+        if (imports_have_changed(m_checked_env))
+            m_only_checked_until = optional<pos_info>(0, 0);
+    } catch (...) {
         m_only_checked_until = optional<pos_info>(0, 0);
+    }
 
     if (m_only_checked_until) {
         // keep all snapshots before the change but the last one (which may belong to the command that's being changed)

--- a/src/vim/syntax/lean.vim
+++ b/src/vim/syntax/lean.vim
@@ -23,13 +23,14 @@ syn case match
 
 " keywords
 syn keyword leanKeyword import prelude tactic_hint protected private noncomputable
-syn keyword leanKeyword definition renaming hiding exposing parameter parameters
+syn keyword leanKeyword def definition renaming hiding exposing parameter parameters
 syn keyword leanKeyword begin proof qed conjecture constant constants hypothesis lemma
 syn keyword leanKeyword corollary variable variables premise premises theory print theorem proposition
 syn keyword leanKeyword example abstract open as export override axiom axioms inductive
 syn keyword leanKeyword with structure record universe universes alias help environment options
 syn keyword leanKeyword precedence reserve match infix infixl infixr notation postfix prefix
 syn keyword leanKeyword tactic_infix tactic_infixl tactic_infixr tactic_notation tactic_postfix
+syn keyword leanKeyword meta run_command do
 syn keyword leanKeyword tactic_prefix eval check end reveal this suppose using namespace section
 syn keyword leanKeyword fields find_decl attribute local set_option extends include omit classes
 syn keyword leanKeyword instances coercions attributes raw migrate replacing calc have show suffices
@@ -39,9 +40,9 @@ syn match leanOp        ":"
 syn match leanOp        "="
 
 " constants
-syn keyword leanConstant "#" "@" "->" "∼" "↔" "/" "==" ":=" "<->" "/\\" "\\/" "∧" "∨"
+syn keyword leanConstant "#" "@" "->" "∼" "↔" "/" "==" ":=" "<->" "/\\" "\\/" "∧" "∨" ">>=" ">>"
 syn keyword leanConstant ≠ < > ≤ ≥ ¬ <= >= ⁻¹ ⬝ ▸ + * - / λ
-syn keyword leanConstant → ∃ ∀
+syn keyword leanConstant → ∃ ∀ Π ←
 
 " modifiers (pragmas)
 syn keyword leanModifier contained containedin=leanBracketEncl persistent notation visible instance trans_instance class parsing_only
@@ -61,7 +62,8 @@ syn region      leanEncl            matchgroup=leanDelim start="(" end=")" conta
 syn region      leanBracketEncl     matchgroup=leanDelim start="\[" end="\]" contains=ALLBUT,leanBrackErr keepend
 syn region      leanEncl            matchgroup=leanDelim start="{"  end="}" contains=ALLBUT,leanBraceErr,leanModifier keepend
 
-syn region      leanNotation        start=+`+    end=+`+
+" FIXME(gabriel): distinguish backquotes in notations from names
+" syn region      leanNotation        start=+`+    end=+`+
 
 syn keyword	leanTodo	containedin=leanComment TODO FIXME BUG FIX
 


### PR DESCRIPTION
This fixes the rest of issue #1169.  Now when you press C-c C-g at a point where there is no goal, then the _lean-info_ buffer is updated as well, preventing confusion.

I've also updated the next-error-mode to reuse the same buffer, and added a convenient `with-output-to-lean-info` macro.
