### PR TITLE
super, a superposition prover

### DIFF
--- a/library/data/monad/transformers.lean
+++ b/library/data/monad/transformers.lean
@@ -1,0 +1,40 @@
+namespace monad
+
+class monad_transformer (transformer : ∀m [monad m], Type → Type) :=
+(is_monad : ∀m [monad m], monad (transformer m))
+(monad_lift : ∀m [monad m] A, m A → transformer m A)
+
+instance transformed_monad (m t) [monad_transformer t] [monad m] : monad (t m) :=
+monad_transformer.is_monad t m
+
+class has_monad_lift (m n : Type → Type) :=
+(monad_lift : ∀A, m A → n A)
+
+instance monad_transformer_lift (t m) [monad_transformer t] [monad m] : has_monad_lift m (t m) :=
+⟨monad_transformer.monad_lift t m⟩
+
+class has_monad_lift_t (m n : Type → Type) :=
+(monad_lift : ∀A, m A → n A)
+
+def monad_lift {m n} [has_monad_lift_t m n] {A} : m A → n A :=
+has_monad_lift_t.monad_lift n A
+
+prefix `♯ `:0 := monad_lift
+
+instance has_monad_lift_t_trans (m n o) [has_monad_lift n o] [has_monad_lift_t m n] : has_monad_lift_t m o :=
+⟨ λA (ma : m A), has_monad_lift.monad_lift o A $ has_monad_lift_t.monad_lift n A ma ⟩
+
+instance has_monad_lift_t_refl (m) [monad m] : has_monad_lift_t m m :=
+⟨ λA, id ⟩
+
+end monad
+
+namespace state_t
+
+def state_t_monad_lift (S) (m) [monad m] (A) (f : m A) : state_t S m A :=
+take state, do res ← f, return (res, state)
+
+instance (S) : monad.monad_transformer (state_t S) :=
+⟨ state_t.monad S, state_t_monad_lift S ⟩
+
+end state_t

--- a/library/init/category/state.lean
+++ b/library/init/category/state.lean
@@ -70,4 +70,7 @@ def read {σ : Type} {m : Type → Type} [monad m] : state_t σ m σ :=
 
 def write {σ : Type} {m : Type → Type} [monad m] : σ → state_t σ m unit :=
 λ s' s, return ((), s')
+
+def modify {σ : Type} {m : Type → Type} [monad m] (f : σ → σ) : state_t σ m unit :=
+do s ← read, write (f s)
 end state_t

--- a/library/init/data/option/basic.lean
+++ b/library/init/data/option/basic.lean
@@ -9,6 +9,22 @@ open decidable
 
 universe variables u v
 
+namespace option
+
+def to_monad {m : Type → Type} [monad m] [alternative m] {A} : option A → m A
+| none := failure
+| (some a) := return a
+
+def get_or_else {α : Type u} : option α → α → α
+| (some x) _ := x
+| none     e := e
+
+def is_some {α : Type u} : option α → bool
+| (some _) := tt
+| none     := ff
+
+end option
+
 instance (α : Type u) : inhabited (option α) :=
 ⟨none⟩
 

--- a/library/init/data/unsigned.lean
+++ b/library/init/data/unsigned.lean
@@ -22,7 +22,13 @@ if h : n < unsigned_sz then fin.mk n h else fin.mk 0 zero_lt_unsigned_sz
 
 def to_nat (c : unsigned) : nat :=
 fin.val c
+
+def succ (i : unsigned) :=
+of_nat i^.to_nat^.succ
+
 end unsigned
+
+instance : has_zero unsigned := ⟨unsigned.of_nat 0⟩
 
 instance : decidable_eq unsigned :=
 have decidable_eq (fin unsigned_sz), from fin.decidable_eq _,

--- a/library/init/meta/declaration.lean
+++ b/library/init/meta/declaration.lean
@@ -72,6 +72,11 @@ meta def declaration.type : declaration → expr
 | (declaration.cnst n ls t tr) := t
 | (declaration.ax n ls t) := t
 
+meta def declaration.value : declaration → expr
+| (declaration.defn n ls t v h tr) := v
+| (declaration.thm n ls t v) := v^.get
+| _ := default expr
+
 meta def declaration.update_type : declaration → expr → declaration
 | (declaration.defn n ls t v h tr) new_t := declaration.defn n ls new_t v h tr
 | (declaration.thm n ls t v)       new_t := declaration.thm n ls new_t v

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -144,6 +144,10 @@ meta def local_pp_name : expr → name
 | (local_const x n bi t) := n
 | e                      := name.anonymous
 
+meta def local_type : expr → expr
+| (local_const _ _ _ t) := t
+| e := e
+
 meta def is_constant_of : expr → name → bool
 | (const n₁ ls) n₂ := to_bool (n₁ = n₂)
 | e             n  := ff
@@ -230,5 +234,26 @@ meta def binding_body : expr → expr
 | e             := e
 
 meta def prop : expr := expr.sort level.zero
