### PR TITLE
Fix segfault in add_decl tactic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -460,7 +460,7 @@ file(GLOB_RECURSE LEAN_SOURCES
   "${LEAN_SOURCE_DIR}/[A-Za-z]*.cpp"
   "${LEAN_SOURCE_DIR}/[A-Za-z]*.h")
 add_style_check_target(style "${LEAN_SOURCES}")
-#add_test(NAME style_check COMMAND "${PYTHON_EXECUTABLE}" "${LEAN_SOURCE_DIR}/cmake/Modules/cpplint.py" ${LEAN_SOURCES})
+add_test(NAME style_check COMMAND "${PYTHON_EXECUTABLE}" "${LEAN_SOURCE_DIR}/cmake/Modules/cpplint.py" ${LEAN_SOURCES})
 endif()
 
 if("${CROSS_COMPILE}" MATCHES "ON" OR "${CMAKE_C_COMPILER}" MATCHES "emcc")

--- a/src/library/compiler/vm_compiler.cpp
+++ b/src/library/compiler/vm_compiler.cpp
@@ -335,6 +335,7 @@ environment vm_compile(environment const & env, buffer<pair<name, expr>> const &
 }
 
 environment vm_compile(environment const & env, declaration const & d) {
+    if (!d.is_definition()) return env;
     buffer<pair<name, expr>> procs;
     preprocess(env, d, procs);
     return vm_compile(env, procs);

--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -5,6 +5,7 @@ Author: Daniel Selsam, Leonardo de Moura
 */
 #include <functional>
 #include <iostream>
+#include <limits>
 #include "util/flet.h"
 #include "util/freset.h"
 #include "util/pair.h"

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Leonardo de Moura
 */
+#include <string>
 #include "kernel/type_checker.h"
 #include "kernel/inductive/inductive.h"
 #include "library/inductive_compiler/ginductive.h"

--- a/tests/lean/run/declare_axiom.lean
+++ b/tests/lean/run/declare_axiom.lean
@@ -1,0 +1,5 @@
+open tactic
+
+run_command (do
+  e ← to_expr `(false),
+  add_decl $ declaration.ax `useful_assumption [] e)


### PR DESCRIPTION
When declaring an axiom via the `add_decl` tactic, you get a segfault.

(I also noticed that the style check test accidentally got commented out at some point.  Git blamed me for it, so I took the liberty of uncommenting it and fixing the lingering style issues.)