### PR TITLE
Wrap snapshots and module_infos in shared_ptrs

### DIFF
--- a/doc/make/msys2.md
+++ b/doc/make/msys2.md
@@ -11,11 +11,6 @@ It is easy to install all dependencies, it produces native
 
 ## Installing dependencies
 
-Lean requires Python2 or Python3. If you do not have a Python installation on your machine,
-please download and install one from [Python.org](https://www.python.org/downloads/windows).
-Also please make sure that your `PATH` environment variable includes the installed
-Python directory (i.e. `C:\Python27`).
-
 [The official webpage of msys2][msys2] provides one-click installers.
 We assume that you install [msys2][msys2] at `c:\msys64`.
 Once installed it, you can run msys2 shell from the start menu.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -317,7 +317,7 @@ if(NOT "${EMSCRIPTEN}" AND NOT "${TCMALLOC_FOUND}" AND NOT "${JEMALLOC_FOUND}" A
 endif()
 
 # Python
-find_package(PythonInterp REQUIRED)
+find_package(PythonInterp)
 
 include_directories(${LEAN_SOURCE_DIR})
 
@@ -452,7 +452,7 @@ endif()
 add_subdirectory(tests/util/lp)
 
 # Include style check
-if (NOT(${CMAKE_SYSTEM_NAME} MATCHES "Windows"))
+if (NOT(${CMAKE_SYSTEM_NAME} MATCHES "Windows") AND PYTHONINTERP_FOUND)
 include(StyleCheck)
 file(GLOB_RECURSE LEAN_SOURCES
   "${LEAN_SOURCE_DIR}"
@@ -541,9 +541,9 @@ else()
 endif()
 # CPack -- Debian
 if(STATIC)
-  SET(CPACK_DEBIAN_PACKAGE_DEPENDS "python")
+  SET(CPACK_DEBIAN_PACKAGE_DEPENDS "")
 else()
-  SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++-4.8-dev,libgmp-dev,libmpfr-dev,python")
+  SET(CPACK_DEBIAN_PACKAGE_DEPENDS "libstdc++-4.8-dev,libgmp-dev,libmpfr-dev")
 endif()
 SET(CPACK_DEBIAN_PACKAGE_DESCRIPTION "Lean Theorem Prover")
 SET(CPACK_DEBIAN_PACKAGE_SECTION "devel")

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2279,7 +2279,7 @@ bool parse_commands(environment & env, io_state & ios, char const * fname) {
     vfs.m_modules_to_load_from_source.insert(std::string(fname));
     module_mgr mod_mgr(&vfs, &get_global_message_buffer(), env, ios);
 
-    auto mod = mod_mgr.get_module(fname).m_result.get();
+    auto mod = mod_mgr.get_module(fname)->m_result.get();
 
     lean_assert(mod.m_env);
     env = *mod.m_env;

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -171,7 +171,7 @@ parser::parser(environment const & env, io_state const & ios,
                module_loader const & import_fn,
                std::istream & strm, std::string const & file_name,
                bool use_exceptions,
-               snapshot const * s, snapshot_vector * sv):
+               std::shared_ptr<snapshot const> const & s, snapshot_vector * sv):
     m_env(env), m_ios(ios), m_verbose(true),
     m_use_exceptions(use_exceptions),
     m_import_fn(import_fn),
@@ -2239,10 +2239,11 @@ bool parser::curr_is_command_like() const {
 void parser::save_snapshot(scope_message_context & smc) {
     if (!m_snapshot_vector)
         return;
-    if (m_snapshot_vector->empty() || m_snapshot_vector->back().m_pos != m_scanner.get_pos_info()) {
-        m_snapshot_vector->push_back(snapshot(m_env, smc.get_sub_buckets(), m_local_level_decls, m_local_decls,
-                                              m_level_variables, m_variables, m_include_vars,
-                                              m_ios.get_options(), m_imports_parsed, m_parser_scope_stack, m_scanner.get_pos_info()));
+    if (m_snapshot_vector->empty() || m_snapshot_vector->back()->m_pos != m_scanner.get_pos_info()) {
+        m_snapshot_vector->push_back(std::make_shared<snapshot>(
+                m_env, smc.get_sub_buckets(), m_local_level_decls, m_local_decls,
+                m_level_variables, m_variables, m_include_vars,
+                m_ios.get_options(), m_imports_parsed, m_parser_scope_stack, m_scanner.get_pos_info()));
     }
 }
 

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -74,7 +74,7 @@ struct snapshot {
         m_options(opts), m_imports_parsed(imports_parsed), m_parser_scope_stack(pss), m_pos(pos) {}
 };
 
-typedef std::vector<snapshot> snapshot_vector;
+typedef std::vector<std::shared_ptr<snapshot const>> snapshot_vector;
 
 class show_goal_exception : public std::exception {
 public:
@@ -220,7 +220,7 @@ public:
            module_loader const & import_fn,
            std::istream & strm, std::string const & file_name,
            bool use_exceptions = false,
-           snapshot const * s = nullptr, snapshot_vector * sv = nullptr);
+           std::shared_ptr<snapshot const> const & s = {}, snapshot_vector * sv = nullptr);
     ~parser();
 
     void enable_show_goal(pos_info const & pos);

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -21,11 +21,11 @@ namespace lean {
 
 void module_mgr::mark_out_of_date(module_id const & id, buffer<module_id> & to_rebuild) {
     for (auto & mod : m_modules) {
-        if (mod.second.m_out_of_date) continue;
-        for (auto & dep : mod.second.m_deps) {
+        if (mod.second->m_out_of_date) continue;
+        for (auto & dep : mod.second->m_deps) {
             if (dep.first == id) {
                 to_rebuild.push_back(mod.first);
-                mod.second.m_out_of_date = true;
+                mod.second->m_out_of_date = true;
                 mark_out_of_date(mod.first, to_rebuild);
                 break;
             }
@@ -38,12 +38,12 @@ class parse_lean_task : public task<module_info::parse_result> {
     std::string m_contents;
     snapshot_vector m_snapshots;
     bool m_use_snapshots;
-    std::vector<std::tuple<module_id, module_name, module_info>> m_deps;
+    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> m_deps;
 
 public:
     parse_lean_task(std::string const & contents, environment const & initial_env,
                     snapshot_vector const & snapshots, bool use_snapshots,
-                    std::vector<std::tuple<module_id, module_name, module_info>> const & deps) :
+                    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> const & deps) :
         m_initial_env(initial_env), m_contents(contents),
         m_snapshots(snapshots), m_use_snapshots(use_snapshots),
         m_deps(deps) {}
@@ -55,7 +55,7 @@ public:
 
     std::vector<generic_task_result> get_dependencies() override {
         std::vector<generic_task_result> deps;
-        for (auto & d : m_deps) deps.push_back(std::get<2>(d).m_result);
+        for (auto & d : m_deps) deps.push_back(std::get<2>(d)->m_result);
         return deps;
     }
 
@@ -65,12 +65,12 @@ public:
                 if (std::get<0>(d) == base &&
                         std::get<1>(d).m_name == import.m_name &&
                         std::get<1>(d).m_relative == import.m_relative) {
-                    auto mod_info = std::get<2>(d);
+                    auto & mod_info = std::get<2>(d);
 
                     return loaded_module {
-                            mod_info.m_mod,
-                            mod_info.m_result.get().m_obj_code,
-                            mod_info.m_result.get().m_obj_code_delayed_proofs,
+                            mod_info->m_mod,
+                            mod_info->m_result.get().m_obj_code,
+                            mod_info->m_result.get().m_obj_code_delayed_proofs,
                     };
                 }
             }
@@ -87,7 +87,7 @@ public:
 
         module_info::parse_result mod;
 
-        mod.m_snapshots = m_snapshots;
+        mod.m_snapshots = std::move(m_snapshots);
 
         {
             std::ostringstream obj_code_buf(std::ios_base::binary);
@@ -105,21 +105,21 @@ public:
 };
 
 class olean_compilation_task : public task<unit> {
-    module_info m_mod;
+    std::shared_ptr<module_info const> m_mod;
 
 public:
-    olean_compilation_task(module_info const & mod) : m_mod(mod) {}
+    olean_compilation_task(std::shared_ptr<module_info const> const & mod) : m_mod(mod) {}
     task_kind get_kind() const override { return task_kind::parse; }
 
     std::vector<generic_task_result> get_dependencies() override {
-        if (auto res = m_mod.m_result.peek()) {
+        if (auto res = m_mod->m_result.peek()) {
             std::vector<generic_task_result> deps;
             res->m_env->for_each_declaration([&] (declaration const & d) {
                 if (d.is_theorem()) deps.push_back(d.get_value_task());
             });
             return deps;
         } else {
-            return {m_mod.m_result};
+            return {m_mod->m_result};
         }
     }
 
@@ -128,12 +128,12 @@ public:
     }
 
     unit execute() override {
-        if (m_mod.m_source != module_src::LEAN)
+        if (m_mod->m_source != module_src::LEAN)
             throw exception("cannot build olean from olean");
-        auto res = m_mod.m_result.get();
+        auto res = m_mod->m_result.get();
         auto env = *res.m_env;
 
-        auto olean_fn = olean_of_lean(m_mod.m_mod);
+        auto olean_fn = olean_of_lean(m_mod->m_mod);
         exclusive_file_lock output_lock(olean_fn);
         std::ofstream out(olean_fn, std::ios_base::binary);
         export_module(out, env);
@@ -148,7 +148,8 @@ static module_id resolve(module_id const & module_file_name, module_name const &
 }
 
 void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set module_stack) {
-    if (m_modules.count(id) && !m_modules.at(id).m_out_of_date) return;
+    if (auto & existing_mod = m_modules[id])
+        if (!existing_mod->m_out_of_date) return;
 
     auto orig_module_stack = module_stack;
     if (module_stack.contains(id)) {
@@ -164,7 +165,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
     scope_traces_as_messages scope_trace_msgs(id, {1, 0});
 
     try {
-        bool already_have_lean_version = m_modules.count(id) && m_modules.at(id).m_source == module_src::LEAN;
+        bool already_have_lean_version = m_modules[id] && m_modules[id]->m_source == module_src::LEAN;
 
         std::string contents;
         module_src src;
@@ -178,36 +179,35 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             auto olean_fn = olean_of_lean(id);
             auto parsed_olean = parse_olean(in2, olean_fn);
 
-            module_info mod;
+            auto mod = std::make_shared<module_info>();
 
-            mod.m_mod = id;
-            mod.m_source = module_src::OLEAN;
-            mod.m_version = m_current_period;
-            mod.m_trans_mtime = mod.m_mtime = mtime;
+            mod->m_mod = id;
+            mod->m_source = module_src::OLEAN;
+            mod->m_version = m_current_period;
+            mod->m_trans_mtime = mod->m_mtime = mtime;
 
             for (auto & d : parsed_olean.first) {
                 auto d_id = resolve(id, d);
                 build_module(d_id, true, module_stack);
 
-                mod.m_deps.push_back(std::make_pair(d_id, d));
+                mod->m_deps.push_back(std::make_pair(d_id, d));
 
-                auto & d_mod = m_modules.at(d_id);
-                mod.m_trans_mtime = std::max(mod.m_trans_mtime, d_mod.m_trans_mtime);
+                auto & d_mod = m_modules[d_id];
+                mod->m_trans_mtime = std::max(mod->m_trans_mtime, d_mod->m_trans_mtime);
             }
 
-            if (mod.m_trans_mtime > mod.m_mtime)
+            if (mod->m_trans_mtime > mod->m_mtime)
                 return build_module(id, false, orig_module_stack);
 
             module_info::parse_result res;
             res.m_obj_code = obj_code;
             res.m_ok = true;
-            mod.m_result = mk_pure_task_result(res, "Loading " + olean_fn);
+            mod->m_result = mk_pure_task_result(res, "Loading " + olean_fn);
 
             get_global_task_queue().cancel_if(
                     [=] (generic_task * t) {
                         return t->get_version() < m_current_period && t->get_module_id() == id;
                     });
-            if (auto old = m_modules[id].m_result) old.cancel();
             m_modules[id] = mod;
         } else if (src == module_src::LEAN) {
             std::istringstream in(contents);
@@ -228,30 +228,30 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
             auto imports = get_direct_imports(id, contents);
 
-            module_info mod;
-            mod.m_mod = id;
-            mod.m_source = module_src::LEAN;
-            mod.m_trans_mtime = mod.m_mtime = mtime;
+            auto mod = std::make_shared<module_info>();
+            mod->m_mod = id;
+            mod->m_source = module_src::LEAN;
+            mod->m_trans_mtime = mod->m_mtime = mtime;
             for (auto & d : imports) {
                 auto d_id = resolve(id, d);
                 build_module(d_id, true, module_stack);
-                mod.m_deps.push_back({ d_id, d });
-                mod.m_trans_mtime = std::max(mod.m_trans_mtime, m_modules.at(d_id).m_trans_mtime);
+                mod->m_deps.push_back({ d_id, d });
+                mod->m_trans_mtime = std::max(mod->m_trans_mtime, m_modules[d_id]->m_trans_mtime);
             }
             if (m_use_snapshots) {
-                mod.m_lean_contents = optional<std::string>(contents);
-                mod.m_still_valid_snapshots = snapshots;
+                mod->m_lean_contents = optional<std::string>(contents);
+                mod->m_still_valid_snapshots = snapshots;
             }
-            mod.m_version = m_current_period;
+            mod->m_version = m_current_period;
 
             auto deps = gather_transitive_imports(id, imports);
-            mod.m_result = get_global_task_queue().submit<parse_lean_task>(
+            mod->m_result = get_global_task_queue().submit<parse_lean_task>(
                     contents, m_initial_env,
                     snapshots, m_use_snapshots,
                     deps);
 
             if (m_save_olean)
-                mod.m_olean_task = get_global_task_queue().submit<olean_compilation_task>(mod);
+                mod->m_olean_task = get_global_task_queue().submit<olean_compilation_task>(mod);
 
             get_global_task_queue().cancel_if([=] (generic_task * t) {
                 return t->get_version() < m_current_period && t->get_module_id() == id && t->get_pos() >= task_pos;
@@ -264,10 +264,11 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
         message_builder msg(m_initial_env, m_ios, id, pos_info {1, 0}, ERROR);
         msg.set_exception(ex);
         msg.report();
+        throw ex;
     }
 }
 
-module_info module_mgr::get_module(module_id const & id) {
+std::shared_ptr<module_info const> module_mgr::get_module(module_id const & id) {
     unique_lock<mutex> lock(m_mutex);
     name_set module_stack;
     build_module(id, true, module_stack);
@@ -278,8 +279,8 @@ void module_mgr::invalidate(module_id const & id) {
     unique_lock<mutex> lock(m_mutex);
     m_current_period++;
 
-    if (m_modules.count(id)) {
-        m_modules.at(id).m_out_of_date = true;
+    if (auto & mod = m_modules[id]) {
+        mod->m_out_of_date = true;
 
         buffer<module_id> to_rebuild;
         mark_out_of_date(id, to_rebuild);
@@ -305,36 +306,35 @@ static optional<pos_info> get_first_diff_pos(std::string const & a, std::string 
 }
 
 snapshot_vector module_mgr::get_snapshots(module_id const & id) {
-    return get_module(id).m_result.get().m_snapshots;
+    return get_module(id)->m_result.get().m_snapshots;
 }
 
 bool
 module_mgr::get_snapshots_or_unchanged_module(module_id const &id, std::string const &contents, time_t /* mtime */,
                                               snapshot_vector &vector) {
-    if (!m_modules.count(id)) return false;
+    auto & mod = m_modules[id];
+    if (!mod) return false;
+    if (mod->m_source != module_src::LEAN) return false;
 
-    auto & mod = m_modules.at(id);
-    if (mod.m_source != module_src::LEAN) return false;
-
-    for (auto d : mod.m_deps) {
-        if (m_modules.at(d.first).m_version > mod.m_version) {
-            mod.m_still_valid_snapshots.clear();
+    for (auto d : mod->m_deps) {
+        if (m_modules[d.first]->m_version > mod->m_version) {
+            mod->m_still_valid_snapshots.clear();
             return false;
         }
     }
 
-    if (!mod.m_lean_contents) return false;
+    if (!mod->m_lean_contents) return false;
 
-    if (*mod.m_lean_contents == contents) return true;
+    if (*mod->m_lean_contents == contents) return true;
 
-    if (mod.m_result) {
-        if (auto parse_res = mod.m_result.peek())
-            mod.m_still_valid_snapshots = parse_res->m_snapshots;
+    if (mod->m_result) {
+        if (auto parse_res = mod->m_result.peek())
+            mod->m_still_valid_snapshots = parse_res->m_snapshots;
     }
-    if (mod.m_still_valid_snapshots.empty()) return false;
+    if (mod->m_still_valid_snapshots.empty()) return false;
 
-    if (auto diff_pos = get_first_diff_pos(contents, *mod.m_lean_contents)) {
-        auto & snaps = mod.m_still_valid_snapshots;
+    if (auto diff_pos = get_first_diff_pos(contents, *mod->m_lean_contents)) {
+        auto & snaps = mod->m_still_valid_snapshots;
         auto it = snaps.begin();
         while (it != snaps.end() && it->m_pos < *diff_pos)
             it++;
@@ -357,23 +357,23 @@ std::vector<module_name> module_mgr::get_direct_imports(module_id const & id, st
     return p.get_imports();
 }
 
-void module_mgr::gather_transitive_imports(std::vector<std::tuple<module_id, module_name, module_info>> & res,
+void module_mgr::gather_transitive_imports(std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> & res,
                                            std::unordered_set<module_id> & visited,
                                            module_id const & id,
                                            module_name const & import) {
     auto import_id = resolve(id, import);
-    res.push_back(std::make_tuple(id, import, m_modules.at(import_id)));
+    res.push_back(std::make_tuple(id, import, m_modules[import_id]));
     if (!visited.count(import_id)) {
         visited.insert(import_id);
-        for (auto & d : m_modules.at(import_id).m_deps)
+        for (auto & d : m_modules[import_id]->m_deps)
             gather_transitive_imports(res, visited, import_id, d.second);
     }
 }
 
-std::vector<std::tuple<module_id, module_name, module_info>> module_mgr::gather_transitive_imports(
+std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> module_mgr::gather_transitive_imports(
         module_id const & id, std::vector<module_name> const & imports) {
     std::unordered_set<module_id> visited;
-    std::vector<std::tuple<module_id, module_name, module_info>> res;
+    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> res;
     for (auto & i : imports) gather_transitive_imports(res, visited, id, i);
     return res;
 }

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -81,7 +81,7 @@ public:
         std::istringstream in(m_contents);
         parser p(m_initial_env, get_global_ios(), import_fn, in, get_module_id(),
                  use_exceptions,
-                 (m_snapshots.empty() || !m_use_snapshots) ? nullptr : &m_snapshots.back(),
+                 (m_snapshots.empty() || !m_use_snapshots) ? std::shared_ptr<snapshot>() : m_snapshots.back(),
                  m_use_snapshots ? &m_snapshots : nullptr);
         bool parsed_ok = p();
 
@@ -221,7 +221,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
                     return;
                 }
             }
-            auto task_pos = snapshots.empty() ? pos_info {1, 0} : snapshots.back().m_pos;
+            auto task_pos = snapshots.empty() ? pos_info {1, 0} : snapshots.back()->m_pos;
             scoped_task_context scope_task_ctx2(id, task_pos);
 
             scope_message_context scope_msg_ctx2(bucket_name);
@@ -336,7 +336,7 @@ module_mgr::get_snapshots_or_unchanged_module(module_id const &id, std::string c
     if (auto diff_pos = get_first_diff_pos(contents, *mod->m_lean_contents)) {
         auto & snaps = mod->m_still_valid_snapshots;
         auto it = snaps.begin();
-        while (it != snaps.end() && it->m_pos < *diff_pos)
+        while (it != snaps.end() && (*it)->m_pos < *diff_pos)
             it++;
         if (it != snaps.begin())
             it--;

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -79,16 +79,16 @@ class module_mgr {
     message_buffer * m_msg_buf;
 
     mutex m_mutex;
-    std::unordered_map<module_id, module_info> m_modules;
+    std::unordered_map<module_id, std::shared_ptr<module_info>> m_modules;
 
     void mark_out_of_date(module_id const & id, buffer<module_id> & to_rebuild);
     void build_module(module_id const & id, bool can_use_olean, name_set module_stack);
     std::vector<module_name> get_direct_imports(module_id const & id, std::string const & contents);
     void gather_transitive_imports(
-        std::vector<std::tuple<module_id, module_name, module_info>> & res,
+        std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> & res,
         std::unordered_set<module_id> & visited,
         module_id const & id, module_name const & import);
-    std::vector<std::tuple<module_id, module_name, module_info>> gather_transitive_imports(
+    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> gather_transitive_imports(
             module_id const & id, std::vector<module_name> const & imports);
     bool get_snapshots_or_unchanged_module(
             module_id const & id, std::string const & contents, time_t mtime, snapshot_vector &vector);
@@ -99,7 +99,7 @@ public:
 
     void invalidate(module_id const & id);
 
-    module_info get_module(module_id const &);
+    std::shared_ptr<module_info const> get_module(module_id const &);
 
     snapshot_vector get_snapshots(module_id const & id);
 

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -467,8 +467,7 @@ int main(int argc, char ** argv) {
             return ok ? 0 : 1;
         }
 
-        std::vector<std::pair<module_id, module_info>> mods;
-        std::vector<std::pair<module_id, task_result<std::string>>> olean_contents;
+        std::vector<std::pair<module_id, std::shared_ptr<module_info const>>> mods;
         for (auto & mod : module_args) {
             auto mod_info = mod_mgr.get_module(mod);
             mods.push_back({mod, mod_info});
@@ -476,8 +475,8 @@ int main(int argc, char ** argv) {
 
         for (auto & mod : mods) {
             try {
-                auto res = mod.second.m_result.get();
-                if (mod.second.m_olean_task) mod.second.m_olean_task.get();
+                auto res = mod.second->m_result.get();
+                if (mod.second->m_olean_task) mod.second->m_olean_task.get();
                 ok = ok && res.m_ok;
             } catch (exception & ex) {
                 ok = false;
@@ -488,12 +487,12 @@ int main(int argc, char ** argv) {
         if (export_txt && !mods.empty()) {
             exclusive_file_lock export_lock(*export_txt);
             std::ofstream out(*export_txt);
-            export_module_as_lowtext(out, *mods.front().second.m_result.get().m_env);
+            export_module_as_lowtext(out, *mods.front().second->m_result.get().m_env);
         }
         if (export_all_txt && !mods.empty()) {
             exclusive_file_lock export_lock(*export_all_txt);
             std::ofstream out(*export_all_txt);
-            export_all_as_lowtext(out, *mods.front().second.m_result.get().m_env);
+            export_all_as_lowtext(out, *mods.front().second->m_result.get().m_env);
         }
         if (doc) {
             exclusive_file_lock export_lock(*doc);

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -151,7 +151,7 @@ json server::handle_check(json const &) {
     }
 
     bool is_ok = false;
-    if (auto res = m_mod_mgr->get_module(m_file_name).m_result.peek()) {
+    if (auto res = m_mod_mgr->get_module(m_file_name)->m_result.peek()) {
         is_ok = res->m_ok;
     }
 
@@ -332,7 +332,7 @@ json server::handle_info(json const & req) {
 
     auto opts = m_ios.get_options();
     auto env = m_initial_env;
-    if (auto mod = m_mod_mgr->get_module(m_file_name).m_result.peek()) {
+    if (auto mod = m_mod_mgr->get_module(m_file_name)->m_result.peek()) {
         if (mod->m_env) env = *mod->m_env;
         if (!mod->m_snapshots.empty()) opts = mod->m_snapshots.back().m_options;
     }

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -33,7 +33,7 @@ class server : public module_vfs {
     std::string m_file_name;
     std::string m_content;
 
-    snapshot const * get_closest_snapshot(unsigned linenum);
+    std::shared_ptr<snapshot const> get_closest_snapshot(unsigned linenum);
 
     json handle_request(json const & req);
 

--- a/tests/lean/attribute_bug1.lean.expected.out
+++ b/tests/lean/attribute_bug1.lean.expected.out
@@ -1,9 +1,9 @@
-attribute_bug1.lean:7:0: error: simplify tactic failed to simplify
+attribute_bug1.lean:7:3: error: simplify tactic failed to simplify
 state:
 n : ℕ
 ⊢ f n = n + 1
 constant fdef : ∀ (n : ℕ), f n = n + 1
-attribute_bug1.lean:19:0: error: simplify tactic failed to simplify
+attribute_bug1.lean:19:3: error: simplify tactic failed to simplify
 state:
 n : ℕ
 ⊢ f n = n + 1

--- a/tests/lean/by_contradiction.lean.expected.out
+++ b/tests/lean/by_contradiction.lean.expected.out
@@ -8,7 +8,7 @@ a_1 : ¬¬a = b,
 H : ¬a = b
 ⊢ false
 -------
-by_contradiction.lean:22:0: error: tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute classical.prop_decidable [instance]' is used all propositions are decidable)
+by_contradiction.lean:22:3: error: tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute classical.prop_decidable [instance]' is used all propositions are decidable)
 state:
 p q : Prop,
 a : ¬¬p

--- a/tests/lean/ctx_error_msgs.lean.expected.out
+++ b/tests/lean/ctx_error_msgs.lean.expected.out
@@ -1,4 +1,4 @@
-ctx_error_msgs.lean:4:0: error: infer type failed, function expected at
+ctx_error_msgs.lean:4:3: error: infer type failed, function expected at
   f a
 term
   f
@@ -7,16 +7,16 @@ has type
 state:
 f a : ℕ
 ⊢ true
-ctx_error_msgs.lean:11:0: error: infer type failed, unknown variable
+ctx_error_msgs.lean:11:3: error: infer type failed, unknown variable
   a
 state:
 ⊢ true
-ctx_error_msgs.lean:18:0: error: infer type failed, incorrect number of universe levels
+ctx_error_msgs.lean:18:3: error: infer type failed, incorrect number of universe levels
   eq
 state:
 a : ℕ
 ⊢ true
-ctx_error_msgs.lean:23:0: error: infer type failed, incorrect number of universe levels
+ctx_error_msgs.lean:23:3: error: infer type failed, incorrect number of universe levels
   eq.{0 0}
 state:
 a : ℕ

--- a/tests/lean/focus_tac.lean.expected.out
+++ b/tests/lean/focus_tac.lean.expected.out
@@ -8,7 +8,7 @@ x : ℕ := ?m_1
 --- inside focus tac ---
 a : ℕ
 ⊢ ℕ
-focus_tac.lean:4:0: error: focus tactic failed, focused goal has not been solved
+focus_tac.lean:4:3: error: focus tactic failed, focused goal has not been solved
 state:
 a : ℕ
 ⊢ ℕ

--- a/tests/lean/format_thunk1.lean.expected.out
+++ b/tests/lean/format_thunk1.lean.expected.out
@@ -1,4 +1,4 @@
-format_thunk1.lean:4:0: error: invalid definev tactic, value has type
+format_thunk1.lean:4:3: error: invalid definev tactic, value has type
   ℕ
 but is expected to have type
   string

--- a/tests/lean/set_attr1.lean.expected.out
+++ b/tests/lean/set_attr1.lean.expected.out
@@ -1,4 +1,4 @@
-set_attr1.lean:14:0: error: tactic failed, there are unsolved goals
+set_attr1.lean:14:3: error: tactic failed, there are unsolved goals
 state:
 n : ℕ
 ⊢ f n = n + 1

--- a/tests/lean/subst_bug.lean.expected.out
+++ b/tests/lean/subst_bug.lean.expected.out
@@ -1,4 +1,4 @@
-subst_bug.lean:4:0: error: tactic failed, there are unsolved goals
+subst_bug.lean:4:3: error: tactic failed, there are unsolved goals
 state:
 b2 : bool
 ⊢ ff && b2 = ff

--- a/tests/lean/tactic_failure.lean.expected.out
+++ b/tests/lean/tactic_failure.lean.expected.out
@@ -1,4 +1,4 @@
-tactic_failure.lean:4:0: error: assumption tactic failed
+tactic_failure.lean:4:3: error: assumption tactic failed
 state:
 A B : Type,
 Hb : B

--- a/tests/lean/unify_tac1.lean.expected.out
+++ b/tests/lean/unify_tac1.lean.expected.out
@@ -1,4 +1,4 @@
-unify_tac1.lean:12:0: error: is_def_eq failed
+unify_tac1.lean:12:3: error: is_def_eq failed
 state:
 A : Type,
 a : A,


### PR DESCRIPTION
This should get rid of most of the copying.