### PR TITLE
fix(library/mt_task_queue): reverse dependencies may already be queued

### DIFF
--- a/src/library/mt_task_queue.cpp
+++ b/src/library/mt_task_queue.cpp
@@ -125,6 +125,7 @@ void mt_task_queue::spawn_worker() {
                                         enqueue(rdep);
                                 }
                                 break;
+                            case task_result_state::QUEUED: break;
                             case task_result_state::FAILED: break;
                             default:
                                 lean_unreachable();


### PR DESCRIPTION
When we check whether the dependencies for a task have already been evaluated and then accordingly move the task from waiting to queued, we do not remove it from the reverse dependency lists it appears in.

This bug was introduced earlier today with the last commit in PR #1206.

(BTW, it's really nice that the "compare & pull request" button on github works again since we are back on the master branch.  It was a chore to switch from master to lean3 every time you made a pull request.)