### PR TITLE
Exit with failure if examples fail

### DIFF
--- a/src/kernel/declaration.cpp
+++ b/src/kernel/declaration.cpp
@@ -60,7 +60,7 @@ unsigned declaration::get_num_univ_params() const { return length(get_univ_param
 expr const & declaration::get_type() const { return m_ptr->m_type; }
 
 task_result<expr> const & declaration::get_value_task() const {
-    lean_assert(is_definition());
+    lean_assert(is_theorem());
     return m_ptr->m_proof;
 }
 expr const & declaration::get_value() const {

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -47,9 +47,9 @@ struct module_info {
     struct parse_result {
         options               m_opts;
 
-        bool m_parsed_ok = false;
+        task_result<bool> m_parsed_ok;
         task_result<bool> m_proofs_are_correct;
-        bool is_ok() const { return m_parsed_ok && m_proofs_are_correct.get(); }
+        bool is_ok() const;
 
         std::shared_ptr<loaded_module const> m_loaded_module;
 

--- a/tests/lean/fail/example.lean
+++ b/tests/lean/fail/example.lean
@@ -1,0 +1,2 @@
+open tactic expr
+example : false := by do exact $ const `does_not_exist []

--- a/tests/lean/run/apply4.lean
+++ b/tests/lean/run/apply4.lean
@@ -20,7 +20,7 @@ set_option pp.all false
 example (a b : nat) : a = 0 → a = b :=
 by do
   intro `H,
-  apply_core semireducible tt ff (expr.const `foo [level.of_nat 1]),
+  apply_core semireducible ff tt ff (expr.const `foo [level.of_nat 1]),
   trace_state,
   a ← get_local `a,
   trace_state,
@@ -45,6 +45,6 @@ by do
 example (a b : nat) : a = 0 → a = b :=
 by do
   `[intro],
-  apply_core semireducible tt ff (expr.const `foo [level.of_nat 1]),
+  apply_core semireducible ff tt ff (expr.const `foo [level.of_nat 1]),
   `[exact inhabited.mk a],
   reflexivity

--- a/tests/lean/run/auto_quote1.lean
+++ b/tests/lean/run/auto_quote1.lean
@@ -56,7 +56,7 @@ begin
   induction m with m' ih,
   { -- Remark: Used change here to make sure nat.zero is replaced with polymorphic zero.
     -- dsimp tactic should fix that in the future.
-    change n + 0 = 0 + n, rw zadd n },
+    change n + 0 = 0 + n, simp [zadd] },
   { change succ (n + m') = succ m' + n,
     rw [succ_add, ih] }
 end
@@ -72,7 +72,7 @@ begin
   induction m with m' ih,
   show n + 0 = 0 + n,
   begin
-    change n + 0 = 0 + n, rw zadd n
+    change n + 0 = 0 + n, simp [zadd]
   end,
   show n + succ m' = succ m' + n, {
     change succ (n + m') = succ m' + n,

--- a/tests/lean/run/elab_crash1.lean
+++ b/tests/lean/run/elab_crash1.lean
@@ -4,10 +4,10 @@ meta definition to_expr_target (a : pexpr) : tactic expr :=
 do tgt ← target,
    to_expr `((%%a : %%tgt))
 
-example (A : Type) (a : A) : A :=
+noncomputable example (A : Type) (a : A) : A :=
 by do to_expr_target `(sorry) >>= exact
 
-example (A : Type) (a : A) : A :=
+noncomputable example (A : Type) (a : A) : A :=
 by do refine `(sorry)
 
 example (a : nat) : nat :=

--- a/tests/lean/run/simplify_with_hypotheses.lean
+++ b/tests/lean/run/simplify_with_hypotheses.lean
@@ -1,9 +1,9 @@
 open tactic
 
-example (A : Type) (a₁ a₂ : A) (f : A → A) (H₀ : a₁ = a₂) : f a₁ = f a₂ := by simp_using_hs >> try reflexivity
+example (A : Type) (a₁ a₂ : A) (f : A → A) (H₀ : a₁ = a₂) : f a₁ = f a₂ := by do simp_using_hs >> try reflexivity
 
 example (A : Type) (a₁ a₁' a₂ a₂' : A) (f : A → A) (H₀ : a₁' = a₂') (H₁ : f a₁ = a₁') (H₂ : f a₂ = a₂')
-: f a₁ = f a₂ := by simp_using_hs >> try reflexivity
+: f a₁ = f a₂ := by do simp_using_hs >> try reflexivity
 
 constants (A : Type.{1}) (x y z w : A) (f : A → A) (H₁ : f (f x) = f y) (H₂ : f (f y) = f z) (H₃ : f (f z) = w)
 


### PR DESCRIPTION
Unfortunately this regression made us miss a few failing tests:
```
        330 - leanruntest_apply4.lean (Failed)
        341 - leanruntest_auto_quote1.lean (Failed)
        371 - leanruntest_cases_tac1.lean (Failed)
        373 - leanruntest_cc1.lean (Failed)
        474 - leanruntest_elab_crash1.lean (Failed)
        716 - leanruntest_simp_if_true_false.lean (Failed)
        720 - leanruntest_simplify_with_hypotheses.lean (Failed)
        767 - leanruntest_unfold_issue.lean (Failed)
```

I've fixed apply4, auto_quote1, elab_crash1, and simplify_with_hypotheses.  With the rest I don't really know what they should test.