### PR TITLE
Improve goal display

### DIFF
--- a/src/emacs/README.md
+++ b/src/emacs/README.md
@@ -34,10 +34,10 @@ Key Bindings and Commands
 | <kbd>M-.</kbd>     | jump to definition in source file (`lean-find-definition`)                      |
 | <kbd>TAB</kbd>     | tab complete identifier, option, filename, etc. (`lean-tab-indent-or-complete`) |
 | <kbd>C-c C-k</kbd> | shows the keystroke needed to input the symbol under the cursor                 |
-| <kbd>C-c C-g</kbd> | show goal in tactic proof (`lean-show-goal-at-pos`)                             |
 | <kbd>C-c C-x</kbd> | execute lean in stand-alone mode (`lean-std-exe`)                               |
-| <kbd>C-c C-n</kbd> | toggle next-error-mode: shows next error in dedicated lean-info buffer          |
-| <kbd>C-c C-r</kbd> | restart the lean server                                                         |
+| <kbd>C-c C-g</kbd> | toggle showing current tactic proof goal (`lean-toggle-show-goal`)              |
+| <kbd>C-c C-n</kbd> | toggle showing next error in dedicated buffer (`lean-toggle-next-error`)        |
+| <kbd>C-c C-r</kbd> | restart the lean server (`lean-server-restart`)                                 |
 | <kbd>C-c ! n</kbd> | flycheck: go to next error                                                      |
 | <kbd>C-c ! p</kbd> | flycheck: go to previous error                                                  |
 | <kbd>C-c ! l</kbd> | flycheck: show list of errors                                                   |

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -89,8 +89,8 @@
   (local-set-key lean-keybinding-server-restart            'lean-server-restart)
   (local-set-key lean-keybinding-find-definition           'lean-find-definition)
   (local-set-key lean-keybinding-tab-indent-or-complete    'lean-tab-indent-or-complete)
-  (local-set-key lean-keybinding-lean-show-goal-at-pos     'lean-show-goal-at-pos)
-  (local-set-key lean-keybinding-lean-next-error-mode      'lean-next-error-mode)
+  (local-set-key lean-keybinding-lean-toggle-show-goal     'lean-toggle-show-goal)
+  (local-set-key lean-keybinding-lean-toggle-next-error    'lean-toggle-next-error)
   )
 
 (defun lean-define-key-binding (key cmd)
@@ -109,7 +109,8 @@
     ["Create a new project" (call-interactively 'lean-project-create) (not (lean-project-inside-p))]
     "-----------------"
     ["Show type info"       lean-show-type                    (and lean-eldoc-use eldoc-mode)]
-    ["Show goal"            lean-show-goal-at-pos             t]
+    ["Toggle goal display"  lean-toggle-show-goal             t]
+    ["Toggle next error display" lean-toggle-next-error       t]
     ["Find definition at point" lean-find-definition          t]
     "-----------------"
     ["Run flycheck"         flycheck-compile                  (and lean-flycheck-use flycheck-mode)]
@@ -121,9 +122,7 @@
      ["Use flycheck (on-the-fly syntax check)"
       lean-toggle-flycheck-mode :active t :style toggle :selected flycheck-mode]
      ["Show type at point"
-      lean-toggle-eldoc-mode :active t :style toggle :selected eldoc-mode]
-     ["Show next error in dedicated buffer"
-      lean-next-error-mode :active t :style toggle :selected lean-next-error-mode])
+      lean-toggle-eldoc-mode :active t :style toggle :selected eldoc-mode])
     "-----------------"
     ["Customize lean-mode" (customize-group 'lean)            t]))
 
@@ -135,6 +134,10 @@
     (focus-in-hook                       . lean-server-show-messages)
     ;; Handle events that may start automatic syntax checks
     (before-save-hook                    . lean-whitespace-cleanup)
+    ;; info windows
+    (post-command-hook                   . lean-show-goal--handler)
+    (post-command-hook                   . lean-next-error--handler)
+    (flycheck-after-syntax-check-hook    . lean-next-error--handler)
     )
   "Hooks which lean-mode needs to hook in.
 

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -90,7 +90,6 @@
   (local-set-key lean-keybinding-find-definition           'lean-find-definition)
   (local-set-key lean-keybinding-tab-indent-or-complete    'lean-tab-indent-or-complete)
   (local-set-key lean-keybinding-lean-show-goal-at-pos     'lean-show-goal-at-pos)
-  (local-set-key lean-keybinding-lean-show-id-keyword-info 'lean-show-id-keyword-info)
   (local-set-key lean-keybinding-lean-next-error-mode      'lean-next-error-mode)
   )
 
@@ -111,7 +110,6 @@
     "-----------------"
     ["Show type info"       lean-show-type                    (and lean-eldoc-use eldoc-mode)]
     ["Show goal"            lean-show-goal-at-pos             t]
-    ["Show id/keyword info" lean-show-id-keyword-info         t]
     ["Find definition at point" lean-find-definition          t]
     "-----------------"
     ["Run flycheck"         flycheck-compile                  (and lean-flycheck-use flycheck-mode)]

--- a/src/emacs/lean-settings.el
+++ b/src/emacs/lean-settings.el
@@ -135,9 +135,6 @@ false (nil)."
 (defcustom lean-keybinding-lean-show-goal-at-pos (kbd "C-c C-g")
   "Lean Keybinding for show-goal-at-pos"
   :group 'lean-keybinding  :type 'key-sequence)
-(defcustom lean-keybinding-lean-show-id-keyword-info (kbd "C-c C-p")
-  "Lean Keybinding for show-id-keyword-info"
-  :group 'lean-keybinding  :type 'key-sequence)
 (defcustom lean-keybinding-lean-next-error-mode (kbd "C-c C-n")
   "Lean Keybinding for lean-next-error-mode"
   :group 'lean-keybinding  :type 'key-sequence)

--- a/src/emacs/lean-settings.el
+++ b/src/emacs/lean-settings.el
@@ -132,10 +132,10 @@ false (nil)."
 (defcustom lean-keybinding-tab-indent-or-complete (kbd "TAB")
   "Lean Keybinding for tab-indent-or-complete"
   :group 'lean-keybinding  :type 'key-sequence)
-(defcustom lean-keybinding-lean-show-goal-at-pos (kbd "C-c C-g")
+(defcustom lean-keybinding-lean-toggle-show-goal (kbd "C-c C-g")
   "Lean Keybinding for show-goal-at-pos"
   :group 'lean-keybinding  :type 'key-sequence)
-(defcustom lean-keybinding-lean-next-error-mode (kbd "C-c C-n")
-  "Lean Keybinding for lean-next-error-mode"
+(defcustom lean-keybinding-lean-toggle-next-error (kbd "C-c C-n")
+  "Lean Keybinding for lean-toggle-next-error"
   :group 'lean-keybinding  :type 'key-sequence)
 (provide 'lean-settings)

--- a/src/emacs/lean-type.el
+++ b/src/emacs/lean-type.el
@@ -107,13 +107,21 @@
   (interactive)
   (lean-eldoc-documentation-function lean-show-type-add-to-kill-ring))
 
-(defun lean-show-goal-at-pos ()
+(defconst lean-show-goal-buffer-name "*Lean Goal*")
+
+(defun lean-show-goal--handler ()
+  (when (lean-info-buffer-active lean-show-goal-buffer-name)
+    (lean-get-info-record-at-point
+     (lambda (info-record)
+       (lean-with-info-output-to-buffer
+        lean-show-goal-buffer-name
+        (-if-let (state (plist-get info-record :state))
+            (princ state)))))))
+
+(defun lean-toggle-show-goal ()
   "Show goal at the current point."
   (interactive)
-  (lean-get-info-record-at-point
-   (lambda (info-record)
-     (-if-let (state (plist-get info-record :state))
-         (with-output-to-lean-info (princ state))
-       (message "No goal found at point")))))
+  (lean-toggle-info-buffer lean-show-goal-buffer-name)
+  (lean-show-goal--handler))
 
 (provide 'lean-type)

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -249,6 +249,7 @@ public:
 
     void set_break_at_pos(pos_info const & pos) { m_break_at_pos = some(pos); }
     optional<pos_info> const & get_break_at_pos() const { return m_break_at_pos; }
+    bool get_complete() { return m_complete; }
     void set_complete(bool complete) { m_complete = complete; }
     /** \brief Throw \c break_at_pos_exception with given context if \c m_break_at_pos is inside current token. */
     void check_break_at_pos(break_at_pos_exception::token_context ctxt = break_at_pos_exception::token_context::none);

--- a/src/shell/server.cpp
+++ b/src/shell/server.cpp
@@ -365,6 +365,11 @@ public:
                         prefix = prefix.substr(0, *stop);
                     switch (e.m_token_info.m_context) {
                         case break_at_pos_exception::token_context::expr:
+                            // no empty prefix completion for declarations
+                            if (!prefix.size()) {
+                                m_server->send_msg(cmd_res(m_seq_num, j));
+                                return {};
+                            }
                             if (!m_skip_completions)
                                 j["completions"] = get_decl_completions(prefix, snap->m_env, snap->m_options);
                             break;

--- a/tests/lean/interactive/complete.lean
+++ b/tests/lean/interactive/complete.lean
@@ -5,6 +5,10 @@ inductive foo
 example := foo
            --^ "command": "complete"
 
+-- should not complete empty declaration completion
+example := foo
+         --^ "command": "complete"
+
 @[reducible]
 --^ "command": "complete", "skip_completions": true
 example := foo

--- a/tests/lean/interactive/complete.lean.expected.out
+++ b/tests/lean/interactive/complete.lean.expected.out
@@ -1,4 +1,5 @@
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"completions":[{"source":{"column":10,"line":3},"text":"foo","type":"Type"},{"source":{"column":10,"line":3},"text":"foo.induction_on","type":"∀ (C : foo → Prop) (n : foo), C n"},{"source":{"column":10,"line":3},"text":"foo.rec","type":"Π (C : foo → Type l) (n : foo), C n"},{"source":{"column":10,"line":3},"text":"foo.rec_on","type":"Π (C : foo → Type l) (n : foo), C n"}],"prefix":"fo","response":"ok","seq_num":6}
-{"prefix":"","response":"ok","seq_num":9}
+{"response":"ok","seq_num":10}
 {"prefix":"","response":"ok","seq_num":13}
+{"prefix":"","response":"ok","seq_num":17}

--- a/tests/lean/interactive/info_goal.lean
+++ b/tests/lean/interactive/info_goal.lean
@@ -2,6 +2,8 @@ example : ℕ → ℕ :=
 begin
   exact id
 --^ "command": "info"
+          ,
+        --^ "command": "info"
 end
 --^ "command": "info"
 

--- a/tests/lean/interactive/info_goal.lean.expected.out
+++ b/tests/lean/interactive/info_goal.lean.expected.out
@@ -1,4 +1,5 @@
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"record":{"full-id":"tactic.interactive.exact","source":{"column":9,"file":"/library/init/meta/interactive.lean","line":126},"state":"⊢ ℕ → ℕ","type":"interactive.types.qexpr0 → tactic unit"},"response":"ok","seq_num":4}
 {"record":{"state":"no goals"},"response":"ok","seq_num":6}
-{"record":{"state":"⊢ ℕ → ℕ"},"response":"ok","seq_num":9}
+{"record":{"state":"no goals"},"response":"ok","seq_num":8}
+{"record":{"state":"⊢ ℕ → ℕ"},"response":"ok","seq_num":11}


### PR DESCRIPTION
![foo](https://cloud.githubusercontent.com/assets/109126/22041810/aedd1a72-dd08-11e6-9e28-7e5ea363cef6.png)

`C-c C-g` and `C-c C-n` now each toggle the visibility of a separate, auto-updating info buffer (just like `C-c ! l`). The buffers stop updating when they are invisible; there is no more need for a special minor mode like `lean-next-error-mode`. I'd welcome feedback about how you use the buffers and whether we should have a nice default layout like the one shown above.
Also, `,` in begin-end blocks will now show the following tactic state.