### PR TITLE
Avoid segfault on missing import file

### DIFF
--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -261,19 +261,17 @@ void module_mgr::build_module(module_id const & id, bool can_use_olean, name_set
             mod->m_source = module_src::LEAN;
             mod->m_trans_mtime = mod->m_mtime = mtime;
             for (auto & d : imports) {
-                module_id d_id;
-                std::shared_ptr<module_info const> d_mod;
                 try {
-                    d_id = resolve(id, d);
+                    module_id d_id = resolve(id, d);
                     build_module(d_id, true, module_stack);
-                    d_mod = m_modules[d_id];
+                    auto d_mod = m_modules[d_id];
                     mod->m_trans_mtime = std::max(mod->m_trans_mtime, d_mod->m_trans_mtime);
+                    mod->m_deps.push_back({ d_id, d, d_mod });
                 } catch (throwable & ex) {
                     message_builder msg(m_initial_env, m_ios, id, pos_info {1, 0}, ERROR);
                     msg.set_exception(ex);
                     msg.report();
                 }
-                mod->m_deps.push_back({ d_id, d, d_mod });
             }
             if (m_use_snapshots) {
                 mod->m_lean_contents = optional<std::string>(contents);

--- a/tests/lean/missing_import.lean
+++ b/tests/lean/missing_import.lean
@@ -1,0 +1,1 @@
+import does.not.exist

--- a/tests/lean/missing_import.lean.expected.out
+++ b/tests/lean/missing_import.lean.expected.out
@@ -1,0 +1,2 @@
+missing_import.lean:1:0: error: file 'does/not/exist' not found in the LEAN_PATH
+missing_import.lean:1:0: error: invalid import


### PR DESCRIPTION
As reported in #1262

Note that a missing import will also prevent all other imports.