### PR TITLE
[RFC] Importing modules as a direct operation on environments

### DIFF
--- a/library/data/bitvec.lean
+++ b/library/data/bitvec.lean
@@ -22,7 +22,7 @@ begin unfold bitvec, apply_instance end
 def zero {n : ℕ} : bitvec n := tuple.repeat ff
 
 -- Create a bitvector with the constant one.
-def one {n : ℕ} : bitvec (succ n) := tuple.append (tuple.repeat ff : bitvec n) [ tt ]
+def one {n : ℕ} : bitvec (succ n) := tuple.append (tuple.repeat ff : bitvec n) (tt :: nil)
 
 section shift
 

--- a/library/data/bitvec.lean
+++ b/library/data/bitvec.lean
@@ -22,7 +22,7 @@ begin unfold bitvec, apply_instance end
 def zero {n : ℕ} : bitvec n := tuple.repeat ff
 
 -- Create a bitvector with the constant one.
-def one {n : ℕ} : bitvec (succ n) := tuple.append (tuple.repeat ff : bitvec n) (tt :: nil)
+def one {n : ℕ} : bitvec (succ n) := tuple.append (tuple.repeat ff : bitvec n) [ tt ]
 
 section shift
 

--- a/src/api/module.cpp
+++ b/src/api/module.cpp
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include <string>
+#include <vector>
 #include "util/lean_path.h"
 #include "library/module.h"
 #include "library/util.h"

--- a/src/api/module.cpp
+++ b/src/api/module.cpp
@@ -21,9 +21,11 @@ lean_bool lean_env_import(lean_env env, lean_ios ios, lean_list_name modules, le
     check_nonnull(ios);
     check_nonnull(modules);
     auto new_env = to_env_ref(env);
+    std::vector<module_name> imports;
     for (name const & n : to_list_name_ref(modules)) {
-        new_env = import_module(new_env, "", {n, optional<unsigned>()}, mk_olean_loader());
+        imports.push_back({n, optional<unsigned>()});
     }
+    new_env = import_modules(new_env, "", imports, mk_olean_loader(new_env));
     *r = of_env(new environment(new_env));
     LEAN_CATCH;
 }

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2190,6 +2190,7 @@ void parser::process_imports() {
         (mk_message(m_last_cmd_pos, WARNING) << "imported file uses 'sorry'").report();
 #endif
     }
+    m_env = push_scope(m_env, ios(), scope_kind::Namespace);
     m_imports_parsed = true;
 }
 
@@ -2258,7 +2259,7 @@ bool parser::parse_commands() {
         }
         scope_message_context scope_msg_ctx("end");
         save_snapshot(scope_parser_msgs);
