### PR TITLE
fix(library/module_mgr): fix unnecessary copy

### DIFF
--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -61,7 +61,7 @@ public:
 
     module_info::parse_result execute() override {
         module_loader import_fn = [=] (module_id const & base, module_name const & import) {
-            for (auto d : m_deps) {
+            for (auto & d : m_deps) {
                 if (std::get<0>(d) == base &&
                         std::get<1>(d).m_name == import.m_name &&
                         std::get<1>(d).m_relative == import.m_relative) {


### PR DESCRIPTION
Just noticed this when looking at memory profiling results.