### PR TITLE
fix(type_context): check for variables in infer_core

### DIFF
--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -820,7 +820,11 @@ expr type_context::infer(expr const & e) {
 expr type_context::infer_core(expr const & e) {
     lean_assert(!is_var(e));
     lean_assert(closed(e));
-
+    if (is_var(e)) {
+      throw generic_exception(e, [=](formatter const & fmt) {
+	  return format("type checker does not support free variables") + pp_indent_expr(fmt, e);
+	});
+    }
     auto & cache = m_cache->m_infer_cache;
     unsigned postponed_sz = m_postponed.size();
     auto it = cache.find(e);


### PR DESCRIPTION
The following produces an "unreachable code reached" error:
```lean
open expr tactic

example foo trivial := by do
t ← infer_type (var 0),
to_expr `(trivial) >>= apply
```

`type_context::infer_core` wasn't checking for bad inputs. I'm not sure if this is the right exception to throw here, so if not, feel free to ignore this PR and handle the exception differently!