### PR TITLE
chore(frontends/lean/print_cmd): update print command to keyword changes

### DIFF
--- a/tests/lean/1299.lean.expected.out
+++ b/tests/lean/1299.lean.expected.out
@@ -1,6 +1,6 @@
 (a, a)
 d1 : true = true
-definition d1 : true = true :=
+def d1 : true = true :=
 new_ax
 (a, a)
 1299.lean:13:8: error: invalid theorem 'd2', theorems should not depend on axioms introduced using tactics (solution: mark theorem as a definition)

--- a/tests/lean/584a.lean.expected.out
+++ b/tests/lean/584a.lean.expected.out
@@ -1,5 +1,5 @@
 foo : Π (A : Type u_1) [H : inhabited A], A → A
 foo' : Π {A : Type u_1} [H : inhabited A] {x : A}, A
 foo ℕ 10 : ℕ
-definition test : ∀ {A : Type u} [H : inhabited A], @foo' ℕ nat.inhabited (5 + 5) = 10 :=
+def test : ∀ {A : Type u} [H : inhabited A], @foo' ℕ nat.inhabited (5 + 5) = 10 :=
 λ {A : Type u} [H : inhabited A], @rfl ℕ (@foo' ℕ nat.inhabited (5 + 5))

--- a/tests/lean/671.lean.expected.out
+++ b/tests/lean/671.lean.expected.out
@@ -1,2 +1,2 @@
-protected definition nat.add : ℕ → ℕ → ℕ :=
+protected def nat.add : ℕ → ℕ → ℕ :=
 nat.add._main

--- a/tests/lean/assert_tac3.lean.expected.out
+++ b/tests/lean/assert_tac3.lean.expected.out
@@ -4,7 +4,7 @@ x : ℕ := ?m_1
 
 a : ℕ
 ⊢ ℕ
-definition tst2 : ∀ (a : ℕ), a = a :=
+def tst2 : ∀ (a : ℕ), a = a :=
 λ (a : ℕ), let x : ℕ := a in eq.refl a
 a b : ℕ,
 x : ℕ := ?m_1

--- a/tests/lean/curly_notation.lean.expected.out
+++ b/tests/lean/curly_notation.lean.expected.out
@@ -1,11 +1,11 @@
 {1, 2, 3} : set ℕ
 {1} : set ℕ
 ∅ : set ℕ
-definition s1 : set ℕ :=
+def s1 : set ℕ :=
 {1, 2 + 3, 3, 4}
-definition s2 : set char :=
+def s2 : set char :=
 {#"a", #"b", #"c"}
-definition s3 : set string :=
+def s3 : set string :=
 {"hello", "world"}
 {a ∈ s1 | a > 1} : set ℕ
 {a ∈ s1 | a > 1} : set ℕ

--- a/tests/lean/import_invalid_tk.lean.expected.out
+++ b/tests/lean/import_invalid_tk.lean.expected.out
@@ -1,4 +1,4 @@
 import_invalid_tk.lean:1:21: error: invalid binary digit
-attribute [reducible]
-definition bitvec : ℕ → Type :=
+@[reducible]
+def bitvec : ℕ → Type :=
 λ (n : ℕ), tuple bool n

--- a/tests/lean/minimize_errors.lean.expected.out
+++ b/tests/lean/minimize_errors.lean.expected.out
@@ -6,7 +6,7 @@ but is expected to have type
   ℕ → ℕ → ℕ
 f : ℕ → ℕ → ℕ
 g : ℕ → ℕ → ℕ
-noncomputable definition g : ℕ → ℕ → ℕ :=
+noncomputable def g : ℕ → ℕ → ℕ :=
 f
-noncomputable definition h : ℕ → ℕ → ℕ :=
+noncomputable def h : ℕ → ℕ → ℕ :=
 h._main

--- a/tests/lean/missing_import.lean.expected.out
+++ b/tests/lean/missing_import.lean.expected.out
@@ -1,6 +1,6 @@
 missing_import.lean:1:0: error: file 'does/not/exist' not found in the LEAN_PATH
 missing_import.lean:1:0: error: invalid import: does.not.exist
 could not resolve import: does.not.exist
-attribute [reducible]
-definition bitvec : ℕ → Type :=
+@[reducible]
+def bitvec : ℕ → Type :=
 λ (n : ℕ), tuple bool n

--- a/tests/lean/pp_binder_types.lean.expected.out
+++ b/tests/lean/pp_binder_types.lean.expected.out
@@ -1,4 +1,4 @@
-definition f : Π (n : ℕ), n = n → ℕ → ℕ :=
+def f : Π (n : ℕ), n = n → ℕ → ℕ :=
 λ (n : ℕ) (H : n = n) (m : ℕ), id (n + m)
-definition f : Π (n : ℕ), n = n → ℕ → ℕ :=
+def f : Π (n : ℕ), n = n → ℕ → ℕ :=
 λ (n : ℕ) (H : n = n) (m : ℕ), id (n + m)

--- a/tests/lean/print_meta.lean
+++ b/tests/lean/print_meta.lean
@@ -1,0 +1,1 @@
+print tactic.intro

--- a/tests/lean/print_meta.lean.expected.out
+++ b/tests/lean/print_meta.lean.expected.out
@@ -1,0 +1,4 @@
+meta def tactic.intro : name → tactic expr :=
+λ (n : name),
+  tactic.target >>= λ (t : expr),
+    ite (↑(expr.is_pi t) ∨ ↑(expr.is_let t)) (tactic.intro_core n) (tactic.whnf_target >> tactic.intro_core n)

--- a/tests/lean/private_structure.lean.expected.out
+++ b/tests/lean/private_structure.lean.expected.out
@@ -17,7 +17,7 @@ private_structure.lean:29:6: error: unknown identifier 'point.induction_on'
 private_structure.lean:30:6: error: unknown identifier 'point.no_confusion'
 private_structure.lean:31:6: error: unknown identifier 'point.x'
 private_structure.lean:32:6: error: unknown identifier 'point.y'
-definition foo.bla : Type :=
+def foo.bla : Type :=
 point
 private_structure.lean:37:7: error: invalid constructor ⟨...⟩, type is a private inductive datatype
 foo.mk : foo.bla

--- a/tests/lean/user_attribute.lean.expected.out
+++ b/tests/lean/user_attribute.lean.expected.out
@@ -1,10 +1,10 @@
 eq.refl
-attribute [foo, refl]
+@[foo, refl]
 constructor eq.refl : ∀ {α : Type u} (a : α), a = a
 [eq.refl]
 ---
 eq.refl
-attribute [foo, foo.baz, refl]
+@[foo, foo.baz, refl]
 constructor eq.refl : ∀ {α : Type u} (a : α), a = a
 [eq.refl]
 user_attribute.lean:24:0: error: an attribute named [reducible] has already been registered


### PR DESCRIPTION
`print` now outputs `@[reducible] meta def foo` instead of `attribute [reducible] definition foo`, to be consistent with the usage in the library.