### PR TITLE
Show goal via info manager

### DIFF
--- a/src/emacs/lean-debug.el
+++ b/src/emacs/lean-debug.el
@@ -13,6 +13,8 @@
     (when (or (called-interactively-p 'any) print-msg)
       (message "lean: turn on debug mode"))
     (get-buffer-create lean-debug-buffer-name)
+    (display-buffer lean-debug-buffer-name 'display-buffer-reuse-window
+                    '((reusable-frames . t)))
     (setq-local lean-debug-mode t)))
 
 (defun lean-turn-off-debug-mode (&optional print-msg)
@@ -21,12 +23,6 @@
     (when (or (called-interactively-p 'any) print-msg)
       (message "lean: turn off debug mode"))
     (setq-local lean-debug-mode nil)))
-
-(defun lean-toggle-debug-mode ()
-  (interactive)
-  (if lean-debug-mode
-      (lean-turn-off-debug-mode (called-interactively-p 'any))
-    (lean-turn-on-debug-mode (called-interactively-p 'any))))
 
 (defun lean-output-to-buffer (buffer-name format-string args)
   (with-current-buffer
@@ -56,6 +52,9 @@
   :init-value nil
   :lighter lean-debug-mode-line
   :group 'lean
-  :require 'lean)
+  :require 'lean
+  (if lean-debug-mode
+      (lean-turn-on-debug-mode (called-interactively-p 'any))
+    (lean-turn-off-debug-mode (called-interactively-p 'any))))
 
 (provide 'lean-debug)

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -52,19 +52,6 @@
               (or arg "")
               (shell-quote-argument (f-full target-file-name))))))
 
-(defun lean-show-goal-at-pos ()
-  "Show goal at the current point."
-  (interactive)
-  (lean-server-sync)
-  (lean-server-send-command
-   (list :command "show_goal"
-         :line (line-number-at-pos)
-         :col (current-column))
-   (cl-function
-    (lambda (&key state) (with-output-to-lean-info (princ state))))
-   (cl-function
-    (lambda (&key message) (with-output-to-lean-info (princ message))))))
-
 (defun lean-std-exe ()
   (interactive)
   (lean-execute))

--- a/src/emacs/lean-settings.el
+++ b/src/emacs/lean-settings.el
@@ -122,11 +122,6 @@ false (nil)."
   :group 'lean
   :type 'boolean)
 
-(defcustom lean-show-proofstate-in-minibuffer nil
-  "Set this variable to true to show proof state at minibuffer."
-  :group 'lean
-  :type 'boolean)
-
 (defcustom lean-proofstate-display-style 'show-first-and-other-conclusions
   "Choose how to display proof state in *lean-info* buffer."
   :group 'lean

--- a/src/emacs/lean-type.el
+++ b/src/emacs/lean-type.el
@@ -85,20 +85,12 @@
 
 (defun lean-eldoc-documentation-function-cont (info-record &optional add-to-kill-ring)
   "Continuation for lean-eldoc-documentation-function"
-  (let* ((info-string (lean-info-record-to-string info-record))
-         (proofstate (plist-get info-record :proofstate)))
+  (let ((info-string (lean-info-record-to-string info-record)))
     (when info-string
       (when add-to-kill-ring
         (kill-new
          (substring-no-properties info-string)))
-      ;; Display on Mini-buffer
-      (when (or lean-show-proofstate-in-minibuffer
-                (not proofstate))
-        (message "%s" info-string))
-      ;; Display on Info Buffer
-      ; (with-output-to-lean-info
-                                        ; (princ info-string))
-      )))
+      (message "%s" info-string))))
 
 (defun lean-eldoc-documentation-function (&optional add-to-kill-ring)
   "Show information of lean expression at point if any"
@@ -112,5 +104,14 @@
   "Show information of lean-expression at point if any."
   (interactive)
   (lean-eldoc-documentation-function lean-show-type-add-to-kill-ring))
+
+(defun lean-show-goal-at-pos ()
+  "Show goal at the current point."
+  (interactive)
+  (lean-get-info-record-at-point
+   (lambda (info-record)
+     (-if-let (state (plist-get info-record :state))
+         (with-output-to-lean-info (princ state))
+       (message "No goal found at point")))))
 
 (provide 'lean-type)

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -109,10 +109,6 @@ elaborator::elaborator(environment const & env, options const & opts, metavar_co
                        local_context const & lctx, optional<info_manager> & infom):
     m_env(env), m_opts(opts),
     m_ctx(env, opts, mctx, lctx, get_tcm(), transparency_mode::Semireducible), m_owns_infom(infom) {
-    unsigned line, col;
-    if (has_show_goal(m_opts, line, col)) {
-        m_show_goal_pos = pos_info(line, col);
-    }
     if (infom) {
         g_infom = &*infom;
     }
@@ -2315,26 +2311,6 @@ tactic_state elaborator::mk_tactic_state_for(expr const & mvar) {
     return ::lean::mk_tactic_state_for(m_env, m_opts, mctx, lctx, type);
 }
 
-void elaborator::show_goal(tactic_state const & s, expr const & start_ref, expr const & end_ref, expr const & curr_ref) {
-    if (!m_show_goal_pos) return;
-    pos_info_provider * provider = get_pos_info_provider();
-    if (!provider) return;
-    unsigned line  = m_show_goal_pos->first;
-    unsigned col   = m_show_goal_pos->second;
-    auto start_pos = provider->get_pos_info(start_ref);
-    auto end_pos   = provider->get_pos_info(end_ref);
-    auto curr_pos  = provider->get_pos_info(curr_ref);
-    if (!start_pos || !end_pos || !curr_pos)
-        return;
-    if (start_pos->first > line || (start_pos->first == line && start_pos->second > col))
-        return;
-    if (end_pos->first < line || (end_pos->first == line && end_pos->second < col))
-        return;
-    if (curr_pos->first < line || (curr_pos->first == line && curr_pos->second < col))
-        return;
-    throw show_goal_exception(*curr_pos, s);
-}
-
 /* Apply the given tactic to the state 's'.
    Report any errors detected during the process using position information associated with 'ref'. */
 tactic_state elaborator::execute_tactic(expr const & tactic, tactic_state const & s, expr const & ref) {
@@ -2378,8 +2354,6 @@ tactic_state elaborator::execute_tactic(expr const & tactic, tactic_state const 
 
 tactic_state elaborator::execute_begin_end_tactics(buffer<expr> const & tactics, tactic_state const & s, expr const & ref) {
     lean_assert(!tactics.empty());
-    expr start_ref = tactics[0];
-    expr end_ref   = ref;
     list<expr> gs = s.goals();
     if (!gs) throw elaborator_exception(ref, "tactic failed, there are no goals to be solved");
     tactic_state new_s = set_goals(s, to_list(head(gs)));
@@ -2387,7 +2361,6 @@ tactic_state elaborator::execute_begin_end_tactics(buffer<expr> const & tactics,
         expr const & curr_ref = tactic;
         trace_elab_debug(tout() << "executing tactic:\n" << tactic << "\n";);
         if (is_begin_end_element(tactic)) {
-            show_goal(new_s, start_ref, end_ref, curr_ref);
             add_tactic_state_info(new_s, curr_ref);
             new_s = execute_tactic(get_annotation_arg(tactic), new_s, curr_ref);
         } else if (is_begin_end_block(tactic)) {
@@ -2398,8 +2371,7 @@ tactic_state elaborator::execute_begin_end_tactics(buffer<expr> const & tactics,
             throw elaborator_exception(curr_ref, "ill-formed 'begin ... end' tactic block");
         }
     }
-    add_tactic_state_info(new_s, end_ref);
-    show_goal(new_s, start_ref, end_ref, end_ref);
+    add_tactic_state_info(new_s, ref);
     if (new_s.goals()) throw_unsolved_tactic_state(new_s, "tactic failed, there are unsolved goals", ref);
     return set_goals(new_s, tail(gs));
 }
@@ -2427,7 +2399,6 @@ void elaborator::invoke_begin_end_tactics(expr const & mvar, buffer<expr> const 
 void elaborator::invoke_atomic_tactic(expr const & mvar, expr const & tactic) {
     expr const & ref = mvar;
     tactic_state s       = mk_tactic_state_for(mvar);
-    show_goal(s, tactic, mvar, tactic);
     add_tactic_state_info(s, ref);
     trace_elab(tout() << "initial tactic state\n" << s.pp() << "\n";);
     tactic_state new_s   = execute_tactic(tactic, s, ref);
@@ -2546,12 +2517,6 @@ void elaborator::ensure_no_unassigned_metavars(expr const & e) {
             if (!has_expr_metavar(e)) return false;
             if (is_metavar_decl_ref(e) && !mctx.is_assigned(e)) {
                 tactic_state s = mk_tactic_state_for(e);
-                if (m_show_goal_pos && get_pos_info_provider()) {
-                    if (auto pos = get_pos_info_provider()->get_pos_info(e)) {
-                        if (pos == m_show_goal_pos)
-                            throw show_goal_exception(*pos, s);
-                    }
-                }
                 throw_unsolved_tactic_state(s, "don't know how to synthesize placeholder", e);
             }
             return true;

--- a/src/frontends/lean/elaborator.h
+++ b/src/frontends/lean/elaborator.h
@@ -87,9 +87,6 @@ private:
 
     bool              m_in_pattern{false};
 
-    /* Position information for show goal feature */
-    optional<pos_info> m_show_goal_pos;
-
     expr get_default_numeral_type();
 
     typedef std::function<format(expr const &)> pp_fn;
@@ -218,7 +215,6 @@ private:
     expr visit(expr const & e, optional<expr> const & expected_type);
 
     void add_tactic_state_info(tactic_state const & s, expr const & ref);
-    void show_goal(tactic_state const & s, expr const & start_ref, expr const & end_ref, expr const & curr_ref);
     tactic_state mk_tactic_state_for(expr const & mvar);
     tactic_state execute_tactic(expr const & tactic, tactic_state const & s, expr const & ref);
     tactic_state execute_begin_end_tactics(buffer<expr> const & tactics, tactic_state const & s, expr const & ref);

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -88,8 +88,6 @@ json server::handle_request(json const & req) {
         return handle_check(req);
     } else if (command == "complete") {
         return handle_complete(req);
-    } else if (command == "show_goal") {
-        return handle_show_goal(req);
     } else if (command == "info") {
         return handle_info(req);
     }
@@ -345,44 +343,6 @@ json server::handle_complete(json const & req) {
     json res;
     res["response"] = "ok";
     res["completions"] = completions;
-    return res;
-}
-
-json server::handle_show_goal(json const &req) {
-    pos_info pos(req["line"], req["col"]);
-
-    if (!m_snapshots.size()) handle_check({});
-
-    snapshot * snap = nullptr;
-    for (auto & s : m_snapshots) {
-        if (s.m_pos.first < pos.first)
-            snap = &s;
-    }
-
-    std::istringstream in(m_content);
-    bool use_exceptions = false;
-    optional<std::string> base_dir;
-    parser p(m_initial_env, m_ios, in, m_file_name.c_str(),
-             base_dir, use_exceptions, m_num_threads, snap);
-
-    p.enable_show_goal(pos);
-
-    try {
-        p();
-    } catch (show_goal_exception & ex) {
-        json res;
-        res["response"] = "ok";
-        res["line"] = ex.m_pos.first;
-        res["col"] = ex.m_pos.second;
-        std::stringstream buf;
-        buf << ex.m_state.pp();
-        res["state"] = buf.str();
-        return res;
-    }
-
-    json res;
-    res["response"] = "error";
-    res["message"] = "could not find goal";
     return res;
 }
 

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -34,7 +34,6 @@ class server {
     json handle_sync(json const & req);
     json handle_check(json const & req);
     json handle_complete(json const & req);
-    json handle_show_goal(json const & req);
     json handle_info(json const & req);
 
     json serialize_decl(name const & short_name, name const & long_name, environment const & env, options const & o);


### PR DESCRIPTION
Note that this implementation is slightly pickier right now than the current one: `C-c C-g` will only work on the tactic identifier itself, not on any tactic parameters. I'm planning to use something like `show_goal_exception` inside the parser in order to make the server more aware of the lexical context of a position, which should fix this issue and bring us back contextual autocompletion. Which is also why I haven't completely removed that exception class yet.