### PR TITLE
[WIP] Try to reduce flickering of error list

### DIFF
--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -134,6 +134,7 @@
     ;; server
     ;; (kill-buffer-hook                    . lean-server-stop)
     (after-change-functions              . lean-server-change-hook)
+    (focus-in-hook                       . lean-server-show-messages)
     ;; Handle events that may start automatic syntax checks
     (before-save-hook                    . lean-whitespace-cleanup)
     )


### PR DESCRIPTION
This commit tries to make error list updates less distracting by restricting them to every 200ms and removing the need to toggle `flycheck-mode`, which used to temporarily move focus to the error list.

I will have to check a few more scenarios to make sure the list is eventually correct, but thought you might be interested in testing the approach.