### PR TITLE
Various shell fixes.

### DIFF
--- a/src/library/mt_task_queue.cpp
+++ b/src/library/mt_task_queue.cpp
@@ -313,6 +313,11 @@ void mt_task_queue::cancel(generic_task_result const & t) {
     cancel_core(t);
 }
 
+void mt_task_queue::join() {
+    unique_lock<mutex> lock(m_mutex);
+    m_queue_removed.wait(lock, [=] { return empty_core(); });
+}
+
 bool mt_task_queue::empty_core() {
     for (auto & w : m_workers) {
         if (w->m_current_task)

--- a/src/library/mt_task_queue.h
+++ b/src/library/mt_task_queue.h
@@ -67,6 +67,7 @@ public:
     ~mt_task_queue();
 
     optional<generic_task_result> get_current_task() override;
+    void join() override;
     bool empty() override;
 
     void wait(generic_task_result const & t) override;

--- a/src/library/st_task_queue.cpp
+++ b/src/library/st_task_queue.cpp
@@ -15,6 +15,8 @@ void st_task_queue::wait(generic_task_result const & t) {
         std::rethrow_exception(t->m_ex);
 }
 
+void st_task_queue::join() {}
+
 bool st_task_queue::empty() {
     return true;
 }

--- a/src/library/st_task_queue.h
+++ b/src/library/st_task_queue.h
@@ -19,6 +19,7 @@ public:
 
     optional<generic_task_result> get_current_task() override;
     bool empty() override;
+    void join() override;
     void wait(generic_task_result const & t) override;
     void cancel(generic_task_result const & t) override;
 

--- a/src/library/task_queue.h
+++ b/src/library/task_queue.h
@@ -235,6 +235,7 @@ public:
 
     virtual optional<generic_task_result> get_current_task() = 0;
     virtual bool empty() = 0;
+    virtual void join() = 0;
 
     template <typename T, typename... As>
     task_result<typename T::result> submit(As... args) {

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -476,14 +476,15 @@ int main(int argc, char ** argv) {
             mods.push_back({mod, mod_info});
         }
 
+        tq->join();
+
         for (auto & mod : mods) {
             try {
                 auto res = mod.second->m_result.get();
-                if (mod.second->m_olean_task) mod.second->m_olean_task.get();
                 ok = ok && res.m_ok;
             } catch (exception & ex) {
                 ok = false;
-                message_builder(env, ios, mod.first, {1, 0}, ERROR).set_exception(ex).report();
+                // exception has already been reported
             }
         }
 

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -136,7 +136,7 @@ static struct option g_long_options[] = {
 };
 
 static char const * g_opt_str =
-    "PdD:qpgvht:012E:AB:j:012rM:012"
+    "PdD:qpgvht:012E:A:B:j:012rM:012"
 #if defined(LEAN_MULTI_THREAD)
     "s:012"
 #endif


### PR DESCRIPTION
As reported by @jroesch on slack, if you called the lean executable on a
non-existing file, it aborted with a file_not_found_exception.  This happened
because we called lrealpath outside the try-catch block in `shell.cpp`.