+
+meta def imp (a b : expr) : expr :=
+pi `a binder_info.default a b
+
+meta def and_ (a b : expr) : expr :=
+app (app (const ``and []) a) b
+
+meta def not_ (a : expr) : expr :=
+app (const ``not []) a
+
+meta def false_ : expr := const ``false []
+
+meta def lambdas : list expr → expr → expr
+| (local_const uniq pp info t :: es) f :=
+  lam pp info t (abstract_local (lambdas es f) uniq)
+| _ f := f
+
+meta def pis : list expr → expr → expr
+| (local_const uniq pp info t :: es) f :=
+  pi pp info t (abstract_local (pis es f) uniq)
+| _ f := f
 
 end expr

--- a/library/init/meta/format.lean
+++ b/library/init/meta/format.lean
@@ -103,7 +103,7 @@ meta instance {α : Type u} [has_to_format α] : has_to_format (option α) :=
   (to_fmt "none")
   (λ a, to_fmt "(some " ++ nest 6 (to_fmt a) ++ to_fmt ")")⟩
 
-meta instance {α : Type u} {β : Type v} [has_to_format α] [has_to_format β] : has_to_format (sum α β) :=
+meta instance sum_has_to_format {α : Type u} {β : Type v} [has_to_format α] [has_to_format β] : has_to_format (sum α β) :=
 ⟨λ s, sum.cases_on s
   (λ a, to_fmt "(inl " ++ nest 5 (to_fmt a) ++ to_fmt ")")
   (λ b, to_fmt "(inr " ++ nest 5 (to_fmt b) ++ to_fmt ")")⟩

--- a/library/init/meta/rb_map.lean
+++ b/library/init/meta/rb_map.lean
@@ -28,6 +28,28 @@ meta def of_list {key : Type} {data : Type} [has_ordering key] : list (key × da
 | []           := mk key data
 | ((k, v)::ls) := insert (of_list ls) k v
 
+meta def keys {key : Type} {data : Type} (m : rb_map key data) : list key :=
+fold m [] (λk v ks, k :: ks)
+
+meta def values {key : Type} {data : Type} (m : rb_map key data) : list data :=
+fold m [] (λk v vs, v :: vs)
+
+meta def to_list {key : Type} {data : Type} (m : rb_map key data) : list (key × data) :=
+fold m [] (λk v res, (k, v) :: res)
+
+meta def set_of_list {A} [has_ordering A] : list A → rb_map A unit
+| []      := mk _ _
+| (x::xs) := insert (set_of_list xs) x ()
+
+meta def map {A B C} [has_ordering A] (f : B → C) (m : rb_map A B) : rb_map A C :=
+fold m (mk _ _) (λk v res, insert res k (f v))
+
+meta def for {A B C} [has_ordering A] (m : rb_map A B) (f : B → C) : rb_map A C :=
+map f m
+
+meta def filter {A B} [has_ordering A] (m : rb_map A B) (f : B → Prop) [decidable_pred f] :=
+fold m (mk _ _) $ λa b m', if f b then insert m' a b else m'
+
 end rb_map
 
 attribute [reducible]

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -654,6 +654,13 @@ do u ← mk_meta_univ,
    t ← mk_meta_var (expr.sort u),
    mk_meta_var t
 
+meta def mk_local' (pp_name : name) (bi : binder_info) (type : expr) : tactic expr := do
+uniq_name ← mk_fresh_name,
+return $ expr.local_const uniq_name pp_name bi type
+
+meta def mk_local_def (pp_name : name) (type : expr) : tactic expr :=
+mk_local' pp_name binder_info.default type
+
 private meta def get_pi_arity_aux : expr → tactic nat
 | (expr.pi n bi d b) :=
   do m     ← mk_fresh_name,

--- a/library/tools/super/cdcl.lean
+++ b/library/tools/super/cdcl.lean
@@ -1,0 +1,49 @@
+import .clause .clausifier .cdcl_solver
+open tactic expr monad super
+
+private meta def theory_solver_of_tactic (th_solver : tactic unit) : cdcl.solver (option cdcl.proof_term) :=
+do s ← state_t.read, ♯do
+hyps ← return $ s↣trail↣for (λe, e↣hyp),
+subgoal ← mk_meta_var s↣local_false,
+goals ← get_goals,
+set_goals [subgoal],
+hvs ← for hyps (λhyp, assertv hyp↣local_pp_name hyp↣local_type hyp),
+solved ← (do th_solver, now, return tt) <|> return ff,
+set_goals goals,
+if solved then do
+  proof ← instantiate_mvars subgoal,
+  proof' ← whnf proof, -- gets rid of the unnecessary asserts
+  return $ some proof'
+else
+  return none
+
+meta def cdcl_t (th_solver : tactic unit) : tactic unit := do
+as_refutation, local_false ← target,
+clauses ← clauses_of_context, clauses ← get_clauses_classical clauses,
+for clauses (λc, do c_pp ← pp c, clause.validate c <|> fail c_pp),
+res ← cdcl.solve (theory_solver_of_tactic th_solver) local_false clauses,
+match res with
+| (cdcl.result.unsat proof) := exact proof
+| (cdcl.result.sat interp) :=
+  let interp' := do e ← interp↣to_list, [if e↣2 = tt then e↣1 else not_ e↣1] in
+  do pp_interp ← pp interp',
+     fail (to_fmt "satisfying assignment: " ++ pp_interp)
+end
+
+meta def cdcl : tactic unit := cdcl_t skip
+
+example {a} : a → ¬a → false := by cdcl
+example {a} : a ∨ ¬a := by cdcl
+example {a b} : a → (a → b) → b := by cdcl
+example {a b c} : (a → b) → (¬a → b) → (b → c) → b ∧ c := by cdcl
+
+private meta def lit_unification : tactic unit :=
+do ls ← local_context, first $ do l ← ls, [do apply l, assumption]
+example {p : ℕ → Type _} : p 2 ∨ p 4 → (p (2*2) → p (2+0)) → p (1+1) :=
+by cdcl_t lit_unification
+
+example {p : ℕ → Prop} :
+        list.foldl (λf v, f ∧ (v ∨ ¬v)) true (map p (list.range 5)) :=
+begin (target >>= whnf >>= change), cdcl end
+
+example {a b c : Type _} : (a → b) → (b → c) → (a → c) := by cdcl

--- a/library/tools/super/cdcl_solver.lean
+++ b/library/tools/super/cdcl_solver.lean
@@ -1,0 +1,408 @@
+import .clause data.monad.transformers
+open tactic expr monad super
+
+namespace cdcl
+
+@[reducible] meta def prop_var := expr
+@[reducible] meta def proof_term := expr
+@[reducible] meta def proof_hyp := expr
+
+meta inductive trail_elem
+| dec : prop_var → bool → proof_hyp → trail_elem
+| propg : prop_var → bool → proof_term → proof_hyp → trail_elem
+| dbl_neg_propg : prop_var → bool → proof_term → proof_hyp → trail_elem
+
+namespace trail_elem
+
+meta def var : trail_elem → prop_var
+| (dec v _ _) := v
+| (propg v _ _ _) := v
+| (dbl_neg_propg v _ _ _) := v
+
+meta def phase : trail_elem → bool
+| (dec _ ph _) := ph
+| (propg _ ph _ _) := ph
+| (dbl_neg_propg _ ph _ _) := ph
+
+meta def hyp : trail_elem → proof_hyp
+| (dec _ _ h) := h
+| (propg _ _ _ h) := h
+| (dbl_neg_propg _ _ _ h) := h
+
+meta def is_decision : trail_elem → bool
+| (dec _ _ _) := tt
+| (propg _ _ _ _) := ff
+| (dbl_neg_propg _ _ _ _) := ff
+
+end trail_elem
+
+meta structure var_state :=
+(phase : bool)
+(assigned : option proof_hyp)
+
+meta structure learned_clause :=
+(c : clause)
+(actual_proof : proof_term)
+
+meta inductive prop_lit
+| neg : prop_var → prop_lit
+| pos : prop_var → prop_lit
+
+namespace prop_lit
+
+meta instance : has_ordering prop_lit :=
+⟨λl₁ l₂, match l₁, l₂ with
+| pos _, neg _ := ordering.gt
+| neg _, pos _ := ordering.lt
+| pos v₁, pos v₂ := has_ordering.cmp v₁ v₂
+| neg v₁, neg v₂ := has_ordering.cmp v₁ v₂
+end⟩
+
+meta def of_cls_lit : clause.literal → prop_lit
+| (clause.literal.left v) := neg v
+| (clause.literal.right v) := pos v
+
+meta def of_var_and_phase (v : prop_var) : bool → prop_lit
+| tt := pos v
+| ff := neg v
+
+end prop_lit
+
+meta def watch_map := rb_map name (ℕ × ℕ × clause)
+
+meta structure state :=
+(trail : list trail_elem)
+(vars : rb_map prop_var var_state)
+(unassigned : rb_map prop_var prop_var)
+(clauses : list clause)
+(learned : list learned_clause)
+(watches : rb_map prop_lit watch_map)
+(conflict : option proof_term)
+(unitp_queue : list prop_var)
+(local_false : expr)
+
+namespace state
+
+meta def initial (local_false : expr) : state := {
+  trail := [],
+  vars := rb_map.mk _ _,
+  unassigned := rb_map.mk _ _,
+  clauses := [],
+  learned := [],
+  watches := rb_map.mk _ _,
+  conflict := none,
+  unitp_queue := [],
+  local_false := local_false
+}
+
+meta def watches_for (st : state) (pl : prop_lit) : watch_map :=
+(st↣watches↣find pl)↣get_or_else (rb_map.mk _ _)
+
+end state
+
+meta def solver := state_t state tactic
+meta instance : monad solver := state_t.monad _ _
+meta instance : has_monad_lift tactic solver := monad.monad_transformer_lift (state_t state) tactic
+
+meta def fail {A B} [has_to_format B] (b : B) : solver A :=
+♯ @tactic.fail A B _ b
+
+meta def get_local_false : solver expr :=
+do st ← state_t.read, return st↣local_false
+
+meta def mk_var_core (v : prop_var) (ph : bool) : solver unit := do
+state_t.modify $ λst, match st↣vars↣find v with
+| (some _) := st
+| none := { st with
+    vars := st↣vars↣insert v ⟨ph, none⟩,
+    unassigned := st↣unassigned↣insert v v
+  }
+end
+
+meta def mk_var (v : prop_var) : solver unit := mk_var_core v ff
+
+meta def set_conflict (proof : proof_term) : solver unit :=
+state_t.modify $ λst, { st with conflict := some proof }
+
+meta def has_conflict : solver bool :=
+do st ← state_t.read, return st↣conflict↣is_some
+
+meta def push_trail (elem : trail_elem) : solver unit := do
+st ← state_t.read,
+match st↣vars↣find elem↣var with
+| none := fail $ "unknown variable: " ++ elem↣var↣to_string
+| some ⟨_, some _⟩ := fail $ "adding already assigned variable to trail: " ++ elem↣var↣to_string
+| some ⟨_, none⟩ :=
+  state_t.write { st with
+    vars := st↣vars↣insert elem↣var ⟨elem↣phase, some elem↣hyp⟩,
+    unassigned := st↣unassigned↣erase elem↣var,
+    trail := elem :: st↣trail,
+    unitp_queue := elem↣var :: st↣unitp_queue
+  }
+end
+
+meta def pop_trail_core : solver (option trail_elem) := do
+st ← state_t.read,
+match st↣trail with
+| elem :: rest := do
+  state_t.write { st with trail := rest,
+    vars := st↣vars↣insert elem↣var ⟨elem↣phase, none⟩,
+    unassigned := st↣unassigned↣insert elem↣var elem↣var,
+    unitp_queue := [] },
+  return $ some elem
+| [] := return none
+end
+
+meta def is_decision_level_zero : solver bool :=
+do st ← state_t.read, return $ st↣trail↣for_all $ λelem, ¬elem↣is_decision
+
+meta def revert_to_decision_level_zero : unit → solver unit | () := do
+is_dl0 ← is_decision_level_zero,
+if is_dl0 then return ()
+else do pop_trail_core, revert_to_decision_level_zero ()
+
+meta def formula_of_lit (local_false : expr) (v : prop_var) (ph : bool) :=
+if ph then v else imp v local_false
+
+meta def lookup_var (v : prop_var) : solver (option var_state) :=
+do st ← state_t.read, return $ st↣vars↣find v
+
+meta def add_propagation (v : prop_var) (ph : bool) (just : proof_term) (just_is_dn : bool) : solver unit :=
+do v_st ← lookup_var v, local_false ← get_local_false, match v_st with
+| none := fail $ "propagating unknown variable: " ++ v↣to_string
+| some ⟨assg_ph, some proof⟩ :=
+    if ph = assg_ph then
+      return ()
+    else if assg_ph ∧ ¬just_is_dn then
+      set_conflict (app just proof)
+    else
+      set_conflict (app proof just)
+| some ⟨_, none⟩ := do
+    hyp_name ← ♯mk_fresh_name,
+    hyp ← return $ local_const hyp_name hyp_name binder_info.default (formula_of_lit local_false v ph),
+    if just_is_dn then do
+      push_trail $ trail_elem.dbl_neg_propg v ph just hyp
+    else do
+      push_trail $ trail_elem.propg v ph just hyp
+end
+
+meta def add_decision (v : prop_var) (ph : bool) := do
+hyp_name ← ♯mk_fresh_name,
+local_false ← get_local_false,
+hyp ← return $ local_const hyp_name hyp_name binder_info.default (formula_of_lit local_false v ph),
+push_trail $ trail_elem.dec v ph hyp
+
+meta def lookup_lit (l : clause.literal) : solver (option (bool × proof_hyp)) :=
+do var_st_opt ← lookup_var l↣formula, match var_st_opt with
+| none := return none
+| some ⟨ph, none⟩ := return none
+| some ⟨ph, some proof⟩ :=
+  return $ some (if l↣is_neg then bnot ph else ph, proof)
+end
+
+meta def lit_is_false (l : clause.literal) : solver bool :=
+do s ← lookup_lit l, return $ match s with
+| some (ff, _) := tt
+| _ := ff
+end
+
+meta def lit_is_not_false (l : clause.literal) : solver bool :=
+do isf ← lit_is_false l, return $ bnot isf
+
+meta def cls_is_false (c : clause) : solver bool :=
+lift list.band $ mapm lit_is_false c↣get_lits
+
+private meta def unit_propg_cls' : clause → solver (option prop_var) | c :=
+if c↣num_lits = 0 then return (some c↣proof)
+else let hd := c↣get_lit 0 in
+do lit_st ← lookup_lit hd, match lit_st with
+| some (ff, isf_prf) := unit_propg_cls' (c↣inst isf_prf)
+| _                  := return none
+end
+
+meta def unit_propg_cls : clause → solver unit | c :=
+do has_confl ← has_conflict,
+if has_confl then return () else
+if c↣num_lits = 0 then do set_conflict c↣proof
+else let hd := c↣get_lit 0 in
+do lit_st ← lookup_lit hd, match lit_st with
+| some (ff, isf_prf) := unit_propg_cls (c↣inst isf_prf)
+| some (tt, _) := return ()
+| none :=
+do fls_prf_opt ← unit_propg_cls' (c↣inst (expr.mk_var 0)),
+match fls_prf_opt with
+| some fls_prf := do
+fls_prf' ← return $ lam `H binder_info.default c↣type↣binding_domain fls_prf,
+if hd↣is_neg then
+  add_propagation hd↣formula ff fls_prf' ff
+else
+  add_propagation hd↣formula tt fls_prf' tt
+| none := return ()
+end
+end
+
+private meta def modify_watches_for (pl : prop_lit) (f : watch_map → watch_map) : solver unit :=
+state_t.modify $ λst, { st with
+  watches := st↣watches↣insert pl $ f $ st↣watches_for pl
+}
+
+private meta def add_watch (n : name) (c : clause) (i j : ℕ) : solver unit :=
+let l := c↣get_lit i, pl := prop_lit.of_cls_lit l in
+modify_watches_for pl $ λw, w↣insert n (i,j,c)
+
+private meta def remove_watch (n : name) (c : clause) (i : ℕ) : solver unit :=
+let l := c↣get_lit i, pl := prop_lit.of_cls_lit l in
+modify_watches_for pl $ λw, w↣erase n
+
+private meta def set_watches (n : name) (c : clause) : solver unit :=
+if c↣num_lits = 0 then
+  set_conflict c↣proof
+else if c↣num_lits = 1 then
+  unit_propg_cls c
+else do
+  not_false_lits ← filter (λi, lit_is_not_false (c↣get_lit i)) (list.range c↣num_lits),
+  match not_false_lits with
+  | [] := do
+      add_watch n c 0 1,
+      add_watch n c 1 0,
+      unit_propg_cls c
+  | [i] :=
+      let j := if i = 0 then 1 else 0 in do
+      add_watch n c i j,
+      add_watch n c j i,
+      unit_propg_cls c
+  | (i::j::_) := do
+      add_watch n c i j,
+      add_watch n c j i
+  end
+
+meta def update_watches (n : name) (c : clause) (i₁ i₂ : ℕ) : solver unit := do
+remove_watch n c i₁,
+remove_watch n c i₂,
+set_watches n c
+
+meta def mk_clause (c : clause) : solver unit := do
+c ← ♯c↣distinct,
+for c↣get_lits (λl, mk_var l↣formula),
+revert_to_decision_level_zero (),
+state_t.modify $ λst, { st with clauses := c :: st↣clauses },
+c_name ← ♯mk_fresh_name,
+set_watches c_name c
+
+meta def unit_propg_var (v : prop_var) : solver unit :=
+do st ← state_t.read, if st↣conflict↣is_some then return () else
+match st↣vars↣find v with
+| some ⟨ph, none⟩ := fail $ "propagating unassigned variable: " ++ v↣to_string
+| none := fail $ "unknown variable: " ++ v↣to_string
+| some ⟨ph, some _⟩ :=
+  let watches := st↣watches_for $ prop_lit.of_var_and_phase v (bnot ph) in
+  for' watches↣to_list $ λw, update_watches w↣1 w↣2↣2↣2 w↣2↣1 w↣2↣2↣1
+end
+
+meta def analyze_conflict' (local_false : expr) : proof_term → list trail_elem → clause
+| proof (trail_elem.dec v ph hyp :: es) :=
+  let abs_prf := abstract_local proof hyp↣local_uniq_name in
+  if has_var abs_prf then
+    clause.close_const (analyze_conflict' proof es) hyp
+  else
+    analyze_conflict' proof es
+| proof (trail_elem.propg v ph l_prf hyp :: es) :=
+  let abs_prf := abstract_local proof hyp↣local_uniq_name in
+  if has_var abs_prf then
+    analyze_conflict' (app (lam hyp↣local_pp_name binder_info.default (formula_of_lit local_false v ph) abs_prf) l_prf) es
+  else
+    analyze_conflict' proof es
+| proof (trail_elem.dbl_neg_propg v ph l_prf hyp :: es) :=
+  let abs_prf := abstract_local proof hyp↣local_uniq_name in
+  if has_var abs_prf then
+    analyze_conflict' (app l_prf (lambdas [hyp] proof)) es
+  else
+    analyze_conflict' proof es
+| proof [] := ⟨0, 0, proof, local_false, local_false⟩
+
+meta def analyze_conflict (proof : proof_term) : solver clause :=
+do st ← state_t.read, return $ analyze_conflict' st↣local_false proof st↣trail
+
+meta def add_learned (c : clause) : solver unit := do
+prf_abbrev_name ← ♯mk_fresh_name,
+c' ← return { c with proof := local_const prf_abbrev_name prf_abbrev_name binder_info.default c↣type },
+state_t.modify $ λst, { st with learned := ⟨c', c↣proof⟩ :: st↣learned },
+c_name ← ♯mk_fresh_name,
+set_watches c_name c'
+
+meta def backtrack_with : clause → solver unit | conflict_clause := do
+isf ← cls_is_false conflict_clause,
+if ¬isf then
+  state_t.modify (λst, { st with conflict := none })
+else do
+  removed_elem ← pop_trail_core,
+  if removed_elem↣is_some then
+    backtrack_with conflict_clause
+  else
+    return ()
+
+meta def replace_learned_clauses' : proof_term → list learned_clause → proof_term
+| proof [] := proof
+| proof (⟨c, actual_proof⟩ :: lcs) :=
+  let abs_prf := abstract_local proof c↣proof↣local_uniq_name in
+  if has_var abs_prf then
+    replace_learned_clauses' (elet c↣proof↣local_pp_name c↣type actual_proof abs_prf) lcs
+  else
+    replace_learned_clauses' proof lcs
+
+meta def replace_learned_clauses (proof : proof_term) : solver proof_term :=
+do st ← state_t.read, return $ replace_learned_clauses' proof st↣learned
+
+meta inductive result
+| unsat : proof_term → result
+| sat : rb_map prop_var bool → result
+
+variable theory_solver : solver (option proof_term)
+
+meta def unit_propg : unit → solver unit | () := do
+st ← state_t.read,
+if st↣conflict↣is_some then return () else
+match st↣unitp_queue with
+| [] := return ()
+| (v::vs) := do
+  state_t.write { st with unitp_queue := vs },
+  unit_propg_var v,
+  unit_propg ()
+end
+
+private meta def run' : unit → solver result | () := do
+unit_propg (),
+st ← state_t.read,
+match st↣conflict with
+| some conflict := do
+  conflict_clause ← analyze_conflict conflict,
+  if conflict_clause↣num_lits = 0 then do
+    proof ← replace_learned_clauses conflict_clause↣proof,
+    return (result.unsat proof)
+  else do
+    backtrack_with conflict_clause,
+    add_learned conflict_clause,
+    run' ()
+| none :=
+  match st↣unassigned↣min with
+  | none := do
+    theory_conflict ← theory_solver,
+    match theory_conflict with
+    | some conflict := do set_conflict conflict, run' ()
+    | none := return $ result.sat (st↣vars↣for (λvar_st, var_st↣phase))
+    end
+  | some unassigned :=
+    match st↣vars↣find unassigned with
+    | some ⟨ph, none⟩ := do add_decision unassigned ph, run' ()
+    | _ := fail $ "unassigned variable is assigned: " ++ unassigned↣to_string
+    end
+  end
+end
+
+meta def run : solver result := run' theory_solver ()
+
+meta def solve (local_false : expr) (clauses : list clause) : tactic result := do
+res ← (do for clauses mk_clause, run theory_solver) (state.initial local_false),
+return res↣1
+
+end cdcl

--- a/library/tools/super/clause.lean
+++ b/library/tools/super/clause.lean
@@ -1,0 +1,250 @@
+import init.meta.tactic .utils .trim
+open expr list tactic monad decidable
+
+namespace super
+
+meta def is_local_not (local_false : expr) (e : expr) : option expr :=
+match e with
+| (pi _ _ a b) := if b = local_false then some a else none
+| _ := if local_false = false_ then is_not e else none
+end
+
+meta structure clause :=
+(num_quants : ℕ)
+(num_lits : ℕ)
+(proof : expr)
+(type : expr)
+(local_false : expr)
+
+namespace clause
+
+private meta def tactic_format (c : clause) : tactic format := do
+prf_fmt : format ← pp (proof c),
+type_fmt ← pp (type c),
+loc_fls_fmt ← pp c↣local_false,
+return $ prf_fmt ++ to_fmt " : " ++ type_fmt ++ to_fmt " (" ++
+  to_fmt (num_quants c) ++ to_fmt " quants, "
+  ++ to_fmt (num_lits c) ++ to_fmt " lits)"
+
+meta instance : has_to_tactic_format clause := ⟨tactic_format⟩
+
+meta def num_binders (c : clause) : ℕ := num_quants c + num_lits c
+
+meta def inst (c : clause) (e : expr) : clause :=
+(if num_quants c > 0
+  then mk (num_quants c - 1) (num_lits c)
+  else mk 0 (num_lits c - 1))
+(app (proof c) e) (instantiate_var (binding_body (type c)) e) c↣local_false
+
+meta def instn (c : clause) (es : list expr) : clause :=
+foldr (λe c', inst c' e) c es
+
+meta def open_const (c : clause) : tactic (clause × expr) := do
+n ← mk_fresh_name,
+b ← return $ local_const n (binding_name (type c)) (binding_info (type c)) (binding_domain (type c)),
+return (inst c b, b)
+
+meta def open_meta (c : clause) : tactic (clause × expr) := do
+b ← mk_meta_var (binding_domain (type c)),
+return (inst c b, b)
+
+meta def close_const (c : clause) (e : expr) : clause :=
+match e with
+| local_const uniq pp info t :=
+    let abst_type' := abstract_local (type c) (local_uniq_name e) in
+    let type' := pi pp binder_info.default t (abstract_local (type c) uniq) in
+    let abs_prf := abstract_local (proof c) uniq in
+    let proof' := lambdas [e] c↣proof in
+    if num_quants c > 0 ∨ has_var abst_type' then
+      { c with num_quants := c↣num_quants + 1, proof := proof', type := type' }
+    else
+      { c with num_lits := c↣num_lits + 1, proof := proof', type := type' }
+| _ := ⟨0, 0, default expr, default expr, default expr⟩
+end
+
+meta def open_constn : clause → ℕ → tactic (clause × list expr)
+| c 0 := return (c, nil)
+| c (n+1) := do
+  (c', b) ← open_const c,
+  (c'', bs) ← open_constn c' n,
+  return (c'', b::bs)
+
+meta def open_metan : clause → ℕ → tactic (clause × list expr)
+| c 0 := return (c, nil)
+| c (n+1) := do
+  (c', b) ← open_meta c,
+  (c'', bs) ← open_metan c' n,
+  return (c'', b::bs)
+
+meta def close_constn : clause → list expr → clause
+| c [] := c
+| c (b::bs') := close_const (close_constn c bs') b
+
+set_option eqn_compiler.max_steps 500
+
+private meta def parse_clause (local_false : expr) : expr → expr → tactic clause
+| proof (pi n bi d b) := do
+  lc_n ← mk_fresh_name,
+  lc ← return $ local_const lc_n n bi d,
+  c ← parse_clause (app proof lc) (instantiate_var b lc),
+  return $ c↣close_const $ local_const lc_n n binder_info.default d
+| proof (app (const ``not []) formula) := parse_clause proof (formula↣imp false_)
+| proof type :=
+if type = local_false then do
+  return { num_quants := 0, num_lits := 0, proof := proof, type := type, local_false := local_false }
+else do
+  univ ← infer_univ type,
+  not_type ← return $ imp type local_false,
+  parse_clause (lam `H binder_info.default not_type $ app (mk_var 0) proof) (imp not_type local_false)
+
+meta def of_proof_and_type (local_false proof type : expr) : tactic clause :=
+parse_clause local_false proof type
+
+meta def of_proof (local_false proof : expr) : tactic clause := do
+type ← infer_type proof,
+of_proof_and_type local_false proof type
+
+meta def of_classical_proof (proof : expr) : tactic clause :=
+of_proof false_ proof
+
+meta def inst_mvars (c : clause) : tactic clause := do
+proof' ← instantiate_mvars (proof c),
+type' ← instantiate_mvars (type c),
+return { c with proof := proof', type := type' }
+
+meta inductive literal
+| left : expr → literal
+| right : expr → literal
+
+namespace literal
+
+meta instance : decidable_eq literal := by mk_dec_eq_instance
+
+meta def formula : literal → expr
+| (left f) := f
+| (right f) := f
+
+meta def is_neg : literal → bool
+| (left _) := tt
+| (right _) := ff
+
+meta def is_pos (l : literal) : bool := bnot l↣is_neg
+
+meta def to_formula (l : literal) : tactic expr :=
+if is_neg l then mk_mapp ``not [some (formula l)]
+else return (formula l)
+
+meta def type_str : literal → string
+| (literal.left _) := "left"
+| (literal.right _) := "right"
+
+meta instance : has_to_tactic_format literal :=
+⟨λl, do
+pp_f ← pp l↣formula,
+return $ to_fmt l↣type_str ++ " (" ++ pp_f ++ ")"⟩
+
+end literal
+
+private meta def get_binding_body : expr → ℕ → expr
+| e 0 := e
+| e (i+1) := get_binding_body e↣binding_body i
+
+meta def get_binder (e : expr) (i : nat) :=
+binding_domain (get_binding_body e i)
+
+meta def validate (c : clause) : tactic unit := do
+concl ← return $ get_binding_body c↣type c↣num_binders,
+unify concl c↣local_false
+      <|> (do pp_concl ← pp concl, pp_lf ← pp c↣local_false,
+              fail $ to_fmt "wrong local false: " ++ pp_concl ++ " =!= " ++ pp_lf),
+type' ← infer_type c↣proof,
+unify c↣type type' <|> (do pp_ty ← pp c↣type, pp_ty' ← pp type',
+                           fail (to_fmt "wrong type: " ++ pp_ty ++ " =!= " ++ pp_ty'))
+
+meta def get_lit (c : clause) (i : nat) : literal :=
+let bind := get_binder (type c) (num_quants c + i) in
+match is_local_not c↣local_false bind with
+| some formula := literal.right formula
+| none         := literal.left bind
+end
+
+meta def lits_where (c : clause) (p : literal → bool) : list nat :=
+list.filter (λl, p (get_lit c l)) (range (num_lits c))
+
+meta def get_lits (c : clause) : list literal :=
+list.map (get_lit c) (range c↣num_lits)
+
+meta def is_maximal (gt : expr → expr → bool) (c : clause) (i : nat) : bool :=
+list.empty (list.filter (λj, gt (get_lit c j)↣formula (get_lit c i)↣formula) (range c↣num_lits))
+
+meta def normalize (c : clause) : tactic clause := do
+opened  ← open_constn c (num_binders c),
+lconsts_in_types ← return $ contained_lconsts_list (list.map local_type opened.2),
+quants' ← return $ list.filter (λlc, rb_map.contains lconsts_in_types (local_uniq_name lc))
+                                                      opened.2,
+lits' ← return $ list.filter (λlc, ¬rb_map.contains lconsts_in_types (local_uniq_name lc))
+                                                     opened.2,
+return $ close_constn opened.1 (quants' ++ lits')
+
+meta def whnf_head_lit (c : clause) : tactic clause := do
+atom' ← whnf $ literal.formula $ get_lit c 0,
+return $
+if literal.is_neg (get_lit c 0) then
+  { c with type := imp atom' (binding_body c↣type) }
+else
+  { c with type := imp (app (const ``not []) atom') c↣type↣binding_body }
+
+end clause
+
+meta def unify_lit (l1 l2 : clause.literal) : tactic unit :=
+if clause.literal.is_pos l1 = clause.literal.is_pos l2 then
+  unify_core transparency.none (clause.literal.formula l1) (clause.literal.formula l2)
+else
+  fail "cannot unify literals"
+
+-- FIXME: this is most definitely broken with meta-variables that were already in the goal
+meta def sort_and_constify_metas : list expr → tactic (list expr)
+| exprs_with_metas := do
+inst_exprs ← mapm instantiate_mvars exprs_with_metas,
+metas ← return $ inst_exprs >>= get_metas,
+match list.filter (λm, ¬has_meta_var (get_meta_type m)) metas with
+| [] :=
+     if metas^.empty then
+       return []
+     else do
+       for' metas (λm, do trace (expr.to_string m), t ← infer_type m, trace (expr.to_string t)),
+       fail "could not sort metas"
+| ((mvar n t) :: _) := do
+  t' ← infer_type (mvar n t),
+  uniq ← mk_fresh_name,
+  c ← return (local_const uniq uniq binder_info.default t'),
+  unify c (mvar n t),
+  rest ← sort_and_constify_metas metas,
+  return (rest ++ [c])
+| _ := failed
+end
+
+namespace clause
+
+meta def meta_closure (metas : list expr) (qf : clause) : tactic clause := do
+bs ← sort_and_constify_metas metas,
+qf' ← clause.inst_mvars qf,
+clause.inst_mvars $ clause.close_constn qf' bs
+
+private meta def distinct' (local_false : expr) : list expr → expr → clause
+| [] proof := ⟨ 0, 0, proof, local_false, local_false ⟩
+| (h::hs) proof :=
+  let (dups, rest) := partition (λh' : expr, h↣local_type = h'↣local_type) hs,
+      proof_wo_dups := foldl (λproof (h' : expr),
+                              instantiate_var (abstract_local proof h'↣local_uniq_name) h)
+                         proof dups in
+    (distinct' rest proof_wo_dups)↣close_const h
+
+meta def distinct (c : clause) : tactic clause := do
+(qf, vs) ← c↣open_constn c↣num_quants,
+(fls, hs) ← qf↣open_constn qf↣num_lits,
+return $ (distinct' c↣local_false hs fls↣proof)↣close_constn vs
+
+end clause
+
+end super

--- a/library/tools/super/clause_ops.lean
+++ b/library/tools/super/clause_ops.lean
@@ -1,0 +1,67 @@
+import .clause data.monad.transformers
+open monad tactic expr
+
+namespace super
+
+meta def on_left_at {m} [monad m] (c : clause) (i : ℕ)
+                    [has_monad_lift_t tactic m]
+                    -- f gets a type and returns a list of proofs of that type
+                    (f : expr → m (list (list expr × expr))) : m (list clause) := do
+op : clause × list expr ← ♯c↣open_constn (c↣num_quants + i),
+♯ @guard tactic _ (op↣1↣get_lit 0)↣is_neg _,
+new_hyps ← f (op↣1↣get_lit 0)↣formula,
+return $ new_hyps↣for (λnew_hyp,
+  (op↣1↣inst new_hyp↣2)↣close_constn (op↣2 ++ new_hyp↣1))
+
+meta def on_left_at_dn {m} [monad m] [alternative m] (c : clause) (i : ℕ)
+                    [has_monad_lift_t tactic m]
+                    -- f gets a hypothesis of ¬type and returns a list of proofs of false
+                    (f : expr → m (list (list expr × expr))) : m (list clause) := do
+qf : clause × list expr ← ♯c↣open_constn c↣num_quants,
+op : clause × list expr ← ♯qf↣1↣open_constn c↣num_lits,
+lci ← (op↣2↣nth i)↣to_monad,
+♯ @guard tactic _ (qf↣1↣get_lit i)↣is_neg _,
+h ← ♯ mk_local_def `h $ imp (qf↣1↣get_lit i)↣formula c↣local_false,
+new_hyps ← f h,
+return $ new_hyps↣for $ λnew_hyp,
+  (((clause.mk 0 0 new_hyp↣2 c↣local_false c↣local_false)↣close_const h)↣inst
+               (op↣1↣close_const lci)↣proof)↣close_constn
+  (qf↣2 ++ op↣2↣remove_nth i ++ new_hyp↣1)
+
+meta def on_right_at {m} [monad m] (c : clause) (i : ℕ)
+                     [has_monad_lift_t tactic m]
+                     -- f gets a hypothesis and returns a list of proofs of false
+                     (f : expr → m (list (list expr × expr))) : m (list clause) := do
+op : clause × list expr ← ♯c↣open_constn (c↣num_quants + i),
+♯ @guard tactic _ ((op↣1↣get_lit 0)↣is_pos) _,
+h ← ♯ mk_local_def `h (op↣1↣get_lit 0)↣formula,
+new_hyps ← f h,
+return $ new_hyps↣for (λnew_hyp,
+  (op↣1↣inst (lambdas [h] new_hyp↣2))↣close_constn (op↣2 ++ new_hyp↣1))
+
+meta def on_right_at' {m} [monad m] (c : clause) (i : ℕ)
+                     [has_monad_lift_t tactic m]
+                     -- f gets a hypothesis and returns a list of proofs
+                     (f : expr → m (list (list expr × expr))) : m (list clause) := do
+op : clause × list expr ← ♯c↣open_constn (c↣num_quants + i),
+♯ @guard tactic _ ((op↣1↣get_lit 0)↣is_pos) _,
+h ← ♯ mk_local_def `h (op↣1↣get_lit 0)↣formula,
+new_hyps ← f h,
+for new_hyps (λnew_hyp, do
+  type ← ♯ infer_type new_hyp↣2,
+  nh ← ♯ mk_local_def `nh $ imp type c↣local_false,
+  return $ (op↣1↣inst (lambdas [h] (app nh new_hyp↣2)))↣close_constn (op↣2 ++ new_hyp↣1 ++ [nh]))
+
+meta def on_first_right (c : clause) (f : expr → tactic (list (list expr × expr))) : tactic (list clause) :=
+first $ do i ← list.range c↣num_lits, [on_right_at c i f]
+
+meta def on_first_right' (c : clause) (f : expr → tactic (list (list expr × expr))) : tactic (list clause) :=
+first $ do i ← list.range c↣num_lits, [on_right_at' c i f]
+
+meta def on_first_left (c : clause) (f : expr → tactic (list (list expr × expr))) : tactic (list clause) :=
+first $ do i ← list.range c↣num_lits, [on_left_at c i f]
+
+meta def on_first_left_dn (c : clause) (f : expr → tactic (list (list expr × expr))) : tactic (list clause) :=
+first $ do i ← list.range c↣num_lits, [on_left_at_dn c i f]
+
+end super

--- a/library/tools/super/clausifier.lean
+++ b/library/tools/super/clausifier.lean
@@ -1,0 +1,272 @@
+import .clause .clause_ops
+import .prover_state .misc_preprocessing
+open expr list tactic monad decidable
+
+universe variable u
+
+namespace super
+
+meta def try_option {a : Type (u + 1)} (tac : tactic a) : tactic (option a) :=
+lift some tac <|> return none
+
+meta def inf_whnf_l (c : clause) : tactic (list clause) :=
+on_first_left c $ λtype, do
+  type' ← whnf_core transparency.reducible type,
+  guard $ type' ≠ type,
+  h ← mk_local_def `h type',
+  return [([h], h)]
+
+meta def inf_whnf_r (c : clause) : tactic (list clause) :=
+on_first_right c $ λha, do
+  a' ← whnf_core transparency.reducible ha↣local_type,
+  guard $ a' ≠ ha↣local_type,
+  hna ← mk_local_def `hna (imp a' c↣local_false),
+  return [([hna], app hna ha)]
+
+set_option eqn_compiler.max_steps 500
+
+meta def inf_false_l (c : clause) : tactic (list clause) :=
+first $ do i ← list.range c↣num_lits,
+  if c↣get_lit i = clause.literal.left false_
+  then [return []]
+  else []
+
+meta def inf_false_r (c : clause) : tactic (list clause) :=
+on_first_right c $ λhf,
+  if hf↣local_type = c↣local_false
+  then return [([], hf)]
+  else match hf↣local_type with
+  | const ``false [] := do
+    pr ← mk_app ``false.rec [c↣local_false, hf],
+    return [([], pr)]
+  | _ := failed
+  end
+
+meta def inf_true_l (c : clause) : tactic (list clause) :=
+on_first_left c $ λt,
+  match t with
+  | (const ``true []) := return [([], const ``true.intro [])]
+  | _ := failed
+  end
+
+meta def inf_true_r (c : clause) : tactic (list clause) :=
+first $ do i ← list.range c↣num_lits,
+  if c↣get_lit i = clause.literal.right (const ``true [])
+  then [return []]
+  else []
+
+meta def inf_not_l (c : clause) : tactic (list clause) :=
+on_first_left c $ λtype,
+  match type with
+  | app (const ``not []) a := do
+    hna ← mk_local_def `h (imp a false_),
+    return [([hna], hna)]
+  | _ := failed
+  end
+
+meta def inf_not_r (c : clause) : tactic (list clause) :=
+on_first_right c $ λhna,
+  match hna↣local_type with
+  | app (const ``not []) a := do
+    hnna ← mk_local_def `h (imp (imp a false_) c↣local_false),
+    return [([hnna], app hnna hna)]
+  | _ := failed
+  end
+
+meta def inf_and_l (c : clause) : tactic (list clause) :=
+on_first_left c $ λab,
+  match ab with
+  | (app (app (const ``and []) a) b) := do
+    ha ← mk_local_def `l a,
+    hb ← mk_local_def `r b,
+    pab ← mk_mapp ``and.intro [some a, some b, some ha, some hb],
+    return [([ha, hb], pab)]
+  | _ := failed
+  end
+
+meta def inf_and_r (c : clause) : tactic (list clause) :=
+on_first_right' c $ λhyp, do
+  pa ← mk_mapp ``and.left [none, none, some hyp],
+  pb ← mk_mapp ``and.right [none, none, some hyp],
+  return [([], pa), ([], pb)]
+
+meta def inf_or_r (c : clause) : tactic (list clause) :=
+on_first_right c $ λhab,
+  match hab↣local_type with
+  | (app (app (const ``or []) a) b) := do
+    hna ← mk_local_def `l (imp a c↣local_false),
+    hnb ← mk_local_def `r (imp b c↣local_false),
+    proof ← mk_app ``or.elim [a, b, c↣local_false, hab, hna, hnb],
+    return [([hna, hnb], proof)]
+  | _ := failed
+  end
+
+meta def inf_or_l (c : clause) : tactic (list clause) :=
+on_first_left c $ λab,
+  match ab with
+  | (app (app (const ``or []) a) b) := do
+    ha ← mk_local_def `l a,
+    hb ← mk_local_def `l b,
+    pa ← mk_mapp ``or.inl [some a, some b, some ha],
+    pb ← mk_mapp ``or.inr [some a, some b, some hb],
+    return [([ha], pa), ([hb], pb)]
+  | _ := failed
+  end
+
+meta def inf_all_r (c : clause) : tactic (list clause) :=
+on_first_right' c $ λhallb,
+  match hallb↣local_type with
+  | (pi n bi a b) := do
+    ha ← mk_local_def `x a,
+    return [([ha], app hallb ha)]
+  | _ := failed
+  end
+
+lemma imp_l {F a b} [decidable a] : ((a → b) → F) → ((a → F) → F) :=
+λhabf haf, decidable.by_cases
+    (assume ha :   a, haf ha)
+    (assume hna : ¬a, habf (take ha, absurd ha hna))
+
+lemma imp_l' {F a b} [decidable F] : ((a → b) → F) → ((a → F) → F) :=
+λhabf haf, decidable.by_cases
+    (assume hf :   F, hf)
+    (assume hnf : ¬F, habf (take ha, absurd (haf ha) hnf))
+
+lemma imp_l_c {F : Prop} {a b} : ((a → b) → F) → ((a → F) → F) :=
+λhabf haf, classical.by_cases
+    (assume hf :   F, hf)
+    (assume hnf : ¬F, habf (take ha, absurd (haf ha) hnf))
+
+meta def inf_imp_l (c : clause) : tactic (list clause) :=
+on_first_left_dn c $ λhnab,
+  match hnab↣local_type with
+  | (pi _ _ (pi _ _ a b) _) :=
+    if b↣has_var then failed else do
+    hna ← mk_local_def `na (imp a c↣local_false),
+    pf ← first (do r ← [``super.imp_l, ``super.imp_l', ``super.imp_l_c],
+                 [mk_app r [hnab, hna]]),
+    hb ← mk_local_def `b b,
+    return [([hna], pf), ([hb], app hnab (lam `a binder_info.default a hb))]
+  | _ := failed
+  end
+
+meta def inf_ex_l (c : clause) : tactic (list clause) :=
+on_first_left c $ λexp,
+  match exp with
+  | (app (app (const ``Exists [u]) dom) pred) := do
+    hx ← mk_local_def `x dom,
+    predx ← whnf $ app pred hx,
+    hpx ← mk_local_def `hpx predx,
+    return [([hx,hpx], app_of_list (const ``exists.intro [u])
+                       [dom, pred, hx, hpx])]
+  | _ := failed
+  end
+
+lemma demorgan' {F a} {b : a → Prop} : ((∀x, b x) → F) → (((∃x, b x → F) → F) → F) :=
+assume hab hnenb,
+  classical.by_cases
+    (assume h : ∃x, ¬b x, begin cases h with x, apply hnenb, existsi x, intros, contradiction end)
+    (assume h : ¬∃x, ¬b x, hab (take x,
+      classical.by_cases
+        (assume bx : b x, bx)
+        (assume nbx : ¬b x, begin assert hf : false, apply h, existsi x, assumption, contradiction end)))
+
+meta def inf_all_l (c : clause) : tactic (list clause) :=
+on_first_left_dn c $ λhnallb,
+  match hnallb↣local_type with
+  | pi _ _ (pi n bi a b) _ := do
+    enb ← mk_mapp ``Exists [none, some $ lam n binder_info.default a (imp b c↣local_false)],
+    hnenb ← mk_local_def `h (imp enb c↣local_false),
+    pr ← mk_app ``super.demorgan' [hnallb, hnenb],
+    return [([hnenb], pr)]
+  | _ := failed
+  end
+
+meta def inf_ex_r  (c : clause) : tactic (list clause) := do
+(qf, ctx) ← c↣open_constn c↣num_quants,
+skolemized ← on_first_right' qf $ λhexp,
+  match hexp↣local_type with
+  | (app (app (const ``Exists [u]) d) p) := do
+    sk_sym_name_pp ← get_unused_name `sk (some 1),
+    inh_lc ← mk_local' `w binder_info.implicit d,
+    sk_sym ← mk_local_def sk_sym_name_pp (pis (ctx ++ [inh_lc]) d),
+    sk_p ← whnf_core transparency.none $ app p (app_of_list sk_sym (ctx ++ [inh_lc])),
+    sk_ax ← mk_mapp ``Exists [some (local_type sk_sym),
+      some (lambdas [sk_sym] (pis (ctx ++ [inh_lc]) (imp hexp↣local_type sk_p)))],
+    sk_ax_name ← get_unused_name `sk_axiom (some 1), assert sk_ax_name sk_ax,
+    nonempt_of_inh ← mk_mapp ``nonempty.intro [some d, some inh_lc],
+    eps ← mk_mapp ``classical.epsilon [some d, some nonempt_of_inh, some p],
+    existsi (lambdas (ctx ++ [inh_lc]) eps),
+    eps_spec ← mk_mapp ``classical.epsilon_spec [some d, some p],
+    exact (lambdas (ctx ++ [inh_lc]) eps_spec),
+    sk_ax_local ← get_local sk_ax_name, cases_using sk_ax_local [sk_sym_name_pp, sk_ax_name],
+    sk_ax' ← get_local sk_ax_name,
+    return [([inh_lc], app_of_list sk_ax' (ctx ++ [inh_lc, hexp]))]
+  | _ := failed
+  end,
+return $ skolemized↣for (λs, s↣close_constn ctx)
+
+meta def first_some {a : Type} : list (tactic (option a)) → tactic (option a)
+| [] := return none
+| (x::xs) := do xres ← x, match xres with some y := return (some y) | none := first_some xs end
+
+private meta def get_clauses_core' (rules : list (clause → tactic (list clause)))
+     : list clause → tactic (list clause) | cs :=
+lift list.join $ do
+for cs $ λc, do first $
+rules↣for (λr, r c >>= get_clauses_core') ++ [return [c]]
+
+meta def get_clauses_core (rules : list (clause → tactic (list clause))) (initial : list clause)
+     : tactic (list clause) := do
+clauses ← get_clauses_core' rules initial,
+filter (λc, lift bnot $ is_taut c) $ list.nub_on clause.type clauses
+
+meta def clausification_rules_intuit : list (clause → tactic (list clause)) :=
+[ inf_false_l, inf_false_r, inf_true_l, inf_true_r,
+  inf_not_l, inf_not_r,
+  inf_and_l, inf_and_r,
+  inf_or_l, inf_or_r,
+  inf_ex_l,
+  inf_whnf_l, inf_whnf_r ]
+
+meta def clausification_rules_classical : list (clause → tactic (list clause)) :=
+[ inf_false_l, inf_false_r, inf_true_l, inf_true_r,
+  inf_not_l, inf_not_r,
+  inf_and_l, inf_and_r,
+  inf_or_l, inf_or_r,
+  inf_imp_l, inf_all_r,
+  inf_ex_l,
+  inf_all_l, inf_ex_r,
+  inf_whnf_l, inf_whnf_r ]
+
+meta def get_clauses_classical : list clause → tactic (list clause) :=
+get_clauses_core clausification_rules_classical
+meta def get_clauses_intuit : list clause → tactic (list clause) :=
+get_clauses_core clausification_rules_intuit
+
+meta def as_refutation : tactic unit := do
+repeat (do intro1, skip),
+tgt ← target,
+if tgt^.is_constant || tgt^.is_local_constant then skip else do
+local_false_name ← get_unused_name `F none, tgt_type ← infer_type tgt,
+definev local_false_name tgt_type tgt, local_false ← get_local local_false_name,
+target_name ← get_unused_name `target none,
+assertv target_name (imp tgt local_false) (lam `hf binder_info.default tgt $ mk_var 0),
+change local_false
+
+meta def clauses_of_context : tactic (list clause) := do
+local_false ← target,
+l ← local_context,
+monad.for l (clause.of_proof local_false)
+
+@[super.inf]
+meta def clausification_inf : inf_decl := inf_decl.mk 0 $
+λgiven, list.foldr orelse (return ()) $
+        do r ← clausification_rules_classical,
+           [do cs ← ♯ r given↣c,
+               cs' ← ♯ get_clauses_classical cs,
+               for' cs' (λc, mk_derived c given↣sc↣sched_now >>= add_inferred),
+               remove_redundant given↣id []]
+
+
+end super

--- a/library/tools/super/datatypes.lean
+++ b/library/tools/super/datatypes.lean
@@ -1,0 +1,52 @@
+import .clause_ops .prover_state data.monad.transformers
+open expr tactic monad
+
+namespace super
+
+meta def has_diff_constr_eq_l (c : clause) : tactic bool := do
+env ← get_env,
+return $ list.bor $ do
+  l ← c↣get_lits,
+  guard l↣is_neg,
+  return $ match is_eq l↣formula with
+  | some (lhs, rhs) :=
+    if env↣is_constructor_app lhs ∧ env↣is_constructor_app rhs ∧
+       lhs↣get_app_fn↣const_name ≠ rhs↣get_app_fn↣const_name then
+      tt
+    else
+      ff
+  | _ := ff
+  end
+
+meta def diff_constr_eq_l_pre := preprocessing_rule $
+filter (λc, lift bnot $♯ has_diff_constr_eq_l c↣c)
+
+meta def try_no_confusion_eq_r (c : clause) (i : ℕ) : tactic (list clause) :=
+on_right_at' c i $ λhyp,
+  match is_eq hyp↣local_type with
+  | some (lhs, rhs) := do
+    env ← get_env,
+    lhs ← whnf lhs, rhs ← whnf rhs,
+    guard $ env↣is_constructor_app lhs ∧ env↣is_constructor_app rhs,
+    pr ← mk_app (lhs↣get_app_fn↣const_name↣get_prefix <.> "no_confusion") [false_, lhs, rhs, hyp],
+    -- FIXME: change to local false ^^
+    ty ← infer_type pr, ty ← whnf ty,
+    pr ← to_expr `(@eq.mpr _ %%ty rfl %%pr), -- FIXME
+    return [([], pr)]
+  | _ := failed
+  end
+
+example (x y : ℕ) (h : nat.zero = nat.succ nat.zero) (h2 : nat.succ x = nat.succ y) : true := by do
+h ← get_local `h >>= clause.of_classical_proof,
+h2 ← get_local `h2 >>= clause.of_classical_proof,
+cs ← try_no_confusion_eq_r h 0,
+for' cs clause.validate,
+cs ← try_no_confusion_eq_r h2 0,
+for' cs clause.validate,
+to_expr `(trivial) >>= exact
+
+@[super.inf]
+meta def datatype_infs : inf_decl := inf_decl.mk 10 $ take given, do
+sequence' (do i ← list.range given↣c↣num_lits, [inf_if_successful 0 given $ try_no_confusion_eq_r given↣c i])
+
+end super

--- a/library/tools/super/defs.lean
+++ b/library/tools/super/defs.lean
@@ -1,0 +1,31 @@
+import .clause_ops .prover_state
+open tactic expr monad
+
+namespace super
+
+-- FIXME: how to cleanly unfold one level of definitions?
+-- what should one level even be? consider dvd->has_dvd->nat_has_dvd->...
+meta def try_unfold_one_def (type : expr) : tactic expr := do
+whnf type
+
+meta def try_unfold_def_left (c : clause) (i : ℕ) : tactic (list clause) :=
+on_left_at c i $ λt, do
+  t' ← try_unfold_one_def t,
+  ht' ← mk_local_def `h t',
+  return [([ht'], ht')]
+
+meta def try_unfold_def_right (c : clause) (i : ℕ) : tactic (list clause) :=
+on_right_at c i $ λh, do
+  t' ← try_unfold_one_def h↣local_type,
+  hnt' ← mk_local_def `h (imp t' c↣local_false),
+  return [([hnt'], app hnt' h)]
+
+@[super.inf]
+meta def unfold_def_inf : inf_decl := inf_decl.mk 40 $ take given, sequence' $ do
+r ← [try_unfold_def_right, try_unfold_def_left],
+-- NOTE: we cannot restrict to selected literals here
+-- as this might prevent factoring, e.g. _n>0_ ∨ is_pos(0)
+i ← list.range given↣c↣num_lits,
+[inf_if_successful 3 given (r given↣c i)]
+
+end super

--- a/library/tools/super/equality.lean
+++ b/library/tools/super/equality.lean
@@ -1,0 +1,37 @@
+import .clause .prover_state .utils
+open tactic monad expr list
+
+namespace super
+
+meta def try_unify_eq_l (c : clause) (i : nat) : tactic clause := do
+guard $ clause.literal.is_neg (clause.get_lit c i),
+qf ← clause.open_metan c c↣num_quants,
+match is_eq (qf↣1↣get_lit i)↣formula with
+| none := failed
+| some (lhs, rhs) := do
+unify lhs rhs,
+ty ← infer_type lhs,
+univ ← infer_univ ty,
+refl ← return $ app_of_list (const ``eq.refl [univ]) [ty, lhs],
+opened ← clause.open_constn qf↣1 i,
+clause.meta_closure qf↣2 $ clause.close_constn (opened↣1↣inst refl) opened↣2
+end
+
+@[super.inf]
+meta def unify_eq_inf : inf_decl := inf_decl.mk 40 $ take given, sequence' $ do
+i ← given↣selected,
+[inf_if_successful 0 given (do u ← try_unify_eq_l given↣c i, return [u])]
+
+meta def has_refl_r (c : clause) : bool :=
+list.bor $ do
+literal ← c↣get_lits,
+guard literal↣is_pos,
+match is_eq literal↣formula with
+| some (lhs, rhs) := [decidable.to_bool (lhs = rhs)]
+| none := []
+end
+
+meta def refl_r_pre : prover unit :=
+preprocessing_rule $ take new, return $ filter (λc, ¬has_refl_r c↣c) new
+
+end super

--- a/library/tools/super/examples.lean
+++ b/library/tools/super/examples.lean
@@ -1,0 +1,83 @@
+import .prover
+open tactic
+
+constant nat_has_dvd : has_dvd nat
+attribute [instance] nat_has_dvd
+
+noncomputable def prime (n : ℕ) := ∀d, dvd d n → d = 1 ∨ d = n
+axiom dvd_refl (m : ℕ) : dvd m m
+axiom dvd_mul (m n k : ℕ) : dvd m n → dvd m (n*k)
+
+axiom nat_mul_cancel_one (m n : ℕ) : m = m * n → n = 1
+
+example {m n : ℕ} : prime (m * n) → m = 1 ∨ n = 1 :=
+begin with_lemmas dvd_refl dvd_mul nat_mul_cancel_one, super end
+
+example : nat.zero ≠ nat.succ nat.zero := by super
+example (x y : ℕ) : nat.succ x = nat.succ y → x = y := by super
+example (i) (a b c : i) : [a,b,c] = [b,c,a] -> a = b ∧ b = c := by super
+
+definition is_positive (n : ℕ) := n > 0
+example (n : ℕ) : n > 0 ↔ is_positive n := by super
+
+example (m n : ℕ) : 0 + m = 0 + n → m = n :=
+by super with nat.zero_add
+
+local attribute [simp] nat.zero_add nat.succ_add
+@[simp] lemma nat_add_succ (m n : ℕ) : m + nat.succ n = nat.succ (m + n) := rfl
+@[simp] lemma nat_zero_has_zero : nat.zero = 0 := rfl
+example : ∀x y : ℕ, x + y = y + x :=
+begin intros, induction x, super, super end
+
+example (i) [inhabited i] : nonempty i := by super
+example (i) [nonempty i] : ¬(inhabited i → false) := by super
+
+example : nonempty ℕ := by super
+example : ¬(inhabited ℕ → false) := by super
+
+example {a b} : ¬(b ∨ ¬a) ∨ (a → b) := by super
+example {a} : a ∨ ¬a := by super
+example {a} : (a ∧ a) ∨ (¬a ∧ ¬a) := by super
+example (i) (c : i) (p : i → Prop) (f : i → i) :
+  p c → (∀x, p x → p (f x)) → p (f (f (f c))) := by super
+
+example (i) (p : i → Prop) : ∀x, p x → ∃x, p x := by super
+
+example (i) [nonempty i] (p : i → i → Prop) : (∀x y, p x y) → ∃x, ∀z, p x z := by super
+
+example (i) [nonempty i] (p : i → Prop) : (∀x, p x) → ¬¬∀x, p x := by super
+
+-- Requires non-empty domain.
+example {i} [nonempty i] (p : i → Prop) :
+  (∀x y, p x ∨ p y) → ∃x y, p x ∧ p y := by super
+
+example (i) (a b : i) (p : i → Prop) (H : a = b) : p b → p a :=
+by super
+
+example (i) (a b : i) (p : i → Prop) (H : a = b) : p a → p b :=
+by super
+
+example (i) (a b : i) (p : i → Prop) (H : a = b) : p b = p a :=
+by super
+
+example (i) (c : i) (p : i → Prop) (f g : i → i) :
+p c → (∀x, p x → p (f x)) → (∀x, p x → f x = g x) → f (f c) = g (g c) :=
+by super
+
+example (i) (p q : i → i → Prop) (a b c d : i) :
+  (∀x y z, p x y ∧ p y z → p x z) →
+  (∀x y z, q x y ∧ q y z → q x z) →
+  (∀x y, q x y → q y x) →
+  (∀x y, p x y ∨ q x y) →
+  p a b ∨ q c d :=
+by super
+
+-- This example from Davis-Putnam actually requires a non-empty domain
+example (i) [nonempty i] (f g : i → i → Prop) :
+  ∃x y, ∀z, (f x y → f y z ∧ f z z) ∧ (f x y ∧ g x y → g x z ∧ g z z) :=
+by super
+
+example (person) [nonempty person] (drinks : person → Prop) :
+  ∃canary, drinks canary → ∀other, drinks other := by super
+
+example {p q : ℕ → Prop} {r} : (∀x y, p x ∧ q y ∧ r) -> ∀x, (p x ∧ r ∧ q x) := by super

--- a/library/tools/super/factoring.lean
+++ b/library/tools/super/factoring.lean
@@ -1,0 +1,46 @@
+import .clause .prover_state .subsumption
+open tactic expr monad
+
+namespace super
+
+variable gt : expr → expr → bool
+
+meta def inst_lit (c : clause) (i : nat) (e : expr) : tactic clause := do
+opened ← clause.open_constn c i,
+return $ clause.close_constn (clause.inst opened.1 e) opened.2
+
+private meta def try_factor' (c : clause) (i j : nat) : tactic clause := do
+qf ← clause.open_metan c c↣num_quants,
+unify_lit (qf↣1↣get_lit i) (qf↣1↣get_lit j),
+qfi ← clause.inst_mvars qf.1,
+guard $ clause.is_maximal gt qfi i,
+at_j ← clause.open_constn qf.1 j,
+hyp_i ← option.to_monad (list.nth at_j.2 i),
+clause.meta_closure qf↣2 $ (at_j↣1↣inst hyp_i)↣close_constn at_j↣2
+
+meta def try_factor (c : clause) (i j : nat) : tactic clause :=
+if i > j then try_factor' gt c j i else try_factor' gt c i j
+
+meta def try_infer_factor (c : derived_clause) (i j : nat) : prover unit := do
+f ← ♯ try_factor gt c↣c i j,
+ss ← ♯ does_subsume f c↣c,
+if ss then do
+  f ← mk_derived f c↣sc↣sched_now,
+  add_inferred f,
+  remove_redundant c↣id [f]
+else do
+  inf_score 1 [c↣sc] >>= mk_derived f >>= add_inferred
+
+@[super.inf]
+meta def factor_inf : inf_decl := inf_decl.mk 40 $
+take given, do gt ← get_term_order, sequence' $ do
+  i ← given↣selected,
+  j ← list.range given↣c↣num_lits,
+  return $ try_infer_factor gt given i j <|> return ()
+
+meta def factor_dup_lits_pre := preprocessing_rule $ take new, do
+♯ for new $ λdc, do
+  dist ← dc↣c↣distinct,
+  return { dc with c := dist }
+
+end super

--- a/library/tools/super/inhabited.lean
+++ b/library/tools/super/inhabited.lean
@@ -1,0 +1,65 @@
+import .clause_ops .prover_state
+open expr tactic monad
+
+namespace super
+
+meta def try_nonempty_lookup_left (c : clause) : tactic (list clause) :=
+on_first_left_dn c $ λhnx,
+  match is_local_not c↣local_false hnx↣local_type with
+  | some type := do
+    univ ← infer_univ type,
+    lf_univ ← infer_univ c↣local_false,
+    guard $ lf_univ = level.zero,
+    inst ← mk_instance (app (const ``nonempty [univ]) type),
+    instt ← infer_type inst,
+    return [([], app_of_list (const ``nonempty.elim [univ])
+                             [type, c↣local_false, inst, hnx])]
+  | _ := failed
+  end
+
+meta def try_nonempty_left (c : clause) : tactic (list clause) :=
+on_first_left c $ λprop,
+  match prop with
+  | (app (const ``nonempty [u]) type) := do
+    x ← mk_local_def `x type,
+    return [([x], app_of_list (const ``nonempty.intro [u]) [type, x])]
+  | _ := failed
+  end
+
+meta def try_nonempty_right (c : clause) : tactic (list clause) :=
+on_first_right c $ λhnonempty,
+  match hnonempty↣local_type with
+  | (app (const ``nonempty [u]) type) := do
+    lf_univ ← infer_univ c↣local_false,
+    guard $ lf_univ = level.zero,
+    hnx ← mk_local_def `nx (imp type c↣local_false),
+    return [([hnx], app_of_list (const ``nonempty.elim [u])
+                                [type, c↣local_false, hnonempty, hnx])]
+  | _ := failed
+  end
+
+meta def try_inhabited_left (c : clause) : tactic (list clause) :=
+on_first_left c $ λprop,
+  match prop with
+  | (app (const ``inhabited [u]) type) := do
+    x ← mk_local_def `x type,
+    return [([x], app_of_list (const ``inhabited.mk [u]) [type, x])]
+  | _ := failed
+  end
+
+meta def try_inhabited_right (c : clause) : tactic (list clause) :=
+on_first_right' c $ λhinh,
+  match hinh↣local_type with
+  | (app (const ``inhabited [u]) type) :=
+    return [([], app_of_list (const ``inhabited.default [u]) [type, hinh])]
+  | _ := failed
+  end
+
+@[super.inf]
+meta def inhabited_infs : inf_decl := inf_decl.mk 10 $ take given, do
+for' [try_nonempty_lookup_left,
+       try_nonempty_left, try_nonempty_right,
+       try_inhabited_left, try_inhabited_right] $ λr,
+      simp_if_successful given (r given↣c)
+
+end super

--- a/library/tools/super/lpo.lean
+++ b/library/tools/super/lpo.lean
@@ -1,0 +1,66 @@
+-- Polytime version of lexicographic path order as described in:
+-- Things to know when implementing LPO, Bernd Löchner, ESFOR 2004
+import .utils
+open expr decidable monad
+
+def lex {T} [decidable_eq T] (gt : T → T → bool) : list T → list T → bool
+| (s::ss) (t::ts) := if s = t then lex ss ts else gt s t
+| _ _ := ff
+
+def majo {T} (gt : T → T → bool) (s : T) : list T → bool
+| [] := tt
+| (t::ts) := gt s t && majo ts
+
+meta def alpha (lpo : expr → expr → bool) : list expr → expr → bool
+| [] _ := ff
+| (s::ss) t := to_bool (s = t) || lpo s t || alpha ss t
+
+meta def lex_ma (lpo : expr → expr → bool) (s t : expr) : list expr → list expr → bool
+| (si::ss) (ti::ts) :=
+  if si = ti then lex_ma ss ts
+  else if lpo si ti then majo lpo s ts
+  else alpha lpo (si::ss) t
+| _ _ := ff
+
+meta def lpo (prec_gt : expr → expr → bool) : expr → expr → bool | s t :=
+if prec_gt (get_app_fn s) (get_app_fn t) then majo lpo s (get_app_args t)
+else if get_app_fn s = get_app_fn t then lex_ma lpo s t (get_app_args s) (get_app_args t)
+else alpha lpo (get_app_args s) t
+
+meta def prec_gt_of_name_list (ns : list name) : expr → expr → bool :=
+let nis := rb_map.of_list (list.zip_with_index ns) in
+λs t, match (rb_map.find nis (name_of_funsym s), rb_map.find nis (name_of_funsym t)) with
+| (some si, some ti) := to_bool (si > ti)
+| _ := ff
+end
+
+open tactic
+example (m n : ℕ) : true := by do
+e₁ ← to_expr `((0 + (m : ℕ)) + 0),
+e₂ ← to_expr `(0 + (0 + (m : ℕ))),
+e₃ ← to_expr `(0 + (m : ℕ)),
+prec ← return (contained_funsyms e₁)↣keys,
+prec_gt ← return $ prec_gt_of_name_list prec,
+guard $ lpo prec_gt e₁ e₃,
+guard $ lpo prec_gt e₂ e₃,
+to_expr `(trivial) >>= apply
+
+/-
+open tactic
+example (i : Type) (f : i → i) (c d x : i) : true := by do
+ef ← get_local `f, ec ← get_local `c, ed ← get_local `d,
+syms ← return [ef,ec,ed],
+prec_gt ← return $ prec_gt_of_name_list (list.map local_uniq_name [ef, ec, ed]),
+sequence' (do s1 ← syms, s2 ← syms, return (do
+  s1_fmt ← pp s1, s2_fmt ← pp s2,
+  trace (s1_fmt ++ to_fmt " > " ++ s2_fmt ++ to_fmt ": " ++ to_fmt (prec_gt s1 s2))
+)),
+
+exprs ← @mapM tactic _ _ _ to_expr [`(f c), `(f (f c)), `(f d), `(f x), `(f (f x))],
+sequence' (do e1 ← exprs, e2 ← exprs, return (do
+  e1_fmt ← pp e1, e2_fmt ← pp e2,
+  trace (e1_fmt ++ to_fmt" > " ++ e2_fmt ++ to_fmt": " ++ to_fmt (lpo prec_gt e1 e2))
+)),
+
+mk_const ``true.intro >>= apply
+-/

--- a/library/tools/super/misc_preprocessing.lean
+++ b/library/tools/super/misc_preprocessing.lean
@@ -1,0 +1,33 @@
+import .clause .prover_state
+open expr list monad
+
+namespace super
+
+meta def is_taut (c : clause) : tactic bool := do
+qf ← c^.open_constn c↣num_quants,
+return $ list.bor $ do
+  l1 ← qf^.1^.get_lits, guard l1^.is_neg,
+  l2 ← qf^.1^.get_lits, guard l2^.is_pos,
+  [decidable.to_bool $ l1^.formula = l2^.formula]
+
+open tactic
+example (i : Type) (p : i → i → Type) (c : i) (h : ∀ (x : i), p x c → p x c) : true := by do
+h ← get_local `h, hcls ← clause.of_classical_proof h,
+taut ← is_taut hcls,
+when (¬taut) failed,
+to_expr `(trivial) >>= apply
+
+meta def tautology_removal_pre : prover unit :=
+preprocessing_rule $ λnew, filter (λc, lift bnot $♯ is_taut c↣c) new
+
+meta def remove_duplicates : list derived_clause → list derived_clause
+| [] := []
+| (c :: cs) :=
+  let (same_type, other_type) := partition (λc' : derived_clause, c'↣c↣type = c↣c↣type) cs in
+  { c with sc := foldl score.min c↣sc (same_type↣for $ λc, c↣sc) } :: remove_duplicates other_type
+
+meta def remove_duplicates_pre : prover unit :=
+preprocessing_rule $ λnew,
+return $ remove_duplicates new
+
+end super

--- a/library/tools/super/prover.lean
+++ b/library/tools/super/prover.lean
@@ -1,0 +1,117 @@
+import .clause .prover_state data.monad.transformers
+import .misc_preprocessing
+import .selection
+import .trim
+
+-- default inferences
+-- 0
+import .clausifier
+-- 10
+import .inhabited
+import .datatypes
+-- 20
+import .subsumption
+-- 30
+import .splitting
+-- 40
+import .factoring
+import .resolution
+import .superposition
+import .equality
+import .simp
+import .defs
+
+open monad tactic expr
+
+declare_trace super
+set_option trace.super false
+
+namespace super
+
+meta def trace_clauses : prover unit :=
+do state ← state_t.read, ♯ trace state
+
+meta def run_prover_loop
+  (literal_selection : selection_strategy)
+  (clause_selection : clause_selection_strategy)
+  (preprocessing_rules : list (prover unit))
+  (inference_rules : list inference)
+  : ℕ → prover (option expr) | i := do
+sequence' preprocessing_rules,
+new ← take_newly_derived, for' new register_as_passive,
+♯ when (is_trace_enabled_for `super) $ for' new $ λn,
+  tactic.trace { n with c := { (n↣c) with proof := const (mk_simple_name " derived") [] } },
+needs_sat_run ← flip monad.lift state_t.read (λst, st↣needs_sat_run),
+if needs_sat_run then do
+  res ← do_sat_run,
+  match res with
+  | some proof := return (some proof)
+  | none := do
+    model ← flip monad.lift state_t.read (λst, st↣current_model),
+    ♯ when (is_trace_enabled_for `super) (do
+      pp_model ← pp (model↣to_list↣for (λlit, if lit↣2 = tt then lit↣1 else not_ lit↣1)),
+      trace $ to_fmt "sat model: " ++ pp_model),
+    run_prover_loop i
+  end
+else do
+passive ← get_passive,
+if rb_map.size passive = 0 then return none else do
+given_name ← clause_selection i,
+given ← option.to_monad (rb_map.find passive given_name),
+-- trace_clauses,
+remove_passive given_name,
+given ← literal_selection given,
+♯ when (is_trace_enabled_for `super) (do
+  fmt ← pp given, trace (to_fmt "given: " ++ fmt)),
+add_active given,
+seq_inferences inference_rules given,
+run_prover_loop (i+1)
+
+meta def default_preprocessing : list (prover unit) :=
+[
+factor_dup_lits_pre,
+remove_duplicates_pre,
+refl_r_pre,
+diff_constr_eq_l_pre,
+tautology_removal_pre,
+subsumption_interreduction_pre,
+forward_subsumption_pre,
+return ()
+]
+
+end super
+
+open super
+
+meta def super (sos_lemmas : list expr) : tactic unit := with_trim $ do
+as_refutation, local_false ← target,
+clauses ← clauses_of_context,
+sos_clauses ← monad.for sos_lemmas (clause.of_proof local_false),
+initial_state ← prover_state.initial local_false (clauses ++ sos_clauses),
+inf_names ← attribute.get_instances `super.inf,
+infs ← for inf_names $ λn, eval_expr inf_decl (const n []),
+infs ← return $ list.map inf_decl.inf $ list.sort_on inf_decl.prio infs,
+res ← run_prover_loop selection21 (age_weight_clause_selection 3 4)
+  default_preprocessing infs
+  0 initial_state,
+match res with
+| (some empty_clause, st) := apply empty_clause
+| (none, saturation) := do sat_fmt ← pp saturation,
+                           fail $ to_fmt "saturation:" ++ format.line ++ sat_fmt
+end
+
+namespace tactic.interactive
+
+meta def with_lemmas (ls : types.raw_ident_list) : tactic unit := monad.for' ls $ λl, do
+p ← mk_const l,
+t ← infer_type p,
+n ← get_unused_name p↣get_app_fn↣const_name none,
+tactic.assertv n t p
+
+meta def super (extra_clause_names : types.raw_ident_list)
+               (extra_lemma_names : types.with_ident_list) : tactic unit := do
+with_lemmas extra_clause_names,
+extra_lemmas ← monad.for extra_lemma_names mk_const,
+super extra_lemmas
+
+end tactic.interactive

--- a/library/tools/super/prover_state.lean
+++ b/library/tools/super/prover_state.lean
@@ -1,0 +1,433 @@
+import .clause .lpo .cdcl_solver data.monad.transformers
+open tactic monad expr
+
+namespace super
+
+structure score :=
+(priority : ℕ)
+(in_sos : bool)
+(cost : ℕ)
+(age : ℕ)
+
+namespace score
+def prio.immediate : ℕ := 0
+def prio.default   : ℕ := 1
+def prio.never     : ℕ := 2
+
+def sched_default (sc : score) : score := { sc with priority := prio.default }
+def sched_now (sc : score) : score := { sc with priority := prio.immediate }
+
+def inc_cost (sc : score) (n : ℕ) : score := { sc with cost := sc↣cost + n }
+
+def min (a b : score) : score :=
+{ priority := nat.min a↣priority b↣priority,
+  in_sos := a↣in_sos && b↣in_sos,
+  cost := nat.min a↣cost b↣cost,
+  age := nat.min a↣age b↣age }
+
+def combine (a b : score) : score :=
+{ priority := nat.max a↣priority b↣priority,
+  in_sos := a↣in_sos && b↣in_sos,
+  cost := a↣cost + b↣cost,
+  age := nat.max a↣age b↣age }
+end score
+
+namespace score
+meta instance : has_to_string score :=
+⟨λe, "[" ++ to_string e↣priority ++
+     "," ++ to_string e↣cost ++
+     "," ++ to_string e↣age ++
+     ",sos=" ++ to_string e↣in_sos ++ "]"⟩
+end score
+
+def clause_id := ℕ
+namespace clause_id
+def to_nat (id : clause_id) : ℕ := id
+instance : decidable_eq clause_id := nat.decidable_eq
+instance : has_ordering clause_id := nat.has_ordering
+end clause_id
+
+meta structure derived_clause :=
+(id : clause_id)
+(c : clause)
+(selected : list ℕ)
+(assertions : list expr)
+(sc : score)
+
+namespace derived_clause
+
+meta instance : has_to_tactic_format derived_clause :=
+⟨λc, do
+c_fmt ← pp c↣c,
+ass_fmt ← pp (c↣assertions↣for (λa, a↣local_type)),
+return $
+to_string c↣sc ++ " " ++
+c_fmt ++ " <- " ++ ass_fmt ++
+" (selected: " ++ to_fmt c↣selected ++
+")"
+⟩
+
+meta def clause_with_assertions (ac : derived_clause) : clause :=
+ac↣c↣close_constn ac↣assertions
+
+end derived_clause
+
+meta structure locked_clause :=
+(dc : derived_clause)
+(reasons : list (list expr))
+
+namespace locked_clause
+
+meta instance : has_to_tactic_format locked_clause :=
+⟨λc, do
+c_fmt ← pp c↣dc,
+reasons_fmt ← pp (c↣reasons↣for (λr, r↣for (λa, a↣local_type))),
+return $ c_fmt ++ " (locked in case of: " ++ reasons_fmt ++ ")"
+⟩
+
+end locked_clause
+
+meta structure prover_state :=
+(active : rb_map clause_id derived_clause)
+(passive : rb_map clause_id derived_clause)
+(newly_derived : list derived_clause)
+(prec : list expr)
+(locked : list locked_clause)
+(local_false : expr)
+(sat_solver : cdcl.state)
+(current_model : rb_map expr bool)
+(sat_hyps : rb_map expr (expr × expr))
+(needs_sat_run : bool)
+(clause_counter : nat)
+
+open prover_state
+
+private meta def join_with_nl : list format → format :=
+list.foldl (λx y, x ++ format.line ++ y) format.nil
+
+private meta def prover_state_tactic_fmt (s : prover_state) : tactic format := do
+active_fmts ← mapm pp $ rb_map.values s↣active,
+passive_fmts ← mapm pp $ rb_map.values s↣passive,
+new_fmts ← mapm pp s↣newly_derived,
+locked_fmts ← mapm pp s↣locked,
+sat_fmts ← mapm pp s↣sat_solver↣clauses,
+prec_fmts ← mapm pp s↣prec,
+return (join_with_nl
+  ([to_fmt "active:"] ++ map (append (to_fmt "  ")) active_fmts ++
+  [to_fmt "passive:"] ++ map (append (to_fmt "  ")) passive_fmts ++
+  [to_fmt "new:"] ++ map (append (to_fmt "  ")) new_fmts ++
+  [to_fmt "locked:"] ++ map (append (to_fmt "  ")) locked_fmts ++
+  [to_fmt "sat formulas:"] ++ map (append (to_fmt "  ")) sat_fmts ++
+  [to_fmt "precedence order: " ++ to_fmt prec_fmts]))
+
+meta instance : has_to_tactic_format prover_state :=
+⟨prover_state_tactic_fmt⟩
+
+meta def prover := state_t prover_state tactic
+meta instance : monad prover := state_t.monad _ _
+meta instance : has_monad_lift tactic prover := monad.monad_transformer_lift (state_t prover_state) tactic
+
+meta def prover.fail {A B : Type} [has_to_format B] (msg : B) : prover A := ♯ @tactic.fail A _ _ msg
+
+meta def prover.failed {A : Type} : prover A :=
+prover.fail "failed"
+
+meta def prover.orelse {A : Type} (p1 p2 : prover A) : prover A :=
+take state, p1 state <|> p2 state
+
+meta instance : alternative prover :=
+alternative.mk (@monad.map _ _)
+  (@applicative.pure _ (monad_is_applicative prover))
+  (@applicative.seq _ (monad_is_applicative prover))
+  @prover.failed
+  @prover.orelse
+
+meta def selection_strategy := derived_clause → prover derived_clause
+
+meta def get_active : prover (rb_map clause_id derived_clause) :=
+do state ← state_t.read, return state↣active
+
+meta def add_active (a : derived_clause) : prover unit :=
+do state ← state_t.read,
+state_t.write { state with active := state↣active↣insert a↣id a }
+
+meta def get_passive : prover (rb_map clause_id derived_clause) :=
+lift passive state_t.read
+
+meta def get_precedence : prover (list expr) :=
+do state ← state_t.read, return state↣prec
+
+meta def get_term_order : prover (expr → expr → bool) := do
+state ← state_t.read,
+return $ lpo (prec_gt_of_name_list (map name_of_funsym state↣prec))
+
+private meta def set_precedence (new_prec : list expr) : prover unit :=
+do state ← state_t.read, state_t.write { state with prec := new_prec }
+
+meta def register_consts_in_precedence (consts : list expr) := do
+p ← get_precedence,
+p_set ← return (rb_map.set_of_list (map name_of_funsym p)),
+new_syms ← return $ list.filter (λc, ¬p_set↣contains (name_of_funsym c)) consts,
+set_precedence (new_syms ++ p)
+
+meta def in_sat_solver {A} (cmd : cdcl.solver A) : prover A := do
+state ← state_t.read,
+result ← ♯ cmd state↣sat_solver,
+state_t.write { state with sat_solver := result↣2 },
+return result↣1
+
+meta def collect_ass_hyps (c : clause) : prover (list expr) :=
+let lcs := contained_lconsts c↣proof in
+do st ← state_t.read,
+return (do
+  hs ← st↣sat_hyps↣values,
+  h ← [hs↣1, hs↣2],
+  guard $ lcs↣contains h↣local_uniq_name,
+  [h])
+
+meta def get_clause_count : prover ℕ :=
+do s ← state_t.read, return s↣clause_counter
+
+meta def get_new_cls_id : prover clause_id := do
+state ← state_t.read,
+state_t.write { state with clause_counter := state↣clause_counter + 1 },
+return state↣clause_counter
+
+meta def mk_derived (c : clause) (sc : score) : prover derived_clause := do
+ass ← collect_ass_hyps c,
+id ← ♯ get_new_cls_id,
+return { id := id, c := c, selected := [], assertions := ass, sc := sc }
+
+meta def add_inferred (c : derived_clause) : prover unit := do
+c' ← ♯c↣c↣normalize, c' ← return { c with c := c' },
+register_consts_in_precedence (contained_funsyms c'↣c↣type)↣values,
+state ← state_t.read,
+state_t.write { state with newly_derived := c' :: state↣newly_derived }
+
+
+
+-- FIXME: what if we've seen the variable before, but with a weaker score?
+meta def mk_sat_var (v : expr) (suggested_ph : bool) (suggested_ev : score) : prover unit :=
+do st ← state_t.read, if st↣sat_hyps↣contains v then return () else do
+hpv ← ♯ mk_local_def `h v,
+hnv ← ♯ mk_local_def `hn $ imp v st↣local_false,
+state_t.modify $ λst, { st with sat_hyps := st↣sat_hyps↣insert v (hpv, hnv) },
+in_sat_solver $ cdcl.mk_var_core v suggested_ph,
+match v with
+| (pi _ _ _ _) := do
+  c ← ♯ clause.of_proof st↣local_false hpv,
+  mk_derived c suggested_ev >>= add_inferred
+| _ := do cp ← ♯ clause.of_proof st↣local_false hpv, mk_derived cp suggested_ev >>= add_inferred,
+          cn ← ♯ clause.of_proof st↣local_false hnv, mk_derived cn suggested_ev >>= add_inferred
+end
+
+meta def get_sat_hyp_core (v : expr) (ph : bool) : prover (option expr) :=
+flip monad.lift state_t.read $ λst,
+  match st↣sat_hyps↣find v with
+  | some (hp, hn) := some $ if ph then hp else hn
+  | none := none
+  end
+
+meta def get_sat_hyp (v : expr) (ph : bool) : prover expr :=
+do hyp_opt ← get_sat_hyp_core v ph,
+match hyp_opt with
+| some hyp := return hyp
+| none := prover.fail $ "unknown sat variable: " ++ v↣to_string
+end
+
+meta def add_sat_clause (c : clause) (suggested_ev : score) : prover unit := do
+c ← ♯ c↣distinct,
+already_added ← flip monad.lift state_t.read $ λst, decidable.to_bool $
+                     c↣type ∈ st↣sat_solver↣clauses↣for (λd, d↣type),
+if already_added then return () else do
+for c↣get_lits $ λl, mk_sat_var l↣formula l↣is_neg suggested_ev,
+in_sat_solver $ cdcl.mk_clause c,
+state_t.modify $ λst, { st with needs_sat_run := tt }
+
+meta def sat_eval_lit (v : expr) (pol : bool) : prover bool :=
+do v_st ← flip monad.lift state_t.read $ λst, st↣current_model↣find v,
+match v_st with
+| some ph := return $ if pol then ph else bnot ph
+| none := return tt
+end
+
+meta def sat_eval_assertion (assertion : expr) : prover bool :=
+do lf ← flip monad.lift state_t.read $ λst, st↣local_false,
+match is_local_not lf assertion↣local_type with
+| some v := sat_eval_lit v ff
+| none := sat_eval_lit assertion↣local_type tt
+end
+
+meta def sat_eval_assertions : list expr → prover bool
+| (a::ass) := do v_a ← sat_eval_assertion a,
+if v_a then
+sat_eval_assertions ass
+else
+return ff
+| [] := return tt
+
+private meta def intern_clause (c : derived_clause) : prover derived_clause := do
+hyp_name ← ♯ get_unused_name (mk_simple_name $ "clause_" ++ to_string c↣id↣to_nat) none,
+c' ← return $ c↣c↣close_constn c↣assertions,
+♯ assertv hyp_name c'↣type c'↣proof,
+proof' ← ♯ get_local hyp_name,
+type ← ♯ infer_type proof', -- FIXME: otherwise ""
+return { c with c := { (c↣c : clause) with proof := app_of_list proof' c↣assertions } }
+
+meta def register_as_passive (c : derived_clause) : prover unit := do
+c ← intern_clause c,
+ass_v ← sat_eval_assertions c↣assertions,
+if c↣c↣num_quants = 0 ∧ c↣c↣num_lits = 0 then
+  add_sat_clause c↣clause_with_assertions c↣sc
+else if ¬ass_v then do
+  state_t.modify $ λst, { st with locked := ⟨c, []⟩ :: st↣locked }
+else do
+  state_t.modify $ λst, { st with passive := st↣passive↣insert c↣id c }
+
+meta def remove_passive (id : clause_id) : prover unit :=
+do state ← state_t.read, state_t.write { state with passive := state↣passive↣erase id }
+
+meta def move_locked_to_passive : prover unit := do
+locked ← flip monad.lift state_t.read (λst, st↣locked),
+new_locked ← flip filter locked (λlc, do
+  reason_vals ← mapm sat_eval_assertions lc↣reasons,
+  c_val ← sat_eval_assertions lc↣dc↣assertions,
+  if reason_vals↣for_all (λr, r = ff) ∧ c_val then do
+    state_t.modify $ λst, { st with passive := st↣passive↣insert lc↣dc↣id lc↣dc },
+    return ff
+  else
+    return tt
+),
+state_t.modify $ λst, { st with locked := new_locked }
+
+meta def move_active_to_locked : prover unit :=
+do active ← get_active, for' active↣values $ λac, do
+  c_val ← sat_eval_assertions ac↣assertions,
+  if ¬c_val then do
+     state_t.modify $ λst, { st with
+       active := st↣active↣erase ac↣id,
+       locked := ⟨ac, []⟩ :: st↣locked
+     }
+  else
+    return ()
+
+meta def move_passive_to_locked : prover unit :=
+do passive ← flip monad.lift state_t.read $ λst, st↣passive, for' passive↣to_list $ λpc, do
+  c_val ← sat_eval_assertions pc↣2↣assertions,
+  if ¬c_val then do
+    state_t.modify $ λst, { st with
+      passive := st↣passive↣erase pc↣1,
+      locked := ⟨pc↣2, []⟩ :: st↣locked
+    }
+  else
+    return ()
+
+meta def do_sat_run : prover (option expr) :=
+do sat_result ← in_sat_solver $ cdcl.run (return none),
+state_t.modify $ λst, { st with needs_sat_run := ff },
+old_model ← lift prover_state.current_model state_t.read,
+match sat_result with
+| (cdcl.result.unsat proof) := return (some proof)
+| (cdcl.result.sat new_model) := do
+    state_t.modify $ λst, { st with current_model := new_model },
+    move_locked_to_passive,
+    move_active_to_locked,
+    move_passive_to_locked,
+    return none
+end
+
+meta def take_newly_derived : prover (list derived_clause) := do
+state ← state_t.read,
+state_t.write { state with newly_derived := [] },
+return state↣newly_derived
+
+meta def remove_redundant (id : clause_id) (parents : list derived_clause) : prover unit := do
+guard $ parents↣for_all $ λp, p↣id ≠ id,
+red ← flip monad.lift state_t.read (λst, st↣active↣find id),
+match red with
+| none := return ()
+| some red := do
+let reasons := parents↣for (λp, p↣assertions),
+    assertion := red↣assertions in
+if reasons↣for_all $ λr, r↣subset_of assertion then do
+  state_t.modify $ λst, { st with active := st↣active↣erase id }
+else do
+  state_t.modify $ λst, { st with active := st↣active↣erase id,
+                                 locked := ⟨red, reasons⟩ :: st↣locked }
+end
+
+meta def inference := derived_clause → prover unit
+meta structure inf_decl := (prio : ℕ) (inf : inference)
+meta def inf_attr : user_attribute :=
+⟨ `super.inf, "inference for the super prover" ⟩
+run_command attribute.register `super.inf_attr
+
+meta def seq_inferences : list inference → inference
+| [] := λgiven, return ()
+| (inf::infs) := λgiven, do
+    inf given,
+    now_active ← get_active,
+    if rb_map.contains now_active given↣id then
+      seq_inferences infs given
+    else
+      return ()
+
+meta def simp_inference (simpl : derived_clause → prover (option clause)) : inference :=
+λgiven, do maybe_simpld ← simpl given,
+match maybe_simpld with
+| some simpld := do
+  derived_simpld ← mk_derived simpld given↣sc↣sched_now,
+  add_inferred derived_simpld,
+  remove_redundant given↣id []
+| none := return ()
+end
+
+meta def preprocessing_rule (f : list derived_clause → prover (list derived_clause)) : prover unit := do
+state ← state_t.read,
+newly_derived' ← f state↣newly_derived,
+state' ← state_t.read,
+state_t.write { state' with newly_derived := newly_derived' }
+
+meta def clause_selection_strategy := ℕ → prover clause_id
+
+namespace prover_state
+
+meta def empty (local_false : expr) : prover_state :=
+{ active := rb_map.mk _ _, passive := rb_map.mk _ _,
+  newly_derived := [], prec := [], clause_counter := 0,
+  local_false := local_false,
+  locked := [], sat_solver := cdcl.state.initial local_false,
+  current_model := rb_map.mk _ _, sat_hyps := rb_map.mk _ _, needs_sat_run := ff }
+
+meta def initial (local_false : expr) (clauses : list clause) : tactic prover_state := do
+after_setup ← for' clauses (λc,
+  let in_sos := decidable.to_bool ((contained_lconsts c↣proof)↣size = 0) in
+  do mk_derived c { priority := score.prio.immediate, in_sos := in_sos,
+                    age := 0, cost := 0 } >>= add_inferred
+) $ empty local_false,
+return after_setup.2
+
+end prover_state
+
+meta def inf_score (add_cost : ℕ) (scores : list score) : prover score := do
+age ← get_clause_count,
+return $ list.foldl score.combine { priority := score.prio.default,
+                                    in_sos := tt,
+                                    age := age,
+                                    cost := add_cost
+                                  } scores
+
+meta def inf_if_successful (add_cost : ℕ) (parent : derived_clause) (tac : tactic (list clause)) : prover unit :=
+(do inferred ← ♯tac,
+    for' inferred $ λc,
+      inf_score add_cost [parent↣sc] >>= mk_derived c >>= add_inferred)
+<|> return ()
+
+meta def simp_if_successful (parent : derived_clause) (tac : tactic (list clause)) : prover unit :=
+(do inferred ← ♯tac,
+    for' inferred $ λc,
+      mk_derived c parent↣sc↣sched_now >>= add_inferred,
+    remove_redundant parent↣id [])
+<|> return ()
+
+end super

--- a/library/tools/super/resolution.lean
+++ b/library/tools/super/resolution.lean
@@ -1,0 +1,57 @@
+import .clause .prover_state .utils
+open tactic monad
+
+namespace super
+
+variable gt : expr → expr → bool
+variables (ac1 ac2 : derived_clause)
+variables (c1 c2 : clause)
+variables (i1 i2 : nat)
+
+-- c1 : ... → ¬a → ...
+-- c2 : ... →  a → ...
+meta def try_resolve : tactic clause := do
+qf1 ← c1↣open_metan c1↣num_quants,
+qf2 ← c2↣open_metan c2↣num_quants,
+-- FIXME: using default transparency unifies m*n with (x*y*z)*w here ???
+unify_core transparency.reducible (qf1↣1↣get_lit i1)↣formula (qf2↣1↣get_lit i2)↣formula,
+qf1i ← qf1↣1↣inst_mvars,
+guard $ clause.is_maximal gt qf1i i1,
+op1 ← qf1↣1↣open_constn i1,
+op2 ← qf2↣1↣open_constn c2↣num_lits,
+a_in_op2 ← (op2↣2↣nth i2)↣to_monad,
+clause.meta_closure (qf1.2 ++ qf2.2) $
+  (op1↣1↣inst (op2↣1↣close_const a_in_op2)↣proof)↣close_constn (op1↣2 ++ op2↣2↣remove_nth i2)
+
+meta def try_add_resolvent : prover unit := do
+c' ← ♯ try_resolve gt ac1↣c ac2↣c i1 i2,
+inf_score 1 [ac1↣sc, ac2↣sc] >>= mk_derived c' >>= add_inferred
+
+meta def maybe_add_resolvent : prover unit :=
+try_add_resolvent gt ac1 ac2 i1 i2 <|> return ()
+
+meta def resolution_left_inf : inference :=
+take given, do active ← get_active, sequence' $ do
+  given_i ← given↣selected,
+  guard $ clause.literal.is_neg (given↣c↣get_lit given_i),
+  other ← rb_map.values active,
+  guard $ ¬given↣sc↣in_sos ∨ ¬other↣sc↣in_sos,
+  other_i ← other↣selected,
+  guard $ clause.literal.is_pos (other↣c↣get_lit other_i),
+  [maybe_add_resolvent gt other given other_i given_i]
+
+meta def resolution_right_inf : inference :=
+take given, do active ← get_active, sequence' $ do
+  given_i ← given↣selected,
+  guard $ clause.literal.is_pos (given↣c↣get_lit given_i),
+  other ← rb_map.values active,
+  guard $ ¬given↣sc↣in_sos ∨ ¬other↣sc↣in_sos,
+  other_i ← other↣selected,
+  guard $ clause.literal.is_neg (other↣c↣get_lit other_i),
+  [maybe_add_resolvent gt given other given_i other_i]
+
+@[super.inf]
+meta def resolution_inf : inf_decl := inf_decl.mk 40 $
+take given, do gt ← get_term_order, resolution_left_inf gt given >> resolution_right_inf gt given
+
+end super

--- a/library/tools/super/selection.lean
+++ b/library/tools/super/selection.lean
@@ -1,0 +1,74 @@
+import .prover_state
+
+namespace super
+
+meta def simple_selection_strategy (f : (expr → expr → bool) → clause → list ℕ) : selection_strategy :=
+take dc, do gt ← get_term_order, return $
+         if dc↣selected↣empty ∧ dc↣c↣num_lits > 0
+         then { dc with selected := f gt dc↣c }
+         else dc
+
+meta def dumb_selection : selection_strategy :=
+simple_selection_strategy $ λgt c,
+match c↣lits_where clause.literal.is_neg with
+| [] := list.range c↣num_lits
+| neg_lit::_ := [neg_lit]
+end
+
+meta def selection21 : selection_strategy :=
+simple_selection_strategy $ λgt c,
+let maximal_lits := list.filter_maximal (λi j,
+  gt (c↣get_lit i)↣formula (c↣get_lit j)↣formula) (list.range c↣num_lits) in
+if list.length maximal_lits = 1 then maximal_lits else
+let neg_lits := list.filter (λi, (c↣get_lit i)↣is_neg) (list.range c↣num_lits),
+    maximal_neg_lits := list.filter_maximal (λi j,
+      gt (c↣get_lit i)↣formula (c↣get_lit j)↣formula) neg_lits in
+if ¬maximal_neg_lits^.empty then
+  list.taken 1 maximal_neg_lits
+else
+  maximal_lits
+
+meta def selection22 : selection_strategy :=
+simple_selection_strategy $ λgt c,
+let maximal_lits := list.filter_maximal (λi j,
+  gt (c↣get_lit i)↣formula (c↣get_lit j)↣formula) (list.range c↣num_lits),
+  maximal_lits_neg := list.filter (λi, (c↣get_lit i)↣is_neg) maximal_lits in
+if ¬maximal_lits_neg^.empty then
+  list.taken 1 maximal_lits_neg
+else
+  maximal_lits
+
+meta def clause_weight (c : derived_clause) : nat :=
+(c↣c↣get_lits↣for (λl, expr_size l↣formula + if l↣is_pos then 10 else 1))↣sum
+
+meta def find_minimal_by (passive : rb_map clause_id derived_clause)
+                         {A} [has_ordering A]
+                         (f : derived_clause → A) : clause_id :=
+match rb_map.min $ rb_map.of_list $ passive↣values↣for $ λc, (f c, c↣id) with
+| some id := id
+| none := nat.zero
+end
+
+meta def age_of_clause_id : name → ℕ
+| (name.mk_numeral i _) := unsigned.to_nat i
+| _ := 0
+
+meta def find_minimal_weight (passive : rb_map clause_id derived_clause) : clause_id :=
+find_minimal_by passive $ λc, (c↣sc↣priority, clause_weight c + c↣sc↣cost, c↣sc↣age, c↣id)
+
+meta def find_minimal_age (passive : rb_map clause_id derived_clause) : clause_id :=
+find_minimal_by passive $ λc, (c↣sc↣priority, c↣sc↣age, c↣id)
+
+meta def weight_clause_selection : clause_selection_strategy :=
+take iter, do state ← state_t.read, return $ find_minimal_weight state↣passive
+
+meta def oldest_clause_selection : clause_selection_strategy :=
+take iter, do state ← state_t.read, return $ find_minimal_age state↣passive
+
+meta def age_weight_clause_selection (thr mod : ℕ) : clause_selection_strategy :=
+take iter, if iter % mod < thr then
+              weight_clause_selection iter
+           else
+              oldest_clause_selection iter
+
+end super

--- a/library/tools/super/simp.lean
+++ b/library/tools/super/simp.lean
@@ -1,0 +1,39 @@
+import .clause_ops .prover_state
+open tactic monad
+
+namespace super
+
+meta def prove_using_assumption : tactic unit := do
+tgt ← target,
+ass ← mk_local_def `h tgt,
+exact ass
+
+meta def simplify_capturing_assumptions (type : expr) : tactic (expr × expr × list expr) := do
+(type', heq) ← simplify default_simplify_config [] type,
+hyps ← return $ contained_lconsts type,
+hyps' ← return $ contained_lconsts_list [type', heq],
+add_hyps ← return $ list.filter (λn : expr, ¬hyps↣contains n↣local_uniq_name) hyps'↣values,
+return (type', heq, add_hyps)
+
+meta def try_simplify_left (c : clause) (i : ℕ) : tactic (list clause) :=
+on_left_at c i $ λtype, do
+  (type', heq, add_hyps) ← simplify_capturing_assumptions type,
+  hyp ← mk_local_def `h type',
+  prf  ← mk_app ``eq.mpr [heq, hyp],
+  return [(hyp::add_hyps, prf)]
+
+meta def try_simplify_right (c : clause) (i : ℕ) : tactic (list clause) :=
+on_right_at' c i $ λhyp, do
+  (type', heq, add_hyps) ← simplify_capturing_assumptions hyp↣local_type,
+  heqtype ← infer_type heq,
+  heqsymm ← mk_app ``eq.symm [heq],
+  prf  ← mk_app ``eq.mpr [heqsymm, hyp],
+  return [(add_hyps, prf)]
+
+@[super.inf]
+meta def simp_inf : inf_decl := inf_decl.mk 40 $ take given, sequence' $ do
+r ← [try_simplify_right, try_simplify_left],
+i ← list.range given↣c↣num_lits,
+[inf_if_successful 2 given (r given↣c i)]
+
+end super

--- a/library/tools/super/splitting.lean
+++ b/library/tools/super/splitting.lean
@@ -1,0 +1,74 @@
+import .prover_state
+open monad expr list tactic
+
+namespace super
+
+private meta def find_components : list expr → list (list (expr × ℕ)) → list (list (expr × ℕ))
+| (e::es) comps :=
+  let (contain_e, do_not_contain_e) :=
+      partition (λc : list (expr × ℕ), c↣exists_ $ λf,
+        (abstract_local f↣1 e↣local_uniq_name)↣has_var) comps in
+    find_components es $ list.join contain_e :: do_not_contain_e
+| _ comps := comps
+
+meta def get_components (hs : list expr) : list (list expr) :=
+(find_components hs (hs↣zip_with_index↣for $ λh, [h]))↣for $ λc,
+(sort_on (λh : expr × ℕ, h↣2) c)↣for $ λh, h↣1
+
+example (i : Type) (p q : i → Prop) (H : ∀x y, p x → q y → false) : true := by do
+h ← get_local `H >>= clause.of_classical_proof,
+(op, lcs) ← h↣open_constn h↣num_binders,
+guard $ (get_components lcs)↣length = 2,
+triv
+
+example (i : Type) (p : i → i → Prop) (H : ∀x y z, p x y → p y z → false) : true := by do
+h ← get_local `H >>= clause.of_classical_proof,
+(op, lcs) ← h↣open_constn h↣num_binders,
+guard $ (get_components lcs)↣length = 1,
+triv
+
+meta def extract_assertions : clause → prover (clause × list expr) | c :=
+if c↣num_lits = 0 then return (c, [])
+else if c↣num_quants ≠ 0 then do
+  qf ← ♯ c↣open_constn c↣num_quants,
+  qf_wo_as ← extract_assertions qf↣1,
+  return (qf_wo_as↣1↣close_constn qf↣2, qf_wo_as↣2)
+else do
+  hd ← return $ c↣get_lit 0,
+  hyp_opt ← get_sat_hyp_core hd↣formula hd↣is_neg,
+  match hyp_opt with
+  | some h := do
+      wo_as ← extract_assertions (c↣inst h),
+      return (wo_as↣1, h :: wo_as↣2)
+  | _ := do
+      op ← ♯c↣open_const,
+      op_wo_as ← extract_assertions op↣1,
+      return (op_wo_as↣1↣close_const op↣2, op_wo_as↣2)
+  end
+
+meta def mk_splitting_clause' (empty_clause : clause) : list (list expr) → tactic (list expr × expr)
+| [] := return ([], empty_clause↣proof)
+| ([p] :: comps) := do p' ← mk_splitting_clause' comps, return (p::p'↣1, p'↣2)
+| (comp :: comps) := do
+  (hs, p') ← mk_splitting_clause' comps,
+  hnc ← mk_local_def `hnc (imp (pis comp empty_clause↣local_false) empty_clause↣local_false),
+  p'' ← return $ app hnc (lambdas comp p'),
+  return (hnc::hs, p'')
+
+meta def mk_splitting_clause (empty_clause : clause) (comps : list (list expr)) : tactic clause := do
+(hs, p) ← mk_splitting_clause' empty_clause comps,
+return $ { empty_clause with proof := p }↣close_constn hs
+
+@[super.inf]
+meta def splitting_inf : inf_decl := inf_decl.mk 30 $ take given, do
+lf ← flip monad.lift state_t.read $ λst, st↣local_false,
+op ← ♯ given↣c↣open_constn given↣c↣num_binders,
+if list.bor (given↣c↣get_lits↣for $ λl, (is_local_not lf l↣formula)↣is_some) then return () else
+let comps := get_components op↣2 in
+if comps↣length < 2 then return () else do
+splitting_clause ← ♯ mk_splitting_clause op↣1 comps,
+ass ← collect_ass_hyps splitting_clause,
+add_sat_clause (splitting_clause↣close_constn ass) given↣sc↣sched_default,
+remove_redundant given↣id []
+
+end super

--- a/library/tools/super/subsumption.lean
+++ b/library/tools/super/subsumption.lean
@@ -1,0 +1,87 @@
+import .clause .prover_state
+open tactic monad
+
+namespace super
+
+private meta def try_subsume_core : list clause.literal → list clause.literal → tactic unit
+| [] _ := skip
+| small large := first $ do
+  i ← small↣zip_with_index, j ← large↣zip_with_index,
+  return $ do
+    unify_lit i.1 j.1,
+    try_subsume_core (small↣remove_nth i.2) (large↣remove_nth j.2)
+
+-- FIXME: this is incorrect if a quantifier is unused
+meta def try_subsume (small large : clause) : tactic unit := do
+small_open ← clause.open_metan small (clause.num_quants small),
+large_open ← clause.open_constn large (clause.num_quants large),
+guard $ small↣num_lits ≤ large↣num_lits,
+try_subsume_core small_open↣1↣get_lits large_open↣1↣get_lits
+
+meta def does_subsume (small large : clause) : tactic bool :=
+(try_subsume small large >> return tt) <|> return ff
+
+meta def does_subsume_with_assertions (small large : derived_clause) : prover bool := do
+if small↣assertions↣subset_of large↣assertions then do
+  ♯ does_subsume small↣c large↣c
+else
+  return ff
+
+meta def any_tt {m : Type → Type} [monad m] (active : rb_map clause_id derived_clause) (pred : derived_clause → m bool) : m bool :=
+active↣fold (return ff) $ λk a cont, do
+  v ← pred a, if v then return tt else cont
+
+meta def any_tt_list {m : Type → Type} [monad m] {A} (pred : A → m bool) : list A → m bool
+| [] := return ff
+| (x::xs) := do v ← pred x, if v then return tt else any_tt_list xs
+
+@[super.inf]
+meta def forward_subsumption : inf_decl := inf_decl.mk 20 $
+take given, do active ← get_active,
+sequence' $ do a ← active↣values,
+  guard $ a↣id ≠ given↣id,
+  return $ do
+    ss ← ♯ does_subsume a↣c given↣c,
+    if ss
+    then remove_redundant given↣id [a]
+    else return ()
+
+meta def forward_subsumption_pre : prover unit := preprocessing_rule $ λnew, do
+active ← get_active, filter (λn, do
+  do ss ← any_tt active (λa,
+        if a↣assertions↣subset_of n↣assertions then do
+          ♯ does_subsume a↣c n↣c
+        else
+          -- TODO: move to locked
+          return ff),
+     return (bnot ss)) new
+
+meta def subsumption_interreduction : list derived_clause → prover (list derived_clause)
+| (c::cs) := do
+  -- TODO: move to locked
+  cs_that_subsume_c ← filter (λd, does_subsume_with_assertions d c) cs,
+  if ¬cs_that_subsume_c^.empty then
+    -- TODO: update score
+    subsumption_interreduction cs
+  else do
+    cs_not_subsumed_by_c ← filter (λd, lift bnot (does_subsume_with_assertions c d)) cs,
+    cs' ← subsumption_interreduction cs_not_subsumed_by_c,
+    return (c::cs')
+| [] := return []
+
+meta def subsumption_interreduction_pre : prover unit :=
+preprocessing_rule $ λnew,
+let new' := list.sort_on (λc : derived_clause, c↣c↣num_lits) new in
+subsumption_interreduction new'
+
+meta def keys_where_tt {m} {K V : Type} [monad m] (active : rb_map K V) (pred : V → m bool) : m (list K) :=
+@rb_map.fold _ _ (m (list K)) active (return []) $ λk a cont, do
+  v ← pred a, rest ← cont, return $ if v then k::rest else rest
+
+@[super.inf]
+meta def backward_subsumption : inf_decl := inf_decl.mk 20 $ λgiven, do
+active ← get_active,
+ss ← ♯ keys_where_tt active (λa, does_subsume given↣c a↣c),
+sequence' $ do id ← ss, guard (id ≠ given↣id), [remove_redundant id [given]]
+
+end super

--- a/library/tools/super/superposition.lean
+++ b/library/tools/super/superposition.lean
@@ -1,0 +1,137 @@
+import .clause .prover_state .utils
+open tactic monad expr
+
+namespace super
+
+meta def get_rwr_positions : expr → list (list ℕ)
+| (app a b) := [[]] ++
+  do arg ← list.zip_with_index (get_app_args (app a b)),
+     pos ← get_rwr_positions arg↣1,
+     [arg↣2 :: pos]
+| (var _) := []
+| e := [[]]
+
+meta def get_position : expr → list ℕ → expr
+| (app a b) (p::ps) :=
+match list.nth (get_app_args (app a b)) p with
+| some arg := get_position arg ps
+| none := (app a b)
+end
+| e _ := e
+
+meta def replace_position (v : expr) : expr → list ℕ → expr
+| (app a b) (p::ps) :=
+let args := get_app_args (app a b) in
+match args↣nth p with
+| some arg := app_of_list a↣get_app_fn $ args↣update_nth p $ replace_position arg ps
+| none := app a b
+end
+| e [] := v
+| e _ := e
+
+variable gt : expr → expr → bool
+variables (c1 c2 : clause)
+variables (ac1 ac2 : derived_clause)
+variables (i1 i2 : nat)
+variable pos : list ℕ
+variable ltr : bool
+variable congr_ax : name
+
+lemma {u v w} sup_ltr (F : Type u) (A : Type v) (a1 a2) (f : A → Type w) : (f a1 → F) → f a2 → a1 = a2 → F :=
+take hnfa1 hfa2 heq, hnfa1 (@eq.rec A a2 f hfa2 a1 heq↣symm)
+lemma {u v w} sup_rtl (F : Type u) (A : Type v) (a1 a2) (f : A → Type w) : (f a1 → F) → f a2 → a2 = a1 → F :=
+take hnfa1 hfa2 heq, hnfa1 (@eq.rec A a2 f hfa2 a1 heq)
+
+meta def is_eq_dir (e : expr) (ltr : bool) : option (expr × expr) :=
+match is_eq e with
+| some (lhs, rhs) := if ltr then some (lhs, rhs) else some (rhs, lhs)
+| none := none
+end
+
+meta def try_sup : tactic clause := do
+guard $ (c1↣get_lit i1)↣is_pos,
+qf1 ← c1↣open_metan c1↣num_quants,
+qf2 ← c2↣open_metan c2↣num_quants,
+(rwr_from, rwr_to) ← (is_eq_dir (qf1↣1↣get_lit i1)↣formula ltr)↣to_monad,
+atom ← return (qf2↣1↣get_lit i2)↣formula,
+eq_type ← infer_type rwr_from,
+atom_at_pos_type ← infer_type $ get_position atom pos,
+unify eq_type atom_at_pos_type,
+unify_core transparency.none rwr_from (get_position atom pos),
+rwr_from' ← instantiate_mvars rwr_from,
+rwr_to' ← instantiate_mvars rwr_to,
+guard $ ¬gt rwr_to' rwr_from',
+rwr_ctx_varn ← mk_fresh_name,
+abs_rwr_ctx ← return $
+  lam rwr_ctx_varn binder_info.default eq_type
+  (if (qf2↣1↣get_lit i2)↣is_neg
+   then replace_position (mk_var 0) atom pos
+   else imp (replace_position (mk_var 0) atom pos) c2↣local_false),
+lf_univ ← infer_univ c1↣local_false,
+univ ← infer_univ eq_type,
+atom_univ ← infer_univ atom,
+op1 ← qf1↣1↣open_constn i1,
+op2 ← qf2↣1↣open_constn c2↣num_lits,
+hi2 ← (op2↣2↣nth i2)↣to_monad,
+new_atom ← whnf $ app abs_rwr_ctx rwr_to',
+new_hi2 ← return $ local_const hi2↣local_uniq_name `H binder_info.default new_atom,
+new_fin_prf ←
+  return $ app_of_list (const congr_ax [lf_univ, univ, atom_univ]) [c1↣local_false, eq_type, rwr_from, rwr_to,
+            abs_rwr_ctx, (op2↣1↣close_const hi2)↣proof, new_hi2],
+clause.meta_closure (qf1↣2 ++ qf2↣2) $ (op1↣1↣inst new_fin_prf)↣close_constn (op1↣2 ++ op2↣2↣update_nth i2 new_hi2)
+
+example (i : Type) (a b : i) (p : i → Prop) (H : a = b) (Hpa : p a) : true := by do
+H ← get_local `H >>= clause.of_classical_proof,
+Hpa ← get_local `Hpa >>= clause.of_classical_proof,
+a ← get_local `a,
+try_sup (λx y, ff) H Hpa 0 0 [0] tt ``super.sup_ltr >>= clause.validate,
+to_expr `(trivial) >>= apply
+
+example (i : Type) (a b : i) (p : i → Prop) (H : a = b) (Hpa : p a → false) (Hpb : p b → false) : true := by do
+H ← get_local `H >>= clause.of_classical_proof,
+Hpa ← get_local `Hpa >>= clause.of_classical_proof,
+Hpb ← get_local `Hpb >>= clause.of_classical_proof,
+try_sup (λx y, ff) H Hpa 0 0 [0] tt ``super.sup_ltr >>= clause.validate,
+try_sup (λx y, ff) H Hpb 0 0 [0] ff ``super.sup_rtl >>= clause.validate,
+to_expr `(trivial) >>= apply
+
+meta def rwr_positions (c : clause) (i : nat) : list (list ℕ) :=
+get_rwr_positions (c↣get_lit i)↣formula
+
+meta def try_add_sup : prover unit :=
+(do c' ← ♯ try_sup gt ac1↣c ac2↣c i1 i2 pos ltr congr_ax,
+    inf_score 2 [ac1↣sc, ac2↣sc] >>= mk_derived c' >>= add_inferred)
+  <|> return ()
+
+meta def superposition_back_inf : inference :=
+take given, do active ← get_active, sequence' $ do
+  given_i ← given↣selected,
+  guard (given↣c↣get_lit given_i)↣is_pos,
+  option.to_monad $ is_eq (given↣c↣get_lit given_i)↣formula,
+  other ← rb_map.values active,
+  guard $ ¬given↣sc↣in_sos ∨ ¬other↣sc↣in_sos,
+  other_i ← other↣selected,
+  pos ← rwr_positions other↣c other_i,
+  -- FIXME(gabriel): ``sup_ltr fails to resolve at runtime
+  [do try_add_sup gt given other given_i other_i pos tt ``super.sup_ltr,
+      try_add_sup gt given other given_i other_i pos ff ``super.sup_rtl]
+
+meta def superposition_fwd_inf : inference :=
+take given, do active ← get_active, sequence' $ do
+  given_i ← given↣selected,
+  other ← rb_map.values active,
+  guard $ ¬given↣sc↣in_sos ∨ ¬other↣sc↣in_sos,
+  other_i ← other↣selected,
+  guard (other↣c↣get_lit other_i)↣is_pos,
+  option.to_monad $ is_eq (other↣c↣get_lit other_i)↣formula,
+  pos ← rwr_positions given↣c given_i,
+  [do try_add_sup gt other given other_i given_i pos tt ``super.sup_ltr,
+      try_add_sup gt other given other_i given_i pos ff ``super.sup_rtl]
+
+@[super.inf]
+meta def superposition_inf : inf_decl := inf_decl.mk 40 $
+take given, do gt ← get_term_order,
+superposition_fwd_inf gt given,
+superposition_back_inf gt given
+
+end super

--- a/library/tools/super/trim.lean
+++ b/library/tools/super/trim.lean
@@ -1,0 +1,63 @@
+import .utils
+open monad expr tactic
+
+namespace super
+
+meta def count_var_occs : unsigned → expr → ℕ
+| k (var k')              := if k = k' then 1 else 0
+| _ (sort _)              := 0
+| _ (const _ _)           := 0
+| _ (mvar _ _)            := 0
+| k (local_const _ _ _ t) := count_var_occs k t
+| k (app a b)             := count_var_occs k a + count_var_occs k b
+| k (lam _ _ t b)         := count_var_occs k t + count_var_occs k^.succ b
+| k (pi _ _ t b)          := count_var_occs k t + count_var_occs k^.succ b
+| k (elet _ t v b)        := count_var_occs k t + count_var_occs k v + count_var_occs k^.succ b
+| _ (macro _ _ _)         := 0 -- TODO(gabriel)
+
+-- TODO(gabriel): rewrite using conversions
+meta def trim : expr → tactic expr
+| (app (lam n m d b) arg) :=
+  if has_var b = ff ∨ count_var_occs 0 b ≤ 1 then
+    trim (instantiate_var b arg)
+  else
+    lift₂ app (trim (lam n m d b)) (trim arg)
+| (app a b) := lift₂ app (trim a) (trim b)
+| (lam n m d b) := do
+  x ← mk_local' `x m d,
+  b' ← trim (instantiate_var b x),
+  return $ lam n m d (abstract_local b' x^.local_uniq_name)
+| (elet n t v b) :=
+  if has_var b then do
+    x ← mk_local_def `x t,
+    b' ← trim (instantiate_var b x),
+    return $ elet n t v (abstract_local b' x^.local_uniq_name)
+  else
+    trim b
+| e := return e
+
+-- iterate trim until convergence
+meta def trim' : expr → tactic expr
+| e := do e' ← trim e,
+          if e =ₐ e' then
+            return e
+          else
+            trim' e'
+
+open tactic
+
+meta def with_trim {α} (tac : tactic α) : tactic α := do
+gs ← get_goals,
+match gs with
+| (g::gs) := do
+  g' ← infer_type g >>= mk_meta_var,
+  set_goals [g'],
+  r ← tac,
+  now,
+  set_goals (g::gs),
+  instantiate_mvars g' >>= trim' >>= exact,
+  return r
+| [] := fail "no goal"
+end
+
+end super

--- a/library/tools/super/utils.lean
+++ b/library/tools/super/utils.lean
@@ -1,0 +1,149 @@
+open tactic expr list
+
+meta def get_metas : expr → list expr
+| (var _) := []
+| (sort _) := []
+| (const _ _) := []
+| (mvar n t) := expr.mvar n t :: get_metas t
+| (local_const _ _ _ t) := get_metas t
+| (app a b) := get_metas a ++ get_metas b
+| (lam _ _ d b) := get_metas d ++ get_metas b
+| (pi _ _ d b) := get_metas d ++ get_metas b
+| (elet _ t v b) := get_metas t ++ get_metas v ++ get_metas b
+| (macro _ _ _) := []
+
+meta def get_meta_type : expr → expr
+| (mvar _ t) := t
+| _ := mk_var 0
+
+-- TODO(gabriel): think about how to handle the avalanche of implicit arguments
+meta def expr_size : expr → nat
+| (var _) := 1
+| (sort _) := 1
+| (const _ _) := 1
+| (mvar n t) := 1
+| (local_const _ _ _ _) := 1
+| (app a b) := expr_size a + expr_size b
+| (lam _ _ d b) := 1 + expr_size b
+| (pi _ _ d b) := 1 + expr_size b
+| (elet _ t v b) := 1 + expr_size v + expr_size b
+| (macro _ _ _) := 1
+
+namespace ordering
+
+def is_lt {A} [has_ordering A] (x y : A) : bool :=
+match has_ordering.cmp x y with ordering.lt := tt | _ := ff end
+
+end ordering
+
+namespace list
+
+meta def nub {A} [has_ordering A] (l : list A) : list A :=
+rb_map.keys (rb_map.set_of_list l)
+
+meta def nub_on {A B} [has_ordering B] (f : A → B) (l : list A) : list A :=
+rb_map.values (rb_map.of_list (map (λx, (f x, x)) l))
+
+def nub_on' {A B} [decidable_eq B] (f : A → B) : list A → list A
+| [] := []
+| (x::xs) := x :: filter (λy, f x ≠ f y) (nub_on' xs)
+
+def for_all {A} (l : list A) (p : A → Prop) [decidable_pred p] : bool :=
+list.all l (λx, to_bool (p x))
+
+def exists_ {A} (l : list A) (p : A → Prop) [decidable_pred p] : bool :=
+list.any l (λx, to_bool (p x))
+
+def subset_of {A} [decidable_eq A] (xs ys : list A) :=
+xs↣for_all (λx, x ∈ ys)
+
+def filter_maximal {A} (gt : A → A → bool) (l : list A) : list A :=
+filter (λx, l↣for_all (λy, ¬gt y x)) l
+
+private def zip_with_index' {A} : ℕ → list A → list (A × ℕ)
+| _ nil := nil
+| i (x::xs) := (x,i) :: zip_with_index' (i+1) xs
+
+def zip_with_index {A} : list A → list (A × ℕ) :=
+zip_with_index' 0
+
+def partition {A} (pred : A → Prop) [decidable_pred pred] : list A → list A × list A
+| (x::xs) := match partition xs with (ts,fs) := if pred x then (x::ts, fs) else (ts, x::fs) end
+| [] := ([],[])
+
+meta def merge_sorted {A} [has_ordering A] : list A → list A → list A
+| [] ys := ys
+| xs [] := xs
+| (x::xs) (y::ys) :=
+  if ordering.is_lt x y then
+    x :: merge_sorted xs (y::ys)
+  else
+    y :: merge_sorted (x::xs) ys
+
+meta def sort {A} [has_ordering A] : list A → list A
+| (x::xs) :=
+  let (smaller, greater_eq) := partition (λy, ordering.is_lt y x) xs in
+  merge_sorted (sort smaller) (x :: sort greater_eq)
+| [] := []
+
+meta def sort_on {A B} (f : A → B) [has_ordering B] : list A → list A :=
+@sort _ ⟨λx y, has_ordering.cmp (f x) (f y)⟩
+
+end list
+
+meta def name_of_funsym : expr → name
+| (local_const uniq _ _ _) := uniq
+| (const n _) := n
+| _ := name.anonymous
+
+private meta def contained_funsyms' : expr → rb_map name expr → rb_map name expr
+| (var _) m := m
+| (sort _) m := m
+| (const n ls) m := rb_map.insert m n (const n ls)
+| (mvar _ t) m := contained_funsyms' t m
+| (local_const uniq pp bi t) m := rb_map.insert m uniq (local_const uniq pp bi t)
+| (app a b) m := contained_funsyms' a (contained_funsyms' b m)
+| (lam _ _ d b) m := contained_funsyms' d (contained_funsyms' b m)
+| (pi _ _ d b) m := contained_funsyms' d (contained_funsyms' b m)
+| (elet _ t v b) m := contained_funsyms' t (contained_funsyms' v (contained_funsyms' b m))
+| (macro _ _ _) m := m
+
+meta def contained_funsyms (e : expr) : rb_map name expr :=
+contained_funsyms' e (rb_map.mk name expr)
+
+private meta def contained_lconsts' : expr → rb_map name expr → rb_map name expr
+| (var _) m := m
+| (sort _) m := m
+| (const _ _) m := m
+| (mvar _ t) m := contained_lconsts' t m
+| (local_const uniq pp bi t) m := contained_lconsts' t (rb_map.insert m uniq (local_const uniq pp bi t))
+| (app a b) m := contained_lconsts' a (contained_lconsts' b m)
+| (lam _ _ d b) m := contained_lconsts' d (contained_lconsts' b m)
+| (pi _ _ d b) m := contained_lconsts' d (contained_lconsts' b m)
+| (elet _ t v b) m := contained_lconsts' t (contained_lconsts' v (contained_lconsts' b m))
+| (macro _ _ _) m := m
+
+meta def contained_lconsts (e : expr) : rb_map name expr :=
+contained_lconsts' e (rb_map.mk name expr)
+
+meta def contained_lconsts_list (es : list expr) : rb_map name expr :=
+list.foldl (λlcs e, contained_lconsts' e lcs) (rb_map.mk name expr) es
+
+namespace tactic
+
+meta def infer_univ (type : expr) : tactic level :=
+do sort_of_type ← infer_type type >>= whnf,
+match sort_of_type with
+| sort lvl := return lvl
+| not_sort := do fmt ← pp not_sort,
+                 fail $ to_fmt "cannot get universe level of sort: " ++ fmt
+end
+
+end tactic
+
+namespace nat
+
+def min (m n : ℕ) := if m < n then m else n
+def max (m n : ℕ) := if m > n then m else n
+
+end nat

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -82,7 +82,7 @@ class module_mgr {
     mutex m_mutex;
     std::unordered_map<module_id, std::shared_ptr<module_info>> m_modules;
 
-    void mark_out_of_date(module_id const & id);
+    void mark_out_of_date(module_id const & id, buffer<module_id> & to_rebuild);
     void build_module(module_id const & id, bool can_use_olean, name_set module_stack);
     std::vector<module_name> get_direct_imports(module_id const & id, std::string const & contents);
     void gather_transitive_imports(


### PR DESCRIPTION
As discussed on slack, it's probably a good idea to include super in the main repo.  Because at least for now, that's the only way other people can actually try it out.

Notable features:
 * First-order complete  superposition prover with splitting and extensible inferences.  (`super` tactic)
 * Toy SAT solver.  (`cdcl` tactic)
 * Proof trimming to reduce size of produced proofs.
 * Makes an effort to produce constructive proofs.  (Well, this was more relevant when we still had HoTT support.)

If you have any questions, please ask.  I'm just terribly busy ATM or I'd write a longer summary.

I have tried to put most of the generally useful utility functions into the right modules, though there are still a few ones left in `tools.super`.
 * Since super heavily uses monad transformers, I have added a module for monad transformers in `data.monad.transformers`.  This also includes an explicit type-parameter preserving coercion `♯` between monads.  Unfortunately I couldn't get typeclass inference to work here, and had to declare all of the `monad_lift tactic prover_state`, etc., instances manually.
 * There is merge sort, but I didn't put it into the list module because it depends on `has_ordering` instead of `decidable_linear_order`.  Unfortunately there is almost no type that has both typeclasses, and I need it for `expr` which only has `has_ordering`.