### PR TITLE
fix(tactic/dsimplify.cpp): must whnf in post to be idempotent

### DIFF
--- a/src/library/tactic/dsimplify.cpp
+++ b/src/library/tactic/dsimplify.cpp
@@ -205,7 +205,11 @@ optional<pair<expr, bool>> dsimplify_fn::pre(expr const & e) {
 }
 
 optional<pair<expr, bool>> dsimplify_fn::post(expr const & e) {
-    expr curr_e = e;
+    expr curr_e;
+    {
+        type_context::transparency_scope s(m_ctx, transparency_mode::Reducible);
+        curr_e = m_ctx.whnf(e);
+    }
     while (true) {
         check_system("dsimplify");
         inc_num_steps();

--- a/tests/lean/dsimp_whnf_post.lean
+++ b/tests/lean/dsimp_whnf_post.lean
@@ -1,0 +1,6 @@
+structure Foo := (foo : unit)
+
+def my_foo : Foo := Foo.mk ()
+@[simp] lemma my_foo.def : my_foo = Foo.mk () := rfl
+
+example : Foo.foo my_foo = () := by dsimp

--- a/tests/lean/dsimp_whnf_post.lean.expected.out
+++ b/tests/lean/dsimp_whnf_post.lean.expected.out
@@ -1,0 +1,3 @@
+dsimp_whnf_post.lean:6:36: error: tactic failed, there are unsolved goals
+state:
+⊢ () = ()


### PR DESCRIPTION
On master, the test file leaves the following state:
```Lean
Foo.foo (Foo.mk ()) = ()
```
`whnf` is called during `pre` and then the subterm is simplified but no `refl_lemma` fires during `post` and so the term is not revisited even though `whnf` can make progress. `dsimp` would need to be called twice to complete the simplification.