### PR TITLE
Show cumulative runtime in profiler

### DIFF
--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -624,8 +624,8 @@ public:
     class profiler {
         typedef std::unique_ptr<interruptible_thread> thread_ptr;
         struct snapshot_core {
-            chrono::milliseconds                  m_duration;
-            std::vector<pair<unsigned, unsigned>> m_stack;
+            chrono::milliseconds                       m_duration;
+            std::vector<std::pair<unsigned, unsigned>> m_stack;
         };
         vm_state &                 m_state;
         atomic<bool>               m_stop;
@@ -638,12 +638,14 @@ public:
         ~profiler();
 
         struct snapshot {
-            unsigned                          m_duration;
-            std::vector<pair<name, unsigned>> m_stack;
+            chrono::milliseconds                   m_duration;
+            std::vector<std::pair<name, unsigned>> m_stack;
         };
 
         struct snapshots {
-            std::vector<snapshot> m_snapshots;
+            std::vector<snapshot>                              m_snapshots;
+            std::vector<std::pair<name, chrono::milliseconds>> m_cum_times;
+            chrono::milliseconds                               m_total_time;
             void display(std::ostream & out) const;
         };
         bool enabled() const { return m_thread_ptr.get() != nullptr; }


### PR DESCRIPTION
Example:
```
elaboration time for prime
type checking time for prime
  567ms   100.0%   super
  567ms   100.0%   tactic.interactive.super
  567ms   100.0%   _tactic
  567ms   100.0%   tactic.monad._lambda_3
  564ms    99.5%   super.run_prover_loop
  559ms    98.6%   super.run_prover_loop._lambda_33
  559ms    98.6%   super.run_prover_loop._lambda_32
  558ms    98.4%   super.run_prover_loop._lambda_31
  558ms    98.4%   super.run_prover_loop._lambda_20
  558ms    98.4%   super.run_prover_loop._lambda_29
  558ms    98.4%   super.run_prover_loop._lambda_16
  558ms    98.4%   super.run_prover_loop._lambda_30
  558ms    98.4%   super.run_prover_loop._lambda_19
  558ms    98.4%   super.run_prover_loop._lambda_14
  558ms    98.4%   super.run_prover_loop._lambda_18
  558ms    98.4%   super.run_prover_loop._lambda_17
  558ms    98.4%   super.run_prover_loop._lambda_15
  551ms    97.2%   super.run_prover_loop._lambda_13
  438ms    77.2%   tactic.alternative._lambda_9
  437ms    77.1%   tactic_orelse
  426ms    75.1%   tactic.alternative._lambda_7
  414ms    73.0%   super.seq_inferences
  403ms    71.1%   super.seq_inferences._lambda_1
  403ms    71.1%   super._lambda_2
  373ms    65.8%   super.seq_inferences._lambda_3
  372ms    65.6%   super.seq_inferences._lambda_2
  317ms    55.9%   super.alternative._lambda_11
  316ms    55.7%   super.prover.orelse
  308ms    54.3%   super.alternative._lambda_9
  308ms    54.3%   super.prover.orelse._lambda_1
  266ms    46.9%   super.run_prover_loop._lambda_28
  266ms    46.9%   super.run_prover_loop._lambda_27
  266ms    46.9%   super.run_prover_loop._lambda_26
  207ms    36.5%   super.superposition_inf._lambda_5
  207ms    36.5%   super.superposition_inf._lambda_4
  190ms    33.5%   super.try_add_sup
```