### PR TITLE
alternative names in init

### DIFF
--- a/library/init/algebra/group.lean
+++ b/library/init/algebra/group.lean
@@ -59,6 +59,8 @@ monoid.mul_one
 @[simp] lemma mul_left_inv [group α] : ∀ a : α, a⁻¹ * a = 1 :=
 group.mul_left_inv
 
+def inv_mul_self := @mul_left_inv
+
 @[simp] lemma inv_mul_cancel_left [group α] (a b : α) : a⁻¹ * (a * b) = b :=
 by rw [-mul_assoc, mul_left_inv, one_mul]
 
@@ -77,6 +79,8 @@ inv_eq_of_mul_eq_one (mul_left_inv a)
 @[simp] lemma mul_right_inv [group α] (a : α) : a * a⁻¹ = 1 :=
 have a⁻¹⁻¹ * a⁻¹ = 1, by rw mul_left_inv,
 by rwa [inv_inv] at this
+
+def mul_inv_self := @mul_right_inv
 
 lemma inv_inj [group α] {a b : α} (h : a⁻¹ = b⁻¹) : a = b :=
 have a = a⁻¹⁻¹, by simp,
@@ -273,6 +277,11 @@ run_command transport_to_additive `eq_mul_of_mul_inv_eq `eq_add_of_add_neg_eq
 run_command transport_to_additive `eq_mul_of_inv_mul_eq `eq_add_of_neg_add_eq
 run_command transport_to_additive `mul_eq_of_eq_inv_mul `add_eq_of_eq_neg_add
 run_command transport_to_additive `mul_eq_of_eq_mul_inv `add_eq_of_eq_add_neg
+
+def neg_add_self := @add_left_neg
+def add_neg_self := @add_right_neg
+def eq_of_add_eq_add_left := @add_left_cancel
+def eq_of_add_eq_add_right := @add_right_cancel
 
 @[reducible] protected def algebra.sub [add_group α] (a b : α) : α :=
 a + -b

--- a/library/init/algebra/order.lean
+++ b/library/init/algebra/order.lean
@@ -42,11 +42,17 @@ class linear_strong_order_pair (α : Type u) extends strong_order_pair α, linea
 class decidable_linear_order (α : Type u) extends linear_strong_order_pair α :=
 (decidable_lt : decidable_rel lt)
 
+attribute [refl]
 lemma le_refl [weak_order α] : ∀ a : α, a ≤ a :=
 weak_order.le_refl
 
+def le.refl := @le_refl
+
+attribute [trans]
 lemma le_trans [weak_order α] : ∀ {a b c : α}, a ≤ b → b ≤ c → a ≤ c :=
 weak_order.le_trans
+
+def le.trans := @le_trans
 
 lemma le_antisymm [weak_order α] : ∀ {a b : α}, a ≤ b → b ≤ a → a = b :=
 weak_order.le_antisymm
@@ -54,8 +60,11 @@ weak_order.le_antisymm
 lemma le_of_eq [weak_order α] {a b : α} : a = b → a ≤ b :=
 λ h, h ▸ le_refl a
 
+attribute [trans]
 lemma ge_trans [weak_order α] : ∀ {a b c : α}, a ≥ b → b ≥ c → a ≥ c :=
 λ a b c h₁ h₂, le_trans h₂ h₁
+
+def ge.trans := @ge_trans
 
 lemma le_total [linear_weak_order α] : ∀ a b : α, a ≤ b ∨ b ≤ a :=
 linear_weak_order.le_total
@@ -69,11 +78,17 @@ strict_order.lt_irrefl
 lemma gt_irrefl [strict_order α] : ∀ a : α, ¬ a > a :=
 lt_irrefl
 
+attribute [trans]
 lemma lt_trans [strict_order α] : ∀ {a b c : α}, a < b → b < c → a < c :=
 strict_order.lt_trans
 
+def lt.trans := @lt_trans
+
+attribute [trans]
 lemma gt_trans [strict_order α] : ∀ {a b c : α}, a > b → b > c → a > c :=
 λ a b c h₁ h₂, lt_trans h₂ h₁
