### PR TITLE
[RFC] New lean server protocol

### DIFF
--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -82,7 +82,7 @@ class module_mgr {
     mutex m_mutex;
     std::unordered_map<module_id, std::shared_ptr<module_info>> m_modules;
 
-    void mark_out_of_date(module_id const & id);
+    void mark_out_of_date(module_id const & id, buffer<module_id> & to_rebuild);
     void build_module(module_id const & id, bool can_use_olean, name_set module_stack);
     std::vector<module_name> get_direct_imports(module_id const & id, std::string const & contents);
     void gather_transitive_imports(


### PR DESCRIPTION
I have spent the day on drafting a prototype for the new lean server protocol
as discussed in issue #1197.  The implementation works, and you can try it out.
I would appreciate if someone with emacs 24 could see whether it works, I'm
almost certain I used some 25-only features.

To do (aka what's missing from #1197):
* *No indication whether lean is still running, or what it is working on.*
* Opening a file most likely recompiles all its reverse dependencies even if you don't change anything.
* No information about currently visible files is exchanged.
* Unloading single files is not supported.
* No debugger interface.

### Short overview of server protocol

It looks almost like before, with two main differences: 1) commands that return
responses such as info or complete now take an additional `seq_num` parameter,
which is a sequentially increasing number maintained by the client.  2)
Messages are no longer returned on check, but in separate unsolicited messages.

Example exchange:
```
18:37:08.976 -- server<= {"seq_num":0,"command":"sync","file_name":"/home/gebner/scratch7.lean","content":"example : true := ⟨⟩"}
18:37:09.025 -- server=> {"message":"file invalidated","response":"ok","seq_num":0}

18:37:15.954 -- server<= {"seq_num":1,"command":"info","file_name":"/home/gebner/scratch7.lean","line":1,"column":10}
18:37:15.965 -- server=> {"record":{"full-id":"true","source":{"column":10,"file":"/home/gebner/lean/library/init/core.lean","line":90},"type":"Prop"},"response":"ok","seq_num":1}
...
18:37:24.389 -- server<= {"seq_num":3,"command":"sync","file_name":"/home/gebner/scratch7.lean","content":"example : tre := ⟨⟩"}
18:37:24.407 -- server=> {"message":"file invalidated","response":"ok","seq_num":3}

18:37:24.622 -- server=> {"msg":{"caption":"","file_name":"/home/gebner/scratch7.lean","pos_col":10,"pos_line":1,"severity":"error","text":"unknown identifier 'tre'"},"response":"additional_message"}
```

Note that each command sent by the client carries a sequence number, which is
returned by the server with the corresponding response.  The last response does
not correspond to a request, it transports an error message.

Possible requests/commands (all of them have mandatory `command` and `seq_num` fields):
* `sync` (parameters `file_name`, `content`): informs the server about file contents
* `info` (parameters `file_name`, `line`, `column`): request information about the thing at the given position
* `complete` (parameters `file_name`, `line`, `column`): request auto-completion choices at the given position

Possible responses (the kind is indicated in the `response` field):
* `ok` (has `seq_num`): result of a successful request
* `error` (has `message`): error
  * can have an optional `seq_num` field if the error is related to a request
* `additional_message` (has `msg` field containing a single message)
* `all_messages` (has `msgs` field containing an array of messages)

In the spirit of "never transfer changes, always transfer the whole file", the
protocol does not support deleting messages in any fancy way.  If a message
should no longer be shown, you have to send an `all_messages` response
containing the now valid messages.  The `additional_message` response just adds
a single new message; but we could get rid of that.

Project handling is not very sophisticated either: we spawn one lean server per
project.  Invalidation across project boundaries is not supported.  If you
change something in the standard library and want to use it somewhere else,
please restart the lean server.

### Emacs interface

Since we have unsolicited responses from the server, we can no longer use
tq.el, but have to roll our own version with process filters.  No major
problems there.  We store a list of the currently valid messages client-side.
lean-debug-mode is now set globally instead of per-buffer.

On the flycheck side, we now use flycheck only as a dumb error message viewer
(see flycheck/flycheck#774).  We do the change detection ourselves.  200ms
after the last change, we send the contents to the server.  Whenever new
messages arrive, we let flycheck "check" the buffer.  Our flycheck checker only
returns the currently stored messages.  This is the same technique that
`intero-mode` uses as well.