### PR TITLE
fix(tests/shared/thread): fix single-threaded build

### DIFF
--- a/src/tests/shared/thread.cpp
+++ b/src/tests/shared/thread.cpp
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Leonardo de Moura
 */
-#include <thread>
 #include <iostream>
 #include "api/lean.h"
 
@@ -61,6 +60,9 @@ void test_import() {
     lean_ios_del(ios);
 }
 
+#if defined(LEAN_MULTI_THREAD)
+#include <thread>
+
 int main() {
     std::thread t1(test_import);
     std::thread t2(test_import);
@@ -68,3 +70,10 @@ int main() {
     t2.join();
     return 0;
 }
+#else
+int main() {
+    test_import();
+    test_import();
+    return 0;
+}
+#endif


### PR DESCRIPTION
This fixes the current build failure for the single-threaded build.

I have unsuccessfully tried to fix the `shared/thread_test` as well, which fails on both macOS and in the test-coverage build.  But I couldn't reproduce the failure so far.  Here is the relevant error from travis:
```
*** Error in `/home/travis/build/leanprover/lean/build/tests/shared/thread_test': corrupted double-linked list: 0x00000000021bfd20 ***
740/740 Test #739: thread_test .................................................***Exception: Other  1.34 sec
```