### PR TITLE
fix(equations_compiler/elim_match): whnf before concluding var is not…

### DIFF
--- a/src/library/equations_compiler/elim_match.cpp
+++ b/src/library/equations_compiler/elim_match.cpp
@@ -431,7 +431,8 @@ struct elim_match_fn {
        \remark It may not be because of dependent pattern matching. */
     bool is_next_var(problem const & P) {
         lean_assert(P.m_var_stack);
-        expr const & x = head(P.m_var_stack);
+        type_context ctx = mk_type_context(P);
+        expr const & x = whnf_constructor(ctx, head(P.m_var_stack));
         return is_local(x);
     }
 

--- a/tests/lean/run/vec_eqns_plus_instead_of_succ.lean
+++ b/tests/lean/run/vec_eqns_plus_instead_of_succ.lean
@@ -1,0 +1,21 @@
+open nat
+
+inductive Vec (X : Type*) : ℕ → Type*
+| nil {} : Vec 0
+| cons   : X → Pi {n : nat}, Vec n → Vec (n + 1)
+
+namespace Vec
+
+def get₁ {A : Type} : Π {n : ℕ}, Vec A (n + 1) → A
+| n (cons x₁ xs) := x₁
+
+def get₂ {A : Type} : Π {n : ℕ}, Vec A (n + 2) → A
+| n (cons x₁ (cons x₂ xs)) := x₂
+
+def get₃ {A : Type} : Π {n : ℕ}, Vec A (n + 3) → A
+| n (cons x₁ (cons x₂ (cons x₃ xs))) := x₃
+
+def get₄ {A : Type} : Π {n : ℕ}, Vec A (n + 4) → A
+| n (cons x₁ (cons x₂ (cons x₃ (cons x₄ xs)))) := x₄
+
+end Vec


### PR DESCRIPTION
… a local

On master, there are situations when the following error is triggered:
https://github.com/leanprover/lean/blob/master/src/library/equations_compiler/elim_match.cpp#L983
when `p` is actually a local, but it was not a local until the `whnf_constructor` right above it.

Here is the example:
```Lean
open nat

inductive Vec (X : Type*) : ℕ → Type*
| nil {} : Vec 0
| cons   : X → Pi {n : nat}, Vec n → Vec (n + 1)

namespace Vec

-- The following two work:
def get₂ {A : Type} : Π {n : ℕ}, Vec A (succ $ succ n) → A
| n (cons x₁ (cons x₂ xs)) := x₂

def get₂a {A : Type} : Π {n : ℕ}, Vec A (n+2) → A
| 0 (cons x₁ (cons x₂ xs)) := x₂
| (n+1) (cons x₁ (cons x₂ xs)) := x₂ 

-- The next three all throw the error mentioned above 
def get₂b {A : Type} : Π {n : ℕ}, Vec A (n+2) → A
| n (cons x₁ (cons x₂ xs)) := x₂

def get₂c {A : Type} : Π {n : ℕ}, Vec A (n+2) → A
| .n (@cons .A x₁ .(n+1) (@cons .A x₂ n xs)) := x₂

def get₂d {A : Type} : Π {n : ℕ}, Vec A (n+2) → A
| .n (@cons .A x₁ (n+1) (@cons .A x₂ .n xs)) := x₂

end Vec
```

Note: this fix is only a possible suggestion. I do not understand the eqn-compiler well enough to know if this is the right fix. 
