### PR TITLE
Refactoring bitvec

### DIFF
--- a/library/data/bitvec.lean
+++ b/library/data/bitvec.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2015 Joe Hendrix. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Author: Joe Hendrix
+Authors: Joe Hendrix, Sebastian Ullrich
 
 Basic operations on bitvectors.
 
@@ -9,55 +9,58 @@ This is a work-in-progress, and contains additions to other theories.
 -/
 import data.tuple
 
-def bitvec (n : ℕ) := tuple bool n
+@[reducible] def bitvec (n : ℕ) := tuple bool n
 
 namespace bitvec
 open nat
 open tuple
 
-instance (n : nat) : decidable_eq (bitvec n) :=
-begin unfold bitvec, apply_instance end
+local infix `++ₜ`:65 := tuple.append
 
 -- Create a zero bitvector
-def zero {n : ℕ} : bitvec n := tuple.repeat ff
+@[reducible] protected def zero (n : ℕ) : bitvec n := repeat ff n
 
 -- Create a bitvector with the constant one.
-def one {n : ℕ} : bitvec (succ n) := tuple.append (tuple.repeat ff : bitvec n) [ tt ]
+@[reducible] protected def one : Π (n : ℕ), bitvec n
+| 0        := []
+| (succ n) := repeat ff n ++ₜ [tt]
+
+protected def cong {a b : ℕ} (h : a = b) : bitvec a → bitvec b
+| ⟨x, p⟩ := ⟨x, h ▸ p⟩
 
 section shift
+  variable {n : ℕ}
 
-  -- shift left
-  def shl {n : ℕ} : bitvec n → ℕ → bitvec n
-    | x i :=
-       if le : i ≤ n then
-         let eq := nat.sub_add_cancel le in
-         cast (congr_arg bitvec eq) (tuple.append (dropn i x) (zero : bitvec i))
-       else
-         zero
+  def shl (x : bitvec n) (i : ℕ) : bitvec n :=
+  let r := dropn i x ++ₜ repeat ff (min n i) in
+  have length r = n, begin dsimp, rewrite [nat.sub_add_min_cancel] end,
+  bitvec.cong this r
+
+  def fill_shr (x : bitvec n) (i : ℕ) (fill : bool) : bitvec n :=
+  let y := repeat fill (min n i) ++ₜ firstn (n-i) x in
+  have length y = n, from if h : i ≤ n then
+    begin
+      dsimp,
+      rw [min_eq_right h, min_eq_left (sub_le _ _), -nat.add_sub_assoc h,
+        nat.add_sub_cancel_left]
+    end
+  else
+    have h : i ≥ n, from le_of_not_ge h,
+    begin
+      dsimp,
+      rw [min_eq_left h, sub_eq_zero_of_le h, min_eq_left (zero_le _)],
+      apply rfl
+    end,
+  bitvec.cong this y
 
   -- unsigned shift right
-  def ushr {n : ℕ} : bitvec n → ℕ → bitvec n
-    | x i :=
-      if le : i ≤ n then
-        let y : bitvec (n-i) := @firstn _ _ _ (sub_le n i) x in
-        let eq := calc (i+(n-i)) = (n - i) + i : nat.add_comm i (n - i)
-                            ...  = n           : nat.sub_add_cancel le in
-        cast (congr_arg bitvec eq) (tuple.append zero y)
-      else
-        zero
+  def ushr (x : bitvec n) (i : ℕ) : bitvec n :=
+  fill_shr x i ff
 
   -- signed shift right
-  def sshr {m : ℕ} : bitvec (succ m) → ℕ → bitvec (succ m)
-    | x i :=
-      let n := succ m in
-      if le : i ≤ n then
-        let z : bitvec i := repeat (head x) in
-        let y : bitvec (n-i) := @firstn _ _ (n - i) (sub_le n i) x in
-        let eq := calc (i+(n-i)) = (n-i) + i : nat.add_comm i (n - i)
-                            ...  = n         : nat.sub_add_cancel le in
-        cast (congr_arg bitvec eq) (tuple.append z y)
-      else
-        zero
+  def sshr : Π {m : ℕ}, bitvec m → ℕ → bitvec m
+  | 0        _ _ := []
+  | (succ m) x i := head x :: fill_shr (tail x) i (head x)
 
 end shift
 
