### PR TITLE
[RFC] Importing modules using an in-memory structured representation of olean files

### DIFF
--- a/src/api/module.cpp
+++ b/src/api/module.cpp
@@ -21,9 +21,11 @@ lean_bool lean_env_import(lean_env env, lean_ios ios, lean_list_name modules, le
     check_nonnull(ios);
     check_nonnull(modules);
     auto new_env = to_env_ref(env);
+    std::vector<module_name> imports;
     for (name const & n : to_list_name_ref(modules)) {
-        new_env = import_module(new_env, "", {n, optional<unsigned>()}, mk_olean_loader());
+        imports.push_back({n, optional<unsigned>()});
     }
+    new_env = import_modules(new_env, "", imports, mk_olean_loader());
     *r = of_env(new environment(new_env));
     LEAN_CATCH;
 }

--- a/src/api/module.cpp
+++ b/src/api/module.cpp
@@ -31,8 +31,9 @@ lean_bool lean_env_import(lean_env env, lean_ios ios, lean_list_name modules, le
 lean_bool lean_env_export(lean_env env, char const * fname, lean_exception * ex) {
     LEAN_TRY;
     check_nonnull(env);
+    auto lm = export_module(to_env_ref(env), fname);
     std::ofstream out(fname, std::ofstream::binary);
-    export_module(out, to_env_ref(env));
+    write_module(lm, out);
     LEAN_CATCH;
 }
 

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2166,18 +2166,16 @@ void parser::process_imports() {
     unsigned fingerprint = 0;
     auto imports = parse_imports(fingerprint);
 
-    for (auto & n : imports) {
-        try {
-            m_env = import_module(m_env, m_file_name, n, m_import_fn);
-        } catch (exception & ex) {
-            m_found_errors = true;
-            parser_exception error((sstream() << "invalid import '" << n.m_name << "'").str(),
-                                   m_file_name.c_str(), m_last_cmd_pos.first, m_last_cmd_pos.second);
-            if (!m_use_exceptions && m_show_errors)
-                report_message(error);
-            if (m_use_exceptions)
-                throw error;
-        }
+    try {
+        m_env = import_modules(m_env, m_file_name, imports, m_import_fn);
+    } catch (exception & ex) {
+        m_found_errors = true;
+        parser_exception error((sstream() << "invalid import").str(),
+                               m_file_name.c_str(), m_last_cmd_pos.first, m_last_cmd_pos.second);
+        if (!m_use_exceptions && m_show_errors)
+            report_message(error);
+        if (m_use_exceptions)
+            throw error;
     }
 
     m_env = update_fingerprint(m_env, fingerprint);

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2330,12 +2330,9 @@ bool parse_commands(environment & env, io_state & ios, char const * fname) {
     vfs.m_modules_to_load_from_source.insert(std::string(fname));
     module_mgr mod_mgr(&vfs, &get_global_message_buffer(), env, ios);
 
-    auto mod = mod_mgr.get_module(fname)->m_result.get();
-
-    lean_assert(mod.m_env);
-    env = *mod.m_env;
-
-    return mod.m_ok;
+    auto mod = mod_mgr.get_module(fname);
+    env = mod->get_produced_env();
+    return mod->m_result.get().m_ok;
 }
 
 void initialize_parser() {

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -80,7 +80,6 @@ struct token_config {
     typedef token_state  state;
     typedef token_entry  entry;
     static name * g_class_name;
-    static std::string * g_key;
 
     static void add_entry(environment const &, io_state const &, state & s, entry const & e) {
         s.m_table = add_token(s.m_table, e.m_token.c_str(), e.m_prec);
@@ -88,9 +87,7 @@ struct token_config {
     static name const & get_class_name() {
         return *g_class_name;
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static const char * get_serialization_key() { return "TK"; }
     static void  write_entry(serializer & s, entry const & e) {
         s << e.m_token.c_str() << e.m_prec;
     }
@@ -104,7 +101,6 @@ struct token_config {
     }
 };
 name * token_config::g_class_name = nullptr;
-std::string * token_config::g_key = nullptr;
 
 template class scoped_ext<token_config>;
 typedef scoped_ext<token_config> token_ext;
@@ -239,7 +235,6 @@ struct notation_config {
     typedef notation_state  state;
     typedef notation_entry  entry;
     static name * g_class_name;
-    static std::string * g_key;
 
     static void updt_inv_map(state & s, head_index const & idx, entry const & e) {
         if (!e.parse_only())
@@ -281,9 +276,7 @@ struct notation_config {
     static name const & get_class_name() {
         return *g_class_name;
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static char const * get_serialization_key() { return "NOTA"; }
     static void  write_entry(serializer & s, entry const & e) {
         s << static_cast<char>(e.kind()) << e.overload() << e.parse_only() << e.get_expr();
         if (e.is_numeral()) {
@@ -321,7 +314,6 @@ struct notation_config {
     }
 };
 name * notation_config::g_class_name = nullptr;
-std::string * notation_config::g_key = nullptr;
 
 template class scoped_ext<notation_config>;
 typedef scoped_ext<notation_config> notation_ext;
@@ -386,20 +378,16 @@ cmd_table const & get_cmd_table(environment const & env) {
 
 void initialize_parser_config() {
     token_config::g_class_name = new name("notation");
-    token_config::g_key        = new std::string("TK");
     token_ext::initialize();
     notation_config::g_class_name = new name("notation");
-    notation_config::g_key        = new std::string("NOTA");
     notation_ext::initialize();
     g_ext = new cmd_ext_reg();
 }
 void finalize_parser_config() {
     delete g_ext;
     notation_ext::finalize();
-    delete notation_config::g_key;
     delete notation_config::g_class_name;
     token_ext::finalize();
-    delete token_config::g_key;
     delete token_config::g_class_name;
 }
 }

--- a/src/frontends/lean/parser_config.h
+++ b/src/frontends/lean/parser_config.h
@@ -16,6 +16,7 @@ struct token_entry {
     std::string m_token;
     unsigned    m_prec;
     token_entry(std::string const & tk, unsigned prec): m_token(tk), m_prec(prec) {}
+    token_entry() : m_prec(0) {}
 };
 inline token_entry mk_token_entry(std::string const & tk, unsigned prec) { return token_entry(tk, prec); }
 

--- a/src/frontends/smt2/parser.cpp
+++ b/src/frontends/smt2/parser.cpp
@@ -696,8 +696,7 @@ public:
 
         auto mod_ldr = mk_olean_loader();
         optional<unsigned> k;
-        m_env = import_module(m_env, get_stream_name(), {"init", k}, mod_ldr);
-        m_env = import_module(m_env, get_stream_name(), {"smt", k}, mod_ldr);
+        m_env = import_modules(m_env, get_stream_name(), {{"init", k}, {"smt", k}}, mod_ldr);
 
         bool ok = true;
         try {

--- a/src/library/attribute_manager.cpp
+++ b/src/library/attribute_manager.cpp
@@ -32,8 +32,6 @@ void set_user_attribute_ext(std::unique_ptr<user_attribute_ext> ext) {
 
 static std::vector<pair<name, name>> * g_incomp = nullptr;
 
-static std::string * g_key = nullptr;
-
 bool is_system_attribute(name const & attr) {
     return g_system_attributes->contains(attr);
 }
@@ -122,9 +120,7 @@ struct attr_config {
         s.insert(e.m_attr, mk_pair(m, h));
     }
 
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static const char * get_serialization_key() { return "ATTR"; }
 
     static void write_entry(serializer & s, entry const & e) {
         s << e.m_attr << e.m_prio << e.m_record.m_decl << e.m_record.deleted();
@@ -276,13 +272,11 @@ void initialize_attribute_manager() {
     g_system_attributes  = new name_map<attribute_ptr>();
     g_user_attribute_ext.reset(new user_attribute_ext());
     g_incomp             = new std::vector<pair<name, name>>();
-    g_key                = new std::string("ATTR");
     attribute_ext::initialize();
 }
 
 void finalize_attribute_manager() {
     attribute_ext::finalize();
-    delete g_key;
     delete g_incomp;
     g_user_attribute_ext.reset();
     delete g_system_attributes;

--- a/src/library/aux_recursors.cpp
+++ b/src/library/aux_recursors.cpp
@@ -29,21 +29,58 @@ static environment update(environment const & env, aux_recursor_ext const & ext)
     return env.update(g_ext->m_ext_id, std::make_shared<aux_recursor_ext>(ext));
 }
 
-static std::string * g_auxrec_key = nullptr;
-static std::string * g_no_confusion_key = nullptr;
+struct auxrec_modification : public modification {
+    LEAN_MODIFICATION("auxrec")
+
+    name m_decl;
+
+    auxrec_modification() {}
+    auxrec_modification(name const & decl) : m_decl(decl) {}
+
+    void perform(environment & env) const override {
+        aux_recursor_ext ext = get_extension(env);
+        ext.m_aux_recursor_set.insert(m_decl);
+        env = update(env, ext);
+    }
+
+    void serialize(serializer & s) const override {
+        s << m_decl;
+    }
+
+    static std::shared_ptr<modification const> deserialize(deserializer & d) {
+        return std::make_shared<auxrec_modification>(read_name(d));
+    }
+};
+
+struct no_conf_modification : public modification {
+    LEAN_MODIFICATION("no_conf")
+
+    name m_decl;
+
+    no_conf_modification() {}
+    no_conf_modification(name const & decl) : m_decl(decl) {}
+
+    void perform(environment & env) const override {
+        aux_recursor_ext ext = get_extension(env);
+        ext.m_no_confusion_set.insert(m_decl);
+        env = update(env, ext);
+    }
+
+    void serialize(serializer & s) const override {
+        s << m_decl;
+    }
+
+    static std::shared_ptr<modification const> deserialize(deserializer & d) {
+        return std::make_shared<no_conf_modification>(read_name(d));
+    }
+};
 
 environment add_aux_recursor(environment const & env, name const & r) {
-    aux_recursor_ext ext = get_extension(env);
-    ext.m_aux_recursor_set.insert(r);
-    environment new_env = update(env, ext);
-    return module::add(new_env, *g_auxrec_key, [=](environment const &, serializer & s) { s << r; });
+    return module::add_and_perform(env, std::make_shared<auxrec_modification>(r));
 }
 
 environment add_no_confusion(environment const & env, name const & r) {
-    aux_recursor_ext ext = get_extension(env);
-    ext.m_no_confusion_set.insert(r);
-    environment new_env = update(env, ext);
-    return module::add(new_env, *g_no_confusion_key, [=](environment const &, serializer & s) { s << r; });
+    return module::add_and_perform(env, std::make_shared<no_conf_modification>(r));
 }
 
 bool is_aux_recursor(environment const & env, name const & r) {
@@ -54,33 +91,15 @@ bool is_no_confusion(environment const & env, name const & r) {
     return get_extension(env).m_no_confusion_set.contains(r);
 }
 
-static void aux_recursor_reader(deserializer & d, environment & env) {
-    name r;
-    d >> r;
-    aux_recursor_ext ext = get_extension(env);
-    ext.m_aux_recursor_set.insert(r);
-    env = update(env, ext);
-}
-
-static void no_confusion_reader(deserializer & d, environment & env) {
-    name r;
-    d >> r;
-    aux_recursor_ext ext = get_extension(env);
-    ext.m_no_confusion_set.insert(r);
-    env = update(env, ext);
-}
-
 void initialize_aux_recursors() {
     g_ext              = new aux_recursor_ext_reg();
-    g_auxrec_key       = new std::string("auxrec");
-    g_no_confusion_key = new std::string("no_conf");
-    register_module_object_reader(*g_auxrec_key, aux_recursor_reader);
-    register_module_object_reader(*g_no_confusion_key, no_confusion_reader);
+    auxrec_modification::init();
+    no_conf_modification::init();
 }
 
 void finalize_aux_recursors() {
-    delete g_auxrec_key;
-    delete g_no_confusion_key;
+    auxrec_modification::finalize();
+    no_conf_modification::finalize();
     delete g_ext;
 }
 }

--- a/src/library/class.cpp
+++ b/src/library/class.cpp
@@ -76,7 +76,6 @@ struct class_state {
 };
 
 static name * g_class_name = nullptr;
-static std::string * g_key = nullptr;
 
 struct class_config {
     typedef class_state state;
@@ -94,9 +93,7 @@ struct class_config {
     static name const & get_class_name() {
         return *g_class_name;
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static const char * get_serialization_key() { return "class"; }
     static void  write_entry(serializer & s, entry const & e) {
         s << static_cast<char>(e.m_kind);
         switch (e.m_kind) {
@@ -246,7 +243,6 @@ void initialize_class() {
     g_class_attr_name = new name("class");
     g_instance_attr_name = new name("instance");
     g_class_name = new name("class");
-    g_key = new std::string("class");
     class_ext::initialize();
 
     register_system_attribute(basic_attribute(*g_class_attr_name, "type class",
@@ -264,7 +260,6 @@ void initialize_class() {
 
 void finalize_class() {
     class_ext::finalize();
-    delete g_key;
     delete g_class_name;
     delete g_class_attr_name;
     delete g_instance_attr_name;

--- a/src/library/export.cpp
+++ b/src/library/export.cpp
@@ -298,10 +298,7 @@ class exporter {
 
     void export_direct_imports() {
         if (!m_all) {
-            buffer<module_name> imports;
-            to_buffer(get_curr_module_imports(m_env), imports);
-            std::reverse(imports.begin(), imports.end());
-            for (module_name const & m : imports) {
+            for (module_name const & m : get_curr_module_imports(m_env)) {
                 unsigned n = export_name(m.m_name);
                 if (m.m_relative) {
                     m_out << "#RI " << *m.m_relative << " " << n << "\n";

--- a/src/library/inverse.cpp
+++ b/src/library/inverse.cpp
@@ -31,7 +31,6 @@ struct inverse_state {
 };
 
 static name * g_inverse_name = nullptr;
-static std::string * g_key = nullptr;
 
 struct inverse_config {
     typedef inverse_state state;
@@ -42,8 +41,8 @@ struct inverse_config {
     static name const & get_class_name() {
         return *g_inverse_name;
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
+    static const char * get_serialization_key() {
+        return "inverse";
     }
     static void  write_entry(serializer & s, entry const & e) {
         s << e.m_fn << e.m_info.m_arity << e.m_info.m_inv << e.m_info.m_inv_arity << e.m_info.m_lemma;
@@ -107,7 +106,6 @@ environment add_inverse_lemma(environment const & env, name const & lemma, bool 
 
 void initialize_inverse() {
     g_inverse_name = new name("inverse");
-    g_key = new std::string("inverse");
     inverse_ext::initialize();
 
     register_system_attribute(basic_attribute("inverse", "attribute for marking inverse lemmas "
@@ -120,7 +118,6 @@ void initialize_inverse() {
 
 void finalize_inverse() {
     inverse_ext::finalize();
-    delete g_key;
     delete g_inverse_name;
 }
 }

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -300,6 +300,11 @@ struct decl_modification : public modification {
     static std::shared_ptr<modification const> deserialize(deserializer & d) {
         return std::make_shared<decl_modification>(read_declaration(d));
     }
+
+    void get_task_dependencies(std::vector<generic_task_result> & deps) const override {
+        if (m_decl.is_theorem())
+            deps.push_back(m_decl.get_value_task());
+    }
 };
 
 struct inductive_modification : public modification {

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -47,7 +47,7 @@ list<name> const & get_curr_module_decl_names(environment const & env);
 /** \brief Return the list of universes declared in the current module */
 list<name> const & get_curr_module_univ_names(environment const & env);
 /** \brief Return the list of modules directly imported by the current module */
-list<module_name> get_curr_module_imports(environment const & env);
+std::vector<module_name> get_curr_module_imports(environment const & env);
 
 /** \brief Return an environment based on \c env, where all modules in \c modules are imported.
     Modules included directly or indirectly by them are also imported.
@@ -57,13 +57,9 @@ list<module_name> get_curr_module_imports(environment const & env);
     checked. The idea is to save memory.
 */
 environment
-import_module(environment const & env,
-              std::string const & current_mod, module_name const & ref,
-              module_loader const & mod_ldr);
-
-environment mk_preimported_module(environment const & initial_env,
-                                  loaded_module const & lm,
-                                  module_loader const & mod_ldr);
+import_modules(environment const & env,
+               std::string const & current_mod, std::vector<module_name> const & ref,
+               module_loader const & mod_ldr);
 
 /** \brief Return the .olean file where decl_name was defined. The result is none if the declaration
     was not defined in an imported file. */
@@ -79,6 +75,10 @@ environment add_transient_decl_pos_info(environment const & env, name const & de
 /** \brief Store/Export module using \c env. */
 loaded_module export_module(environment const & env, std::string const & mod_name);
 void write_module(loaded_module const & mod, std::ostream & out);
+
+std::shared_ptr<loaded_module const> cache_preimported_env(
+        loaded_module &&, environment const & initial_env,
+        std::function<module_loader()> const & mk_mod_ldr);
 
 std::pair<std::vector<module_name>, std::vector<char>> parse_olean(
         std::istream & in, std::string const & file_name, bool check_hash = true);

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -91,6 +91,7 @@ public:
     virtual const char * get_key() const = 0;
     virtual void perform(environment &) const = 0;
     virtual void serialize(serializer &) const = 0;
+    virtual void get_task_dependencies(std::vector<generic_task_result> &) const {}
 };
 
 #define LEAN_MODIFICATION(k) \

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -15,6 +15,7 @@ Author: Leonardo de Moura
 #include "kernel/inductive/inductive.h"
 #include "library/io_state.h"
 #include "util/task_queue.h"
+#include "util/lazy_value.h"
 
 namespace lean {
 class corrupted_file_exception : public exception {
@@ -34,8 +35,10 @@ struct loaded_module {
     std::string m_module_name;
     std::vector<module_name> m_imports;
     modification_list m_modifications;
+
+    lazy_value<environment> m_env;
 };
-using module_loader = std::function<loaded_module(std::string const &, module_name const &)>;
+using module_loader = std::function<std::shared_ptr<loaded_module const> (std::string const &, module_name const &)>;
 module_loader mk_olean_loader();
 module_loader mk_dummy_loader();
 
@@ -57,6 +60,10 @@ environment
 import_module(environment const & env,
               std::string const & current_mod, module_name const & ref,
               module_loader const & mod_ldr);
+
+environment mk_preimported_module(environment const & initial_env,
+                                  loaded_module const & lm,
+                                  module_loader const & mod_ldr);
 
 /** \brief Return the .olean file where decl_name was defined. The result is none if the declaration
     was not defined in an imported file. */

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -112,9 +112,8 @@ public:
     std::vector<generic_task_result> get_dependencies() override {
         if (auto res = m_mod->m_result.peek()) {
             std::vector<generic_task_result> deps;
-            res->m_env->for_each_declaration([&] (declaration const & d) {
-                if (d.is_theorem()) deps.push_back(d.get_value_task());
-            });
+            for (auto & mdf : res->m_loaded_module->m_modifications)
+                mdf->get_task_dependencies(deps);
             return deps;
         } else {
             return {m_mod->m_result};

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -22,7 +22,7 @@ void module_mgr::mark_out_of_date(module_id const & id, buffer<module_id> & to_r
     for (auto & mod : m_modules) {
         if (!mod.second || mod.second->m_out_of_date) continue;
         for (auto & dep : mod.second->m_deps) {
-            if (dep.first == id) {
+            if (dep.m_mod_info->m_mod == id) {
                 mod.second->m_out_of_date = true;
                 to_rebuild.push_back(mod.first);
                 mark_out_of_date(mod.first, to_rebuild);
@@ -32,17 +32,52 @@ void module_mgr::mark_out_of_date(module_id const & id, buffer<module_id> & to_r
     }
 }
 
+static module_loader mk_loader(module_id const & cur_mod, std::vector<module_info::dependency> const & deps) {
+    auto deps_per_mod_ptr = std::make_shared<std::unordered_map<module_id, std::vector<module_info::dependency>>>();
+    auto & deps_per_mod = *deps_per_mod_ptr;
+
+    buffer<module_info const *> to_process;
+    for (auto & d : deps) {
+        deps_per_mod[cur_mod].push_back(d);
+        to_process.push_back(d.m_mod_info.get());
+    }
+    while (!to_process.empty()) {
+        auto & m = *to_process.back();
+        to_process.pop_back();
+        if (deps_per_mod.count(m.m_mod)) continue;
+
+        for (auto & d : m.m_deps) {
+            deps_per_mod[m.m_mod].push_back(d);
+            if (!deps_per_mod.count(d.m_mod_info->m_mod))
+                to_process.push_back(d.m_mod_info.get());
+        }
+    }
+
+    return[deps_per_mod_ptr] (std::string const & current_module, module_name const & import) {
+        try {
+            for (auto & d : deps_per_mod_ptr->at(current_module)) {
+                if (d.m_import_name.m_name == import.m_name && d.m_import_name.m_relative == import.m_relative) {
+                    return d.m_mod_info->m_result.get().m_loaded_module;
+                }
+            }
+        } catch (std::out_of_range) {
+            lean_unreachable();
+        }
+        throw exception(sstream() << "could not resolve import: " << import.m_name);
+    };
+}
+
 class parse_lean_task : public task<module_info::parse_result> {
     environment m_initial_env;
     std::string m_contents;
     snapshot_vector m_snapshots;
     bool m_use_snapshots;
-    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> m_deps;
+    std::vector<module_info::dependency> m_deps;
 
 public:
     parse_lean_task(std::string const & contents, environment const & initial_env,
                     snapshot_vector const & snapshots, bool use_snapshots,
-                    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> const & deps) :
+                    std::vector<module_info::dependency> const & deps) :
         m_initial_env(initial_env), m_contents(contents),
         m_snapshots(snapshots), m_use_snapshots(use_snapshots),
         m_deps(deps) {}
@@ -54,23 +89,12 @@ public:
 
     std::vector<generic_task_result> get_dependencies() override {
         std::vector<generic_task_result> deps;
-        for (auto & d : m_deps) deps.push_back(std::get<2>(d)->m_result);
+        for (auto & d : m_deps) deps.push_back(d.m_mod_info->m_result);
         return deps;
     }
 
     module_info::parse_result execute() override {
-        auto deps = std::move(m_deps);
-        module_loader import_fn = [=] (module_id const & base, module_name const & import) {
-            for (auto & d : deps) {
-                if (std::get<0>(d) == base &&
-                        std::get<1>(d).m_name == import.m_name &&
-                        std::get<1>(d).m_relative == import.m_relative) {
-                    auto & mod_info = std::get<2>(d);
-                    return mod_info->m_result.get().m_loaded_module;
-                }
-            }
-            throw exception(sstream() << "could not resolve import: " << import.m_name);
-        };
+        auto import_fn = mk_loader(get_module_id(), m_deps);
 
         bool use_exceptions = false;
         std::istringstream in(m_contents);
@@ -91,8 +115,6 @@ public:
             return mk_preimported_module(initial_env, *weak_lm.lock(), import_fn);
         });
         mod.m_loaded_module = lm;
-
-        mod.m_env = optional<environment>(p.env());
 
         mod.m_opts = p.ios().get_options();
 
@@ -189,9 +211,8 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
                 auto d_id = resolve(id, d);
                 build_module(d_id, true, module_stack);
 
-                mod->m_deps.push_back(std::make_pair(d_id, d));
-
                 auto & d_mod = m_modules[d_id];
+                mod->m_deps.push_back({ d_id, d, d_mod });
                 mod->m_trans_mtime = std::max(mod->m_trans_mtime, d_mod->m_trans_mtime);
             }
 
@@ -199,9 +220,20 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
                 return build_module(id, false, orig_module_stack);
 
             module_info::parse_result res;
-            // TODO(gabriel)
-            res.m_loaded_module = std::make_shared<loaded_module>(
-                    loaded_module { id, parsed_olean.first, parse_olean_modifications(parsed_olean.second, id), {} });
+
+            auto lm = std::make_shared<loaded_module>();
+            {
+                lm->m_module_name = id;
+                lm->m_imports = parsed_olean.first;
+                lm->m_modifications = parse_olean_modifications(parsed_olean.second, id);
+                auto lm_ptr = lm.get();
+                auto deps = mod->m_deps;
+                lm->m_env = lazy_value<environment>([=] {
+                    return mk_preimported_module(m_initial_env, *lm_ptr, mk_loader(id, deps));
+                });
+            }
+            res.m_loaded_module = lm;
+
             res.m_ok = true;
             mod->m_result = mk_pure_task_result(res, "Loading " + olean_fn);
 
@@ -236,16 +268,18 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             mod->m_trans_mtime = mod->m_mtime = mtime;
             for (auto & d : imports) {
                 module_id d_id;
+                std::shared_ptr<module_info const> d_mod;
                 try {
                     d_id = resolve(id, d);
                     build_module(d_id, true, module_stack);
-                    mod->m_trans_mtime = std::max(mod->m_trans_mtime, m_modules[d_id]->m_trans_mtime);
+                    d_mod = m_modules[d_id];
+                    mod->m_trans_mtime = std::max(mod->m_trans_mtime, d_mod->m_trans_mtime);
                 } catch (throwable & ex) {
                     message_builder msg(m_initial_env, m_ios, id, pos_info {1, 0}, ERROR);
                     msg.set_exception(ex);
                     msg.report();
                 }
-                mod->m_deps.push_back({ d_id, d });
+                mod->m_deps.push_back({ d_id, d, d_mod });
             }
             if (m_use_snapshots) {
                 mod->m_lean_contents = optional<std::string>(contents);
@@ -253,11 +287,10 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             }
             mod->m_version = m_current_period;
 
-            auto deps = gather_transitive_imports(id, imports);
             mod->m_result = get_global_task_queue()->submit<parse_lean_task>(
                     contents, m_initial_env,
                     snapshots, m_use_snapshots,
-                    deps);
+                    mod->m_deps);
 
             if (m_save_olean)
                 mod->m_olean_task = get_global_task_queue()->submit<olean_compilation_task>(mod);
@@ -325,10 +358,11 @@ module_mgr::get_snapshots_or_unchanged_module(module_id const &id, std::string c
     if (mod->m_source != module_src::LEAN) return false;
 
     for (auto d : mod->m_deps) {
-        if (m_modules[d.first] && m_modules[d.first]->m_version > mod->m_version) {
-            mod->m_still_valid_snapshots.clear();
-            return false;
-        }
+        if (!d.m_mod_info && !m_modules[d.m_id]) continue;
+        if (d.m_mod_info && m_modules[d.m_id] && m_modules[d.m_id] == d.m_mod_info) continue;
+
+        mod->m_still_valid_snapshots.clear();
+        return false;
     }
 
     if (!mod->m_lean_contents) return false;
@@ -363,30 +397,6 @@ std::vector<module_name> module_mgr::get_direct_imports(module_id const & id, st
     parser p(get_initial_env(), m_ios, nullptr, in, id, use_exceptions);
     std::vector<std::pair<module_name, module_id>> deps;
     return p.get_imports();
-}
-
-void module_mgr::gather_transitive_imports(std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> & res,
-                                           std::unordered_set<module_id> & visited,
-                                           module_id const & id,
-                                           module_name const & import) {
-    try {
-        auto import_id = resolve(id, import);
-        if (!m_modules[import_id]) return;
-        res.push_back(std::make_tuple(id, import, m_modules[import_id]));
-        if (!visited.count(import_id)) {
-            visited.insert(import_id);
-            for (auto & d : m_modules[import_id]->m_deps)
-                gather_transitive_imports(res, visited, import_id, d.second);
-        }
-    } catch (file_not_found_exception & ex) {}
-}
-
-std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> module_mgr::gather_transitive_imports(
-        module_id const & id, std::vector<module_name> const & imports) {
-    std::unordered_set<module_id> visited;
-    std::vector<std::tuple<module_id, module_name, std::shared_ptr<module_info const>>> res;
-    for (auto & i : imports) gather_transitive_imports(res, visited, id, i);
-    return res;
 }
 
 std::tuple<std::string, module_src, time_t> fs_module_vfs::load_module(module_id const & id, bool can_use_olean) {

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -128,14 +128,19 @@ public:
     task_kind get_kind() const override { return task_kind::parse; }
 
     std::vector<generic_task_result> get_dependencies() override {
+        std::vector<generic_task_result> deps;
+
+        // Write the olean files in the correct order, so that they have the right mtime.
+        for (auto & d : m_mod->m_deps)
+            deps.push_back(d.m_mod_info->m_olean_task);
+
+        deps.push_back(m_mod->m_result);
         if (auto res = m_mod->m_result.peek()) {
-            std::vector<generic_task_result> deps;
             for (auto & mdf : res->m_loaded_module->m_modifications)
                 mdf->get_task_dependencies(deps);
-            return deps;
-        } else {
-            return {m_mod->m_result};
         }
+        
+        return deps;
     }
 
     void description(std::ostream & out) const override {

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -42,8 +42,7 @@ struct module_info {
         options               m_opts;
         bool m_ok = false;
 
-        std::string m_obj_code;
-        std::vector<task_result<expr>> m_obj_code_delayed_proofs;
+        loaded_module m_loaded_module;
 
         snapshot_vector m_snapshots;
     };

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -42,7 +42,7 @@ struct module_info {
         options               m_opts;
         bool m_ok = false;
 
-        loaded_module m_loaded_module;
+        std::shared_ptr<loaded_module const> m_loaded_module;
 
         snapshot_vector m_snapshots;
     };

--- a/src/library/native_compiler/native_compiler.cpp
+++ b/src/library/native_compiler/native_compiler.cpp
@@ -471,29 +471,30 @@ void native_compile_module(environment const & env) {
     native_compile_module(env, decls);
 }
 
-// Setup for the storage of native modules to .olean files.
-static std::string *g_native_module_key = nullptr;
+struct native_module_path_modification : public modification {
+    LEAN_MODIFICATION("native_module_path")
 
-static void native_module_reader(
-    deserializer & d,
-    environment & /* env */) {
-    name fn;
-    d >> fn;
-    std::cout << "reading native module from meta-data: " << fn << std::endl;
-    // senv.update([&](environment const & env) -> environment {
-    //     vm_decls ext = get_extension(env);
-    //     // ext.update(fn, code_sz, code.data());
-    //     // return update(env, ext);
-    //     return
-    // });
-}
+    name m_native_module_path;
+
+    native_module_path_modification() {}
+    native_module_path_modification(name const & fn) : m_native_module_path(fn) {}
+
+    void perform(environment &) const override {
+        // TODO(gabriel,jared): I have no idea what this is supposed to do.
+        // ???
+    }
+
+    void serialize(serializer & s) const override {
+        s << m_native_module_path;
+    }
+
+    static std::shared_ptr<modification const> deserialize(deserializer & d) {
+        return std::make_shared<native_module_path_modification>(read_name(d));
+    }
+};
 
 environment set_native_module_path(environment & env, name const & n) {
-    return module::add(env, *g_native_module_key, [=] (environment const & e, serializer & s) {
-        std::cout << "writing out" << n << std::endl;
-        s << n;
-        native_compile_module(e);
-    });
+    return module::add(env, std::make_shared<native_module_path_modification>(n));
 }
 
 void initialize_native_compiler() {
@@ -502,12 +503,11 @@ void initialize_native_compiler() {
     register_trace_class({"compiler", "native"});
     register_trace_class({"compiler", "native", "preprocess"});
     register_trace_class({"compiler", "native", "cpp_compiler"});
-    g_native_module_key = new std::string("native_module_path");
-    register_module_object_reader(*g_native_module_key, native_module_reader);
+    native_module_path_modification::init();
 }
 
 void finalize_native_compiler() {
     native::finalize_options();
-    delete g_native_module_key;
+    native_module_path_modification::finalize();
 }
 }

--- a/src/library/private.cpp
+++ b/src/library/private.cpp
@@ -32,12 +32,38 @@ static environment update(environment const & env, private_ext const & ext) {
 }
 
 static name * g_private = nullptr;
-static std::string * g_prv_key = nullptr;
+
+struct private_modification : public modification {
+    LEAN_MODIFICATION("prv")
+
+    name m_name, m_real;
+
+    private_modification() {}
+    private_modification(name const & n, name const & h) : m_name(n), m_real(h) {}
+
+    void perform(environment & env) const override {
+        private_ext ext = get_extension(env);
+        // we restore only the mapping hidden-name -> user-name (for pretty printing purposes)
+        ext.m_inv_map.insert(m_real, m_name);
+        ext.m_counter++;
+        env = update(env, ext);
+    }
+
+    void serialize(serializer & s) const override {
+        s << m_name << m_real;
+    }
+
+    static std::shared_ptr<modification const> deserialize(deserializer & d) {
+        name n, h;
+        d >> n >> h;
+        return std::make_shared<private_modification>(n, h);
+    }
+};
 
 // Make sure the mapping "hidden-name r ==> user-name n" is preserved when we close sections and
 // export .olean files.
 static environment preserve_private_data(environment const & env, name const & r, name const & n) {
-    return module::add(env, *g_prv_key, [=](environment const &, serializer & s) { s << n << r; });
+    return module::add(env, std::make_shared<private_modification>(n, r));
 }
 
 pair<environment, name> add_private_name(environment const & env, name const & n, optional<unsigned> const & extra_hash) {
@@ -56,16 +82,6 @@ pair<environment, name> add_private_name(environment const & env, name const & n
     return mk_pair(new_env, r);
 }
 
-static void private_reader(deserializer & d, environment & env) {
-    name n, h;
-    d >> n >> h;
-    private_ext ext = get_extension(env);
-    // we restore only the mapping hidden-name -> user-name (for pretty printing purposes)
-    ext.m_inv_map.insert(h, n);
-    ext.m_counter++;
-    env = update(env, ext);
-}
-
 optional<name> hidden_to_user_name(environment const & env, name const & n) {
     auto it = get_extension(env).m_inv_map.find(n);
     return it ? optional<name>(*it) : optional<name>();
@@ -78,12 +94,11 @@ bool is_private(environment const & env, name const & n) {
 void initialize_private() {
     g_ext     = new private_ext_reg();
     g_private = new name("private");
-    g_prv_key = new std::string("prv");
-    register_module_object_reader(*g_prv_key, private_reader);
+    private_modification::init();
 }
 
 void finalize_private() {
-    delete g_prv_key;
+    private_modification::finalize();
     delete g_private;
     delete g_ext;
 }

--- a/src/library/projection.cpp
+++ b/src/library/projection.cpp
@@ -38,20 +38,35 @@ static environment update(environment const & env, projection_ext const & ext) {
     return env.update(g_ext->m_ext_id, std::make_shared<projection_ext>(ext));
 }
 
-static std::string * g_proj_key = nullptr;
+struct proj_modification : public modification {
+    LEAN_MODIFICATION("proj")
 
-static environment save_projection_info_core(environment const & env, name const & p, name const & mk, unsigned nparams,
-                                             unsigned i, bool inst_implicit) {
-    projection_ext ext = get_extension(env);
-    ext.m_info.insert(p, projection_info(mk, nparams, i, inst_implicit));
-    return update(env, ext);
-}
+    name m_proj;
+    projection_info m_info;
+
+    proj_modification() {}
+    proj_modification(name const & proj, projection_info const & info) : m_proj(proj), m_info(info) {}
+
+    void perform(environment & env) const override {
+        projection_ext ext = get_extension(env);
+        ext.m_info.insert(m_proj, m_info);
+        env = update(env, ext);
+    }
+
+    void serialize(serializer & s) const override {
+        s << m_proj << m_info.m_constructor << m_info.m_nparams << m_info.m_i << m_info.m_inst_implicit;
+    }
+
+    static std::shared_ptr<modification const> deserialize(deserializer & d) {
+        name p, mk; unsigned nparams, i; bool inst_implicit;
+        d >> p >> mk >> nparams >> i >> inst_implicit;
+        return std::make_shared<proj_modification>(p, projection_info(mk, nparams, i, inst_implicit));
+    }
+};
 
 environment save_projection_info(environment const & env, name const & p, name const & mk, unsigned nparams, unsigned i, bool inst_implicit) {
-    environment new_env = save_projection_info_core(env, p, mk, nparams, i, inst_implicit);
-    return module::add(new_env, *g_proj_key, [=](environment const &, serializer & s) {
-            s << p << mk << nparams << i << inst_implicit;
-        });
+    return module::add_and_perform(env, std::make_shared<proj_modification>(
+            p, projection_info(mk, nparams, i, inst_implicit)));
 }
 
 projection_info const * get_projection_info(environment const & env, name const & p) {
@@ -61,12 +76,6 @@ projection_info const * get_projection_info(environment const & env, name const 
 
 name_map<projection_info> const & get_projection_info_map(environment const & env) {
     return get_extension(env).m_info;
-}
-
-static void projection_info_reader(deserializer & d, environment & env) {
-    name p, mk; unsigned nparams, i; bool inst_implicit;
-    d >> p >> mk >> nparams >> i >> inst_implicit;
-    env = save_projection_info_core(env, p, mk, nparams, i, inst_implicit);
 }
 
 /** \brief Return true iff the type named \c S can be viewed as
@@ -82,12 +91,11 @@ bool is_structure_like(environment const & env, name const & S) {
 
 void initialize_projection() {
     g_ext      = new projection_ext_reg();
-    g_proj_key = new std::string("proj");
-    register_module_object_reader(*g_proj_key, projection_info_reader);
+    proj_modification::init();
 }
 
 void finalize_projection() {
-    delete g_proj_key;
+    proj_modification::finalize();
     delete g_ext;
 }
 }

--- a/src/library/relation_manager.cpp
+++ b/src/library/relation_manager.cpp
@@ -147,8 +147,6 @@ struct rel_state {
     }
 };
 
-static std::string * g_key = nullptr;
-
 struct rel_config {
     typedef rel_state state;
     typedef rel_entry entry;
@@ -161,9 +159,7 @@ struct rel_config {
         case op_kind::Symm:     s.add_symm(env, e.m_name); break;
         }
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static const char * get_serialization_key() { return "REL"; }
     static void  write_entry(serializer & s, entry const & e) {
         s << static_cast<char>(e.m_kind) << e.m_name;
     }
@@ -323,7 +319,6 @@ is_relation_pred mk_is_relation_pred(environment const & env) {
 }
 
 void initialize_relation_manager() {
-    g_key       = new std::string("REL");
     rel_ext::initialize();
     register_system_attribute(basic_attribute("refl", "reflexive relation",
                                               [](environment const & env, io_state const &, name const & d, unsigned,
@@ -352,6 +347,5 @@ void initialize_relation_manager() {
 
 void finalize_relation_manager() {
     rel_ext::finalize();
-    delete g_key;
 }
 }

--- a/src/library/unification_hint.cpp
+++ b/src/library/unification_hint.cpp
@@ -40,8 +40,6 @@ int unification_hint_cmp::operator()(unification_hint const & uh1, unification_h
 
 /* Environment extension */
 
-static std::string * g_key = nullptr;
-
 struct unification_hint_state {
     unification_hints m_hints;
     name_map<unsigned> m_decl_names_to_prio; // Note: redundant but convenient
@@ -127,9 +125,7 @@ struct unification_hint_config {
         // TODO(dhs): the downside to this approach is that a [unify] tag on an actual axiom will be silently ignored.
         if (decl.is_definition()) s.register_hint(e.m_decl_name, decl.get_value(), e.m_priority);
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static const char * get_serialization_key() { return "UNIFICATION_HINT"; }
     static void  write_entry(serializer & s, entry const & e) {
         s << e.m_decl_name << e.m_priority;
     }
@@ -200,8 +196,6 @@ format pp_unification_hints(unification_hints const & hints, formatter const & f
 }
 
 void initialize_unification_hint() {
-    g_key           = new std::string("UNIFICATION_HINT");
-
     unification_hint_ext::initialize();
 
     register_system_attribute(basic_attribute("unify", "unification hint", add_unification_hint));
@@ -209,6 +203,5 @@ void initialize_unification_hint() {
 
 void finalize_unification_hint() {
     unification_hint_ext::finalize();
-    delete g_key;
 }
 }

--- a/src/library/user_recursors.cpp
+++ b/src/library/user_recursors.cpp
@@ -298,8 +298,6 @@ struct recursor_state {
     }
 };
 
-static std::string * g_key = nullptr;
-
 struct recursor_config {
     typedef recursor_state  state;
     typedef recursor_info   entry;
@@ -307,9 +305,7 @@ struct recursor_config {
     static void add_entry(environment const &, io_state const &, state & s, entry const & e) {
         s.insert(e);
     }
-    static std::string const & get_serialization_key() {
-        return *g_key;
-    }
+    static const char * get_serialization_key() { return "UREC"; }
     static void  write_entry(serializer & s, entry const & e) {
         e.write(s);
     }
@@ -357,7 +353,6 @@ static indices_attribute const & get_recursor_attribute() {
 }
 
 void initialize_user_recursors() {
-    g_key        = new std::string("UREC");
     recursor_ext::initialize();
     register_system_attribute(indices_attribute("recursor", "user defined recursor",
                                                 [](environment const & env, io_state const &, name const & n, unsigned,
@@ -372,6 +367,5 @@ void initialize_user_recursors() {
 
 void finalize_user_recursors() {
     recursor_ext::finalize();
-    delete g_key;
 }
 }

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -16,6 +16,7 @@ Author: Leonardo de Moura
 #include "util/sstream.h"
 #include "util/small_object_allocator.h"
 #include "util/sexpr/option_declarations.h"
+#include "util/shared_mutex.h"
 #include "library/constants.h"
 #include "library/kernel_serializer.h"
 #include "library/trace.h"
@@ -272,14 +273,14 @@ void vm_obj_cell::dealloc() {
     }
 }
 
-void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(unsigned)> const & idx2name) {
+void display(std::ostream & out, vm_obj const & o) {
     if (is_simple(o)) {
         out << cidx(o);
     } else if (is_constructor(o)) {
         out << "(#" << cidx(o);
         for (unsigned i = 0; i < csize(o); i++) {
             out << " ";
-            display(out, cfield(o, i), idx2name);
+            display(out, cfield(o, i));
         }
         out << ")";
     } else if (is_mpz(o)) {
@@ -287,14 +288,14 @@ void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(
     } else if (is_external(o)) {
         out << "[external]";
     } else if (is_closure(o)) {
-        if (auto n = idx2name(cfn_idx(o))) {
+        if (auto n = find_vm_name(cfn_idx(o))) {
             out << "(" << *n;
         } else {
             out << "(fn#" << cfn_idx(o);
         }
         for (unsigned i = 0; i < csize(o); i++) {
             out << " ";
-            display(out, cfield(o, i), idx2name);
+            display(out, cfield(o, i));
         }
         out << ")";
     } else if (is_native_closure(o)) {
@@ -302,7 +303,7 @@ void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(
         vm_obj const * args = to_native_closure(o)->get_args();
         for (unsigned i = 0; i < to_native_closure(o)->get_num_args(); i++) {
             out << " ";
-            display(out, args[i], idx2name);
+            display(out, args[i]);
         }
         out << ")";
     } else {
@@ -310,24 +311,18 @@ void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(
     }
 }
 
-void display(std::ostream & out, vm_obj const & o) {
-    display(out, o, [](unsigned) { return optional<name>(); });
-}
-
-static void display_fn(std::ostream & out, std::function<optional<name>(unsigned)> const & idx2name, unsigned fn_idx) {
-    if (auto r = idx2name(fn_idx))
+static void display_fn(std::ostream & out, unsigned fn_idx) {
+    if (auto r = find_vm_name(fn_idx))
         out << *r;
     else
         out << fn_idx;
 }
 
-static void display_builtin_cases(std::ostream & out, std::function<optional<name>(unsigned)> const & idx2name, unsigned cases_idx) {
-    display_fn(out, idx2name, cases_idx);
+static void display_builtin_cases(std::ostream & out, unsigned cases_idx) {
+    display_fn(out, cases_idx);
 }
 
-void vm_instr::display(std::ostream & out,
-                       std::function<optional<name>(unsigned)> const & idx2name,
-                       std::function<optional<name>(unsigned)> const & cases_idx2name) const {
+void vm_instr::display(std::ostream & out) const {
     switch (m_op) {
     case opcode::Push:          out << "push " << m_idx; break;
     case opcode::Ret:           out << "ret"; break;
@@ -346,7 +341,7 @@ void vm_instr::display(std::ostream & out,
         break;
     case opcode::BuiltinCases:
         out << "builtin_cases ";
-        display_builtin_cases(out, cases_idx2name, get_cases_idx());
+        display_builtin_cases(out, get_cases_idx());
         out << ",";
         for (unsigned i = 0; i < get_casesn_size(); i++)
             out << " " << get_casesn_pc(i);
@@ -356,19 +351,19 @@ void vm_instr::display(std::ostream & out,
     case opcode::Apply:         out << "apply"; break;
     case opcode::InvokeGlobal:
         out << "ginvoke ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         break;
     case opcode::InvokeBuiltin:
         out << "builtin ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         break;
     case opcode::InvokeCFun:
         out << "cfun ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         break;
     case opcode::Closure:
         out << "closure ";
-        display_fn(out, idx2name, m_fn_idx);
+        display_fn(out, m_fn_idx);
         out << " " << m_nargs;
         break;
     case opcode::Pexpr:
@@ -376,10 +371,6 @@ void vm_instr::display(std::ostream & out,
     case opcode::LocalInfo:
         out << "localinfo " << m_local_info->first << " @ " << m_local_idx; break;
     }
-}
-
-void vm_instr::display(std::ostream & out) const {
-    display(out, [](unsigned) { return optional<name>(); }, [](unsigned) { return optional<name>(); });
 }
 
 unsigned vm_instr::get_num_pcs() const {
@@ -723,13 +714,10 @@ void vm_instr::serialize(serializer & s, std::function<name(unsigned)> const & i
     }
 }
 
-static unsigned read_fn_idx(deserializer & d, name_map<unsigned> const & name2idx) {
+static unsigned read_fn_idx(deserializer & d) {
     name n;
     d >> n;
-    if (auto r = name2idx.find(n))
-        return *r;
-    else
-        throw corrupted_stream_exception();
+    return get_vm_index(n);
 }
 
 static void read_cases_pcs(deserializer & d, buffer<unsigned> & pcs) {
@@ -738,18 +726,18 @@ static void read_cases_pcs(deserializer & d, buffer<unsigned> & pcs) {
         pcs.push_back(d.read_unsigned());
 }
 
-static vm_instr read_vm_instr(deserializer & d, name_map<unsigned> const & name2idx) {
+static vm_instr read_vm_instr(deserializer & d) {
     opcode op = static_cast<opcode>(d.read_char());
     unsigned pc, idx;
     switch (op) {
     case opcode::InvokeGlobal:
-        return mk_invoke_global_instr(read_fn_idx(d, name2idx));
+        return mk_invoke_global_instr(read_fn_idx(d));
     case opcode::InvokeBuiltin:
-        return mk_invoke_builtin_instr(read_fn_idx(d, name2idx));
+        return mk_invoke_builtin_instr(read_fn_idx(d));
     case opcode::InvokeCFun:
-        return mk_invoke_cfun_instr(read_fn_idx(d, name2idx));
+        return mk_invoke_cfun_instr(read_fn_idx(d));
     case opcode::Closure:
-        idx = read_fn_idx(d, name2idx);
+        idx = read_fn_idx(d);
         return mk_closure_instr(idx, d.read_unsigned());
     case opcode::Push:
         return mk_push_instr(d.read_unsigned());
@@ -906,58 +894,40 @@ void declare_vm_cases_builtin(name const & n, char const * i, vm_cases_function 
 
 /** \brief VM function/constant declarations are stored in an environment extension. */
 struct vm_decls : public environment_extension {
-    name_map<unsigned>        m_name2idx;
-    unsigned_map<vm_decl>     m_decls;
-    unsigned                  m_next_decl_idx{0};
-
-    name_map<unsigned>              m_cases2idx;
+    unsigned_map<vm_decl>           m_decls;
     unsigned_map<vm_cases_function> m_cases;
-    unsigned_map<name>              m_cases_names;
-    unsigned                        m_next_cases_idx{0};
 
     name                            m_monitor;
 
     vm_decls() {
         g_vm_builtins->for_each([&](name const & n, std::tuple<unsigned, char const *, vm_function> const & p) {
-                add_core(vm_decl(n, m_next_decl_idx, std::get<0>(p), std::get<2>(p)));
-                m_next_decl_idx++;
+                add_core(vm_decl(n, get_vm_index(n), std::get<0>(p), std::get<2>(p)));
             });
         g_vm_cbuiltins->for_each([&](name const & n, std::tuple<unsigned, char const *, vm_cfunction> const & p) {
-                add_core(vm_decl(n, m_next_decl_idx, std::get<0>(p), std::get<2>(p)));
-                m_next_decl_idx++;
+                add_core(vm_decl(n, get_vm_index(n), std::get<0>(p), std::get<2>(p)));
             });
         g_vm_cases_builtins->for_each([&](name const & n, std::tuple<char const *, vm_cases_function> const & p) {
-                unsigned idx = m_next_cases_idx;
-                m_cases2idx.insert(n, idx);
+                unsigned idx = get_vm_index(n);
                 m_cases.insert(idx, std::get<1>(p));
-                m_cases_names.insert(idx, n);
-                m_next_cases_idx++;
             });
     }
 
     void add_core(vm_decl const & d) {
-        if (m_name2idx.contains(d.get_name()))
+        if (m_decls.contains(d.get_idx()))
             throw exception(sstream() << "VM already contains code for '" << d.get_name() << "'");
-        m_name2idx.insert(d.get_name(), d.get_idx());
         m_decls.insert(d.get_idx(), d);
     }
 
     void add_native(name const & n, unsigned arity, vm_cfunction fn) {
-        if (auto idx = m_name2idx.find(n)) {
-            lean_assert(m_decls.find(*idx)->get_arity() == arity);
-            m_decls.insert(*idx, vm_decl(n, *idx, arity, fn));
-        } else {
-            add_core(vm_decl(n, m_next_decl_idx, arity, fn));
-            m_next_decl_idx++;
-        }
+        auto idx = get_vm_index(n);
+        DEBUG_CODE(if (auto decl = m_decls.find(idx)) lean_assert(decl->get_arity() == arity);)
+        m_decls.insert(idx, vm_decl(n, idx, arity, fn));
     }
 
     unsigned reserve(name const & n, expr const & e) {
-        if (m_name2idx.contains(n))
+        unsigned idx = get_vm_index(n);
+        if (m_decls.contains(idx))
             throw exception(sstream() << "VM already contains code for '" << n << "'");
-        unsigned idx = m_next_decl_idx;
-        m_next_decl_idx++;
-        m_name2idx.insert(n, idx);
         m_decls.insert(idx, vm_decl(n, idx, e, 0, nullptr, list<vm_local_info>(), optional<pos_info>()));
         return idx;
     }
@@ -965,9 +935,9 @@ struct vm_decls : public environment_extension {
     void update(name const & n, unsigned code_sz, vm_instr const * code,
                 list<vm_local_info> const & args_info, optional<pos_info> const & pos,
                 optional<std::string> const & olean = optional<std::string>()) {
-        lean_assert(m_name2idx.contains(n));
-        unsigned idx      = *m_name2idx.find(n);
+        unsigned idx      = get_vm_index(n);
         vm_decl const * d = m_decls.find(idx);
+        lean_assert(d);
         m_decls.insert(idx, vm_decl(n, idx, d->get_expr(), code_sz, code, args_info, pos, olean));
     }
 };
@@ -1037,21 +1007,23 @@ environment add_native(environment const & env, name const & n, unsigned arity, 
 
 bool is_vm_function(environment const & env, name const & fn) {
     auto const & ext = get_extension(env);
-    return ext.m_name2idx.contains(fn) || g_vm_builtins->contains(fn);
+    return ext.m_decls.contains(get_vm_index(fn)) || g_vm_builtins->contains(fn);
 }
 
 optional<unsigned> get_vm_constant_idx(environment const & env, name const & n) {
     auto const & ext = get_extension(env);
-    if (auto r = ext.m_name2idx.find(n))
-        return optional<unsigned>(*r);
+    auto idx = get_vm_index(n);
+    if (ext.m_decls.contains(idx))
+        return optional<unsigned>(idx);
     else
         return optional<unsigned>();
 }
 
 optional<unsigned> get_vm_builtin_idx(name const & n) {
     lean_assert(g_ext);
-    if (auto r = g_ext->m_init_decls->m_name2idx.find(n))
-        return optional<unsigned>(*r);
+    auto idx = get_vm_index(n);
+    if (g_ext->m_init_decls->m_decls.contains(idx))
+        return optional<unsigned>(idx);
     else
         return optional<unsigned>();
 }
@@ -1094,7 +1066,7 @@ static void code_reader(deserializer & d, environment & env) {
     vm_decls ext = get_extension(env);
     buffer<vm_instr> code;
     for (unsigned i = 0; i < code_sz; i++) {
-        code.push_back(read_vm_instr(d, ext.m_name2idx));
+        code.push_back(read_vm_instr(d));
     }
     ext.update(fn, code_sz, code.data(), args_info, pos, d.get_fname());
     env = update(env, ext);
@@ -1105,7 +1077,7 @@ environment update_vm_code(environment const & env, name const & fn, unsigned co
     vm_decls ext = get_extension(env);
     ext.update(fn, code_sz, code, args_info, pos);
     environment new_env = update(env, ext);
-    unsigned fidx       = *ext.m_name2idx.find(fn);
+    unsigned fidx       = get_vm_index(fn);
     return module::add(new_env, *g_vm_code_key, [=](environment const & env, serializer & s) {
             serialize_code(s, fidx, get_extension(env).m_decls);
         });
@@ -1119,16 +1091,17 @@ environment add_vm_code(environment const & env, name const & fn, expr const & e
 
 optional<vm_decl> get_vm_decl(environment const & env, name const & n) {
     vm_decls const & ext = get_extension(env);
-    if (auto idx = ext.m_name2idx.find(n))
-        return optional<vm_decl>(*ext.m_decls.find(*idx));
+    if (auto decl = ext.m_decls.find(get_vm_index(n)))
+        return optional<vm_decl>(*decl);
     else
         return optional<vm_decl>();
 }
 
 optional<unsigned> get_vm_builtin_cases_idx(environment const & env, name const & n) {
     vm_decls const & ext = get_extension(env);
-    if (auto idx = ext.m_cases2idx.find(n))
-        return optional<unsigned>(*idx);
+    auto idx = get_vm_index(n);
+    if (ext.m_cases.contains(idx))
+        return optional<unsigned>(idx);
     else
         return optional<unsigned>();
 }
@@ -1149,11 +1122,9 @@ vm_state::vm_state(environment const & env, options const & opts):
     m_env(env),
     m_options(opts),
     m_decl_map(get_extension(m_env).m_decls),
-    m_decl_vector(get_extension(m_env).m_next_decl_idx),
+    m_decl_vector(get_vm_index_bound()),
     m_builtin_cases_map(get_extension(m_env).m_cases),
-    m_builtin_cases_vector(get_extension(m_env).m_next_cases_idx),
-    m_builtin_cases_names(get_extension(m_env).m_cases_names),
-    m_fn_name2idx(get_extension(m_env).m_name2idx),
+    m_builtin_cases_vector(get_vm_index_bound()),
     m_code(nullptr),
     m_fn_idx(g_null_fn_idx),
     m_bp(0) {
@@ -1220,9 +1191,7 @@ void vm_state::update_env(environment const & env) {
     m_env         = env;
     auto ext      = get_extension(env);
     m_decl_map    = ext.m_decls;
-    lean_assert(ext.m_next_decl_idx >= m_decl_vector.size());
-    m_decl_vector.resize(ext.m_next_decl_idx);
-    m_fn_name2idx = ext.m_name2idx;
+    m_decl_vector.resize(get_vm_index_bound());
     lean_assert(is_eqp(m_builtin_cases_map, ext.m_cases));
 }
 
@@ -1404,8 +1373,9 @@ vm_obj vm_state::invoke(unsigned fn_idx, unsigned nargs, vm_obj const * as) {
 }
 
 vm_obj vm_state::invoke(name const & fn, unsigned nargs, vm_obj const * as) {
-    if (auto r = m_fn_name2idx.find(fn)) {
-        return invoke(*r, nargs, as);
+    auto idx = get_vm_index(fn);
+    if (m_decl_map.contains(idx)) {
+        return invoke(idx, nargs, as);
     } else {
         throw exception(sstream() << "VM does not have code for '" << fn << "'");
     }
@@ -2524,13 +2494,7 @@ void vm_state::run() {
                 /* We only trace VM in debug mode */
                 lean_trace(name({"vm", "run"}),
                            tout() << m_pc << ": ";
-                           instr.display(tout().get_stream(),
-                                         [&](unsigned idx) {
-                                             return optional<name>(get_decl(idx).get_name());
-                                         },
-                                         [&](unsigned idx) {
-                                             return optional<name>(*m_builtin_cases_names.find(idx));
-                                         });
+                           instr.display(tout().get_stream());
                            tout() << "\n";
                            display_stack(tout().get_stream());
                            tout() << "\n";)
@@ -2965,8 +2929,9 @@ void vm_state::run() {
 }
 
 void vm_state::invoke_fn(name const & fn) {
-    if (auto r = m_fn_name2idx.find(fn)) {
-        invoke_fn(*r);
+    auto idx = get_vm_index(fn);
+    if (m_decl_map.contains(idx)) {
+        invoke_fn(idx);
     } else {
         throw exception(sstream() << "VM does not have code for '" << fn << "'");
     }
@@ -2982,8 +2947,9 @@ void vm_state::invoke_fn(unsigned fn_idx) {
 }
 
 vm_obj vm_state::get_constant(name const & cname) {
-    if (auto fn_idx = m_fn_name2idx.find(cname)) {
-        vm_decl d = get_decl(*fn_idx);
+    auto fn_idx = get_vm_index(cname);
+    if (m_decl_map.contains(fn_idx)) {
+        vm_decl d = get_decl(fn_idx);
         if (d.get_arity() == 0) {
             DEBUG_CODE(unsigned stack_sz = m_stack.size(););
             unsigned saved_pc = m_pc;
@@ -2995,7 +2961,7 @@ vm_obj vm_state::get_constant(name const & cname) {
             lean_assert(m_stack.size() == stack_sz);
             return r;
         } else {
-            return mk_vm_closure(*fn_idx, 0, nullptr);
+            return mk_vm_closure(fn_idx, 0, nullptr);
         }
     } else {
         throw exception(sstream() << "VM does not have code for '" << cname << "'");
@@ -3019,13 +2985,13 @@ void vm_state::apply(unsigned n) {
 }
 
 void vm_state::display(std::ostream & out, vm_obj const & o) const {
-    ::lean::display(out, o,
-                    [&](unsigned idx) { return optional<name>(get_decl(idx).get_name()); });
+    ::lean::display(out, o);
 }
 
 optional<vm_decl> vm_state::get_decl(name const & n) const {
-    if (auto idx = m_fn_name2idx.find(n))
-        return optional<vm_decl>(get_decl(*idx));
+    auto idx = get_vm_index(n);
+    if (m_decl_map.contains(idx))
+        return optional<vm_decl>(get_decl(idx));
     else
         return optional<vm_decl>();
 }
@@ -3177,25 +3143,9 @@ void vm_state::profiler::snapshots::display(std::ostream & out) const {
 }
 
 void display_vm_code(std::ostream & out, environment const & env, unsigned code_sz, vm_instr const * code) {
-    vm_decls const & ext = get_extension(env);
-    auto idx2name = [&](unsigned idx) {
-        if (idx < ext.m_decls.size()) {
-            return optional<name>(ext.m_decls.find(idx)->get_name());
-        } else {
-            return optional<name>();
-        }
-    };
-    auto cases2name = [&](unsigned idx) {
-        if (idx < ext.m_cases_names.size()) {
-            return optional<name>(*ext.m_cases_names.find(idx));
-        } else {
-            return optional<name>();
-        }
-    };
-
     for (unsigned i = 0; i < code_sz; i++) {
         out << i << ": ";
-        code[i].display(out, idx2name, cases2name);
+        code[i].display(out);
         out << "\n";
     }
 }
@@ -3295,7 +3245,70 @@ static void vm_monitor_reader(deserializer & d, environment & env) {
     env = update(env, ext);
 }
 
+class vm_index_manager {
+    shared_mutex m_mutex;
+    std::unordered_map<name, unsigned, name_hash> m_name2idx;
+    std::vector<name> m_idx2name;
+
+public:
+    unsigned get_index(name const & n) {
+        {
+            shared_lock lock(m_mutex);
+            auto it = m_name2idx.find(n);
+            if (it != m_name2idx.end())
+                return it->second;
+        }
+        {
+            exclusive_lock lock(m_mutex);
+            auto it = m_name2idx.find(n);
+            if (it != m_name2idx.end()) {
+                return it->second;
+            } else {
+                auto i = static_cast<unsigned>(m_idx2name.size());
+                m_idx2name.push_back(n);
+                m_name2idx[n] = i;
+                return i;
+            }
+        }
+    }
+
+    unsigned get_index_bound() {
+        shared_lock _(m_mutex);
+        return static_cast<unsigned>(m_idx2name.size());
+    }
+
+    name const & get_name(unsigned idx) {
+        shared_lock lock(m_mutex);
+        lean_assert(idx < m_idx2name.size());
+        return m_idx2name.at(idx);
+    }
+
+    optional<name> find_name(unsigned idx) {
+        shared_lock lock(m_mutex);
+        if (idx < m_idx2name.size()) {
+            return optional<name>(m_idx2name.at(idx));
+        } else {
+            return optional<name>();
+        }
+    }
+};
+static vm_index_manager * g_vm_index_manager = nullptr;
+
+unsigned get_vm_index(name const & n) {
+    return g_vm_index_manager->get_index(n);
+}
+unsigned get_vm_index_bound() {
+    return g_vm_index_manager->get_index_bound();
+}
+name const & get_vm_name(unsigned idx) {
+    return g_vm_index_manager->get_name(idx);
+}
+optional<name> find_vm_name(unsigned idx) {
+    return g_vm_index_manager->find_name(idx);
+}
+
 void initialize_vm_core() {
+    g_vm_index_manager = new vm_index_manager;
     g_vm_builtins = new name_map<std::tuple<unsigned, char const *, vm_function>>();
     g_vm_cbuiltins = new name_map<std::tuple<unsigned, char const *, vm_cfunction>>();
     g_vm_cases_builtins = new name_map<std::tuple<char const *, vm_cases_function>>();
@@ -3311,6 +3324,7 @@ void finalize_vm_core() {
     delete g_vm_builtins;
     delete g_vm_cbuiltins;
     delete g_vm_cases_builtins;
+    delete g_vm_index_manager;
 }
 
 void initialize_vm() {

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -49,7 +49,6 @@ public:
 #define LEAN_VM_BOX(num)    (reinterpret_cast<vm_obj_cell*>((num << 1) | 1))
 #define LEAN_VM_UNBOX(obj)  (reinterpret_cast<size_t>(obj) >> 1)
 
-void display(std::ostream & out, vm_obj const & o, std::function<optional<name>(unsigned)> const & idx2name);
 void display(std::ostream & out, vm_obj const & o);
 
 /** \brief VM object */
@@ -454,9 +453,6 @@ public:
     unsigned get_pc(unsigned i) const;
     void set_pc(unsigned i, unsigned pc);
 
-    void display(std::ostream & out,
-                 std::function<optional<name>(unsigned)> const & idx2name,
-                 std::function<optional<name>(unsigned)> const & cases_idx2name) const;
     void display(std::ostream & out) const;
 
     void serialize(serializer & s, std::function<name(unsigned)> const & idx2name) const;
@@ -573,8 +569,6 @@ class vm_state {
     cache_vector                m_cache_vector; /* for 0-ary declarations */
     builtin_cases_map           m_builtin_cases_map;
     builtin_cases_vector        m_builtin_cases_vector;
-    unsigned_map<name>          m_builtin_cases_names;
-    name_map<unsigned>          m_fn_name2idx;
     vm_instr const *            m_code;   /* code of the current function being executed */
     unsigned                    m_fn_idx; /* function idx being executed */
     unsigned                    m_pc;     /* program counter */
@@ -831,6 +825,11 @@ environment add_native(environment const & env, name const & n, vm_cfunction_6 f
 environment add_native(environment const & env, name const & n, vm_cfunction_7 fn);
 environment add_native(environment const & env, name const & n, vm_cfunction_8 fn);
 environment add_native(environment const & env, name const & n, unsigned arity, vm_cfunction_N fn);
+
+unsigned get_vm_index(name const & n);
+unsigned get_vm_index_bound();
+name const & get_vm_name(unsigned idx);
+optional<name> find_vm_name(unsigned idx);
 
 /** \brief Reserve an index for the given function in the VM, the expression
     \c e is the value of \c fn after preprocessing.

--- a/src/shell/CMakeLists.txt
+++ b/src/shell/CMakeLists.txt
@@ -97,10 +97,12 @@ endif()
 # LEAN TESTS
 file(GLOB LEANTESTS "${LEAN_SOURCE_DIR}/../tests/lean/*.lean")
 FOREACH(T ${LEANTESTS})
-  GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
-  add_test(NAME "leantest_${T_NAME}"
-           WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean"
-           COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  if(NOT T MATCHES "\\.#")
+    GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
+    add_test(NAME "leantest_${T_NAME}"
+             WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean"
+             COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  endif()
 ENDFOREACH(T)
 
 # # SMT2 TESTS
@@ -115,10 +117,12 @@ ENDFOREACH(T)
 # LEAN RUN TESTS
 file(GLOB LEANRUNTESTS "${LEAN_SOURCE_DIR}/../tests/lean/run/*.lean")
 FOREACH(T ${LEANRUNTESTS})
-  GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
-  add_test(NAME "leanruntest_${T_NAME}"
-           WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean/run"
-           COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  if(NOT T MATCHES "\\.#")
+    GET_FILENAME_COMPONENT(T_NAME ${T} NAME)
+    add_test(NAME "leanruntest_${T_NAME}"
+             WORKING_DIRECTORY "${LEAN_SOURCE_DIR}/../tests/lean/run"
+             COMMAND bash "./test_single.sh" "${CMAKE_CURRENT_BINARY_DIR}/lean" ${T_NAME})
+  endif()
 ENDFOREACH(T)
 
 # SMT2 RUN TESTS

--- a/src/shell/lean.cpp
+++ b/src/shell/lean.cpp
@@ -504,7 +504,7 @@ int main(int argc, char ** argv) {
 
         // Options appear to be empty, pretty sure I'm making a mistake here.
         if (compile && !mods.empty()) {
-            auto final_env = *mods.front().second->m_result.get().m_env;
+            auto final_env = mods.front().second->get_produced_env();
             auto final_opts = mods.front().second->m_result.get().m_opts;
             type_context tc(final_env, final_opts);
             lean::scope_trace_env scope2(final_env, final_opts, tc);
@@ -521,13 +521,13 @@ int main(int argc, char ** argv) {
         if (export_txt && !mods.empty()) {
             exclusive_file_lock export_lock(*export_txt);
             std::ofstream out(*export_txt);
-            export_module_as_lowtext(out, *mods.front().second->m_result.get().m_env);
+            export_module_as_lowtext(out, mods.front().second->get_produced_env());
         }
 
         if (export_all_txt && !mods.empty()) {
             exclusive_file_lock export_lock(*export_all_txt);
             std::ofstream out(*export_all_txt);
-            export_all_as_lowtext(out, *mods.front().second->m_result.get().m_env);
+            export_all_as_lowtext(out, mods.front().second->get_produced_env());
         }
         if (doc) {
             exclusive_file_lock export_lock(*doc);

--- a/src/shell/lean_js.cpp
+++ b/src/shell/lean_js.cpp
@@ -46,7 +46,7 @@ public:
     int import_module(std::string mname) {
         try {
             // FIXME(gabriel): discarding proofs fails at the moment with "invalid equation lemma, unexpected form"
-            env = lean::import_module(env, "importing", {mname, optional<unsigned>()}, mk_olean_loader());
+            env = lean::import_modules(env, "importing", {{mname, optional<unsigned>()}}, mk_olean_loader());
             return 0;
         } catch (exception & ex) {
             message_builder(env, ios, "importing", {1, 0}, ERROR).set_exception(ex).report();

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -360,7 +360,8 @@ server::cmd_res server::handle_info(server::cmd_req const & req) {
     auto opts = m_ios.get_options();
     auto env = m_initial_env;
     if (auto mod = m_mod_mgr->get_module(fn)->m_result.peek()) {
-        if (mod->m_env) env = *mod->m_env;
+        if (mod->m_loaded_module->m_env)
+            env = *mod->m_loaded_module->m_env;
         if (!mod->m_snapshots.empty()) opts = mod->m_snapshots.back()->m_options;
     }
 

--- a/src/util/lazy_value.h
+++ b/src/util/lazy_value.h
@@ -1,0 +1,58 @@
+/*
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Gabriel Ebner
+*/
+#pragma once
+#include "util/thread.h"
+#include <functional>
+
+namespace lean {
+
+template <class T>
+class lazy_value {
+    bool m_nonempty = false;
+    mutex m_mutex;
+    optional<T> m_value;
+    std::exception_ptr m_ex;
+    std::function<T()> m_closure;
+
+    T const & get() {
+        lean_assert(m_nonempty);
+        unique_lock<mutex> _(m_mutex);
+        if (m_value) return *m_value;
+        if (m_ex) std::rethrow_exception(m_ex);
+        try {
+            m_value = { m_closure() };
+            m_closure = {};
+            return *m_value;
+        } catch (...) {
+            m_ex = std::current_exception();
+            m_closure = {};
+            throw;
+        }
+    }
+
+public:
+    lazy_value() {}
+    lazy_value(std::function<T()> && closure) : m_nonempty(true), m_closure(closure) {}
+    lazy_value(lazy_value const & other) { *this = other; }
+
+    lazy_value & operator=(lazy_value const & other) {
+        unique_lock<mutex> _(const_cast<lazy_value &>(other).m_mutex);
+        m_nonempty = other.m_nonempty;
+        m_value = other.m_value;
+        m_ex = other.m_ex;
+        m_closure = other.m_closure;
+        return *this;
+    }
+
+    operator bool() const { return m_nonempty; }
+
+    T const & operator*() const {
+        return const_cast<lazy_value *>(this)->get();
+    }
+};
+
+}

--- a/tests/lean/interactive/info1.input.expected.out
+++ b/tests/lean/interactive/info1.input.expected.out
@@ -1,2 +1,2 @@
 {"message":"file invalidated","response":"ok","seq_num":0}
-{"record":{"full-id":"foo.f","source":{"column":4,"line":1},"type":"ℕ → ℕ"},"response":"ok","seq_num":1}
+{"record":{"full-id":"foo.f","source":{"column":4,"file":"/home/leo/projects/lean/tests/lean/interactive/info1.lean","line":1},"type":"ℕ → ℕ"},"response":"ok","seq_num":1}


### PR DESCRIPTION
(I don't know how much time I'll have during the next few days, so I'm putting this here for comments, even though there are still some improvements to try out.)
Same motivation as #1243, different approach: this is option 2 from that PR.

Right now the way we import modules is by essentially going `environment --> std::string --> environment`.  This PR changes this to `environment --> modification_list --> environment`, c.f. `environment --> modification_list --> std::string --> modification_list --> environment` if we save to an olean file, and then load it again.
Basically we introduce an intermediary data structure that contains precisely the information of an olean file, but not serialized.

Performance (current master, this PR w/o init caching, this PR):
```
$ lean --make

76.61user 0.91system 0:28.20elapsed 274%CPU (0avgtext+0avgdata 1006560maxresident)k
40inputs+8984outputs (1major+256530minor)pagefaults 0swaps

51.50user 0.72system 0:18.27elapsed 285%CPU (0avgtext+0avgdata 564004maxresident)k
0inputs+9008outputs (0major+140749minor)pagefaults 0swaps

40.29user 0.68system 0:15.15elapsed 270%CPU (0avgtext+0avgdata 373824maxresident)k
0inputs+9008outputs (0major+94284minor)pagefaults 0swaps

$ lean --make -j0

48.94user 0.44system 0:49.44elapsed 99%CPU (0avgtext+0avgdata 745368maxresident)k
0inputs+8984outputs (0major+191014minor)pagefaults 0swaps

31.44user 0.32system 0:31.80elapsed 99%CPU (0avgtext+0avgdata 446444maxresident)k
0inputs+9008outputs (0major+112103minor)pagefaults 0swaps

24.00user 0.23system 0:24.25elapsed 99%CPU (0avgtext+0avgdata 249584maxresident)k
0inputs+9008outputs (0major+62430minor)pagefaults 0swaps

$ lean standard.lean

0.59user 0.02system 0:00.62elapsed 100%CPU (0avgtext+0avgdata 62500maxresident)k
0inputs+0outputs (0major+14806minor)pagefaults 0swaps

0.33user 0.02system 0:00.36elapsed 99%CPU (0avgtext+0avgdata 50528maxresident)k
0inputs+0outputs (0major+11025minor)pagefaults 0swaps

0.35user 0.03system 0:00.38elapsed 99%CPU (0avgtext+0avgdata 50584maxresident)k
0inputs+0outputs (0major+11028minor)pagefaults 0swaps
```

To sum up, 2x as fast, 3x memory reduction (very similar to the results with #1243, the 6x memory difference there was due to master not doing expression caching on import).

Issues:
* Declaring trace options in a lean file is a global operation, even though it is stored as an environment modification.  I think this is broken right now as well, if you `declare_trace foo` and remove it again, it will be still be declared.
* I disabled expression caching as a performance optimization (~30% faster)
* The big improvement in memory consumption comes not only from reusing expressions and VM declarations across environments, but also from reusing the environments.  As an optimization, I'm caching the result of the first import in a module (usually init).

To do:
* Cache more than just the first import (init).  As a quick fix we could only add init if there are no imports specified in a file.  Another option would be to drop init in the module import code if the second module imports init already.
* There are a few modifications that take a lot of time, which might yield further improvments: 1) eqn_lemmas_modification, creates a simp_lemma on every import, 2) attributes, here we spend a lot of time modifying priority queues, 3) pos_info and source file maps in the module extension, we could speed things up by only having a map for both.