+
+def gt.trans := @gt_trans
 
 lemma ne_of_lt [strict_order α] {a b : α} (h : a < b) : a ≠ b :=
 λ he, absurd h (he ▸ lt_irrefl a)
@@ -90,15 +105,19 @@ lt_asymm h
 lemma le_of_lt [order_pair α] : ∀ {a b : α}, a < b → a ≤ b :=
 order_pair.le_of_lt
 
+attribute [trans]
 lemma lt_of_lt_of_le [order_pair α] : ∀ {a b c : α}, a < b → b ≤ c → a < c :=
 order_pair.lt_of_lt_of_le
 
+attribute [trans]
 lemma lt_of_le_of_lt [order_pair α] : ∀ {a b c : α}, a ≤ b → b < c → a < c :=
 order_pair.lt_of_le_of_lt
 
+attribute [trans]
 lemma gt_of_gt_of_ge [order_pair α] {a b c : α} (h₁ : a > b) (h₂ : b ≥ c) : a > c :=
 lt_of_le_of_lt h₂ h₁
 
+attribute [trans]
 lemma gt_of_ge_of_gt [order_pair α] {a b c : α} (h₁ : a ≥ b) (h₂ : b > c) : a > c :=
 lt_of_lt_of_le h₂ h₁
 

--- a/library/init/algebra/ring.lean
+++ b/library/init/algebra/ring.lean
@@ -21,8 +21,12 @@ variable {α : Type u}
 lemma left_distrib [distrib α] (a b c : α) : a * (b + c) = a * b + a * c :=
 distrib.left_distrib a b c
 
+def mul_add := @left_distrib
+
 lemma right_distrib [distrib α] (a b c : α) : (a + b) * c = a * c + b * c :=
 distrib.right_distrib a b c
+
+def add_mul := @right_distrib
 
 class mul_zero_class (α : Type u) extends has_mul α, has_zero α :=
 (zero_mul : ∀ a : α, 0 * a = 0)
@@ -141,10 +145,14 @@ calc
    a * (b - c) = a * b + a * -c : left_distrib a b (-c)
            ... = a * b - a * c  : by simp
 
+def mul_sub := @mul_sub_left_distrib
+
 lemma mul_sub_right_distrib [s : ring α] (a b c : α) : (a - b) * c = a * c - b * c :=
 calc
   (a - b) * c = a * c  + -b * c : right_distrib a (-b) c
           ... = a * c - b * c   : by simp
+
+def sub_mul := @mul_sub_right_distrib
 
 class comm_ring (α : Type u) extends ring α, comm_semigroup α
 

--- a/library/init/data/nat/basic.lean
+++ b/library/init/data/nat/basic.lean
@@ -79,6 +79,8 @@ lemma zero_le : ∀ (n : ℕ), 0 ≤ n
 lemma zero_lt_succ (n : ℕ) : 0 < succ n :=
 succ_le_succ (zero_le n)
 
+def succ_pos := zero_lt_succ
+
 lemma not_succ_le_zero : ∀ (n : ℕ), succ n ≤ 0 → false
 .
 

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -189,6 +189,8 @@ def lt.step {n m : ℕ} : n < m → n < succ m := less_than.step
 lemma zero_lt_succ_iff_true (n : ℕ) : 0 < succ n ↔ true :=
 iff_true_intro (zero_lt_succ n)
 
+def succ_pos_iff_true := zero_lt_succ_iff_true
+
 protected lemma lt_trans {n m k : ℕ} (h₁ : n < m) : m < k → n < k :=
 nat.le_trans (less_than.step h₁)
 
@@ -274,10 +276,10 @@ lemma le_add_right : ∀ (n k : ℕ), n ≤ n + k
 lemma le_add_left (n m : ℕ): n ≤ m + n :=
 nat.add_comm n m ▸ le_add_right n m
 