@@ -74,54 +77,41 @@ end bitwise
 section arith
   variable {n : ℕ}
 
-  protected def xor3 (x:bool) (y:bool) (c:bool) := bxor (bxor x y) c
-  protected def carry (x:bool) (y:bool) (c:bool) :=
-    x && y || x && c || y && c
+  protected def xor3 (x y c : bool) := bxor (bxor x y) c
+  protected def carry (x y c : bool) :=
+  x && y || x && c || y && c
 
-  def neg : bitvec n → bitvec n
-  | x :=
-    let f := λy c, (y || c, bxor y c) in
-    prod.snd (map_accumr f x ff)
+  def neg (x : bitvec n) : bitvec n :=
+  let f := λ y c, (y || c, bxor y c) in
+  prod.snd (map_accumr f x ff)
 
   -- Add with carry (no overflow)
-  def adc : bitvec n → bitvec n → bool → bitvec (n+1)
-  | x y c :=
-    let f := λx y c, (bitvec.carry x y c, bitvec.xor3 x y c) in
-    let z := tuple.map_accumr₂ f x y c in
-    prod.fst z :: prod.snd z
+  def adc (x y : bitvec n) (c : bool) : bitvec (n+1) :=
+  let f := λ x y c, (bitvec.carry x y c, bitvec.xor3 x y c) in
+  let ⟨c, z⟩ := tuple.map_accumr₂ f x y c in
+  c :: z
 
-  def add : bitvec n → bitvec n → bitvec n
-  | x y := tail (adc x y ff)
+  def add (x y : bitvec n) : bitvec n := tail (adc x y ff)
 
-  protected def borrow (x:bool) (y:bool) (b:bool) :=
-    bnot x && y || bnot x && b || y && b
+  protected def borrow (x y b : bool) :=
+  bnot x && y || bnot x && b || y && b
 
   -- Subtract with borrow
-  def sbb : bitvec n → bitvec n → bool → bool × bitvec n
-  | x y b :=
-    let f := λx y c, (bitvec.borrow x y c, bitvec.xor3 x y c) in
-    tuple.map_accumr₂ f x y b
+  def sbb (x y : bitvec n) (b : bool) : bool × bitvec n :=
+  let f := λ x y c, (bitvec.borrow x y c, bitvec.xor3 x y c) in
+  tuple.map_accumr₂ f x y b
 
-  def sub : bitvec n → bitvec n → bitvec n
-  | x y := prod.snd (sbb x y ff)
+  def sub (x y : bitvec n) : bitvec n := prod.snd (sbb x y ff)
 
-  instance : has_zero (bitvec n) := ⟨zero⟩
-  /- Remark: we used to have the instance has_one only for (bitvec (succ n)).
-     Now, we define it for all n to make sure we don't have to solve unification problems such as:
-     succ ?n =?= (bit0 (bit1 one)) -/
-  instance : has_one (bitvec n) :=
-  match n with
-  | 0            := ⟨zero⟩
-  | (nat.succ n) := ⟨one⟩
-  end
+  instance : has_zero (bitvec n) := ⟨bitvec.zero n⟩
+  instance : has_one (bitvec n)  := ⟨bitvec.one n⟩
   instance : has_add (bitvec n)  := ⟨add⟩
   instance : has_sub (bitvec n)  := ⟨sub⟩
   instance : has_neg (bitvec n)  := ⟨neg⟩
 
-  def mul : bitvec n → bitvec n → bitvec n
-  | x y :=
-    let f := λr b, cond b (r + r + y) (r + r) in
-    list.foldl f 0 (to_list x)
+  def mul (x y : bitvec n) : bitvec n :=
+  let f := λ r b, cond b (r + r + y) (r + r) in
+  list.foldl f 0 (to_list x)
 
   instance : has_mul (bitvec n)  := ⟨mul⟩
 end arith
