### PR TITLE
feat(equations_compiler/structural_rec): heuristic debug error message

### DIFF
--- a/src/library/equations_compiler/structural_rec.cpp
+++ b/src/library/equations_compiler/structural_rec.cpp
@@ -435,6 +435,10 @@ struct structural_rec_fn {
                     return none_expr();
                 }
             } else {
+                if (is_constant(fn, get_and_name())) {
+                    trace_debug_struct_aux(tout() << "note: support for structural recursion eliminating into 'Prop' is limited; "
+                                           << "either use well-founded recursion or wrap the 'Prop' in a structure and then project.\n";);
+                }
                 return none_expr();
             }
         }


### PR DESCRIPTION
I had the following issue except with many other complexities, and the trace did not help me figure out what was wrong:
```Lean
inductive Foo : Type
| node : (ℕ → Foo) → Foo

constant Bar : Type
constant P : Bar → Prop
constant Q : Bar → Type

lemma foo_error : Π (foo : Foo), (∀ (b : Bar), P b)
| (Foo.node f) := λ b, foo_error (f 0) b -- error, well-founded not implemented yet

lemma foo : Π (foo : Foo), (∀ (b : Bar), Q b)
| (Foo.node f) := λ b, foo (f 0) b
```
I added the following `debug.eqn_compiler.structural_rec` trace message, if `to_below` finds `and` instead of the expected `prod`:
```
[debug.eqn_compiler.structural_rec] note: support for structural recursion eliminating into 'Prop' is limited; 
either use well-founded recursion or wrap the 'Prop' in a structure and then project.
```
I don't know if this message or the placement is good enough to merge, or if it will even matter at all once well-founded recursion is implemented. Feel free to close without merging.