-lemma le.elim : ∀ {n m : ℕ}, n ≤ m → ∃ k, n + k = m
+lemma le.dest : ∀ {n m : ℕ}, n ≤ m → ∃ k, n + k = m
 | n .n        (less_than.refl .n)  := ⟨0, rfl⟩
 | n .(succ m) (@less_than.step .n m h) :=
-  match le.elim h with
+  match le.dest h with
   | ⟨w, hw⟩ := ⟨succ w, hw ▸ add_succ n w⟩
   end
 
@@ -285,7 +287,7 @@ lemma le.intro {n m k : ℕ} (h : n + k = m) : n ≤ m :=
 h ▸ le_add_right n k
 
 protected lemma add_le_add_left {n m : ℕ} (h : n ≤ m) (k : ℕ) : k + n ≤ k + m :=
-match le.elim h with
+match le.dest h with
 | ⟨w, hw⟩ := @le.intro _ _ w begin rw [nat.add_assoc, hw] end
 end
 
@@ -293,7 +295,7 @@ protected lemma add_le_add_right {n m : ℕ} (h : n ≤ m) (k : ℕ) : n + k ≤
 begin rw [nat.add_comm n k, nat.add_comm m k], apply nat.add_le_add_left h end
 
 protected lemma le_of_add_le_add_left {k n m : ℕ} (h : k + n ≤ k + m) : n ≤ m :=
-match le.elim h with
+match le.dest h with
 | ⟨w, hw⟩ := @le.intro _ _ w
   begin
     dsimp at hw,
@@ -336,7 +338,7 @@ protected lemma le_iff_lt_or_eq (m n : ℕ) : m ≤ n ↔ m < n ∨ m = n :=
 iff.intro nat.lt_or_eq_of_le nat.le_of_lt_or_eq
 
 lemma mul_le_mul_left {n m : ℕ} (k : ℕ) (h : n ≤ m) : k * n ≤ k * m :=
-match le.elim h with
+match le.dest h with
 | ⟨l, hl⟩ :=
   have k * n + k * l = k * m, by rw [-left_distrib, hl],
   le.intro this

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -202,8 +202,12 @@ iff_false_intro (λ h, absurd h (nat.lt_irrefl n))
 
 lemma self_lt_succ (n : ℕ) : n < succ n := nat.le_refl (succ n)
 
+def lt_succ_self := @self_lt_succ
+
 lemma self_lt_succ_iff_true (n : ℕ) : n < succ n ↔ true :=
 iff_true_intro (self_lt_succ n)
+
+def lt_succ_self_iff_true := @self_lt_succ_iff_true
 
 def lt.base (n : ℕ) : n < succ n := nat.le_refl (succ n)
 

--- a/library/init/data/set.lean
+++ b/library/init/data/set.lean
@@ -22,7 +22,7 @@ instance : has_mem α set :=
 ⟨set.mem⟩
 
 protected def subset (s₁ s₂ : set α) :=
-∀ {a}, a ∈ s₁ → a ∈ s₂
+∀ ⦃a⦄, a ∈ s₁ → a ∈ s₂
 
 instance : has_subset (set α) :=
 ⟨set.subset⟩

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -219,6 +219,8 @@ and.rec h₂ h₁
 lemma and.swap : a ∧ b → b ∧ a :=
 assume ⟨ha, hb⟩, ⟨hb, ha⟩
 
+def and.symm := @and.swap
+
 /- or -/
 
 notation a \/ b := or a b
@@ -235,7 +237,11 @@ assume not_em : ¬(a ∨ ¬a),
     assume pos_a : a, absurd (or.inl pos_a) not_em,
   absurd (or.inr neg_a) not_em
 
+def not_not_em := non_contradictory_em
+
 lemma or.swap : a ∨ b → b ∨ a := or.rec or.inr or.inl
+
+def or.symm := @or.swap
 
 /- xor -/
 def xor (a b : Prop) := (a ∧ ¬ b) ∨ (b ∧ ¬ a)
@@ -307,6 +313,8 @@ iff.intro
   (λ (hl : ¬¬¬a) (ha : a), hl (non_contradictory_intro ha))
   absurd
 