@@ -129,37 +119,54 @@ end arith
 section comparison
   variable {n : ℕ}
 
-  def uborrow : bitvec n → bitvec n → bool := λx y, prod.fst (sbb x y ff)
+  def uborrow (x y : bitvec n) : bool := prod.fst (sbb x y ff)
 
-  def ult (x y : bitvec n) : Prop := uborrow x y = tt
+  def ult (x y : bitvec n) : Prop := uborrow x y
   def ugt (x y : bitvec n) : Prop := ult y x
 
   def ule (x y : bitvec n) : Prop := ¬ (ult y x)
-  def uge : bitvec n → bitvec n → Prop := λx y, ule y x
+  def uge (x y : bitvec n) : Prop := ule y x
 
-  def sborrow : bitvec (succ n) → bitvec (succ n) → bool := λx y,
+  def sborrow : Π {n : ℕ}, bitvec n → bitvec n → bool
+  | 0        _ _ := ff
+  | (succ n) x y :=
      bool.cases_on
        (head x)
        (bool.cases_on (head y) (uborrow (tail x) (tail y)) tt)
        (bool.cases_on (head y) ff (uborrow (tail x) (tail y)))
 
-  def slt : bitvec (succ n) → bitvec (succ n) → Prop := λx y,
-     sborrow x y = tt
-
-  def sgt : bitvec (succ n) → bitvec (succ n) → Prop := λx y, slt y x
-  def sle : bitvec (succ n) → bitvec (succ n) → Prop := λx y, ¬ (slt y x)
-  def sge : bitvec (succ n) → bitvec (succ n) → Prop := λx y, sle y x
+  def slt (x y : bitvec n) : Prop := sborrow x y
+  def sgt (x y : bitvec n) : Prop := slt y x
+  def sle (x y : bitvec n) : Prop := ¬ (slt y x)
+  def sge (x y : bitvec n) : Prop := sle y x
 
 end comparison
 
-section from_bitvec
+section conversion
   variable {α : Type}
 
-  -- Convert a bitvector to another number.
-  def from_bitvec [has_add α] [has_zero α] [has_one α] {n : nat} (v : bitvec n) : α :=
-  let f : α → bool → α := λr b, cond b (r + r + 1) (r + r) in
-  list.foldl f (0 : α) (to_list v)
-end from_bitvec
+  protected def of_nat : Π (n : ℕ), nat → bitvec n
+  | 0        x := nil
+  | (succ n) x := of_nat n (x / 2) ++ₜ [to_bool (x % 2 = 1)]
+
+  protected def of_int : Π (n : ℕ), int → bitvec (succ n)
+  | n (int.of_nat m)          := ff :: bitvec.of_nat n m
+  | n (int.neg_succ_of_nat m) := tt :: not (bitvec.of_nat n m)
+
+  def bits_to_nat (v : list bool) : nat :=
+  list.foldl (λ r b, r + r + cond b 1 0) 0 v
+
+  protected def to_nat {n : nat} (v : bitvec n) : nat :=
+  bits_to_nat (to_list v)
+
+  protected def to_int : Π {n : nat}, bitvec n → int
+  | 0        _ := 0
+  | (succ n) v :=
+    cond (head v)
+      (int.neg_succ_of_nat $ bitvec.to_nat $ not $ tail v)
+      (int.of_nat $ bitvec.to_nat $ tail v)
+
+end conversion
 
 private def to_string {n : nat} : bitvec n → string
 | ⟨bs, p⟩ :=

--- a/library/data/tuple.lean
+++ b/library/data/tuple.lean
@@ -22,6 +22,8 @@ definition nil : tuple α 0 := ⟨[],  rfl⟩
 definition cons : α → tuple α n → tuple α (nat.succ n)
 | a ⟨ v, h ⟩ := ⟨ a::v, congr_arg nat.succ h ⟩
 
+@[reducible] def length (v : tuple α n) : ℕ := n
+
 notation a :: b := cons a b
 notation `[` l:(foldr `, ` (h t, cons h t) nil `]`) := l
 
