### PR TITLE
Super improvements 2

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -210,6 +210,9 @@ meta def trace {α : Type u} [has_to_tactic_format α] (a : α) : tactic unit :=
 do fmt ← pp a,
    return $ _root_.trace_fmt fmt (λ u, ())
 
+meta def trace_call_stack : tactic unit :=
+take state, trace_call_stack (λ u, success u state)
+
 meta def trace_state : tactic unit :=
 do s ← read,
    trace $ to_fmt s

--- a/library/init/util.lean
+++ b/library/init/util.lean
@@ -13,3 +13,7 @@ f ()
 /- This function has a native implementation that displays the given string in the regular output stream. -/
 def trace {α : Type} (s : string) (f : unit → α) : α :=
 f ()
+
+/- This function has a native implementation that shows the VM call stack. -/
+def trace_call_stack {α : Type} (f : unit → α) : α :=
+f ()

--- a/library/tools/super/clause.lean
+++ b/library/tools/super/clause.lean
@@ -217,12 +217,11 @@ match list.filter (λm, ¬has_meta_var (get_meta_type m)) metas with
        for' metas (λm, do trace (expr.to_string m), t ← infer_type m, trace (expr.to_string t)),
        fail "could not sort metas"
 | ((mvar n t) :: _) := do
-  t' ← infer_type (mvar n t),
-  uniq ← mk_fresh_name,
-  c ← return (local_const uniq uniq binder_info.default t'),
+  c ← infer_type (mvar n t) >>= mk_local_def `x,
   unify c (mvar n t),
   rest ← sort_and_constify_metas metas,
-  return (rest ++ [c])
+  c ← instantiate_mvars c,
+  return ([c] ++ rest)
 | _ := failed
 end
 

--- a/library/tools/super/defs.lean
+++ b/library/tools/super/defs.lean
@@ -8,10 +8,8 @@ open tactic expr monad
 
 namespace super
 
--- FIXME: how to cleanly unfold one level of definitions?
--- what should one level even be? consider dvd->has_dvd->nat_has_dvd->...
-meta def try_unfold_one_def (type : expr) : tactic expr := do
-whnf type
+meta def try_unfold_one_def (type : expr) : tactic expr :=
+dunfold_expr_core transparency.all type
 
 meta def try_unfold_def_left (c : clause) (i : ℕ) : tactic (list clause) :=
 on_left_at c i $ λt, do

--- a/library/tools/super/inhabited.lean
+++ b/library/tools/super/inhabited.lean
@@ -8,6 +8,11 @@ open expr tactic monad
 
 namespace super
 
+meta def try_assumption_lookup_left (c : clause) : tactic (list clause) :=
+on_first_left c $ λtype, do
+  ass ← find_assumption type,
+  return [([], ass)]
+
 meta def try_nonempty_lookup_left (c : clause) : tactic (list clause) :=
 on_first_left_dn c $ λhnx,
   match is_local_not c^.local_false hnx^.local_type with
@@ -62,9 +67,10 @@ on_first_right' c $ λhinh,
 
 @[super.inf]
 meta def inhabited_infs : inf_decl := inf_decl.mk 10 $ take given, do
-for' [try_nonempty_lookup_left,
-       try_nonempty_left, try_nonempty_right,
-       try_inhabited_left, try_inhabited_right] $ λr,
+for' [try_assumption_lookup_left,
+      try_nonempty_lookup_left,
+      try_nonempty_left, try_nonempty_right,
+      try_inhabited_left, try_inhabited_right] $ λr,
       simp_if_successful given (r given^.c)
 
 end super

--- a/library/tools/super/lpo.lean
+++ b/library/tools/super/lpo.lean
@@ -34,8 +34,12 @@ else if get_app_fn s = get_app_fn t then lex_ma lpo s t (get_app_args s) (get_ap
 else alpha lpo (get_app_args s) t
 
 meta def prec_gt_of_name_list (ns : list name) : expr → expr → bool :=
-let nis := rb_map.of_list (list.zip_with_index ns) in
-λs t, match (rb_map.find nis (name_of_funsym s), rb_map.find nis (name_of_funsym t)) with
+let nis := rb_map.of_list ns^.zip_with_index in
+λs t, match (nis^.find (name_of_funsym s), nis^.find (name_of_funsym t)) with
 | (some si, some ti) := to_bool (si > ti)
 | _ := ff
 end
+
+meta def mk_lpo (ns : list name) : expr → expr → bool :=
+let prec_gt := prec_gt_of_name_list ns in
+lpo (prec_gt_of_name_list ns)

--- a/library/tools/super/misc_preprocessing.lean
+++ b/library/tools/super/misc_preprocessing.lean
@@ -28,4 +28,8 @@ meta def remove_duplicates_pre : prover unit :=
 preprocessing_rule $ λnew,
 return $ remove_duplicates new
 
+meta def clause_normalize_pre : prover unit :=
+preprocessing_rule $ λnew, for new $ λdc,
+do c' ← dc^.c^.normalize, return { dc with c := c' }
+
 end super

--- a/library/tools/super/prover.lean
+++ b/library/tools/super/prover.lean
@@ -75,6 +75,7 @@ run_prover_loop (i+1)
 meta def default_preprocessing : list (prover unit) :=
 [
 clausify_pre,
+clause_normalize_pre,
 factor_dup_lits_pre,
 remove_duplicates_pre,
 refl_r_pre,

--- a/library/tools/super/prover_state.lean
+++ b/library/tools/super/prover_state.lean
@@ -174,7 +174,7 @@ do state ← state_t.read, return state^.prec
 
 meta def get_term_order : prover (expr → expr → bool) := do
 state ← state_t.read,
-return $ lpo (prec_gt_of_name_list (map name_of_funsym state^.prec))
+return $ mk_lpo (map name_of_funsym state^.prec)
 
 private meta def set_precedence (new_prec : list expr) : prover unit :=
 do state ← state_t.read, state_t.write { state with prec := new_prec }

--- a/library/tools/super/prover_state.lean
+++ b/library/tools/super/prover_state.lean
@@ -118,6 +118,7 @@ passive_fmts ← mapm pp $ rb_map.values s^.passive,
 new_fmts ← mapm pp s^.newly_derived,
 locked_fmts ← mapm pp s^.locked,
 sat_fmts ← mapm pp s^.sat_solver^.clauses,
+sat_model_fmts ← for s^.current_model^.to_list (λx, if x.2 = tt then pp x.1 else pp (not_ x.1)),
 prec_fmts ← mapm pp s^.prec,
 return (join_with_nl
   ([to_fmt "active:"] ++ map (append (to_fmt "  ")) active_fmts ++
@@ -125,6 +126,7 @@ return (join_with_nl
   [to_fmt "new:"] ++ map (append (to_fmt "  ")) new_fmts ++
   [to_fmt "locked:"] ++ map (append (to_fmt "  ")) locked_fmts ++
   [to_fmt "sat formulas:"] ++ map (append (to_fmt "  ")) sat_fmts ++
+  [to_fmt "sat model:"] ++ map (append (to_fmt "  ")) sat_model_fmts ++
   [to_fmt "precedence order: " ++ to_fmt prec_fmts]))
 
 meta instance : has_to_tactic_format prover_state :=

--- a/library/tools/super/superposition.lean
+++ b/library/tools/super/superposition.lean
@@ -84,7 +84,7 @@ atom_univ ← infer_univ atom,
 op1 ← qf1.1^.open_constn i1,
 op2 ← qf2.1^.open_constn c2^.num_lits,
 hi2 ← (op2.2^.nth i2)^.to_monad,
-new_atom ← whnf $ app abs_rwr_ctx rwr_to',
+new_atom ← whnf_core transparency.none $ app abs_rwr_ctx rwr_to',
 new_hi2 ← return $ local_const hi2^.local_uniq_name `H binder_info.default new_atom,
 new_fin_prf ←
   return $ app_of_list (const congr_ax [lf_univ, univ, atom_univ]) [c1^.local_false, eq_type, rwr_from, rwr_to,

--- a/library/tools/super/trim.lean
+++ b/library/tools/super/trim.lean
@@ -8,23 +8,11 @@ open monad expr tactic
 
 namespace super
 
-meta def count_var_occs : unsigned → expr → ℕ
-| k (var k')              := if k = k' then 1 else 0
-| _ (sort _)              := 0
-| _ (const _ _)           := 0
-| _ (mvar _ _)            := 0
-| k (local_const _ _ _ t) := count_var_occs k t
-| k (app a b)             := count_var_occs k a + count_var_occs k b
-| k (lam _ _ t b)         := count_var_occs k t + count_var_occs k^.succ b
-| k (pi _ _ t b)          := count_var_occs k t + count_var_occs k^.succ b
-| k (elet _ t v b)        := count_var_occs k t + count_var_occs k v + count_var_occs k^.succ b
-| _ (macro _ _ _)         := 0 -- TODO(gabriel)
-
 -- TODO(gabriel): rewrite using conversions
 meta def trim : expr → tactic expr
 | (app (lam n m d b) arg) :=
-  if has_var b = ff ∨ count_var_occs 0 b ≤ 1 then
-    trim (instantiate_var b arg)
+  if ¬b^.has_var then
+    trim b
   else
     lift₂ app (trim (lam n m d b)) (trim arg)
 | (app a b) := lift₂ app (trim a) (trim b)

--- a/src/library/vm/vm_aux.cpp
+++ b/src/library/vm/vm_aux.cpp
@@ -23,9 +23,19 @@ vm_obj vm_trace(vm_obj const &, vm_obj const & s, vm_obj const & fn) {
     return invoke(fn, mk_vm_unit());
 }
 
+vm_obj vm_trace_call_stack(vm_obj const &, vm_obj const & fn) {
+    auto & s = get_vm_state();
+    auto out = tout();
+    for (unsigned i = 0; i < s.call_stack_size() - 1; i++) {
+        out << s.call_stack_fn(i) << "\n";
+    }
+    return invoke(fn, mk_vm_unit());
+}
+
 void initialize_vm_aux() {
     DECLARE_VM_BUILTIN("timeit", vm_timeit);
     DECLARE_VM_BUILTIN("trace",  vm_trace);
+    DECLARE_VM_BUILTIN("trace_call_stack", vm_trace_call_stack);
 }
 
 void finalize_vm_aux() {


### PR DESCRIPTION
@leodemoura Could you please take a look at the last commit?  Is there a nicer way to do this?

Basically, I have a function `mk_lpo : list name -> (expr -> expr -> bool)` that takes a precedence list, does some expensive preprocessing (I have factored it out to `to_indices`, so that shows nicely as trace messages and separately in the profiler), and then returns a function that compares two expressions.  (The `let precomputed := expensive in fun x, frob precomputed x` idiom works in Haskell, and I thought it would work here as well.)  However it seems that eta-expansion turns this into a function `list name -> expr -> expr -> bool` that does the preprocessing on every single call.

I have now managed to find a workaround with some crazy extra definitions and boxing functions into `unit × (expr → expr → bool)` containers to prevent eta-expansion.  However this is really fragile and breaks immediately on innocent refactorings, for example if you were to inline `get_term_order'` into `get_term_order`.

To reproduce, you can call `lean -j0 tests/lean/run/super_examples.lean`.  There should be a trace message for every call to `get_term_order`, `mk_lpo`, and `to_indices`.