### PR TITLE
fix(module_mgr): guard all accesses to m_mod_info

### DIFF
--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2166,16 +2166,23 @@ void parser::process_imports() {
     unsigned fingerprint = 0;
     auto imports = parse_imports(fingerprint);
 
-    try {
-        m_env = import_modules(m_env, m_file_name, imports, m_import_fn);
-    } catch (exception & ex) {
+    buffer<import_error> import_errors;
+    m_env = import_modules(m_env, m_file_name, imports, m_import_fn, import_errors);
+
+    if (!import_errors.empty()) {
         m_found_errors = true;
-        parser_exception error((sstream() << "invalid import").str(),
-                               m_file_name.c_str(), m_last_cmd_pos.first, m_last_cmd_pos.second);
-        if (!m_use_exceptions && m_show_errors)
-            report_message(error);
-        if (m_use_exceptions)
-            throw error;
+        for (auto & e : import_errors) {
+            try {
+                std::rethrow_exception(e.m_ex);
+            } catch (throwable & t) {
+                parser_exception error((sstream() << "invalid import: " << e.m_import.m_name << "\n" << t.what()).str(),
+                                       m_file_name.c_str(), m_last_cmd_pos.first, m_last_cmd_pos.second);
+                if (!m_use_exceptions && m_show_errors)
+                    report_message(error);
+                if (m_use_exceptions)
+                    throw error;
+            }
+        }
     }
 
     m_env = update_fingerprint(m_env, fingerprint);

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -444,45 +444,58 @@ std::pair<std::vector<module_name>, std::vector<char>> parse_olean(std::istream 
 }
 
 static void import_module(environment & env, std::string const & module_file_name, module_name const & ref,
-                          module_loader const & mod_ldr) {
-    auto res = mod_ldr(module_file_name, ref);
+                          module_loader const & mod_ldr, buffer<import_error> & import_errors) {
+    try {
+        auto res = mod_ldr(module_file_name, ref);
 
-    auto & ext0 = get_extension(env);
-    if (ext0.m_imported.contains(res->m_module_name)) return;
+        auto & ext0 = get_extension(env);
+        if (ext0.m_imported.contains(res->m_module_name)) return;
 
-    if (ext0.m_imported.empty() && res->m_env) {
-        env = *res->m_env;
-    } else {
-        for (auto & dep : res->m_imports) {
-            import_module(env, res->m_module_name, dep, mod_ldr);
+        if (ext0.m_imported.empty() && res->m_env) {
+            env = *res->m_env;
+        } else {
+            for (auto &dep : res->m_imports) {
+                import_module(env, res->m_module_name, dep, mod_ldr, import_errors);
+            }
+            import_module(res->m_modifications, res->m_module_name, env);
         }
-        import_module(res->m_modifications, res->m_module_name, env);
-    }
 
-    auto ext = get_extension(env);
-    ext.m_imported.insert(res->m_module_name);
-    env = update(env, ext);
+        auto ext = get_extension(env);
+        ext.m_imported.insert(res->m_module_name);
+        env = update(env, ext);
+    } catch (throwable) {
+        import_errors.push_back({module_file_name, ref, std::current_exception()});
+    }
+}
+
+environment import_modules(environment const & env0, std::string const & module_file_name,
+                           std::vector<module_name> const & refs, module_loader const & mod_ldr,
+                           buffer<import_error> & import_errors) {
+    environment env = env0;
+
+    for (auto & ref : refs)
+        import_module(env, module_file_name, ref, mod_ldr, import_errors);
+
+    module_ext ext = get_extension(env);
+    ext.m_direct_imports = refs;
+    return update(env, ext);
 }
 
 environment import_modules(environment const & env0, std::string const & module_file_name,
                            std::vector<module_name> const & refs, module_loader const & mod_ldr) {
-    environment env = env0;
-
-    for (auto & ref : refs)
-        import_module(env, module_file_name, ref, mod_ldr);
-
-    module_ext ext = get_extension(env);
-    ext.m_direct_imports = refs;
-    env = update(env, ext);
-
+    buffer<import_error> import_errors;
+    auto env = import_modules(env0, module_file_name, refs, mod_ldr, import_errors);
+    if (!import_errors.empty()) std::rethrow_exception(import_errors.back().m_ex);
     return env;
 }
 
 static environment mk_preimported_module(environment const & initial_env, loaded_module const & lm, module_loader const & mod_ldr) {
     auto env = initial_env;
+    buffer<import_error> import_errors;
     for (auto & dep : lm.m_imports) {
-        import_module(env, lm.m_module_name, dep, mod_ldr);
+        import_module(env, lm.m_module_name, dep, mod_ldr, import_errors);
     }
+    if (!import_errors.empty()) std::rethrow_exception(import_errors.back().m_ex);
     import_module(lm.m_modifications, lm.m_module_name, env);
     return env;
 }

--- a/src/library/module.h
+++ b/src/library/module.h
@@ -52,14 +52,21 @@ std::vector<module_name> get_curr_module_imports(environment const & env);
 /** \brief Return an environment based on \c env, where all modules in \c modules are imported.
     Modules included directly or indirectly by them are also imported.
     The environment \c env is usually an empty environment.
-
-    If \c keep_proofs is false, then the proof of the imported theorems is discarded after being
-    checked. The idea is to save memory.
 */
 environment
 import_modules(environment const & env,
                std::string const & current_mod, std::vector<module_name> const & ref,
                module_loader const & mod_ldr);
+
+struct import_error {
+    module_id m_mod;
+    module_name m_import;
+    std::exception_ptr m_ex;
+};
+environment
+import_modules(environment const & env,
+               std::string const & current_mod, std::vector<module_name> const & ref,
+               module_loader const & mod_ldr, buffer<import_error> & errors);
 
 /** \brief Return the .olean file where decl_name was defined. The result is none if the declaration
     was not defined in an imported file. */

--- a/tests/lean/missing_import.lean
+++ b/tests/lean/missing_import.lean
@@ -1,0 +1,1 @@
+import does.not.exist

--- a/tests/lean/missing_import.lean
+++ b/tests/lean/missing_import.lean
@@ -1,1 +1,3 @@
-import does.not.exist
+import does.not.exist data.bitvec
+
+print bitvec

--- a/tests/lean/missing_import.lean.expected.out
+++ b/tests/lean/missing_import.lean.expected.out
@@ -1,0 +1,2 @@
+missing_import.lean:1:0: error: file 'does/not/exist' not found in the LEAN_PATH
+missing_import.lean:1:0: error: invalid import

--- a/tests/lean/missing_import.lean.expected.out
+++ b/tests/lean/missing_import.lean.expected.out
@@ -1,2 +1,6 @@
 missing_import.lean:1:0: error: file 'does/not/exist' not found in the LEAN_PATH
-missing_import.lean:1:0: error: invalid import
+missing_import.lean:1:0: error: invalid import: does.not.exist
+could not resolve import: does.not.exist
+attribute [reducible]
+definition bitvec : ℕ → Type :=
+λ (n : ℕ), tuple bool n

--- a/tests/lean/test_single.sh
+++ b/tests/lean/test_single.sh
@@ -22,11 +22,11 @@ fi
 
 echo "-- testing $f"
 "$LEAN" -Dpp.colors=false -Dpp.unicode=true -j0 "$ff" &> "$f.produced.out"
-sed -i 's|does\\not\\exist|does/not/exist|' "$f.produced.out"
-sed -i "/warning: imported file uses 'sorry'/d" "$f.produced.out"
-sed -i "/warning: using 'sorry'/d" "$f.produced.out"
-sed -i "/failed to elaborate theorem/d" "$f.produced.out"
-sed -i "s|^$ff|$f|" "$f.produced.out"
+sed -i.tmp 's|does\\not\\exist|does/not/exist|' "$f.produced.out"
+sed -i.tmp "/warning: imported file uses 'sorry'/d" "$f.produced.out"
+sed -i.tmp "/warning: using 'sorry'/d" "$f.produced.out"
+sed -i.tmp "/failed to elaborate theorem/d" "$f.produced.out"
+sed -i.tmp "s|^$ff|$f|" "$f.produced.out"
 if test -f "$f.expected.out"; then
     if diff --ignore-all-space -I "executing external script" "$f.produced.out" "$f.expected.out"; then
         echo "-- checked"

--- a/tests/lean/test_single.sh
+++ b/tests/lean/test_single.sh
@@ -22,11 +22,11 @@ fi
 
 echo "-- testing $f"
 "$LEAN" -Dpp.colors=false -Dpp.unicode=true -j0 "$ff" &> "$f.produced.out"
-sed "/warning: imported file uses 'sorry'/d" "$f.produced.out" > "$f.produced.out.tmp"
-sed "/warning: using 'sorry'/d" "$f.produced.out.tmp" > "$f.produced.out"
-sed "/failed to elaborate theorem/d" "$f.produced.out" > "$f.produced.out.tmp"
-sed "s|^$ff|$f|" "$f.produced.out.tmp" > "$f.produced.out"
-rm "$f.produced.out.tmp"
+sed -i 's|does\\not\\exist|does/not/exist|' "$f.produced.out"
+sed -i "/warning: imported file uses 'sorry'/d" "$f.produced.out"
+sed -i "/warning: using 'sorry'/d" "$f.produced.out"
+sed -i "/failed to elaborate theorem/d" "$f.produced.out"
+sed -i "s|^$ff|$f|" "$f.produced.out"
 if test -f "$f.expected.out"; then
     if diff --ignore-all-space -I "executing external script" "$f.produced.out" "$f.expected.out"; then
         echo "-- checked"


### PR DESCRIPTION
Fixes #1262.  This is a version of PR #1263 that keeps around information about imports that do not exist yet.