@@ -79,18 +81,17 @@ definition map₂ (f : α → β → φ) : tuple α n → tuple β n → tuple �
                  ... = n                                   : min_self n in
   ⟨ z, p ⟩
 
-definition repeat (a : α) : tuple α n
-  := ⟨ list.repeat a n, list.length_repeat a n ⟩
+definition repeat (a : α) (n : ℕ) : tuple α n :=
+⟨list.repeat a n, list.length_repeat a n⟩
 
-definition dropn : Π (i:ℕ), tuple α n → tuple α (n - i)
-| i ⟨ l, p ⟩ := ⟨ list.dropn i l, p ▸ list.length_dropn i l ⟩
+definition dropn (i : ℕ) : tuple α n → tuple α (n - i)
+| ⟨l, p⟩ := ⟨list.dropn i l, p ▸ list.length_dropn i l⟩
 
-definition firstn : Π (i:ℕ) {p:i ≤ n}, tuple α n → tuple α i
-| i is_le ⟨ l, p ⟩ :=
+definition firstn (i : ℕ) : tuple α n → tuple α (min i n)
+| ⟨l, p⟩ :=
   let q := calc list.length (list.firstn i l)
                    = min i (list.length l)  : list.length_firstn i l
-               ... = min i n                : congr_arg (λ v, min i v) p
-               ... = i                      : min_eq_left is_le in
+               ... = min i n                : congr_arg (min i) p in
   ⟨list.firstn i l, q⟩
 
 section accum

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -24,6 +24,13 @@ notation `-[1+ ` n `]` := int.neg_succ_of_nat n
 instance : decidable_eq int :=
 by tactic.mk_dec_eq_instance
 
+private def int.to_string : int → string
+| (int.of_nat n)          := to_string n
+| (int.neg_succ_of_nat n) := "-" ++ to_string (succ n)
+
+instance : has_to_string int :=
+⟨int.to_string⟩
+
 namespace int
 
 protected theorem coe_nat_eq (n : ℕ) : ↑n = int.of_nat n := rfl

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -691,6 +691,13 @@ have g : ¬ (x ≤ y) → min (succ x) (succ y) = succ (min x y), from λp,
           ... = succ (min x y) : congr_arg succ (eq.symm (if_neg p)),
 decidable.by_cases f g
 
+lemma sub_eq_sub_min (n m : ℕ) : n - m = n - min n m :=
+if h : n ≥ m then by rewrite [min_eq_right h]
+else by rewrite [sub_eq_zero_of_le (le_of_not_ge h), min_eq_left (le_of_not_ge h), nat.sub_self]
+
+lemma sub_add_min_cancel (n m : ℕ) : n - m + min n m = n :=
+by rewrite [sub_eq_sub_min, nat.sub_add_cancel (min_le_left n m)]
+
 /- TODO(Leo): sub + inequalities -/
 
 

--- a/library/init/data/to_string.lean
+++ b/library/init/data/to_string.lean
@@ -74,7 +74,7 @@ instance : has_to_string string :=
 ⟨string.quote⟩
 
 /- Remark: the code generator replaces this definition with one that display natural numbers in decimal notation -/
-def nat.to_string : nat → string
+protected def nat.to_string : nat → string
 | 0        := "zero"
 | (succ a) := "(succ " ++ nat.to_string a ++ ")"
 


### PR DESCRIPTION
I set out to define all signed `bitvec` operations on any `bitvec n`, as discussed in a previous comment. On top of that I did the following changes, mostly taken from [my lean2 fork](https://github.com/Kha/electrolysis/blob/master/thys/bitvec.lean) of the theory.

* (try to) apply style & conventions used in the rest of the standard library
* make parameters explicit that can only be inferred from the return type
* Add two-way conversion functions to/from `nat` and `int`. I've removed the generic unsigned conversion function, assuming that it is easier to just go through `nat`, especially in proofs.

I'm happy to discuss any of these changes. I can also move everything to `library_dev` if that makes more sense, or outright postpone the PR. This was mostly done to get a feeling for working in Lean 3.

/cc @joehendrix