### PR TITLE
[RFC] Highlight pending tasks in emacs

### DIFF
--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -17,34 +17,6 @@
    (flycheck-mode (flycheck-mode -1))
    (t             (flycheck-mode  1))))
 
-(cl-defun lean-flycheck-parse-task (checker buffer cur-file-name
-                                            &key pos_line pos_col desc file_name &allow-other-keys)
-  (if (equal cur-file-name file_name)
-      (flycheck-error-new-at pos_line (1+ pos_col)
-                             'info
-                             (format "still running: %s" desc)
-                             :filename file_name
-                             :checker checker :buffer buffer)
-    (flycheck-error-new-at 1 1
-                           'info
-                           (format "still running: %s" desc)
-                           :filename cur-file-name
-                           :checker checker :buffer buffer)))
-
-(defun lean-flycheck-mk-task-msgs (checker buffer sess)
-  (if (and sess (lean-server-session-tasks sess)
-           (plist-get (lean-server-session-tasks sess) :is_running))
-      (let* ((cur-fn (buffer-file-name))
-             (tasks (lean-server-session-tasks sess))
-             (cur-task (plist-get tasks :cur_task))
-             (tasks-for-cur-file (remove-if-not (lambda (task) (equal cur-fn (plist-get task :file_name)))
-                                                (plist-get tasks :tasks))))
-        (mapcar (lambda (task) (apply #'lean-flycheck-parse-task checker buffer cur-fn task))
-                (if (or (not cur-task)
-                        (and tasks-for-cur-file (equal cur-fn (plist-get cur-task :file_name))))
-                    tasks-for-cur-file
-                  (cons cur-task tasks-for-cur-file))))))
-
 (cl-defun lean-flycheck-parse-error (checker buffer &key pos_line pos_col severity text file_name &allow-other-keys)
   (flycheck-error-new-at pos_line (1+ pos_col)
                          (pcase severity
@@ -61,11 +33,9 @@
         (buffer (current-buffer)))
     (funcall callback 'finished
              (if lean-server-session
-                 (append
-                  (lean-flycheck-mk-task-msgs checker buffer lean-server-session)
-                  (mapcar (lambda (msg) (apply #'lean-flycheck-parse-error checker buffer msg))
-                          (remove-if-not (lambda (msg) (equal cur-fn (plist-get msg :file_name)))
-                                         (lean-server-session-messages lean-server-session))))))))
+                 (mapcar (lambda (msg) (apply #'lean-flycheck-parse-error checker buffer msg))
+                         (remove-if-not (lambda (msg) (equal cur-fn (plist-get msg :file_name)))
+                                        (lean-server-session-messages lean-server-session)))))))
 
 (defun lean-flycheck-init ()
   "Initialize lean-flychek checker"

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -148,6 +148,7 @@ enabled and disabled respectively.")
   "Default lean-mode setup"
   ;; server
   (lean-server-ensure-alive)
+  (setq mode-name '("Lean" (:eval (lean-server-status-string))))
   ;; Flycheck
   (when lean-flycheck-use
     (lean-flycheck-turn-on)

--- a/src/emacs/lean-server.el
+++ b/src/emacs/lean-server.el
@@ -77,6 +77,7 @@
 
 (defun lean-server-handle-signal (process event)
   "Handle signals for lean-server-process"
+  (force-mode-line-update)
   (let ((event-string (s-trim event)))
     (lean-debug "lean-server-handle-signal: %s"
                 (propertize event-string 'face '(:foreground "red")))
@@ -166,7 +167,7 @@
   "Lean server session for the current buffer")
 
 (defun lean-server-status-string ()
-  (if (not lean-server-session) " ☠"
+  (if (not (lean-server-session-alive-p lean-server-session)) " ☠"
     (let ((ts (lean-server-session-tasks lean-server-session)))
       (if (plist-get ts :is_running) " ⌛" " ✓"))))
 

--- a/src/emacs/lean-server.el
+++ b/src/emacs/lean-server.el
@@ -39,6 +39,7 @@
      (lean-server-notify-messages-changed sess))
     ("current_tasks"
      (setf (lean-server-session-tasks sess) res)
+     (force-mode-line-update)
      (lean-server-notify-messages-changed sess))
     ("error"
      (message "error: %s" (plist-get res :message))
@@ -164,11 +165,61 @@
 (defvar-local lean-server-session nil
   "Lean server session for the current buffer")
 
+(defun lean-server-status-string ()
+  (if (not lean-server-session) " ☠"
+    (let ((ts (lean-server-session-tasks lean-server-session)))
+      (if (plist-get ts :is_running) " ⌛" " ✓"))))
+
 (defvar-local lean-server-flycheck-delay-timer nil)
+
+(defvar-local lean-server-task-overlays nil)
+
+(defun lean-server-task-region (task)
+  (let ((bl (1- (plist-get task :pos_line)))
+        (bc (plist-get task :pos_col))
+        (el (1- (plist-get task :end_pos_line)))
+        (ec (plist-get task :end_pos_col)))
+    (save-excursion
+      (widen)
+      (goto-char (point-min))
+      (forward-line bl)
+      (if (equal (cons bl bc) (cons el ec))
+          (progn
+            (let ((beg (point)))
+              (forward-line 1)
+              (cons beg (point))))
+        (forward-char bc)
+        (let ((beg (point)))
+          (goto-char (point-min))
+          (forward-line el)
+          (forward-char ec)
+          (cons beg (point)))))))
+
+(defface lean-server-task-face
+  '((((class color) (background light))
+     :background "navajo white")
+    (((class color) (background dark))
+     :background "salmon4")
+    (t :inverse-video t))
+  "Face to highlight running Lean tasks."
+  :group 'lean-server-faces)
+
+(defun lean-server-update-task-overlays (&optional buf)
+  (dolist (ov lean-server-task-overlays) (delete-overlay ov))
+  (setq lean-server-task-overlays nil)
+  (let ((tasks (if lean-server-session (lean-server-session-tasks lean-server-session)))
+        (cur-fn (buffer-file-name)))
+    (dolist (task tasks)
+      (if (equal (plist-get task :file_name) cur-fn)
+          (let* ((reg (lean-server-task-region task))
+                (ov (make-overlay (car reg) (cdr reg))))
+            (setq lean-server-task-overlays (cons ov lean-server-task-overlays))
+            (overlay-put ov 'face 'lean-server-task-face))))))
 
 (defun lean-server-show-messages (&optional buf)
   (with-current-buffer (or buf (current-buffer))
     (when flycheck-mode
+      (lean-server-update-task-overlays)
       (flycheck-buffer))))
 
 (defun lean-server-notify-messages-changed (sess)

--- a/src/emacs/lean-server.el
+++ b/src/emacs/lean-server.el
@@ -127,6 +127,7 @@
          (req `(:seq_num ,seq-num :command ,cmd-name . ,params))
          (json-array-type 'list)
          (json-object-type 'plist)
+         (json-false :json-false)
          (json-req (json-encode req))
          (cur-buf (current-buffer))
          (wrapped-cb (and cb (lambda (res) (with-current-buffer cur-buf (apply cb :allow-other-keys t res)))))

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -8,6 +8,7 @@ Author: Gabriel Ebner
 #include <string>
 #include <vector>
 #include <algorithm>
+#include "util/utf8.h"
 #include "util/lean_path.h"
 #include "util/file_lock.h"
 #include "library/module_mgr.h"
@@ -78,12 +79,25 @@ static module_loader mk_loader(module_id const & cur_mod, std::vector<module_inf
     };
 }
 
+static pos_info find_end_pos(std::string const & src) {
+    std::istringstream in(src);
+
+    unsigned line_no = 0;
+    std::string line;
+    while (!in.eof()) {
+        line_no++;
+        std::getline(in, line);
+    }
+    return {line_no, static_cast<unsigned>(utf8_strlen(line.c_str()))};
+}
+
 class parse_lean_task : public task<module_info::parse_result> {
     environment m_initial_env;
     std::string m_contents;
     snapshot_vector m_snapshots;
     bool m_use_snapshots;
     std::vector<module_info::dependency> m_deps;
+    pos_info m_end_pos;
 
 public:
     parse_lean_task(std::string const & contents, environment const & initial_env,
@@ -91,8 +105,10 @@ public:
                     std::vector<module_info::dependency> const & deps) :
         m_initial_env(initial_env), m_contents(contents),
         m_snapshots(snapshots), m_use_snapshots(use_snapshots),
-        m_deps(deps) {}
+        m_deps(deps), m_end_pos(find_end_pos(contents)) {}
     task_kind get_kind() const override { return task_kind::parse; }
+
+    pos_info get_end_pos() const override { return m_end_pos; }
 
     void description(std::ostream & out) const override {
         out << "parsing " << get_module_id();

--- a/src/library/module_mgr.cpp
+++ b/src/library/module_mgr.cpp
@@ -66,14 +66,8 @@ static module_loader mk_loader(module_id const & cur_mod, std::vector<module_inf
                 }
             }
         } catch (std::out_of_range) {
-            /* The following line of code is reachable.
-               Repro: create a file containing an "open" comment block.
-               Example:
-
-                 /-
-                   def x := 10
-            */
-            // lean_unreachable();
+            // In files with syntax errors, it can happen that the
+            // initial dependency scan does not find all dependencies.
         }
         throw exception(sstream() << "could not resolve import: " << import.m_name);
     };

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -112,7 +112,6 @@ struct current_tasks_msg {
     current_tasks_msg(mt_tq_status const & st, std::unordered_set<std::string> const & visible_files) {
         m_is_running = st.size() > 0;
         st.for_each([&] (generic_task const * t) {
-            if (m_tasks.size() >= 100) return;
             if (!t->is_tiny() && visible_files.count(t->get_module_id())) {
                 auto j = json_of_task(t);
                 if (!m_cur_task) m_cur_task = {j};

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -101,6 +101,9 @@ struct current_tasks_msg {
         auto pos = t->get_pos();
         j["pos_line"] = pos.first;
         j["pos_col"] = pos.second;
+        auto end_pos = t->get_end_pos();
+        j["end_pos_line"] = end_pos.first;
+        j["end_pos_col"] = end_pos.second;
         j["desc"] = t->description();
         return j;
     }
@@ -111,15 +114,8 @@ struct current_tasks_msg {
         st.for_each([&] (generic_task const * t) {
             if (m_tasks.size() >= 100) return;
             if (!t->is_tiny() && visible_files.count(t->get_module_id())) {
-                if (!m_cur_task) {
-                    m_cur_task = { json_of_task(t) };
-                }
-                json j;
-                j["file_name"] = t->get_module_id();
-                auto pos = t->get_pos();
-                j["pos_line"] = pos.first;
-                j["pos_col"] = pos.second;
-                j["desc"] = t->description();
+                auto j = json_of_task(t);
+                if (!m_cur_task) m_cur_task = {j};
                 m_tasks.push_back(j);
             }
         });

--- a/src/util/task_queue.h
+++ b/src/util/task_queue.h
@@ -142,6 +142,7 @@ public:
 
     virtual task_kind get_kind() const { return task_kind::elab; }
     virtual pos_info get_pos() const { return get_task_pos(); }
+    virtual pos_info get_end_pos() const { return get_pos(); }
 
     message_bucket_id const & get_bucket() const { return m_bucket; }
     period get_version() const { return m_bucket.m_version; }


### PR DESCRIPTION
This highlights the running tasks with a different background color instead of including them in the flycheck error list.  There is now also an hourglass/checkmark indicator next to the Lean mode to indicate server status.  For example, when a `lemma` is being elaborated you have a nice orange background from `lemma` to the end of the proof.

How do you like the color?  It didn't look bad at first with the solarized theme, but it might get annoying after time, or really clash with other backgrounds.