-        m_env = clear_aliases(m_env);
+        m_env = pop_scope(m_env, ios());
         if (has_open_scopes(m_env)) {
             m_found_errors = true;
             if (!m_use_exceptions && m_show_errors)

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -250,19 +250,18 @@ struct notation_config {
 
     static notation_state state_union(notation_state const & a, notation_state const & b) {
         notation_state u;
-        u.m_nud = a.m_nud.merge(b.m_nud, true);
-        u.m_led = a.m_led.merge(b.m_led, true);
+        u.m_nud = b.m_nud.merge(a.m_nud, true);
+        u.m_led = b.m_led.merge(a.m_led, true);
         u.m_num_map = merge(a.m_num_map, b.m_num_map, [] (mpz const &, list<expr> const & es1, list<expr> const & es2) {
             return append(es1, es2); // TODO(gabriel)
         });
         u.m_inv_map = a.m_inv_map;
         b.m_inv_map.for_each([&] (head_index const & i, list<notation_entry> const & es) {
-            for_each(es, [&] (notation_entry const & e) {
+            for (auto & e : reverse(es))
                 u.m_inv_map.insert(i, e); // TODO(gabriel)
-            });
         });
-        u.m_reserved_nud = a.m_reserved_nud.merge(b.m_reserved_nud, true);
-        u.m_reserved_led = a.m_reserved_led.merge(b.m_reserved_led, true);
+        u.m_reserved_nud = b.m_reserved_nud.merge(a.m_reserved_nud, true);
+        u.m_reserved_led = b.m_reserved_led.merge(a.m_reserved_led, true);
         return u;
     }
 

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -82,6 +82,13 @@ struct token_config {
     static name * g_class_name;
     static std::string * g_key;
 
+    static token_state state_union(token_state const & a, token_state const & b) {
+        token_state u;
+        u.m_table = a.m_table;
+        u.m_table.merge(b.m_table);
+        return u;
+    }
+
     static void add_entry(environment const &, io_state const &, state & s, entry const & e) {
         s.m_table = add_token(s.m_table, e.m_token.c_str(), e.m_prec);
     }
@@ -241,6 +248,24 @@ struct notation_config {
     static name * g_class_name;
     static std::string * g_key;
 
+    static notation_state state_union(notation_state const & a, notation_state const & b) {
+        notation_state u;
+        u.m_nud = a.m_nud.merge(b.m_nud, true);
+        u.m_led = a.m_led.merge(b.m_led, true);
+        u.m_num_map = merge(a.m_num_map, b.m_num_map, [] (mpz const &, list<expr> const & es1, list<expr> const & es2) {
+            return append(es1, es2); // TODO(gabriel)
+        });
+        u.m_inv_map = a.m_inv_map;
+        b.m_inv_map.for_each([&] (head_index const & i, list<notation_entry> const & es) {
+            for_each(es, [&] (notation_entry const & e) {
+                u.m_inv_map.insert(i, e); // TODO(gabriel)
+            });
+        });
+        u.m_reserved_nud = a.m_reserved_nud.merge(b.m_reserved_nud, true);
+        u.m_reserved_led = a.m_reserved_led.merge(b.m_reserved_led, true);
+        return u;
+    }
+
     static void updt_inv_map(state & s, head_index const & idx, entry const & e) {
         if (!e.parse_only())
             s.m_inv_map.insert(idx, e);
@@ -369,6 +394,12 @@ struct cmd_ext : public environment_extension {
     cmd_table m_cmds;
     cmd_ext() {
         m_cmds        = get_builtin_cmds();
+    }
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto u = std::make_shared<cmd_ext>();
+        u->m_cmds = merge_prefer_first(static_cast<cmd_ext const &>(ext).m_cmds, m_cmds);
+        return u;
     }
 };
 

--- a/src/frontends/smt2/parser.cpp
+++ b/src/frontends/smt2/parser.cpp
@@ -694,10 +694,10 @@ public:
         scoped_expr_caching disable(false);
         scoped_set_distinguishing_pp_options set(get_distinguishing_pp_options());
 
-        auto mod_ldr = mk_olean_loader();
         optional<unsigned> k;
-        m_env = import_module(m_env, get_stream_name(), {"init", k}, mod_ldr);
-        m_env = import_module(m_env, get_stream_name(), {"smt", k}, mod_ldr);
+        m_env = import_modules(m_env, get_stream_name(),
+                               {{"init", k}, {"smt", k}},
+                               mk_olean_loader(m_env));
 
         bool ok = true;
         try {

--- a/src/kernel/declaration.cpp
+++ b/src/kernel/declaration.cpp
@@ -108,6 +108,22 @@ declaration mk_constant_assumption(name const & n, level_param_names const & par
     return declaration(new declaration::cell(n, params, t, false, trusted));
 }
 
+bool declaration::operator==(declaration const & other) const {
+    if (is_eqp(*this, other)) return true;
+    if (!m_ptr || !other.m_ptr) return false;
+    if (m_ptr->m_theorem != other.m_ptr->m_theorem) return false;
+    if (m_ptr->m_name != other.m_ptr->m_name) return false;
+    if (m_ptr->m_params != other.m_ptr->m_params) return false;
+    if (m_ptr->m_type != other.m_ptr->m_type) return false;
+    if (m_ptr->m_trusted != other.m_ptr->m_trusted) return false;
+    if (m_ptr->m_hints != other.m_ptr->m_hints) return false;
+    if (m_ptr->m_theorem && is_definition()) {
+        return m_ptr->m_proof == other.m_ptr->m_proof || get_value() == other.get_value();
+    } else {
+        return m_ptr->m_value == other.m_ptr->m_value;
+    }
+}
+
 bool use_untrusted(environment const & env, expr const & e) {
     bool found = false;
     for_each(e, [&](expr const & e, unsigned) {

--- a/src/kernel/declaration.h
+++ b/src/kernel/declaration.h
@@ -63,6 +63,11 @@ public:
     kind get_kind() const { return m_kind; }
     bool is_regular() const { return m_kind == Regular; }
     bool use_self_opt() const { return m_self_opt; }
+
+    bool operator==(reducibility_hints const & other) const {
+        return m_kind == other.m_kind && m_height == other.m_height && m_self_opt == other.m_self_opt;
+    }
+    bool operator!=(reducibility_hints const & other) const { return !(*this == other); }
 };
 
 int compare(reducibility_hints const & h1, reducibility_hints const & h2);
@@ -119,6 +124,9 @@ public:
     declaration & operator=(declaration && s);
 
     friend bool is_eqp(declaration const & d1, declaration const & d2) { return d1.m_ptr == d2.m_ptr; }
+
+    bool operator==(declaration const &) const;
+    bool operator!=(declaration const & that) const { return !(*this == that); }
 
     bool is_definition() const;
     bool is_axiom() const;

--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -19,26 +19,6 @@ environment_header::environment_header(unsigned trust_lvl, std::unique_ptr<norma
 
 environment_extension::~environment_extension() {}
 
-struct environment_id::path {
-    atomic<unsigned> m_next_depth;
-    unsigned         m_start_depth;
-    path *           m_prev1;
-    path *           m_prev2;
-    MK_LEAN_RC(); // Declare m_rc counter
-    void dealloc() { delete this; }
-
-    path(unsigned start_depth = 0, path * prev1 = nullptr, path * prev2 = nullptr) :
-            m_next_depth(start_depth + 1), m_start_depth(start_depth),
-            m_prev1(prev1), m_prev2(prev2), m_rc(0) {
-        if (prev1) prev1->inc_ref();
-        if (prev2) prev2->inc_ref();
-    }
-    ~path() {
-        if (m_prev1) m_prev1->dec_ref();
-        if (m_prev2) m_prev2->dec_ref();
-    }
-};
-
 environment_id::environment_id() : m_ptr(new path()), m_depth(0) { m_ptr->inc_ref(); }
 environment_id::environment_id(environment_id const & ancestor, bool) {
     if (ancestor.m_depth == std::numeric_limits<unsigned>::max())

--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -51,13 +51,14 @@ environment_id & environment_id::operator=(environment_id && s) { m_depth = s.m_
 
 bool environment_id::is_ancestor(path const * p, std::unordered_set<path const *> & visited) const {
     while (p != nullptr) {
-        if (!visited.insert(p).second) return false;
         if (p == m_ptr)
             return true;
         if (p->m_start_depth < m_depth)
             return false;
-        if (p->m_prev2 && is_ancestor(p->m_prev2, visited))
-            return true;
+        if (p->m_prev2) {
+            if (!visited.insert(p).second) return false;
+            if (is_ancestor(p->m_prev2, visited)) return true;
+        }
         p = p->m_prev1;
     }
     return false;

--- a/src/kernel/environment.cpp
+++ b/src/kernel/environment.cpp
@@ -30,7 +30,7 @@ environment_id::environment_id(environment_id const & ancestor, bool) {
             .compare_exchange_strong(expected, m_depth + 1)) {
         m_ptr = ancestor.m_ptr;
     } else {
-        m_ptr = new path(m_depth, ancestor.m_ptr);
+        m_ptr = new path(ancestor.m_depth, ancestor.m_ptr);
     }
     m_ptr->inc_ref();
 }

--- a/src/kernel/environment.h
+++ b/src/kernel/environment.h
@@ -57,6 +57,8 @@ public:
 class environment_extension {
 public:
     virtual ~environment_extension();
+
+    virtual std::shared_ptr<environment_extension const> union_with(environment_extension const &) const = 0;
 };
 
 typedef std::vector<std::shared_ptr<environment_extension const>> environment_extensions;
@@ -169,6 +171,8 @@ public:
           - The environment does not contain an axiom named <tt>t.get_declaration().get_name()</tt>
     */
     environment replace(certified_declaration const & t) const;
+
+    environment union_with(environment const &) const;
 
     /**
        \brief Register an environment extension. Every environment

--- a/src/kernel/environment.h
+++ b/src/kernel/environment.h
@@ -8,6 +8,7 @@ Author: Leonardo de Moura
 #include <utility>
 #include <memory>
 #include <vector>
+#include <unordered_set>
 #include "util/rc.h"
 #include "util/optional.h"
 #include "util/list.h"
@@ -72,10 +73,14 @@ class environment_id {
         The bool field is just to make sure this constructor is not confused with a copy constructor
     */
     environment_id(environment_id const & ancestor, bool);
+    environment_id(environment_id const & anc1, environment_id const & anc2);
     /** \brief Create an identifier for an environment without ancestors (e.g., empty environment) */
     environment_id();
     /** Create an identifier for an environment that is a direct descendant of the given one. */
     static environment_id mk_descendant(environment_id const & ancestor) { return environment_id(ancestor, true); }
+    static environment_id mk_descendant(environment_id const & anc1, environment_id const & anc2) { return environment_id(anc1, anc2); }
+
+    bool is_ancestor(path const *, std::unordered_set<path const *> &) const;
 public:
     environment_id(environment_id const & id);
     environment_id(environment_id && id);

--- a/src/kernel/environment.h
+++ b/src/kernel/environment.h
@@ -67,7 +67,27 @@ typedef std::vector<std::shared_ptr<environment_extension const>> environment_ex
 class environment_id {
     friend class environment_id_tester;
     friend class environment; // Only the environment class can create object of this type.
-    struct path;
+
+    struct path {
+        atomic<unsigned> m_next_depth;
+        unsigned         m_start_depth;
+        path *           m_prev1;
+        path *           m_prev2;
+        MK_LEAN_RC(); // Declare m_rc counter
+        void dealloc() { delete this; }
+
+        path(unsigned start_depth = 0, path * prev1 = nullptr, path * prev2 = nullptr) :
+                m_next_depth(start_depth + 1), m_start_depth(start_depth),
+                m_prev1(prev1), m_prev2(prev2), m_rc(0) {
+            if (prev1) prev1->inc_ref();
+            if (prev2) prev2->inc_ref();
+        }
+        ~path() {
+            if (m_prev1) m_prev1->dec_ref();
+            if (m_prev2) m_prev2->dec_ref();
+        }
+    };
+
     path *   m_ptr;
     unsigned m_depth;
     /**

--- a/src/kernel/inductive/inductive.cpp
+++ b/src/kernel/inductive/inductive.cpp
@@ -139,7 +139,15 @@ struct inductive_env_ext : public environment_extension {
     name_map<name>                  m_intro_info;
     name_map<inductive_decl>        m_inductive_info;
 
-    inductive_env_ext() {}
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<inductive_env_ext const &>(ext);
+        auto u = std::make_shared<inductive_env_ext>();
+        u->m_elim_info = merge_prefer_first(m_elim_info, o.m_elim_info);
+        u->m_comp_rules = merge_prefer_first(m_comp_rules, o.m_comp_rules);
+        u->m_intro_info = merge_prefer_first(m_intro_info, o.m_intro_info);
+        u->m_inductive_info = merge_prefer_first(m_inductive_info, o.m_inductive_info);
+        return u;
+    }
 
     void add_elim(name const & n, name const & id_name, level_param_names const & ls,
                   unsigned num_ps, unsigned num_ace, unsigned num_indices, bool is_K_target,

--- a/src/kernel/quotient/quotient.cpp
+++ b/src/kernel/quotient/quotient.cpp
@@ -25,8 +25,11 @@ struct quotient_env_ext : public environment_extension {
     bool m_initialized;
     quotient_env_ext():m_initialized(false){}
 
-    std::shared_ptr<environment_extension const> union_with(environment_extension const &) const override {
-        return std::make_shared<quotient_env_ext>();
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<quotient_env_ext const &>(ext);
+        auto u = std::make_shared<quotient_env_ext>();
+        u->m_initialized = m_initialized || o.m_initialized;
+        return u;
     }
 };
 

--- a/src/kernel/quotient/quotient.cpp
+++ b/src/kernel/quotient/quotient.cpp
@@ -24,6 +24,10 @@ static name * g_quotient_sound = nullptr;
 struct quotient_env_ext : public environment_extension {
     bool m_initialized;
     quotient_env_ext():m_initialized(false){}
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const &) const override {
+        return std::make_shared<quotient_env_ext>();
+    }
 };
 
 /** \brief Auxiliary object for registering the environment extension */

--- a/src/library/aliases.cpp
+++ b/src/library/aliases.cpp
@@ -235,10 +235,6 @@ environment add_aliases(environment const & env, name const & prefix, name const
     return update(env, ext);
 }
 
-environment clear_aliases(environment const & env) {
-    return update(env, aliases_ext());
-}
-
 void for_each_expr_alias(environment const & env, std::function<void(name const &, list<name> const &)> const & fn) {
     aliases_ext ext = get_extension(env);
     ext.for_each_expr_alias(fn);

--- a/src/library/aliases.h
+++ b/src/library/aliases.h
@@ -52,9 +52,6 @@ inline environment overwrite_aliases(environment const & env, name const & prefi
     return add_aliases(env, prefix, new_prefix, 0, nullptr, true);
 }
 
-// TODO(gabriel): just use scopes?
-environment clear_aliases(environment const & env);
-
 bool is_exception(name const & n, name const & prefix, unsigned num_exceptions, name const * exceptions);
 
 void for_each_expr_alias(environment const & env, std::function<void(name const &, list<name> const &)> const & fn);

--- a/src/library/aliases.h
+++ b/src/library/aliases.h
@@ -52,6 +52,9 @@ inline environment overwrite_aliases(environment const & env, name const & prefi
     return add_aliases(env, prefix, new_prefix, 0, nullptr, true);
 }
 
+// TODO(gabriel): just use scopes?
+environment clear_aliases(environment const & env);
+
 bool is_exception(name const & n, name const & prefix, unsigned num_exceptions, name const * exceptions);
 
 void for_each_expr_alias(environment const & env, std::function<void(name const &, list<name> const &)> const & fn);

--- a/src/library/attribute_manager.cpp
+++ b/src/library/attribute_manager.cpp
@@ -106,6 +106,21 @@ struct attr_config {
     typedef attr_state state;
     typedef attr_entry entry;
 
+    static attr_state state_union(attr_state const & a, attr_state const & b) {
+        attr_state u;
+        u = merge(a, b, [] (name const &,
+                            pair<attr_records, unsigned> const & v1,
+                            pair<attr_records, unsigned> const & v2) {
+            attr_records r = v1.first;
+            v2.first.for_each([&] (attr_record const & rec2) {
+                if (!r.contains(rec2))
+                    r.insert(rec2, *v2.first.get_prio(rec2));
+            });
+            return std::make_pair(r, hash(v1.second, v2.second));
+        });
+        return u;
+    }
+
     static unsigned get_entry_hash(entry const & e) {
         return hash(hash(e.m_attr.hash(), e.m_record.hash()), e.m_prio);
     }

--- a/src/library/aux_recursors.cpp
+++ b/src/library/aux_recursors.cpp
@@ -14,6 +14,14 @@ namespace lean {
 struct aux_recursor_ext : public environment_extension {
     name_set m_aux_recursor_set;
     name_set m_no_confusion_set;
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<aux_recursor_ext const &>(ext);
+        auto u = std::make_shared<aux_recursor_ext>();
+        u->m_aux_recursor_set = merge(m_aux_recursor_set, o.m_aux_recursor_set);
+        u->m_no_confusion_set = merge(m_no_confusion_set, o.m_no_confusion_set);
+        return u;
+    }
 };
 
 struct aux_recursor_ext_reg {

--- a/src/library/class.cpp
+++ b/src/library/class.cpp
@@ -84,14 +84,12 @@ struct class_config {
     typedef class_entry entry;
 
     static class_state state_union(class_state const & a, class_state const & b) {
-        class_state u;
-        for (class_state const & x : {a, b}) {
-            x.m_instances.for_each([&](name const & c, list<name> const & is) {
-                u.add_class(c);
-                for (auto & i : reverse(is))
-                    u.add_instance(c, i, x.get_priority(i));
-            });
-        }
+        auto u = a;
+        b.m_instances.for_each([&](name const & c, list<name> const & is) {
+            u.add_class(c);
+            for (auto & i : reverse(is))
+                u.add_instance(c, i, b.get_priority(i));
+        });
         return u;
     }
 

--- a/src/library/documentation.cpp
+++ b/src/library/documentation.cpp
@@ -17,6 +17,14 @@ struct documentation_ext : public environment_extension {
     list<doc_entry>       m_module_doc;
     /** Doc strings for declarations (including imported ones). We store doc_strings for declarations in the .olean files. */
     name_map<std::string> m_doc_string_map;
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<documentation_ext const &>(ext);
+        auto u = std::make_shared<documentation_ext>();
+        // TODO(gabriel): u->m_module_doc
+        u->m_doc_string_map = merge_prefer_first(m_doc_string_map, o.m_doc_string_map);
+        return u;
+    }
 };
 
 struct documentation_ext_reg {

--- a/src/library/fingerprint.cpp
+++ b/src/library/fingerprint.cpp
@@ -12,6 +12,12 @@ namespace lean {
 struct fingerprint_ext : public environment_extension {
     uint64 m_fingerprint;
     fingerprint_ext():m_fingerprint(0) {}
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto u = std::make_shared<fingerprint_ext>();
+        u->m_fingerprint = hash(m_fingerprint, static_cast<fingerprint_ext const &>(ext).m_fingerprint);
+        return u;
+    }
 };
 
 struct fingerprint_ext_reg {

--- a/src/library/inductive_compiler/ginductive.cpp
+++ b/src/library/inductive_compiler/ginductive.cpp
@@ -84,6 +84,19 @@ struct ginductive_env_ext : public environment_extension {
 
     ginductive_env_ext() {}
 
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext_) const override {
+        auto & o = static_cast<ginductive_env_ext const &>(ext_);
+        auto u = std::make_shared<ginductive_env_ext>();
+        u->m_all_nested_inds = append(m_all_nested_inds, o.m_all_nested_inds); // TODO(gabriel)
+        u->m_all_mutual_inds = append(m_all_mutual_inds, o.m_all_mutual_inds); // TODO(gabriel)
+        u->m_ind_to_irs = merge_prefer_first(m_ind_to_irs, o.m_ind_to_irs);
+        u->m_ind_to_mut_inds = merge_prefer_first(m_ind_to_mut_inds, o.m_ind_to_mut_inds);
+        u->m_ind_to_kind = merge_prefer_first(m_ind_to_kind, o.m_ind_to_kind);
+        u->m_num_params = merge_prefer_first(m_num_params, o.m_num_params);
+        u->m_ir_to_ind = merge_prefer_first(m_ir_to_ind, o.m_ir_to_ind);
+        return u;
+    }
+
     void register_ginductive_entry(ginductive_entry const & entry) {
         buffer<list<name> > intro_rules;
         to_buffer(entry.m_intro_rules, intro_rules);

--- a/src/library/inverse.cpp
+++ b/src/library/inverse.cpp
@@ -36,6 +36,12 @@ static std::string * g_key = nullptr;
 struct inverse_config {
     typedef inverse_state state;
     typedef inverse_entry entry;
+    static state state_union(state const & a, state const & b) {
+        state u;
+        u.m_fn_info = merge_prefer_first(a.m_fn_info, b.m_fn_info);
+        u.m_inv_info = merge_prefer_first(a.m_inv_info, b.m_inv_info);
+        return u;
+    }
     static void add_entry(environment const &, io_state const &, state & s, entry const & e) {
         s.add(e);
     }

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -43,15 +43,23 @@ corrupted_file_exception::corrupted_file_exception(std::string const & fname):
 typedef pair<std::string, std::function<void(environment const &, serializer &)>> writer;
 
 struct module_ext : public environment_extension {
-    list<module_name>  m_direct_imports;
+    list<module_name> m_direct_imports;
     list<writer>      m_writers;
     list<name>        m_module_univs;
     list<name>        m_module_decls;
     name_set          m_module_defs;
-    name_set          m_imported;
     // Map from declaration name to olean file where it was defined
     name_map<std::string>     m_decl2olean;
     name_map<pos_info>        m_decl2pos_info;
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<module_ext const &>(ext);
+        auto u = std::make_shared<module_ext>();
+        // TODO(gabriel)
+        u->m_decl2olean = merge_prefer_first(m_decl2olean, o.m_decl2olean);
+        u->m_decl2pos_info = merge_prefer_first(m_decl2pos_info, o.m_decl2pos_info);
+        return u;
+    }
 };
 
 struct module_ext_reg {
@@ -182,25 +190,11 @@ deserializer & operator>>(deserializer & d, module_name & r) {
     return d;
 }
 
-LEAN_THREAD_PTR(std::vector<task_result<expr>>, g_export_delayed_proofs);
-class scoped_delayed_proofs {
-    std::vector<task_result<expr>> * m_old;
-public:
-    scoped_delayed_proofs(std::vector<task_result<expr>> & r) {
-        m_old = g_export_delayed_proofs;
-        g_export_delayed_proofs = &r;
-    }
-    ~scoped_delayed_proofs() {
-        g_export_delayed_proofs = m_old;
-    }
-};
-
 void export_module(std::ostream & out, environment const & env) {
     module_ext const & ext = get_extension(env);
 
     buffer<module_name> imports;
     to_buffer(ext.m_direct_imports, imports);
-    std::reverse(imports.begin(), imports.end());
 
     buffer<writer const *> writers;
     for (writer const & w : ext.m_writers)
@@ -230,13 +224,6 @@ void export_module(std::ostream & out, environment const & env) {
     s2.write_unsigned(r.size());
     for (unsigned i = 0; i < r.size(); i++)
         s2.write_char(r[i]);
-}
-
-std::vector<task_result<expr>> export_module_delayed(std::ostream & out, environment const & env) {
-    std::vector<task_result<expr>> delayed_proofs;
-    scoped_delayed_proofs _(delayed_proofs);
-    export_module(out, env);
-    return delayed_proofs;
 }
 
 typedef std::unordered_map<std::string, module_object_reader> object_readers;
@@ -282,21 +269,10 @@ environment update_module_defs(environment const & env, declaration const & d) {
     }
 }
 
-static declaration theorem2axiom(declaration const & decl) {
-    lean_assert(decl.is_theorem());
-    return mk_axiom(decl.get_name(), decl.get_univ_params(), decl.get_type());
-}
-
 static environment export_decl(environment const & env, declaration const & d) {
     name n = d.get_name();
-    return add(env, *g_decl_key, [=](environment const & env, serializer & s) {
-            auto d = env.get(n);
-            if (g_export_delayed_proofs && d.is_theorem()) {
-                s << true << theorem2axiom(d) << static_cast<unsigned>(g_export_delayed_proofs->size());
-                g_export_delayed_proofs->push_back(d.get_value_task());
-            } else {
-                s << false << d;
-            }
+    return add(env, *g_decl_key, [=](environment const & cur_env, serializer & s) {
+            s << cur_env.get(n);
         });
 }
 
@@ -306,7 +282,9 @@ environment add(environment const & env, certified_declaration const & d) {
     if (!check_computable(new_env, _d.get_name()))
         new_env = mark_noncomputable(new_env, _d.get_name());
     new_env = export_decl(update_module_defs(new_env, _d), _d);
-    return add_decl_pos_info(new_env, _d.get_name());
+    new_env = add_decl_pos_info(new_env, _d.get_name());
+    new_env = add_decl_olean(new_env, _d.get_name(), get_current_module());
+    return new_env;
 }
 
 bool is_definition(environment const & env, name const & n) {
@@ -335,6 +313,7 @@ environment add_inductive(environment                       env,
     ext.m_module_decls = cons(decl.m_name, ext.m_module_decls);
     new_env = update(new_env, ext);
     new_env = add_decl_pos_info(new_env, decl.m_name);
+    new_env = add_decl_olean(new_env, decl.m_name, get_current_module());
     return add(new_env, *g_inductive, [=](environment const &, serializer & s) {
             s << cdecl;
         });
@@ -385,45 +364,32 @@ struct import_helper {
     }
 };
 
-static void import_module(environment & env, std::string const & module_file_name, module_name const & ref,
-                          module_loader const & mod_ldr) {
-    auto res = mod_ldr(module_file_name, ref);
-    if (get_extension(env).m_imported.contains(res.m_module_name)) return;
-    std::istringstream in(res.m_obj_code, std::ios_base::binary);
-    auto olean = parse_olean(in, res.m_module_name, false);
-    for (auto & dep : olean.first) {
-        import_module(env, res.m_module_name, dep, mod_ldr);
+environment import_modules(environment const & env0, std::string const & module_file_name,
+                           std::vector<module_name> const & refs,
+                           module_loader const & mod_ldr) {
+    auto env = env0;
+    for (auto & ref : refs) {
+        auto env_to_import = mod_ldr(module_file_name, ref);
+//        if (!env_to_import.is_descendant(env))
+//            report_message(message(module_file_name, {1,0}, WARNING, "not a zero-cost import: " + ref.m_name.to_string()));
+        env = env.union_with(env_to_import);
     }
     auto ext = get_extension(env);
-    ext.m_imported.insert(res.m_module_name);
+    ext.m_direct_imports = to_list(refs.begin(), refs.end());
+    ext.m_module_decls = {};
+    ext.m_module_defs = {};
+    ext.m_module_univs = {};
+    ext.m_writers = {};
     env = update(env, ext);
-    import_module(olean.second, res.m_module_name, env, res.m_delayed_proofs);
-}
-
-environment import_module(environment const & env0, std::string const & module_file_name,
-                          module_name const & ref,
-                          module_loader const & mod_ldr) {
-    environment env = env0;
-    module_ext ext = get_extension(env);
-    ext.m_direct_imports = cons(ref, ext.m_direct_imports);
-    env = update(env, ext);
-    import_module(env, module_file_name, ref, mod_ldr);
     return env;
 }
 
-static optional<name> import_decl(deserializer & d, environment & env,
-                                  std::vector<task_result<expr>> const & delayed_proofs) {
-    bool is_delayed; d >> is_delayed;
+static optional<name> import_decl(deserializer & d, environment & env) {
     declaration decl = read_declaration(d);
     decl = unfold_untrusted_macros(env, decl);
     if (decl.get_name() == get_sorry_name() && has_sorry(env)) {
         // TODO(gabriel): not sure why this is here
         return optional<name>();
-    }
-    if (is_delayed) {
-        unsigned i; d >> i;
-        auto delayed_proof = delayed_proofs.at(i);
-        decl = mk_theorem(decl.get_name(), decl.get_univ_params(), decl.get_type(), delayed_proof);
     }
     env = import_helper::add_unchecked(env, decl);
     return optional<name>(decl.get_name());
@@ -434,8 +400,7 @@ static void import_universe(deserializer & d, environment & env) {
     env = env.add_universe(l);
 }
 
-void import_module(std::vector<char> const & olean_code, std::string const & file_name, environment & env,
-                   std::vector<task_result<expr>> const & delayed_proofs) {
+void import_module(std::vector<char> const & olean_code, std::string const & file_name, environment & env) {
     // TODO(gabriel): update extension
     std::string s(olean_code.data(), olean_code.size());
     std::istringstream in(s, std::ios_base::binary);
@@ -448,7 +413,7 @@ void import_module(std::vector<char> const & olean_code, std::string const & fil
         if (k == g_olean_end_file) {
             break;
         } else if (k == *g_decl_key) {
-            if (auto decl_name = import_decl(d, env, delayed_proofs))
+            if (auto decl_name = import_decl(d, env))
                 env = add_decl_olean(env, *decl_name, file_name);
         } else if (k == *g_glvl_key) {
             import_universe(d, env);
@@ -467,17 +432,31 @@ void import_module(std::vector<char> const & olean_code, std::string const & fil
     }
 }
 
-module_loader mk_olean_loader() {
-    return[=] (std::string const & module_fn, module_name const & ref) {
+environment import_module(std::istream & in, std::string const & file_name, environment const & env0,
+                          module_loader const & mod_ldr, bool check_hash) {
+    auto parsed = parse_olean(in, file_name, check_hash);
+    auto env = import_modules(env0, file_name, parsed.first, mod_ldr);
+    import_module(parsed.second, file_name, env);
+    return env;
+}
+
+module_loader mk_olean_loader(environment const & env0) {
+    bool check_hash = false;
+    auto cache = std::make_shared<std::unordered_map<std::string, environment>>();
+    module_loader ldr = [=] (std::string const & module_fn, module_name const & ref) {
         auto base_dir = dirname(module_fn.c_str());
         auto fn = find_file(base_dir, ref.m_relative, ref.m_name, ".olean");
-        auto contents = read_file(fn, std::ios_base::binary);
-        return loaded_module { fn, contents, {} };
+        if (!cache->count(fn)) {
+            std::ifstream in(fn, std::ios_base::binary);
+            (*cache)[fn] = import_module(in, fn, env0, ldr, check_hash);
+        }
+        return cache->at(fn);
     };
+    return ldr;
 }
 
 module_loader mk_dummy_loader() {
-    return[=] (std::string const &, module_name const &) -> loaded_module {
+    return[=] (std::string const &, module_name const &) -> environment {
         throw exception("module importing disabled");
     };
 }

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -370,7 +370,7 @@ environment import_modules(environment const & env0, std::string const & module_
     auto env = env0;
     for (auto & ref : refs) {
         auto env_to_import = mod_ldr(module_file_name, ref);
-//        if (!env_to_import.is_descendant(env))
+//        if (!env_to_import.is_descendant(env) && !env.is_descendant(env_to_import))
 //            report_message(message(module_file_name, {1,0}, WARNING, "not a zero-cost import: " + ref.m_name.to_string()));
         env = env.union_with(env_to_import);
     }

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -26,14 +26,8 @@ struct module_name {
     name               m_name;
     optional<unsigned> m_relative;
 };
-
-struct loaded_module {
-    std::string m_module_name;
-    std::string m_obj_code;
-    std::vector<task_result<expr>> m_delayed_proofs;
-};
-using module_loader = std::function<loaded_module(std::string const &, module_name const &)>;
-module_loader mk_olean_loader();
+using module_loader = std::function<environment(std::string const &, module_name const &)>;
+module_loader mk_olean_loader(environment const & env0);
 module_loader mk_dummy_loader();
 
 /** \brief Return the list of declarations performed in the current module */
@@ -51,8 +45,9 @@ list<module_name> get_curr_module_imports(environment const & env);
     checked. The idea is to save memory.
 */
 environment
-import_module(environment const & env,
-              std::string const & current_mod, module_name const & ref,
+import_modules(environment const & env,
+              std::string const & current_mod,
+              std::vector<module_name> const & refs,
               module_loader const & mod_ldr);
 
 /** \brief Return the .olean file where decl_name was defined. The result is none if the declaration
@@ -68,12 +63,13 @@ environment add_transient_decl_pos_info(environment const & env, name const & de
 
 /** \brief Store/Export module using \c env to the output stream \c out. */
 void export_module(std::ostream & out, environment const & env);
-std::vector<task_result<expr>> export_module_delayed(std::ostream & out, environment const & env);
 
 std::pair<std::vector<module_name>, std::vector<char>> parse_olean(
         std::istream & in, std::string const & file_name, bool check_hash = true);
-void import_module(std::vector<char> const & olean_code, std::string const & file_name, environment & env,
-                   std::vector<task_result<expr>> const & delayed_proofs);
+void import_module(std::vector<char> const & olean_code, std::string const & file_name, environment & env);
+environment import_module(std::istream & in, std::string const & file_name,
+                          environment const & env0,
+                          module_loader const & mod_ldr, bool check_hash = true);
 
 /** \brief A reader for importing data from a stream using deserializer \c d.
     There is one way to update the environment being constructed.

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -32,53 +32,77 @@ void module_mgr::mark_out_of_date(module_id const & id, buffer<module_id> & to_r
     }
 }
 
-class parse_lean_task : public task<module_info::parse_result> {
+class parse_task : public task<module_info::parse_result> {
+public:
+    using loaded_deps = std::vector<std::pair<module_name, std::shared_ptr<module_info const>>>;
+
+protected:
     environment m_initial_env;
     std::string m_contents;
+    loaded_deps m_deps;
+
+public:
+    parse_task(std::string const & contents, environment const & initial_env, loaded_deps const & deps) :
+            m_initial_env(initial_env), m_contents(contents), m_deps(deps) {}
+    task_kind get_kind() const override { return task_kind::parse; }
+
+    std::vector<generic_task_result> get_dependencies() override {
+        std::vector<generic_task_result> deps;
+        for (auto & d : m_deps) deps.push_back(d.second->m_result);
+        return deps;
+    }
+
+    module_loader mk_loader() {
+        return[=] (module_id const & base, module_name const & import) {
+            lean_assert(base == get_module_id());
+            for (auto & d : m_deps) {
+                if (d.first.m_name == import.m_name && d.first.m_relative == import.m_relative)
+                    return d.second->m_result.get().m_env;
+            }
+            throw exception(sstream() << "could not resolve import: " << import.m_name);
+        };
+    }
+};
+
+class parse_olean_task : public parse_task {
+public:
+    parse_olean_task(std::string const & contents, environment const & initial_env,
+                     loaded_deps const & deps) :
+        parse_task(contents, initial_env, deps) {}
+
+    void description(std::ostream & out) const override {
+        out << "loading olean for " << get_module_id();
+    }
+
+    module_info::parse_result execute() override {
+        std::istringstream in(m_contents, std::ios_base::binary);
+        module_info::parse_result res;
+        bool check_hash = true;
+        res.m_env = import_module(in, get_module_id(), m_initial_env, mk_loader(), check_hash);
+        res.m_ok = true;
+        return res;
+    }
+};
+
+class parse_lean_task : public parse_task {
     snapshot_vector m_snapshots;
     bool m_use_snapshots;
-    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> m_deps;
 
 public:
     parse_lean_task(std::string const & contents, environment const & initial_env,
                     snapshot_vector const & snapshots, bool use_snapshots,
-                    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> const & deps) :
-        m_initial_env(initial_env), m_contents(contents),
-        m_snapshots(snapshots), m_use_snapshots(use_snapshots),
-        m_deps(deps) {}
-    task_kind get_kind() const override { return task_kind::parse; }
+                    loaded_deps const & deps) :
+        parse_task(contents, initial_env, deps),
+        m_snapshots(snapshots), m_use_snapshots(use_snapshots) {}
 
     void description(std::ostream & out) const override {
         out << "parsing " << get_module_id();
     }
 
-    std::vector<generic_task_result> get_dependencies() override {
-        std::vector<generic_task_result> deps;
-        for (auto & d : m_deps) deps.push_back(std::get<2>(d)->m_result);
-        return deps;
-    }
-
     module_info::parse_result execute() override {
-        module_loader import_fn = [=] (module_id const & base, module_name const & import) {
-            for (auto & d : m_deps) {
-                if (std::get<0>(d) == base &&
-                        std::get<1>(d).m_name == import.m_name &&
-                        std::get<1>(d).m_relative == import.m_relative) {
-                    auto & mod_info = std::get<2>(d);
-
-                    return loaded_module {
-                            mod_info->m_mod,
-                            mod_info->m_result.get().m_obj_code,
-                            mod_info->m_result.get().m_obj_code_delayed_proofs,
-                    };
-                }
-            }
-            throw exception(sstream() << "could not resolve import: " << import.m_name);
-        };
-
         bool use_exceptions = false;
         std::istringstream in(m_contents);
-        parser p(m_initial_env, get_global_ios(), import_fn, in, get_module_id(),
+        parser p(m_initial_env, get_global_ios(), mk_loader(), in, get_module_id(),
                  use_exceptions,
                  (m_snapshots.empty() || !m_use_snapshots) ? std::shared_ptr<snapshot>() : m_snapshots.back(),
                  m_use_snapshots ? &m_snapshots : nullptr);
@@ -88,14 +112,8 @@ public:
 
         mod.m_snapshots = std::move(m_snapshots);
 
-        {
-            std::ostringstream obj_code_buf(std::ios_base::binary);
-            mod.m_obj_code_delayed_proofs =
-                    export_module_delayed(obj_code_buf, p.env());
-            mod.m_obj_code = obj_code_buf.str();
-        }
-
-        mod.m_env = optional<environment>(p.env());
+        mod.m_env = p.env();
+        lean_assert(p.env().is_descendant(m_initial_env));
 
         mod.m_opts = p.ios().get_options();
 
@@ -115,7 +133,7 @@ public:
     std::vector<generic_task_result> get_dependencies() override {
         if (auto res = m_mod->m_result.peek()) {
             std::vector<generic_task_result> deps;
-            res->m_env->for_each_declaration([&] (declaration const & d) {
+            res->m_env.for_each_declaration([&] (declaration const & d) {
                 if (d.is_theorem()) deps.push_back(d.get_value_task());
             });
             return deps;
@@ -132,7 +150,7 @@ public:
         if (m_mod->m_source != module_src::LEAN)
             throw exception("cannot build olean from olean");
         auto res = m_mod->m_result.get();
-        auto env = *res.m_env;
+        auto env = res.m_env;
 
         if (!res.m_ok)
             throw exception("not creating olean file because of errors");
@@ -181,7 +199,8 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
             std::istringstream in2(obj_code, std::ios_base::binary);
             auto olean_fn = olean_of_lean(id);
-            auto parsed_olean = parse_olean(in2, olean_fn);
+            bool check_hash = false;
+            auto parsed_olean = parse_olean(in2, olean_fn, check_hash);
 
             auto mod = std::make_shared<module_info>();
 
@@ -190,23 +209,24 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             mod->m_version = m_current_period;
             mod->m_trans_mtime = mod->m_mtime = mtime;
 
+            parse_task::loaded_deps deps;
+
             for (auto & d : parsed_olean.first) {
                 auto d_id = resolve(id, d);
                 build_module(d_id, true, module_stack);
 
-                mod->m_deps.push_back(std::make_pair(d_id, d));
+                mod->m_deps.push_back({d_id, d});
 
                 auto & d_mod = m_modules[d_id];
                 mod->m_trans_mtime = std::max(mod->m_trans_mtime, d_mod->m_trans_mtime);
+
+                deps.push_back({d, d_mod});
             }
 
             if (mod->m_trans_mtime > mod->m_mtime)
                 return build_module(id, false, orig_module_stack);
 
-            module_info::parse_result res;
-            res.m_obj_code = obj_code;
-            res.m_ok = true;
-            mod->m_result = mk_pure_task_result(res, "Loading " + olean_fn);
+            mod->m_result = get_global_task_queue()->submit<parse_olean_task>(obj_code, m_initial_env, deps);
 
             get_global_task_queue()->cancel_if(
                     [=] (generic_task * t) {
@@ -237,12 +257,15 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             mod->m_mod = id;
             mod->m_source = module_src::LEAN;
             mod->m_trans_mtime = mod->m_mtime = mtime;
+            parse_task::loaded_deps deps;
             for (auto & d : imports) {
                 module_id d_id;
                 try {
                     d_id = resolve(id, d);
                     build_module(d_id, true, module_stack);
-                    mod->m_trans_mtime = std::max(mod->m_trans_mtime, m_modules[d_id]->m_trans_mtime);
+                    auto & d_mod = m_modules[d_id];
+                    mod->m_trans_mtime = std::max(mod->m_trans_mtime, d_mod->m_trans_mtime);
+                    deps.push_back({d, d_mod});
                 } catch (throwable & ex) {
                     message_builder msg(m_initial_env, m_ios, id, pos_info {1, 0}, ERROR);
                     msg.set_exception(ex);
@@ -256,7 +279,6 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             }
             mod->m_version = m_current_period;
 
-            auto deps = gather_transitive_imports(id, imports);
             mod->m_result = get_global_task_queue()->submit<parse_lean_task>(
                     contents, m_initial_env,
                     snapshots, m_use_snapshots,
@@ -366,30 +388,6 @@ std::vector<module_name> module_mgr::get_direct_imports(module_id const & id, st
     parser p(get_initial_env(), m_ios, nullptr, in, id, use_exceptions);
     std::vector<std::pair<module_name, module_id>> deps;
     return p.get_imports();
-}
-
-void module_mgr::gather_transitive_imports(std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> & res,
-                                           std::unordered_set<module_id> & visited,
-                                           module_id const & id,
-                                           module_name const & import) {
-    try {
-        auto import_id = resolve(id, import);
-        if (!m_modules[import_id]) return;
-        res.push_back(std::make_tuple(id, import, m_modules[import_id]));
-        if (!visited.count(import_id)) {
-            visited.insert(import_id);
-            for (auto & d : m_modules[import_id]->m_deps)
-                gather_transitive_imports(res, visited, import_id, d.second);
-        }
-    } catch (file_not_found_exception & ex) {}
-}
-
-std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> module_mgr::gather_transitive_imports(
-        module_id const & id, std::vector<module_name> const & imports) {
-    std::unordered_set<module_id> visited;
-    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> res;
-    for (auto & i : imports) gather_transitive_imports(res, visited, id, i);
-    return res;
 }
 
 std::tuple<std::string, module_src, time_t> fs_module_vfs::load_module(module_id const & id, bool can_use_olean) {

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -182,7 +182,7 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
 
         scope_global_ios scope_ios(m_ios);
         scoped_message_buffer scoped_msg_buf(m_msg_buf);
-        scoped_task_context(id, {1, 0});
+        scoped_task_context _(id, {1, 0});
         message_bucket_id bucket_id { id, m_current_period };
         scope_message_context scope_msg_ctx(bucket_id);
         scope_traces_as_messages scope_trace_msgs(id, {1, 0});

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -38,12 +38,9 @@ struct module_info {
     period m_version = 0;
 
     struct parse_result {
-        optional<environment> m_env;
+        environment           m_env;
         options               m_opts;
         bool m_ok = false;
-
-        std::string m_obj_code;
-        std::vector<task_result<expr>> m_obj_code_delayed_proofs;
 
         snapshot_vector m_snapshots;
     };
@@ -85,12 +82,6 @@ class module_mgr {
     void mark_out_of_date(module_id const & id, buffer<module_id> & to_rebuild);
     void build_module(module_id const & id, bool can_use_olean, name_set module_stack);
     std::vector<module_name> get_direct_imports(module_id const & id, std::string const & contents);
-    void gather_transitive_imports(
-        std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> & res,
-        std::unordered_set<module_id> & visited,
-        module_id const & id, module_name const & import);
-    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> gather_transitive_imports(
-            module_id const & id, std::vector<module_name> const & imports);
     bool get_snapshots_or_unchanged_module(
             module_id const & id, std::string const & contents, time_t mtime, snapshot_vector &vector);
 

--- a/src/library/noncomputable.cpp
+++ b/src/library/noncomputable.cpp
@@ -18,6 +18,12 @@ namespace lean {
 struct noncomputable_ext : public environment_extension {
     name_set m_noncomputable;
     noncomputable_ext() {}
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto u = std::make_shared<noncomputable_ext>();
+        u->m_noncomputable = merge(m_noncomputable, static_cast<noncomputable_ext const &>(ext).m_noncomputable);
+        return u;
+    }
 };
 
 struct noncomputable_ext_reg {

--- a/src/library/projection.cpp
+++ b/src/library/projection.cpp
@@ -21,6 +21,13 @@ namespace lean {
 struct projection_ext : public environment_extension {
     name_map<projection_info> m_info;
     projection_ext() {}
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<projection_ext const &>(ext);
+        auto u = std::make_shared<projection_ext>();
+        u->m_info = merge_prefer_first(m_info, o.m_info);
+        return u;
+    }
 };
 
 struct projection_ext_reg {

--- a/src/library/protected.cpp
+++ b/src/library/protected.cpp
@@ -13,6 +13,13 @@ Author: Leonardo de Moura
 namespace lean {
 struct protected_ext : public environment_extension {
     name_set m_protected; // protected declarations
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<protected_ext const &>(ext);
+        auto u = std::make_shared<protected_ext>();
+        u->m_protected = merge(m_protected, o.m_protected);
+        return u;
+    }
 };
 
 struct protected_ext_reg {

--- a/src/library/relation_manager.cpp
+++ b/src/library/relation_manager.cpp
@@ -152,6 +152,17 @@ static std::string * g_key = nullptr;
 struct rel_config {
     typedef rel_state state;
     typedef rel_entry entry;
+
+    static rel_state state_union(rel_state const & a, rel_state const & o) {
+        rel_state u;
+        u.m_trans_table = merge_prefer_first(a.m_trans_table, o.m_trans_table);
+        u.m_refl_table = merge_prefer_first(a.m_refl_table, o.m_refl_table);
+        u.m_subst_table = merge_prefer_first(a.m_subst_table, o.m_subst_table);
+        u.m_symm_table = merge_prefer_first(a.m_symm_table, o.m_symm_table);
+        u.m_rop_table = merge_prefer_first(a.m_rop_table, o.m_rop_table);
+        return u;
+    }
+
     static void add_entry(environment const & env, io_state const &, state & s, entry const & e) {
         switch (e.m_kind) {
         case op_kind::Relation: s.register_rop(env, e.m_name); break;

--- a/src/library/scoped_ext.cpp
+++ b/src/library/scoped_ext.cpp
@@ -26,6 +26,15 @@ struct scope_mng_ext : public environment_extension {
     list<name>       m_namespaces;        // stack of namespaces/sections
     list<name>       m_headers;           // namespace/section header
     list<scope_kind> m_scope_kinds;
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<scope_mng_ext const &>(ext);
+        if (!empty(m_namespaces) || !empty(o.m_namespaces))
+            throw exception("union failed, namespaces/sections open");
+        auto u = std::make_shared<scope_mng_ext>();
+        u->m_namespace_set = merge(m_namespace_set, o.m_namespace_set);
+        return u;
+    }
 };
 
 struct scope_mng_ext_reg {

--- a/src/library/scoped_ext.h
+++ b/src/library/scoped_ext.h
@@ -128,6 +128,15 @@ public:
         return r;
     }
 
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<scoped_ext const &>(ext);
+        if (!empty(m_scopes) || !empty(o.m_scopes))
+            throw exception("cannot compute union of scoped_exts with non-empty scopes");
+        auto u = std::make_shared<scoped_ext>();
+        u->m_state = Config::state_union(m_state, o.m_state);
+        return u;
+    }
+
     struct reg {
         unsigned m_ext_id;
         reg() {

--- a/src/library/tactic/kabstract.cpp
+++ b/src/library/tactic/kabstract.cpp
@@ -85,6 +85,13 @@ struct key_equivalence_ext : public environment_extension {
         if (!it2) return false;
         return find(*it1) == find(*it2);
     }
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<key_equivalence_ext const &>(ext);
+        auto u = std::make_shared<key_equivalence_ext>(*this);
+        // TODO(gabriel)
+        return u;
+    }
 };
 
 struct key_equivalence_ext_reg {

--- a/src/library/tactic/simp_lemmas.h
+++ b/src/library/tactic/simp_lemmas.h
@@ -67,6 +67,8 @@ public:
     bool is_permutation() const;
 
     format pp(formatter const & fmt) const;
+
+    bool is_ptr_eq(simp_lemma const & o) const { return m_ptr == o.m_ptr; }
 };
 
 bool operator==(simp_lemma const & r1, simp_lemma const & r2);

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -46,6 +46,20 @@ public:
 /* Persisting */
 struct user_attr_ext : public environment_extension {
     name_map<attribute_ptr> m_attrs;
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<user_attr_ext const &>(ext);
+        auto u = std::make_shared<user_attr_ext>();
+        u->m_attrs = merge(m_attrs, o.m_attrs, [=] (name const &, attribute_ptr const & a1, attribute_ptr const & a2) {
+            if (a1 == a2) {
+                return a1;
+            } else {
+                // TODO(gabriel): check for more than pointer equality
+                throw exception("union failed, different user attributes");
+            }
+        });
+        return u;
+    }
 };
 
 struct user_attr_ext_reg {

--- a/src/library/user_recursors.cpp
+++ b/src/library/user_recursors.cpp
@@ -304,6 +304,13 @@ struct recursor_config {
     typedef recursor_state  state;
     typedef recursor_info   entry;
 
+    static recursor_state state_union(recursor_state const & a, recursor_state const & b) {
+        recursor_state u;
+        u.m_recursors = merge_prefer_first(a.m_recursors, b.m_recursors);
+        u.m_type2recursors = merge_prefer_first(a.m_type2recursors, b.m_type2recursors);
+        return u;
+    }
+
     static void add_entry(environment const &, io_state const &, state & s, entry const & e) {
         s.insert(e);
     }

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -303,7 +303,7 @@ void display(std::ostream & out, vm_obj const & o) {
         vm_obj const * args = to_native_closure(o)->get_args();
         for (unsigned i = 0; i < to_native_closure(o)->get_num_args(); i++) {
             out << " ";
-            display(out, args[i], idx2name);
+            display(out, args[i]);
         }
         out << ")";
     } else {
@@ -910,6 +910,15 @@ struct vm_decls : public environment_extension {
                 unsigned idx = get_vm_index(n);
                 m_cases.insert(idx, std::get<1>(p));
             });
+    }
+
+    std::shared_ptr<environment_extension const> union_with(environment_extension const & ext) const override {
+        auto & o = static_cast<vm_decls const &>(ext);
+        auto u = std::make_shared<vm_decls>();
+        u->m_decls = merge_prefer_first(m_decls, o.m_decls);
+        u->m_cases = merge_prefer_first(m_cases, o.m_cases);
+        u->m_monitor = m_monitor;
+        return u;
     }
 
     void add_core(vm_decl const & d) {

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -16,6 +16,7 @@ Author: Leonardo de Moura
 #include "util/sstream.h"
 #include "util/small_object_allocator.h"
 #include "util/sexpr/option_declarations.h"
+#include "util/shared_mutex.h"
 #include "library/constants.h"
 #include "library/kernel_serializer.h"
 #include "library/trace.h"
@@ -272,14 +273,14 @@ void vm_obj_cell::dealloc() {
     }
 }
 
-void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(unsigned)> const & idx2name) {
+void display(std::ostream & out, vm_obj const & o) {
     if (is_simple(o)) {
         out << cidx(o);
     } else if (is_constructor(o)) {
         out << "(#" << cidx(o);
         for (unsigned i = 0; i < csize(o); i++) {
             out << " ";
-            display(out, cfield(o, i), idx2name);
+            display(out, cfield(o, i));
         }
         out << ")";
     } else if (is_mpz(o)) {
@@ -287,14 +288,14 @@ void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(
     } else if (is_external(o)) {
         out << "[external]";
     } else if (is_closure(o)) {
-        if (auto n = idx2name(cfn_idx(o))) {
+        if (auto n = find_vm_name(cfn_idx(o))) {
             out << "(" << *n;
         } else {
             out << "(fn#" << cfn_idx(o);
         }
         for (unsigned i = 0; i < csize(o); i++) {
             out << " ";
-            display(out, cfield(o, i), idx2name);
+            display(out, cfield(o, i));
         }
         out << ")";
     } else if (is_native_closure(o)) {
@@ -310,24 +311,18 @@ void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(
     }
 }
 
-void display(std::ostream & out, vm_obj const & o) {
-    display(out, o, [](unsigned) { return optional<name>(); });
-}
-
-static void display_fn(std::ostream & out, std::function<optional<name>(unsigned)> const & idx2name, unsigned fn_idx) {
-    if (auto r = idx2name(fn_idx))
+static void display_fn(std::ostream & out, unsigned fn_idx) {
+    if (auto r = find_vm_name(fn_idx))
         out << *r;
     else
         out << fn_idx;
 }
 
-static void display_builtin_cases(std::ostream & out, std::function<optional<name>(unsigned)> const & idx2name, unsigned cases_idx) {
-    display_fn(out, idx2name, cases_idx);
+static void display_builtin_cases(std::ostream & out, unsigned cases_idx) {
+    display_fn(out, cases_idx);
 }
 
-void vm_instr::display(std::ostream & out,
-                       std::function<optional<name>(unsigned)> const & idx2name,
-                       std::function<optional<name>(unsigned)> const & cases_idx2name) const {
+void vm_instr::display(std::ostream & out) const {
     switch (m_op) {
     case opcode::Push:          out << "push " << m_idx; break;
     case opcode::Ret:           out << "ret"; break;
@@ -346,7 +341,7 @@ void vm_instr::display(std::ostream & out,
         break;
     case opcode::BuiltinCases:
         out << "builtin_cases ";
-        display_builtin_cases(out, cases_idx2name, get_cases_idx());
+        display_builtin_cases(out, get_cases_idx());
         out << ",";
         for (unsigned i = 0; i < get_casesn_size(); i++)
             out << " " << get_casesn_pc(i);
@@ -356,19 +351,19 @@ void vm_instr::display(std::ostream & out,
     case opcode::Apply:         out << "apply"; break;
     case opcode::InvokeGlobal:
         out << "ginvoke ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         break;
     case opcode::InvokeBuiltin:
         out << "builtin ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         break;
     case opcode::InvokeCFun:
         out << "cfun ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         break;
     case opcode::Closure:
         out << "closure ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         out << " " << m_nargs;
         break;
     case opcode::Pexpr:
@@ -376,10 +371,6 @@ void vm_instr::display(std::ostream & out,
     case opcode::LocalInfo:
         out << "localinfo " << m_local_info->first << " @ " << m_local_idx; break;
     }
-}
-
-void vm_instr::display(std::ostream & out) const {
-    display(out, [](unsigned) { return optional<name>(); }, [](unsigned) { return optional<name>(); });
 }
 
 unsigned vm_instr::get_num_pcs() const {
@@ -723,13 +714,10 @@ void vm_instr::serialize(serializer & s, std::function<name(unsigned)> const & i
     }
 }
 
-static unsigned read_fn_idx(deserializer & d, name_map<unsigned> const & name2idx) {
+static unsigned read_fn_idx(deserializer & d) {
     name n;
     d >> n;
-    if (auto r = name2idx.find(n))
-        return *r;
-    else
-        throw corrupted_stream_exception();
+    return get_vm_index(n);
 }
 
 static void read_cases_pcs(deserializer & d, buffer<unsigned> & pcs) {
@@ -738,18 +726,18 @@ static void read_cases_pcs(deserializer & d, buffer<unsigned> & pcs) {
         pcs.push_back(d.read_unsigned());
 }
 
-static vm_instr read_vm_instr(deserializer & d, name_map<unsigned> const & name2idx) {
+static vm_instr read_vm_instr(deserializer & d) {
     opcode op = static_cast<opcode>(d.read_char());
     unsigned pc, idx;
     switch (op) {
     case opcode::InvokeGlobal:
-        return mk_invoke_global_instr(read_fn_idx(d, name2idx));
+        return mk_invoke_global_instr(read_fn_idx(d));
     case opcode::InvokeBuiltin:
-        return mk_invoke_builtin_instr(read_fn_idx(d, name2idx));
+        return mk_invoke_builtin_instr(read_fn_idx(d));
     case opcode::InvokeCFun:
-        return mk_invoke_cfun_instr(read_fn_idx(d, name2idx));
+        return mk_invoke_cfun_instr(read_fn_idx(d));
     case opcode::Closure:
-        idx = read_fn_idx(d, name2idx);
+        idx = read_fn_idx(d);
         return mk_closure_instr(idx, d.read_unsigned());
     case opcode::Push:
         return mk_push_instr(d.read_unsigned());
@@ -906,58 +894,40 @@ void declare_vm_cases_builtin(name const & n, char const * i, vm_cases_function 
 
 /** \brief VM function/constant declarations are stored in an environment extension. */
 struct vm_decls : public environment_extension {
-    name_map<unsigned>        m_name2idx;
-    unsigned_map<vm_decl>     m_decls;
-    unsigned                  m_next_decl_idx{0};
-
-    name_map<unsigned>              m_cases2idx;
+    unsigned_map<vm_decl>           m_decls;
     unsigned_map<vm_cases_function> m_cases;
-    unsigned_map<name>              m_cases_names;
-    unsigned                        m_next_cases_idx{0};
 
     name                            m_monitor;
 
     vm_decls() {
         g_vm_builtins->for_each([&](name const & n, std::tuple<unsigned, char const *, vm_function> const & p) {
-                add_core(vm_decl(n, m_next_decl_idx, std::get<0>(p), std::get<2>(p)));
-                m_next_decl_idx++;
+                add_core(vm_decl(n, get_vm_index(n), std::get<0>(p), std::get<2>(p)));
             });
         g_vm_cbuiltins->for_each([&](name const & n, std::tuple<unsigned, char const *, vm_cfunction> const & p) {
-                add_core(vm_decl(n, m_next_decl_idx, std::get<0>(p), std::get<2>(p)));
-                m_next_decl_idx++;
+                add_core(vm_decl(n, get_vm_index(n), std::get<0>(p), std::get<2>(p)));
             });
         g_vm_cases_builtins->for_each([&](name const & n, std::tuple<char const *, vm_cases_function> const & p) {
-                unsigned idx = m_next_cases_idx;
-                m_cases2idx.insert(n, idx);
+                unsigned idx = get_vm_index(n);
                 m_cases.insert(idx, std::get<1>(p));
-                m_cases_names.insert(idx, n);
-                m_next_cases_idx++;
             });
     }
 
     void add_core(vm_decl const & d) {
-        if (m_name2idx.contains(d.get_name()))
+        if (m_decls.contains(d.get_idx()))
             throw exception(sstream() << "VM already contains code for '" << d.get_name() << "'");
-        m_name2idx.insert(d.get_name(), d.get_idx());
         m_decls.insert(d.get_idx(), d);
     }
 
     void add_native(name const & n, unsigned arity, vm_cfunction fn) {
-        if (auto idx = m_name2idx.find(n)) {
-            lean_assert(m_decls.find(*idx)->get_arity() == arity);
-            m_decls.insert(*idx, vm_decl(n, *idx, arity, fn));
-        } else {
-            add_core(vm_decl(n, m_next_decl_idx, arity, fn));
-            m_next_decl_idx++;
-        }
+        auto idx = get_vm_index(n);
+        DEBUG_CODE(if (auto decl = m_decls.find(idx)) lean_assert(decl->get_arity() == arity);)
+        m_decls.insert(idx, vm_decl(n, idx, arity, fn));
     }
 
     unsigned reserve(name const & n, expr const & e) {
-        if (m_name2idx.contains(n))
+        unsigned idx = get_vm_index(n);
+        if (m_decls.contains(idx))
             throw exception(sstream() << "VM already contains code for '" << n << "'");
-        unsigned idx = m_next_decl_idx;
-        m_next_decl_idx++;
-        m_name2idx.insert(n, idx);
         m_decls.insert(idx, vm_decl(n, idx, e, 0, nullptr, list<vm_local_info>(), optional<pos_info>()));
         return idx;
     }
@@ -965,9 +935,9 @@ struct vm_decls : public environment_extension {
     void update(name const & n, unsigned code_sz, vm_instr const * code,
                 list<vm_local_info> const & args_info, optional<pos_info> const & pos,
                 optional<std::string> const & olean = optional<std::string>()) {
-        lean_assert(m_name2idx.contains(n));
-        unsigned idx      = *m_name2idx.find(n);
+        unsigned idx      = get_vm_index(n);
         vm_decl const * d = m_decls.find(idx);
+        lean_assert(d);
         m_decls.insert(idx, vm_decl(n, idx, d->get_expr(), code_sz, code, args_info, pos, olean));
     }
 };
@@ -1037,21 +1007,23 @@ environment add_native(environment const & env, name const & n, unsigned arity, 
 
 bool is_vm_function(environment const & env, name const & fn) {
     auto const & ext = get_extension(env);
-    return ext.m_name2idx.contains(fn) || g_vm_builtins->contains(fn);
+    return ext.m_decls.contains(get_vm_index(fn)) || g_vm_builtins->contains(fn);
 }
 
 optional<unsigned> get_vm_constant_idx(environment const & env, name const & n) {
     auto const & ext = get_extension(env);
-    if (auto r = ext.m_name2idx.find(n))
-        return optional<unsigned>(*r);
+    auto idx = get_vm_index(n);
+    if (ext.m_decls.contains(idx))
+        return optional<unsigned>(idx);
     else
         return optional<unsigned>();
 }
 
 optional<unsigned> get_vm_builtin_idx(name const & n) {
     lean_assert(g_ext);
-    if (auto r = g_ext->m_init_decls->m_name2idx.find(n))
-        return optional<unsigned>(*r);
+    auto idx = get_vm_index(n);
+    if (g_ext->m_init_decls->m_decls.contains(idx))
+        return optional<unsigned>(idx);
     else
         return optional<unsigned>();
 }
@@ -1094,7 +1066,7 @@ static void code_reader(deserializer & d, environment & env) {
     vm_decls ext = get_extension(env);
     buffer<vm_instr> code;
     for (unsigned i = 0; i < code_sz; i++) {
-        code.push_back(read_vm_instr(d, ext.m_name2idx));
+        code.push_back(read_vm_instr(d));
     }
     ext.update(fn, code_sz, code.data(), args_info, pos, d.get_fname());
     env = update(env, ext);
@@ -1105,7 +1077,7 @@ environment update_vm_code(environment const & env, name const & fn, unsigned co
     vm_decls ext = get_extension(env);
     ext.update(fn, code_sz, code, args_info, pos);
     environment new_env = update(env, ext);
-    unsigned fidx       = *ext.m_name2idx.find(fn);
+    unsigned fidx       = get_vm_index(fn);
     return module::add(new_env, *g_vm_code_key, [=](environment const & env, serializer & s) {
             serialize_code(s, fidx, get_extension(env).m_decls);
         });
@@ -1119,16 +1091,17 @@ environment add_vm_code(environment const & env, name const & fn, expr const & e
 
 optional<vm_decl> get_vm_decl(environment const & env, name const & n) {
     vm_decls const & ext = get_extension(env);
-    if (auto idx = ext.m_name2idx.find(n))
-        return optional<vm_decl>(*ext.m_decls.find(*idx));
+    if (auto decl = ext.m_decls.find(get_vm_index(n)))
+        return optional<vm_decl>(*decl);
     else
         return optional<vm_decl>();
 }
 
 optional<unsigned> get_vm_builtin_cases_idx(environment const & env, name const & n) {
     vm_decls const & ext = get_extension(env);
-    if (auto idx = ext.m_cases2idx.find(n))
-        return optional<unsigned>(*idx);
+    auto idx = get_vm_index(n);
+    if (ext.m_cases.contains(idx))
+        return optional<unsigned>(idx);
     else
         return optional<unsigned>();
 }
@@ -1149,11 +1122,9 @@ vm_state::vm_state(environment const & env, options const & opts):
     m_env(env),
     m_options(opts),
     m_decl_map(get_extension(m_env).m_decls),
-    m_decl_vector(get_extension(m_env).m_next_decl_idx),
+    m_decl_vector(get_vm_index_bound()),
     m_builtin_cases_map(get_extension(m_env).m_cases),
-    m_builtin_cases_vector(get_extension(m_env).m_next_cases_idx),
-    m_builtin_cases_names(get_extension(m_env).m_cases_names),
-    m_fn_name2idx(get_extension(m_env).m_name2idx),
+    m_builtin_cases_vector(get_vm_index_bound()),
     m_code(nullptr),
     m_fn_idx(g_null_fn_idx),
     m_bp(0) {
@@ -1220,9 +1191,7 @@ void vm_state::update_env(environment const & env) {
     m_env         = env;
     auto ext      = get_extension(env);
     m_decl_map    = ext.m_decls;
-    lean_assert(ext.m_next_decl_idx >= m_decl_vector.size());
-    m_decl_vector.resize(ext.m_next_decl_idx);
-    m_fn_name2idx = ext.m_name2idx;
+    m_decl_vector.resize(get_vm_index_bound());
     lean_assert(is_eqp(m_builtin_cases_map, ext.m_cases));
 }
 
@@ -1404,8 +1373,9 @@ vm_obj vm_state::invoke(unsigned fn_idx, unsigned nargs, vm_obj const * as) {
 }
 
 vm_obj vm_state::invoke(name const & fn, unsigned nargs, vm_obj const * as) {
-    if (auto r = m_fn_name2idx.find(fn)) {
-        return invoke(*r, nargs, as);
+    auto idx = get_vm_index(fn);
+    if (m_decl_map.contains(idx)) {
+        return invoke(idx, nargs, as);
     } else {
         throw exception(sstream() << "VM does not have code for '" << fn << "'");
     }
@@ -2524,13 +2494,7 @@ void vm_state::run() {
                 /* We only trace VM in debug mode */
                 lean_trace(name({"vm", "run"}),
                            tout() << m_pc << ": ";
-                           instr.display(tout().get_stream(),
-                                         [&](unsigned idx) {
-                                             return optional<name>(get_decl(idx).get_name());
-                                         },
-                                         [&](unsigned idx) {
-                                             return optional<name>(*m_builtin_cases_names.find(idx));
-                                         });
+                           instr.display(tout().get_stream());
                            tout() << "\n";
                            display_stack(tout().get_stream());
                            tout() << "\n";)
@@ -2965,8 +2929,9 @@ void vm_state::run() {
 }
 
 void vm_state::invoke_fn(name const & fn) {
-    if (auto r = m_fn_name2idx.find(fn)) {
-        invoke_fn(*r);
+    auto idx = get_vm_index(fn);
+    if (m_decl_map.contains(idx)) {
+        invoke_fn(idx);
     } else {
         throw exception(sstream() << "VM does not have code for '" << fn << "'");
     }
@@ -2982,8 +2947,9 @@ void vm_state::invoke_fn(unsigned fn_idx) {
 }
 
 vm_obj vm_state::get_constant(name const & cname) {
-    if (auto fn_idx = m_fn_name2idx.find(cname)) {
-        vm_decl d = get_decl(*fn_idx);
+    auto fn_idx = get_vm_index(cname);
+    if (m_decl_map.contains(fn_idx)) {
+        vm_decl d = get_decl(fn_idx);
         if (d.get_arity() == 0) {
             DEBUG_CODE(unsigned stack_sz = m_stack.size(););
             unsigned saved_pc = m_pc;
@@ -2995,7 +2961,7 @@ vm_obj vm_state::get_constant(name const & cname) {
             lean_assert(m_stack.size() == stack_sz);
             return r;
         } else {
-            return mk_vm_closure(*fn_idx, 0, nullptr);
+            return mk_vm_closure(fn_idx, 0, nullptr);
         }
     } else {
         throw exception(sstream() << "VM does not have code for '" << cname << "'");
@@ -3019,13 +2985,13 @@ void vm_state::apply(unsigned n) {
 }
 
 void vm_state::display(std::ostream & out, vm_obj const & o) const {
-    ::lean::display(out, o,
-                    [&](unsigned idx) { return optional<name>(get_decl(idx).get_name()); });
+    ::lean::display(out, o);
 }
 
 optional<vm_decl> vm_state::get_decl(name const & n) const {
-    if (auto idx = m_fn_name2idx.find(n))
-        return optional<vm_decl>(get_decl(*idx));
+    auto idx = get_vm_index(n);
+    if (m_decl_map.contains(idx))
+        return optional<vm_decl>(get_decl(idx));
     else
         return optional<vm_decl>();
 }
@@ -3177,25 +3143,9 @@ void vm_state::profiler::snapshots::display(std::ostream & out) const {
 }
 
 void display_vm_code(std::ostream & out, environment const & env, unsigned code_sz, vm_instr const * code) {
-    vm_decls const & ext = get_extension(env);
-    auto idx2name = [&](unsigned idx) {
-        if (idx < ext.m_decls.size()) {
-            return optional<name>(ext.m_decls.find(idx)->get_name());
-        } else {
-            return optional<name>();
-        }
-    };
-    auto cases2name = [&](unsigned idx) {
-        if (idx < ext.m_cases_names.size()) {
-            return optional<name>(*ext.m_cases_names.find(idx));
-        } else {
-            return optional<name>();
-        }
-    };
-
     for (unsigned i = 0; i < code_sz; i++) {
         out << i << ": ";
-        code[i].display(out, idx2name, cases2name);
+        code[i].display(out);
         out << "\n";
     }
 }
@@ -3295,7 +3245,70 @@ static void vm_monitor_reader(deserializer & d, environment & env) {
     env = update(env, ext);
 }
 
+class vm_index_manager {
+    shared_mutex m_mutex;
+    std::unordered_map<name, unsigned, name_hash> m_name2idx;
+    std::vector<name> m_idx2name;
+
+public:
+    unsigned get_index(name const & n) {
+        {
+            shared_lock lock(m_mutex);
+            auto it = m_name2idx.find(n);
+            if (it != m_name2idx.end())
+                return it->second;
+        }
+        {
+            exclusive_lock lock(m_mutex);
+            auto it = m_name2idx.find(n);
+            if (it != m_name2idx.end()) {
+                return it->second;
+            } else {
+                auto i = static_cast<unsigned>(m_idx2name.size());
+                m_idx2name.push_back(n);
+                m_name2idx[n] = i;
+                return i;
+            }
+        }
+    }
+
+    unsigned get_index_bound() {
+        shared_lock _(m_mutex);
+        return static_cast<unsigned>(m_idx2name.size());
+    }
+
+    name const & get_name(unsigned idx) {
+        shared_lock lock(m_mutex);
+        lean_assert(idx < m_idx2name.size());
+        return m_idx2name.at(idx);
+    }
+
+    optional<name> find_name(unsigned idx) {
+        shared_lock lock(m_mutex);
+        if (idx < m_idx2name.size()) {
+            return optional<name>(m_idx2name.at(idx));
+        } else {
+            return optional<name>();
+        }
+    }
+};
+static vm_index_manager * g_vm_index_manager = nullptr;
+
+unsigned get_vm_index(name const & n) {
+    return g_vm_index_manager->get_index(n);
+}
+unsigned get_vm_index_bound() {
+    return g_vm_index_manager->get_index_bound();
+}
+name const & get_vm_name(unsigned idx) {
+    return g_vm_index_manager->get_name(idx);
+}
+optional<name> find_vm_name(unsigned idx) {
+    return g_vm_index_manager->find_name(idx);
+}
+
 void initialize_vm_core() {
+    g_vm_index_manager = new vm_index_manager;
     g_vm_builtins = new name_map<std::tuple<unsigned, char const *, vm_function>>();
     g_vm_cbuiltins = new name_map<std::tuple<unsigned, char const *, vm_cfunction>>();
     g_vm_cases_builtins = new name_map<std::tuple<char const *, vm_cases_function>>();
@@ -3311,6 +3324,7 @@ void finalize_vm_core() {
     delete g_vm_builtins;
     delete g_vm_cbuiltins;
     delete g_vm_cases_builtins;
+    delete g_vm_index_manager;
 }
 
 void initialize_vm() {

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -49,7 +49,6 @@ public:
 #define LEAN_VM_BOX(num)    (reinterpret_cast<vm_obj_cell*>((num << 1) | 1))
 #define LEAN_VM_UNBOX(obj)  (reinterpret_cast<size_t>(obj) >> 1)
 
-void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(unsigned)> const & idx2name);
 void display(std::ostream & out, vm_obj const & o);
 
 /** \brief VM object */
@@ -454,9 +453,6 @@ public:
     unsigned get_pc(unsigned i) const;
     void set_pc(unsigned i, unsigned pc);
 
-    void display(std::ostream & out,
-                 std::function<optional<name>(unsigned)> const & idx2name,
-                 std::function<optional<name>(unsigned)> const & cases_idx2name) const;
     void display(std::ostream & out) const;
 
     void serialize(serializer & s, std::function<name(unsigned)> const & idx2name) const;
@@ -573,8 +569,6 @@ class vm_state {
     cache_vector                m_cache_vector; /* for 0-ary declarations */
     builtin_cases_map           m_builtin_cases_map;
     builtin_cases_vector        m_builtin_cases_vector;
-    unsigned_map<name>          m_builtin_cases_names;
-    name_map<unsigned>          m_fn_name2idx;
     vm_instr const *            m_code;   /* code of the current function being executed */
     unsigned                    m_fn_idx; /* function idx being executed */
     unsigned                    m_pc;     /* program counter */
@@ -831,6 +825,11 @@ environment add_native(environment const & env, name const & n, vm_cfunction_6 f
 environment add_native(environment const & env, name const & n, vm_cfunction_7 fn);
 environment add_native(environment const & env, name const & n, vm_cfunction_8 fn);
 environment add_native(environment const & env, name const & n, unsigned arity, vm_cfunction_N fn);
+
+unsigned get_vm_index(name const & n);
+unsigned get_vm_index_bound();
+name const & get_vm_name(unsigned idx);
+optional<name> find_vm_name(unsigned idx);
 
 /** \brief Reserve an index for the given function in the VM, the expression
     \c e is the value of \c fn after preprocessing.

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -97,10 +97,12 @@ endif()
 # LEAN TESTS
 file(GLOB LEANTESTS "${LEAN_SOURCE_DIR}/../tests/lean/*.lean")
 FOREACH(T ${LEANTESTS})
-  GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
-  add_test(NAME "leantest_${T_NAME}"
-           WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean"
-           COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  if(NOT T MATCHES "\\.#")
+    GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
+    add_test(NAME "leantest_${T_NAME}"
+             WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean"
+             COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  endif()
 ENDFOREACH(T)
 
 # # SMT2 TESTS
@@ -115,10 +117,12 @@ ENDFOREACH(T)
 # LEAN RUN TESTS
 file(GLOB LEANRUNTESTS "${LEAN_SOURCE_DIR}/../tests/lean/run/*.lean")
 FOREACH(T ${LEANRUNTESTS})
-  GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
-  add_test(NAME "leanruntest_${T_NAME}"
-           WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean/run"
-           COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  if(NOT T MATCHES "\\.#")
+    GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
+    add_test(NAME "leanruntest_${T_NAME}"
+             WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean/run"
+             COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  endif()
 ENDFOREACH(T)
 
 # SMT2 RUN TESTS

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -504,7 +504,7 @@ int main(int argc, char ** argv) {
 
         // Options appear to be empty, pretty sure I'm making a mistake here.
         if (compile && !mods.empty()) {
-            auto final_env = *mods.front().second->m_result.get().m_env;
+            auto final_env = mods.front().second->m_result.get().m_env;
             auto final_opts = mods.front().second->m_result.get().m_opts;
             type_context tc(final_env, final_opts);
             lean::scope_trace_env scope2(final_env, final_opts, tc);
@@ -521,13 +521,13 @@ int main(int argc, char ** argv) {
         if (export_txt && !mods.empty()) {
             exclusive_file_lock export_lock(*export_txt);
             std::ofstream out(*export_txt);
-            export_module_as_lowtext(out, *mods.front().second->m_result.get().m_env);
+            export_module_as_lowtext(out, mods.front().second->m_result.get().m_env);
         }
 
         if (export_all_txt && !mods.empty()) {
             exclusive_file_lock export_lock(*export_all_txt);
             std::ofstream out(*export_all_txt);
-            export_all_as_lowtext(out, *mods.front().second->m_result.get().m_env);
+            export_all_as_lowtext(out, mods.front().second->m_result.get().m_env);
         }
         if (doc) {
             exclusive_file_lock export_lock(*doc);

--- a/src/shell/lean_js.cpp
+++ b/src/shell/lean_js.cpp
@@ -46,7 +46,7 @@ public:
     int import_module(std::string mname) {
         try {
             // FIXME(gabriel): discarding proofs fails at the moment with "invalid equation lemma, unexpected form"
-            env = lean::import_module(env, "importing", {mname, optional<unsigned>()}, mk_olean_loader());
+            env = import_modules(env, "importing", {{mname, optional<unsigned>()}}, mk_olean_loader(env));
             return 0;
         } catch (exception & ex) {
             message_builder(env, ios, "importing", {1, 0}, ERROR).set_exception(ex).report();
@@ -58,7 +58,7 @@ public:
         try {
             std::ifstream in(input_filename);
             bool use_exceptions = false;
-            parser p(env, ios, mk_olean_loader(), in, input_filename, use_exceptions);
+            parser p(env, ios, mk_olean_loader(env), in, input_filename, use_exceptions);
             if (p()) return 0;
         } catch (exception & ex) {
             message_builder(env, ios, input_filename, {1, 0}, ERROR).set_exception(ex).report();

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -360,8 +360,8 @@ server::cmd_res server::handle_info(server::cmd_req const & req) {
     auto opts = m_ios.get_options();
     auto env = m_initial_env;
     if (auto mod = m_mod_mgr->get_module(fn)->m_result.peek()) {
-        if (mod->m_env) env = *mod->m_env;
-        if (!mod->m_snapshots.empty()) opts = mod->m_snapshots.back()->m_options;
+        env = mod->m_env;
+        opts = mod->m_opts;
     }
 
     json record;

--- a/src/tests/kernel/environment.cpp
+++ b/src/tests/kernel/environment.cpp
@@ -173,6 +173,14 @@ public:
             }
         }
     }
+
+    static void tst3() {
+        environment_id id0, id = id0;
+        for (unsigned i = 0; i < 100; i++)
+            id = environment_id::mk_descendant(id, id);
+        lean_assert(id.is_descendant(id0));
+        lean_assert(!environment_id().is_descendant(id0));
+    }
 };
 }
 
@@ -188,6 +196,7 @@ int main() {
     tst2();
     environment_id_tester::tst1();
     environment_id_tester::tst2();
+    environment_id_tester::tst3();
     finalize_library_module();
     finalize_library_core_module();
     finalize_kernel_module();

--- a/src/tests/kernel/environment.cpp
+++ b/src/tests/kernel/environment.cpp
@@ -133,6 +133,13 @@ public:
         lean_assert(!id8.is_descendant(id4));
         lean_assert(!id8.is_descendant(id5));
         lean_assert(!id8.is_descendant(id6));
+
+        auto id9 = environment_id::mk_descendant(id3, id6);
+        lean_assert(id9.is_descendant(id6));
+        lean_assert(id9.is_descendant(id4));
+        lean_assert(id9.is_descendant(id1));
+        lean_assert(id9.is_descendant(id3));
+        lean_assert(id9.is_descendant(id2));
     }
 
     static void tst2() {

--- a/src/util/rb_map.h
+++ b/src/util/rb_map.h
@@ -128,5 +128,34 @@ void for_each(rb_map<K, T, CMP> const & m, F && f) {
     return m.for_each(f);
 }
 
+template <class K, class T, class CMP, class F>
+rb_map<K, T, CMP> merge(rb_map<K, T, CMP> const & m1, rb_map<K, T, CMP> const & m2, F && f) {
+    auto r = m1;
+    m2.for_each([&] (K const & k, T const & t2) {
+        if (auto t1 = r.find(k)) {
+            r.insert(k, f(k, *t1, t2));
+        } else {
+            r.insert(k, t2);
+        }
+    });
+    return r;
+};
+template <class K, class T, class CMP, class F>
+rb_map<K, T, CMP> merge_check_compat(rb_map<K, T, CMP> const & m1, rb_map<K, T, CMP> const & m2, F && f) {
+    auto r = m1;
+    m2.for_each([&] (K const & k, T const & t2) {
+        if (auto t1 = r.find(k)) {
+            f(k, *t1, t2);
+        } else {
+            r.insert(k, t2);
+        }
+    });
+    return r;
+};
+template <class K, class T, class CMP>
+rb_map<K, T, CMP> merge_prefer_first(rb_map<K, T, CMP> const & m1, rb_map<K, T, CMP> const & m2) {
+    return merge_check_compat(m1, m2, [] (K const &, T const &, T const &) {});
+};
+
 template<typename T> using unsigned_map = rb_map<unsigned, T, unsigned_cmp>;
 }

--- a/src/util/rb_tree.h
+++ b/src/util/rb_tree.h
@@ -506,6 +506,8 @@ template<typename T, typename CMP>
 rb_tree<T, CMP> insert(rb_tree<T, CMP> const & t, T const & v) { rb_tree<T, CMP> r(t); r.insert(v); return r; }
 template<typename T, typename CMP>
 rb_tree<T, CMP> erase(rb_tree<T, CMP> const & t, T const & v) { rb_tree<T, CMP> r(t); r.erase(v); return r; }
+template <class T, class CMP>
+rb_tree<T, CMP> merge(rb_tree<T, CMP> const & t1, rb_tree<T, CMP> const & t2) { auto r = t1; r.merge(t2); return r; }
 
 struct unsigned_cmp {
     int operator()(unsigned i1, unsigned i2) const { return i1 < i2 ? -1 : (i1 == i2 ? 0 : 1); }

--- a/tests/lean/interactive/info1.input.expected.out
+++ b/tests/lean/interactive/info1.input.expected.out
@@ -1,2 +1,2 @@
 {"message":"file invalidated","response":"ok","seq_num":0}
-{"record":{"full-id":"foo.f","source":{"column":4,"line":1},"type":"ℕ → ℕ"},"response":"ok","seq_num":1}
+{"record":{"full-id":"foo.f","source":{"column":4,"file":"/home/leo/projects/lean/tests/lean/interactive/info1.lean","line":1},"type":"ℕ → ℕ"},"response":"ok","seq_num":1}


### PR DESCRIPTION
Right now we import modules by replaying the serialized representation onto the environment.  Hence processing the imports for one files takes linear time in the number/size of the dependencies.  In particular, if you have n files, `a_1.lean` to `a_n.lean`, where each file imports the previous one, then compiling them all has quadratic runtime.

This PR is ultimately an attempt to reduce this cost (the runtime of the example above is only linear with this PR).  Concretely, we introduce a binary operation `env1.union_with(env2)` on environments.  This operation takes the union of the declarations in both environments (soundness of this inference requires just weakening as far as I can see, and this is true for our environments).  We extend this operation to all environment extensions as well.  However there it is much less well-behaved, e.g. it is non-commutative as we want to give precedence to later imports sometimes.

Importing a module is now defined in terms of the environment that module produces.  I.e. the lean code `import foo` now denotes the command `env = env.union_with(foo)`.  We implement one nice optimization: if `env` is an ancestor of `foo`, then we return `env.union_with(foo) = foo`.  Local attributes, etc., are hidden from other modules via scoping: we open a scope at the begin of a module (right after the imports), and then close it at the end.

The good news: I have gotten it to a point where every single test passes (with the exception of the always problematic `thread_test`), and where there are promising runtime and (unexpectedly) memory improvements.  Compiling the whole standard library from scratch now takes the following time and memory:
```
master:  33.03user 0.72system 0:13.48elapsed 250%CPU 1054M
This PR: 18.42user 0.19system 0:06.96elapsed 267%CPU  169M
```
So roughly twice as fast, and 6x less (peak) memory usage.

The bad news: compiling a single file takes much longer.  In order not to introduce any inconsistencies, we use the same importing approach for olean files as we do for lean files: we construct an environment for every imported module and then take the union.  Compiling just `standard.lean`:
```
master:  0.29user 0.01system 0:00.31elapsed  99%CPU 44M
This PR: 1.37user 0.06system 0:00.68elapsed 211%CPU 81M
```

Alternatives:

1. We could try to implement the ancestor-optimization from this PR with the deserialization-import: if a file uses `import foo bar baz`, then we cache the environment produced after importing `init` and `foo`, in the hope that other files can reuse that environment.

2. Right now the only way of obtaining a list of the modifications made by a module is by producing a byte-level serialization of that list.  We could decouple these two aspects and introduce intermediary data structures for the modifications.  Instead of a list of writers, an environment would then carry a list of modifications.  These modifications could either be serialized, or directly replayed onto another environment.