### PR TITLE
fix(util/thread): do not initialize thread_finalizers_manager in multiple threads

### DIFF
--- a/src/tests/library/expr_lt.cpp
+++ b/src/tests/library/expr_lt.cpp
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #include "util/test.h"
 #include "kernel/abstract.h"
 #include "library/expr_lt.h"
+#include "util/init_module.h"
 using namespace lean;
 
 static void lt(expr const & e1, expr const & e2, bool expected) {
@@ -33,6 +34,8 @@ static void tst1() {
 
 int main() {
     save_stack_info();
+    initialize_util_module();
     tst1();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/exception.cpp
+++ b/src/tests/util/exception.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include "util/test.h"
 #include "util/exception.h"
 #include "util/sstream.h"
+#include "util/init_module.h"
 using namespace lean;
 
 static void tst1() {
@@ -83,10 +84,12 @@ static void tst5() {
 }
 
 int main() {
+    initialize_util_module();
     tst1();
     tst2();
     tst3();
     tst4();
     tst5();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/interval/double_interval.cpp
+++ b/src/tests/util/interval/double_interval.cpp
@@ -8,6 +8,7 @@ Author: Soonho Kong
 #include "util/numerics/double.h"
 #include "util/interval/interval.h"
 #include "tests/util/interval/check.h"
+#include "util/init_module.h"
 
 using namespace lean;
 
@@ -1030,9 +1031,11 @@ static void double_interval_trans() {
 }
 
 int main() {
+    initialize_util_module();
     double_interval_arith();
     double_interval_inf1();
     double_interval_inf2();
     double_interval_trans();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/interval/float_interval.cpp
+++ b/src/tests/util/interval/float_interval.cpp
@@ -8,6 +8,7 @@ Author: Soonho Kong
 #include "util/numerics/float.h"
 #include "util/interval/interval.h"
 #include "tests/util/interval/check.h"
+#include "util/init_module.h"
 
 using namespace lean;
 
@@ -1030,9 +1031,11 @@ static void float_interval_trans() {
 }
 
 int main() {
+    initialize_util_module();
     float_interval_arith();
     float_interval_inf1();
     float_interval_inf2();
     float_interval_trans();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/interval/mpfp_interval.cpp
+++ b/src/tests/util/interval/mpfp_interval.cpp
@@ -8,6 +8,7 @@ Author: Soonho Kong
 #include "util/numerics/mpfp.h"
 #include "util/interval/interval.h"
 #include "tests/util/interval/check.h"
+#include "util/init_module.h"
 
 using namespace lean;
 
@@ -1030,9 +1031,11 @@ static void mpfp_interval_trans() {
 }
 
 int main() {
+    initialize_util_module();
     mpfp_interval_arith();
     mpfp_interval_inf1();
     mpfp_interval_inf2();
     mpfp_interval_trans();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/list.cpp
+++ b/src/tests/util/list.cpp
@@ -10,6 +10,7 @@ Author: Leonardo de Moura
 #include "util/list.h"
 #include "util/list_fn.h"
 #include "util/timeit.h"
+#include "util/init_module.h"
 using namespace lean;
 
 static void tst1() {
@@ -229,6 +230,7 @@ static void tst18() {
 }
 
 int main() {
+    initialize_util_module();
     tst1();
     tst2();
     tst3();
@@ -247,5 +249,6 @@ int main() {
     tst16();
     tst17();
     tst18();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/numerics/mpbq.cpp
+++ b/src/tests/util/numerics/mpbq.cpp
@@ -10,6 +10,7 @@ Author: Leonardo de Moura
 #include "util/test.h"
 #include "util/numerics/mpbq.h"
 #include "util/numerics/mpq.h"
+#include "util/init_module.h"
 using namespace lean;
 
 static void tst1() {
@@ -242,6 +243,7 @@ static void tst10() {
 }
 
 int main() {
+    initialize_util_module();
     tst1();
     tst2();
     tst3();
@@ -252,5 +254,6 @@ int main() {
     tst8();
     tst9();
     tst10();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/numerics/mpq.cpp
+++ b/src/tests/util/numerics/mpq.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include "util/test.h"
 #include "util/serializer.h"
 #include "util/numerics/mpq.h"
+#include "util/init_module.h"
 using namespace lean;
 
 static void tst0() {
@@ -196,6 +197,7 @@ static void tst7() {
 }
 
 int main() {
+    initialize_util_module();
     tst0();
     tst1();
     tst2();
@@ -204,5 +206,6 @@ int main() {
     tst5();
     tst6();
     tst7();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/rb_map.cpp
+++ b/src/tests/util/rb_map.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include "util/test.h"
 #include "util/rb_map.h"
 #include "util/name.h"
+#include "util/init_module.h"
 using namespace lean;
 typedef rb_map<int, name, int_cmp> int2name;
 
@@ -51,8 +52,10 @@ static void tst2() {
 }
 
 int main() {
+    initialize_util_module();
     tst0();
     tst1();
     tst2();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/rb_tree.cpp
+++ b/src/tests/util/rb_tree.cpp
@@ -15,6 +15,7 @@ Author: Leonardo de Moura
 #include "util/rb_tree.h"
 #include "util/timeit.h"
 #include "util/thread.h"
+#include "util/init_module.h"
 using namespace lean;
 
 // Uncomment for running more comprehensive tests
@@ -251,6 +252,7 @@ static void tst7() {
 }
 
 int main() {
+    initialize_util_module();
     tst1();
     tst2();
     tst3();
@@ -258,5 +260,6 @@ int main() {
     tst5();
     tst6();
     tst7();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/sequence.cpp
+++ b/src/tests/util/sequence.cpp
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 */
 #include "util/sequence.h"
 #include "util/test.h"
+#include "util/init_module.h"
 using namespace lean;
 
 namespace lean {
@@ -33,6 +34,8 @@ static void tst1() {
 }
 
 int main() {
+    initialize_util_module();
     tst1();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/trie.cpp
+++ b/src/tests/util/trie.cpp
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 */
 #include "util/test.h"
 #include "util/trie.h"
+#include "util/init_module.h"
 using namespace lean;
 
 static void tst1() {
@@ -63,7 +64,9 @@ static void tst2() {
 }
 
 int main() {
+    initialize_util_module();
     tst1();
     tst2();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }

--- a/src/tests/util/worker_queue.cpp
+++ b/src/tests/util/worker_queue.cpp
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include <vector>
+#include "util/init_module.h"
 #include "util/test.h"
 #include "util/worker_queue.h"
 using namespace lean;
@@ -20,7 +21,9 @@ static void tst1() {
 }
 
 int main() {
+    initialize_util_module();
     save_stack_info();
     tst1();
+    finalize_util_module();
     return has_violations() ? 1 : 0;
 }


### PR DESCRIPTION
So, I believe this is the reason the `thread_test` fails in the test-coverage and macOS builds.  Or maybe it's just one of the bugs, travis will tell.

The problem was the following: `thread_test` starts two threads, each of which allocates a memory pool, which registers a thread finalizers.  Registering a thread finalizer causes the global variable `g_aux` to be initialized if it is not set yet, which is unsafe if done from multiple threads in parallel.