### PR TITLE
feat(emacs/lean-info): push marker to go back after find-definition

### DIFF
--- a/src/emacs/lean-info.el
+++ b/src/emacs/lean-info.el
@@ -56,6 +56,7 @@
         (funcall cont record))))))
 
 (cl-defun lean-find-definition-cont (&key file line column)
+  (when (fboundp 'xref-push-marker-stack) (xref-push-marker-stack))
   (find-file file)
   (goto-char (point-min))
   (forward-line (1- line))


### PR DESCRIPTION
The new `xref` package that @Kha mentioned in #1182 allows you to go back after calling find-definitions.  Supporting this feature just requires us to call `xref-push-marker-stack` when going to a definition.  Then you can go back via `M-,` (default keybinding if you have it).

This feature also integrates seamlessly with the spacemacs `C-t` binding. Regarding spacemacs:  @Kha, you mentioned that you were interested in better spacemacs support for lean, maybe also a spacemacs layer.  Any ideas on how to get that started?  Do you already have some customization?  So far, I've only added support for find-definition as the `M-.` binding conflicts with evil-mode:
```
(spacemacs|define-jump-handlers lean-mode lean-find-definition)
```