### PR TITLE
chore(library/tactic/change_tactic.cpp): better formatting for error …

### DIFF
--- a/src/library/tactic/change_tactic.cpp
+++ b/src/library/tactic/change_tactic.cpp
@@ -34,7 +34,7 @@ vm_obj change(expr const & e, tactic_state const & s) {
             auto thunk = [=]() {
                 format m("tactic.change failed, given type");
                 m += pp_indented_expr(s, e);
-                m += format("is not definitionally equal to");
+                m += line() + format("is not definitionally equal to");
                 m += pp_indented_expr(s, g->get_type());
                 return m;
             };


### PR DESCRIPTION
…message

Before this fix, there would be no space between the first expression and the "is".