### PR TITLE
fix(emacs): bug in suggested Emacs init

### DIFF
--- a/src/emacs/README.md
+++ b/src/emacs/README.md
@@ -65,13 +65,13 @@ Installation
 ============
 
 You can also include lean-mode permanently in your emacs init file.  In this
-case, just put the following code in your Emacs init file:
+case, just put the following code in your Emacs init file (typically `~/.emacs.d/init.el`):
 ```elisp
 ;; You need to modify the following two lines:
 (setq lean-rootdir "~/projects/lean")
 (setq lean-emacs-path "~/projects/lean/src/emacs")
 
-(setq lean-required-packages '(company dash dash-functional f
+(setq lean-mode-required-packages '(company dash dash-functional f
                                flycheck let-alist s seq))
 
 (require 'package)


### PR DESCRIPTION
The original code set the variable `lean-required-packages`, but then expected `lean-mode-required-packages`.

I've also added a hint about where to find your emacs init file; this was something I had to learn to follow these instructions.

A question for follow-up: the requirements sections states that `fill-column-indicator` is a dependency, but the suggested init file does not attempt to install this. Should this be fixed?