+def not_not_not_iff := not_non_contradictory_iff_absurd
+
 lemma imp_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a → b) ↔ (c → d) :=
 iff.intro
   (λ hab hc, iff.mp h₂ (hab (iff.mpr h₁ hc)))
@@ -334,6 +342,8 @@ lemma not_of_not_not_not (h : ¬¬¬a) : ¬a :=
 
 @[simp] lemma not_true : (¬ true) ↔ false :=
 iff_false_intro (not_not_intro trivial)
+
+def not_true_iff := not_true
 
 @[simp] lemma not_false_iff : (¬ false) ↔ true :=
 iff_true_intro not_false
@@ -373,6 +383,8 @@ assume h, iff.mp h trivial
 lemma and.imp (hac : a → c) (hbd : b → d) : a ∧ b → c ∧ d :=
 assume ⟨ha, hb⟩, ⟨hac ha, hbd hb⟩
 
+def and_implies := @and.imp
+
 @[congr] lemma and_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ∧ b) ↔ (c ∧ d) :=
 iff.intro (and.imp (iff.mp h₁) (iff.mp h₂)) (and.imp (iff.mpr h₁) (iff.mpr h₂))
 
@@ -384,10 +396,14 @@ iff.intro
 @[simp] lemma and.comm : a ∧ b ↔ b ∧ a :=
 iff.intro and.swap and.swap
 
+lemma and_comm (a b : Prop) : a ∧ b ↔ b ∧ a := and.comm
+
 @[simp] lemma and.assoc : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) :=
 iff.intro
   (assume ⟨⟨ha, hb⟩, hc⟩, ⟨ha, ⟨hb, hc⟩⟩)
   (assume ⟨ha, ⟨hb, hc⟩⟩, ⟨⟨ha, hb⟩, hc⟩)
+
+lemma and_assoc (a b : Prop) : (a ∧ b) ∧ c ↔ a ∧ (b ∧ c) := and.assoc
 
 @[simp] lemma and.left_comm : a ∧ (b ∧ c) ↔ b ∧ (a ∧ c) :=
 iff.trans (iff.symm and.assoc) (iff.trans (and_congr and.comm (iff.refl c)) and.assoc)
@@ -435,10 +451,15 @@ iff.intro (or.imp (iff.mp h₁) (iff.mp h₂)) (or.imp (iff.mpr h₁) (iff.mpr h
 
 @[simp] lemma or.comm : a ∨ b ↔ b ∨ a := iff.intro or.swap or.swap
 
+lemma or_comm (a b : Prop) : a ∨ b ↔ b ∨ a := or.comm
+
 @[simp] lemma or.assoc : (a ∨ b) ∨ c ↔ a ∨ (b ∨ c) :=
 iff.intro
   (or.rec (or.imp_right or.inl) (λ h, or.inr (or.inr h)))
   (or.rec (λ h, or.inl (or.inl h)) (or.imp_left or.inr))
+
+lemma or_assoc (a b : Prop) : (a ∨ b) ∨ c ↔ a ∨ (b ∨ c) :=
+or.assoc
 
 @[simp] lemma or.left_comm : a ∨ (b ∨ c) ↔ b ∨ (a ∨ c) :=
 iff.trans (iff.symm or.assoc) (iff.trans (or_congr or.comm (iff.refl c)) or.assoc)

--- a/tests/lean/bad_error2.lean
+++ b/tests/lean/bad_error2.lean
@@ -1,7 +1,7 @@
 open nat
 
 example {k n m : ℕ} (h : k + n ≤ k + m) : n ≤ m :=
-match le.elim h with
+match le.dest h with
 | ⟨w, hw⟩ := @le.intro _ _ w
     begin
       -- in the following error pp.beta is automatically disabled


### PR DESCRIPTION
These are mostly some alternative / better names for some basic facts in init.

When I ran tests, `thread_test` failed. Please let me know if I should worry about that.

The main README file still links to standard.md, which we used in Lean 2 to document the library. Do we want to maintain that file or delete it? (If we are still unsure, I can just leave it alone for now.)

There is also a link to a file describing library conventions. I will update that soon.