### PR TITLE
Make find-definition work with structures

### DIFF
--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -840,6 +840,7 @@ struct structure_cmd_fn {
 
     environment operator()() {
         process_header();
+        module::scope_pos_info scope(m_name_pos);
         if (m_p.curr_is_token(get_assign_tk())) {
             m_p.check_token_next(get_assign_tk(), "invalid 'structure', ':=' expected");
             m_mk_pos = m_p.pos();


### PR DESCRIPTION
This records the position of the structure name for all members of the structure.  This is a bit unfortunate for the projections, where we might hope to go to the field declaration directly.