### PR TITLE
Fix cumulative time display in VM profiler

### DIFF
--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -2304,6 +2304,7 @@ vm_state::profiler::~profiler() {
 auto vm_state::profiler::get_snapshots() -> snapshots {
     stop();
     snapshots r;
+    r.m_total_time = chrono::milliseconds(0);
     std::unordered_map<name, chrono::milliseconds, name_hash> cum_times;
     for (snapshot_core const & s : m_snapshots) {
         snapshot new_s;


### PR DESCRIPTION
Right now, the cumulative time always shows `0.0%`.  This happens because the `m_total_time` field is uninitialized in the snapshot structure due to commit 5075891f660db336ef78e7dd9bb7f37861db13eb.