### PR TITLE
fix(emacs): update readme

### DIFF
--- a/src/emacs/README.md
+++ b/src/emacs/README.md
@@ -1,140 +1,18 @@
-Emacs mode for [lean theorem prover][Lean]
+This is the emacs mode for the [Lean theorem prover][lean].
 
 [lean]: https://github.com/leanprover/lean
 
+Quick-start
+===========
 
-Requirements
-============
-
-``lean-mode`` requires [Emacs 24][emacs24] and the following
-packages, which can be installed via <kbd>M-x package-install</kbd>.
-
- - [dash][dash]
- - [dash-functional][dash]
- - [f][f]
- - [s][s]
-
-[emacs24]: http://www.gnu.org/software/emacs
-[dash]: https://github.com/magnars/dash.el
-[f]: https://github.com/rejeep/f.el
-[s]: https://github.com/magnars/s.el
-
-The following packages are *optional*, but we recommend installing them
-to use full features of ``lean-mode``.
-
- - [company][company]
- - [flycheck][flycheck]
- - [fill-column-indicator][fci]
-
-Both the optional and required packages will be installed for you
-automatically the first time you use ``lean-mode``, if you follow the
-installation instructions below.
-
-[company]: http://company-mode.github.io/
-[flycheck]: http://www.flycheck.org/manual/latest/index.html
-[fci]: https://github.com/alpaker/Fill-Column-Indicator
-
-Installation
-============
-
-When Emacs is started, it loads startup information from a special
-initialization file, often called an "init file." The init file can be
-found in different places on different systems:
-
-- Emacs will check for a file named ``.emacs`` in your home directory.
-- With GNU Emacs, it is common to use ``.emacs.d/init.el`` instead.
-- With Aquamacs, it is common to use ``~/Library/Preferences/Aquamacs Emacs/Preferences.el``.
-
-On Windows, there are two additional complications:
-
-- It may be hard to figure out what Emacs considers to be your "home
-  directory".
-- The file explorer may not let you create a file named ``.emacs``,
-  since it begins with a period.
-
-One solution is to run Emacs itself and create the file using C-c C-f
-(control-C, control-F) and then entering ``~/.emacs``. (The tilde
-indicates your home directory.) On Windows, you can also name the file
-``_emacs``.
-
-Put the following code in your Emacs init file:
-
-```elisp
-(require 'package)
-(add-to-list 'package-archives '("melpa" . "http://melpa.milkbox.net/packages/") t)
-(when (< emacs-major-version 24)
-  ;; For important compatibility libraries like cl-lib
-  (add-to-list 'package-archives '("gnu" . "http://elpa.gnu.org/packages/")))
-(package-initialize)
-
-;; Install required/optional packages for lean-mode
-(defvar lean-mode-required-packages
-  '(company dash dash-functional flycheck f
-            fill-column-indicator s))
-(let ((need-to-refresh t))
-  (dolist (p lean-mode-required-packages)
-    (when (not (package-installed-p p))
-      (when need-to-refresh
-        (package-refresh-contents)
-        (setq need-to-refresh nil))
-      (package-install p))))
+If you have built lean from source, all that is necessary is to call the
+`leanemacs_build` script which automatically installs all the dependencies and
+opens up emacs with lean-mode loaded:
+```
+~/projects/lean/bin/leanemacs_build
 ```
 
-Then choose your installation method from the following scenarios, and
-add the corresponding code to your init file:
-
-Case 1: Build Lean from source
------------------------------
-
-```elisp
-;; Set up lean-root path
-(setq lean-rootdir "~/projects/lean")  ;; <=== YOU NEED TO MODIFY THIS
-(setq-local lean-emacs-path
-            (concat (file-name-as-directory lean-rootdir)
-                    (file-name-as-directory "src")
-                    "emacs"))
-(add-to-list 'load-path (expand-file-name lean-emacs-path))
-(require 'lean-mode)
-```
-
-Case 2: Install Lean via apt-get on Ubuntu or via dpkg on Debian
-----------------------------------------------------------------
-
-```elisp
-;; Set up lean-root path
-(setq lean-rootdir "/usr")
-(setq-local lean-emacs-path "/usr/share/emacs/site-lisp/lean")
-(add-to-list 'load-path (expand-file-name lean-emacs-path))
-(require 'lean-mode)
-```
-
-
-Case 3: Install Lean via homebrew on OS X
------------------------------------------
-
-```elisp
-;; Set up lean-root path
-(setq lean-rootdir "/usr/local")
-(setq-local lean-emacs-path "/usr/local/share/emacs/site-lisp/lean")
-(add-to-list 'load-path (expand-file-name lean-emacs-path))
-(require 'lean-mode)
-```
-
-Note: if you install homebrew in a custom location that is not the default
-location, please run `brew info lean`, and it will tell you where the
-lean-mode files are located. With that information, update the
-`lean-emacs-path` variable accordingly.
-
-Case 4: Install Lean in Windows
--------------------------------
-```elisp
-;; Set up lean-root path
-(setq lean-rootdir "\\lean-0.2.0-windows")
-(setq-local lean-emacs-path "\\lean-0.2.0-windows\\share\\emacs\\site-lisp\\lean")
-(add-to-list 'load-path (expand-file-name lean-emacs-path))
-(require 'lean-mode)
-```
-
+If you have installed lean from a binary package, you can run `leanemacs`.
 
 Trying It Out
 =============
@@ -146,38 +24,79 @@ check id
 ```
 the word ``check`` will be underlined, and hovering over it will show
 you the type of ``id``. The mode line will show ``FlyC:0/1``, indicating
-that there are no errors and one piece of information displayed. Whenever
-you type, an asterisk should briefly appear after ``FlyC``, indicating that
-your file is being checked.
-
+that there are no errors and one piece of information displayed.
 
 Key Bindings and Commands
 =========================
 
-|Key                | Function                                                                      |
-|-------------------|-------------------------------------------------------------------------------|
-# |<kbd>M-.</kbd>     | jump to definition in source file (lean-find-tag)                             |
-# |<kbd>TAB</kbd>     | tab complete identifier, option, filename, etc. (lean-tab-indent-or-complete) |
-|<kbd>C-c C-k</kbd> | shows the keystroke needed to input the symbol under the cursor               |
-|<kbd>C-c C-g</kbd> | show goal in tactic proof (lean-show-goal-at-pos)                             |
-|<kbd>C-c C-p</kbd> | print information about identifier (lean-show-id-keyword-info)                |
-# |<kbd>C-c C-t</kbd> | show type (lean-show-type)                                                    |
-# |<kbd>C-c C-f</kbd> | replace underscore by inferred value (lean-fill-placeholder)                  |
-|<kbd>C-c C-x</kbd> | execute lean in stand-alone mode (lean-std-exe)                               |
-|<kbd>C-c C-l</kbd> | execute lean in stand-alone mode (lean-std-exe)                               |
-|<kbd>C-c C-o</kbd> | set option (lean-set-option)                                                  |
-|<kbd>C-c C-e</kbd> | evaluate a lean command (lean-eval-cmd)                                       |
-|<kbd>C-c C-n</kbd> | toggle next-error-mode: shows next error in dedicated lean-info buffer        |
-|<kbd>C-c ! n</kbd> | flycheck: go to next error                                                    |
-|<kbd>C-c ! p</kbd> | flycheck: go to previous error                                                |
-|<kbd>C-c ! l</kbd> | flycheck: show list of errors                                                 |
+| Key                | Function                                                                        |
+|--------------------|---------------------------------------------------------------------------------|
+| <kbd>M-.</kbd>     | jump to definition in source file (`lean-find-definition`)                      |
+| <kbd>TAB</kbd>     | tab complete identifier, option, filename, etc. (`lean-tab-indent-or-complete`) |
+| <kbd>C-c C-k</kbd> | shows the keystroke needed to input the symbol under the cursor                 |
+| <kbd>C-c C-g</kbd> | show goal in tactic proof (`lean-show-goal-at-pos`)                             |
+| <kbd>C-c C-x</kbd> | execute lean in stand-alone mode (`lean-std-exe`)                               |
+| <kbd>C-c C-n</kbd> | toggle next-error-mode: shows next error in dedicated lean-info buffer          |
+| <kbd>C-c C-r</kbd> | restart the lean server                                                         |
+| <kbd>C-c ! n</kbd> | flycheck: go to next error                                                      |
+| <kbd>C-c ! p</kbd> | flycheck: go to previous error                                                  |
+| <kbd>C-c ! l</kbd> | flycheck: show list of errors                                                   |
 
-The Flycheck annotation `FlyC:n/n` indicates the number of errors / responses from Lean. An asterisk
-`*FlyC:n/n` indicates that checking is in progress. Clicking on `FlyC` opens the Flycheck menu.
+In the default configuration, the Flycheck annotation `FlyC:n/n` indicates the
+number of errors / responses from Lean; clicking on `FlyC` opens the Flycheck menu.
 
-To profile Lean performace on the file in the buffer, enter <kbd>M-x lean-execute</kbd> or choose 
-`Lean execute` from the Lean menu, and add the option `--profile`.
+Requirements
+============
 
+``lean-mode`` requires [Emacs 24][emacs24] or later and the following
+packages, which can be installed via <kbd>M-x package-install</kbd>:
+[dash][dash], [dash-functional][dash], [f][f], [s][s], [company][company],
+[flycheck][flycheck], and [fill-column-indicator][fci].
+
+[emacs24]: http://www.gnu.org/software/emacs
+[dash]: https://github.com/magnars/dash.el
+[f]: https://github.com/rejeep/f.el
+[s]: https://github.com/magnars/s.el
+[company]: http://company-mode.github.io/
+[flycheck]: http://www.flycheck.org/manual/latest/index.html
+[fci]: https://github.com/alpaker/Fill-Column-Indicator
+
+Installation
+============
+
+You can also include lean-mode permanently in your emacs init file.  In this
+case, just put the following code in your Emacs init file:
+```elisp
+;; You need to modify the following two lines:
+(setq lean-rootdir "~/projects/lean")
+(setq lean-emacs-path "~/projects/lean/src/emacs")
+
+(setq lean-required-packages '(company dash dash-functional f
+                               fill-column-indicator flycheck let-alist s seq))
+
+(require 'package)
+(add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
+(package-initialize)
+(let ((need-to-refresh t))
+  (dolist (p lean-mode-required-packages)
+    (when (not (package-installed-p p))
+      (when need-to-refresh
+        (package-refresh-contents)
+        (setq need-to-refresh nil))
+      (package-install p))))
+
+(setq load-path (cons lean-emacs-path load-path))
+
+(require 'lean-mode)
+```
+
+If you already have the dependencies installed, the following three lines suffice:
+```elisp
+;; You need to modify the following two lines:
+(setq lean-rootdir "~/projects/lean")
+(setq load-path (cons "~/projects/lean/src/emacs" load-path))
+(require 'lean-mode)
+```
 
 Known Issues and Possible Solutions
 ===================================
@@ -219,19 +138,12 @@ comes with an old version of `mmm-mode` (0.4.8, released in 2004) on ArchLinux
 and it caused this problem. Either removing `proofgeneral` or upgrading
 `mmm-mode` to the latest version (0.5.1 as of 2015 Dec) resolves this issue.
 
-
 Contributions
 =============
 
 Contributions are welcome!
 
-If your contribution is a bug fix, create your topic branch from
-`master`. If it is a new feature, check if there exists a
-WIP(work-in-progress) branch (`vMAJOR.MINOR-wip`). If it does, use
-that branch, otherwise use `master`.
-
-Install [Cask](https://github.com/cask/cask) if you haven't already,
-then:
+Install [Cask](https://github.com/cask/cask) if you haven't already, then:
 
     $ cd /path/to/lean/src/emacs
     $ cask

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -86,7 +86,6 @@
   (local-set-key lean-keybinding-std-exe1                  'lean-std-exe)
   (local-set-key lean-keybinding-std-exe2                  'lean-std-exe)
   (local-set-key lean-keybinding-show-key                  'quail-show-key)
-  (local-set-key lean-keybinding-eval-cmd                  'lean-eval-cmd)
   (local-set-key lean-keybinding-server-restart            'lean-server-restart)
   (local-set-key lean-keybinding-find-definition           'lean-find-definition)
   (local-set-key lean-keybinding-tab-indent-or-complete    'lean-tab-indent-or-complete)
@@ -114,12 +113,10 @@
     ["Show goal"            lean-show-goal-at-pos             t]
     ["Show id/keyword info" lean-show-id-keyword-info         t]
     ["Find definition at point" lean-find-definition          t]
-    ["Global tag search"    lean-global-search                t]
     "-----------------"
     ["Run flycheck"         flycheck-compile                  (and lean-flycheck-use flycheck-mode)]
     ["List of errors"       flycheck-list-errors              (and lean-flycheck-use flycheck-mode)]
     "-----------------"
-    ["Clear all cache"      lean-clear-cache                  t]
     ["Restart lean process" lean-server-restart               t]
     "-----------------"
     ("Configuration"
@@ -200,9 +197,6 @@ Invokes `lean-mode-hook'.
   (pcase-dolist (`(,hook . ,fn) lean-hooks-alist)
     (add-hook hook fn nil 'local))
   (lean-mode-setup))
-
-;;; Automatically update TAGS file without asking
-(setq tags-revert-without-query t)
 
 ;; Automatically use lean-mode for .lean files.
 ;;;###autoload

--- a/src/emacs/load-lean.el
+++ b/src/emacs/load-lean.el
@@ -13,13 +13,19 @@
           (create-image (format "%s/lean.pgm" lean-emacs-path))
         (error nil)))
 
-(setq lean-required-packages '(company dash dash-functional f fill-column-indicator flycheck let-alist s seq))
+(setq lean-required-packages '(company dash dash-functional f
+                               fill-column-indicator flycheck let-alist s seq))
 
 (require 'package)
 (add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/"))
 (package-initialize)
-(unless package-archive-contents (package-refresh-contents))
-(dolist (pkg lean-required-packages) (package-install pkg))
+(let ((need-to-refresh t))
+  (dolist (p lean-required-packages)
+    (when (not (package-installed-p p))
+      (when need-to-refresh
+        (package-refresh-contents)
+        (setq need-to-refresh nil))
+      (package-install p))))
 
 (setq load-path (cons lean-emacs-path load-path))
 
@@ -40,8 +46,9 @@
     (insert "\n")
     (insert "\n\nPlease check our website periodically for news of later versions")
     (insert "\nat http://leanprover.github.io")
-    (insert "\n\nBug reports and suggestions for improvement should be posted at\nhttps://github.com/leanprover/lean/issues")
-    (insert "\n\nTo start using Lean, open a .lean or .hlean file")
+    (insert "\n\nBug reports and suggestions for improvement should be posted at")
+    (insert "\nhttps://github.com/leanprover/lean/issues")
+    (insert "\n\nTo start using Lean, open a .lean file")
     (set-buffer-modified-p nil)
     (text-mode)
     (toggle-read-only)


### PR DESCRIPTION
[Rendered](https://github.com/gebner/lean/blob/emacs-readme/src/emacs/README.md).

This PR simplifies and reorders the README.md for the emacs mode as we reference it from the TPIL tutorial, I also removed several commands that no longer exist.

My main philosophy here was to direct users that are new to emacs to the `leanemacs` scripts, so that they don't have to fiddle with init scripts.  The more advanced users have no need for hand-holding, so I cut down the long section about the init file.

@Kha @jroesch What is the current state of emacs dependency installation for local packages?  Is there a cleaner way to do it than `(dolist (p pkgs) (install-package p))`?

@jroesch I see that you have a repo for a Lean spacemacs layer, should we mention it here?

cc @avigad 