### PR TITLE
fix(emacs/lean-flycheck): only update next-error-mode for current buffer

### DIFF
--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -133,7 +133,9 @@
 (defconst lean-next-error-buffer-name "*Lean Next Error*")
 
 (defun lean-next-error-copy ()
-  (when (and (equal major-mode 'lean-mode))
+  (when (and (equal major-mode 'lean-mode)
+             ; check whether current window of current buffer is selected (i.e., in focus)
+             (eq (current-buffer) (window-buffer)))
     (let* ((errors (sort (flycheck-overlay-errors-in (line-beginning-position) (line-end-position))
                          #'flycheck-error-<)))
 


### PR DESCRIPTION
Fixes #1306.