### PR TITLE
Single-threaded build fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ matrix:
        TESTCOV=ON
 
    - os: linux
+     addons: *gcc6_addons
+     env:
+       CMAKE_CXX_COMPILER=g++-6
+       CMAKE_BUILD_TYPE=Release
+       MULTI_THREAD=OFF
+
+   - os: linux
      env:
        CMAKE_CXX_COMPILER=clang++-3.4
        CMAKE_BUILD_TYPE=Debug
@@ -81,7 +88,15 @@ script:
   - cd build
   - if [[ $TESTCOV != ON ]]; then TESTCOV=OFF; fi
   - if [[ $TCMALLOC != ON ]]; then TCMALLOC=OFF; fi
-  - cmake -DCONSERVE_MEMORY=${CONSERVE_MEMORY} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DTESTCOV=${TESTCOV} -DTCMALLOC=${TCMALLOC} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ../src
+  - if [[ $MULTI_THREAD != OFF ]]; then MULTI_THREAD=ON; fi
+  - if [[ $CONSERVE_MEMORY != ON ]]; then CONSERVE_MEMORY=OFF; fi
+  - cmake -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+          -DCMAKE_CXX_COMPILER=$CMAKE_CXX_COMPILER
+          -DCONSERVE_MEMORY=$CONSERVE_MEMORY
+          -DTESTCOV=$TESTCOV
+          -DTCMALLOC=$TCMALLOC
+          -DMULTI_THREAD=$MULTI_THREAD
+          ../src
   - make -j2
   # TODO(gabriel): add smaller test subset for debug and emscripten builds
   - if [[ $CMAKE_BUILD_TYPE == Release ]]; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ endif()
 
 if(NOT MULTI_THREAD)
   message(STATUS "Disabled multi-thread support, it will not be safe to run multiple threads in parallel")
+  set(AUTO_THREAD_FINALIZATION OFF)
 else()
   set(LEAN_EXTRA_CXX_FLAGS "${LEAN_EXTRA_CXX_FLAGS} -D LEAN_MULTI_THREAD")
 endif()

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -6,10 +6,16 @@ Author: Leonardo de Moura
 */
 #pragma once
 #include <iostream>
+#include <chrono>
+#include <functional>
 
 #ifndef LEAN_STACK_BUFFER_SPACE
 #define LEAN_STACK_BUFFER_SPACE 128*1024  // 128 Kb
 #endif
+
+namespace lean {
+namespace chrono = std::chrono;
+};
 
 #if defined(LEAN_MULTI_THREAD)
 #include <thread>
@@ -17,10 +23,8 @@ Author: Leonardo de Moura
 #include <atomic>
 #include <condition_variable>
 #define LEAN_THREAD_LOCAL thread_local
-#include <chrono>
 
 namespace lean {
-namespace chrono = std::chrono;
 using std::thread;
 using std::mutex;
 using std::recursive_mutex;
@@ -61,10 +65,8 @@ public:
 // NO MULTI THREADING SUPPORT
 #include <utility>
 #include <cstdlib>
-#include <chrono> // NOLINT
 #define LEAN_THREAD_LOCAL
 namespace lean {
-namespace chrono = std::chrono;
 constexpr int memory_order_relaxed = 0;
 constexpr int memory_order_release = 0;
 constexpr int memory_order_acquire = 0;


### PR DESCRIPTION
* The single-threaded build is broken once again right now, so I've added a travis configuration to test it.
* Since we no longer need a boost-specific version of chrono, I've moved the chrono import out of ifdef in thread.h, which now unconditionally aliases chrono to std::chrono.  Should we just drop the wrapper and use std::chrono everywhere?
* If I disable multi-threading but keep automatic thread finalization enabled then I get errors, so the cmake file now disables automatic thread finalization in single-threaded builds.