### PR TITLE
Update msys2.md

### DIFF
--- a/doc/make/msys2.md
+++ b/doc/make/msys2.md
@@ -30,6 +30,6 @@ In the [msys2] shell, execute the following commands.
 git clone https://github.com/leanprover/lean
 cd lean
 mkdir build && cd build
-cmake ../src -G Ninja -D CMAKE_BUILD_TYPE=Release
+cmake ../src -G Ninja
 ninja
 ```


### PR DESCRIPTION
Hi, 

Using a fresh install of the packages listed in the readme, along with the msys2-64 shell, I was unable to build lean on Windows.

1) -D CMAKE_BUILD_TYPE=Release doesn't get parsed correctly, cmake interprets this as a folder location. 

> Andrew Ashworth@ANDREW-DESKTOP MINGW64 /d/projects/lean/build
$ cmake ../src -G Ninja -D CMAKE_BUILD_TYPE=Release
CMake Error: The source directory "D:/projects/lean/build/CMAKE_BUILD_TYPE=Release" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.

2) Even with it parsed by cmake, cmake warns that the variable is not used.

> Andrew Ashworth@ANDREW-DESKTOP MINGW64 /d/projects/lean/build
$ cmake ../src -G Ninja "-D CMAKE_BUILD_TYPE=Release"
-- The CXX compiler identification is GNU 5.3.0
-- The C compiler identification is GNU 5.3.0
-- Check for working CXX compiler using: Ninja
-- Check for working CXX compiler using: Ninja -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Check for working C compiler using: Ninja
-- Check for working C compiler using: Ninja -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- No build type selected, default to Release
-- Lean emacs-mode will be installed at C:/Program Files (x86)/LEAN/share/emacs/site-lisp/lean
-- Lean library will be installed at C:/Program Files (x86)/LEAN/lib/lean
-- Windows detected
-- Compile server enabled
-- Set _GLIBCXX_USE_CXX11_ABI = 0 for a system using MSYS2 + g++
-- Looking for C++ include unistd.h
-- Looking for C++ include unistd.h - found
-- Found MPFR: D:/msys64/mingw64/include (Required is at least version "3.1.0")
-- Found GMP: D:/msys64/mingw64/include (Required is at least version "5.0.5")
-- Found PythonInterp: C:/Users/Andrew/Anaconda3/python.exe (found version "3.5.2")
-- git commit sha1: 317989bf9ef6ae1dec7488c2363dbfcdc16e0756
-- Checking flags for C++11
-- Checking flags for C++11 - Found: -std=c++11
-- Checking flags for C++14
-- Checking flags for C++14 - Found: -std=c++14
-- Checking flags for C++17
-- Checking flags for C++17 - Found: -std=c++17
-- Checking for feature sized_deallocation
-- Checking for feature sized_deallocation - Success
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

     CMAKE_BUILD_TYPE


-- Build files have been written to: D:/projects/lean/build

3) Looking at the CMakeLists.txt, Release is the default build type anyway, so I don't believe this will change anything.

> -- No build type selected, default to Release