### PR TITLE
bitvec refactor

### DIFF
--- a/library/data/list/basic.lean
+++ b/library/data/list/basic.lean
@@ -17,6 +17,7 @@ variables {α : Type u} {β : Type v} {φ : Type w}
 
 /- length theorems -/
 
+@[simp]
 theorem length_append : ∀ (x y : list α), length (x ++ y) = length x + length y
   | [] l := eq.symm (nat.zero_add (length l))
   | (a::s) l :=
@@ -28,6 +29,7 @@ theorem length_concat (a : α) : ∀ (l : list α), length (concat l a) = succ (
   | nil := rfl
   | (cons b l) := congr_arg succ (length_concat l)
 
+@[simp]
 theorem length_dropn
 : ∀ (i : ℕ) (l : list α), length (dropn i l) = length l - i
 | 0 l := rfl
@@ -37,10 +39,12 @@ theorem length_dropn
           = length l - i             : length_dropn i l
       ... = succ (length l) - succ i : nat.sub_eq_succ_sub_succ (length l) i
 
+@[simp]
 theorem length_map (f : α → β) : ∀ (a : list α), length (map f a) = length a
 | [] := rfl
 | (a :: l) := congr_arg succ (length_map l)
 
+@[simp]
 theorem length_repeat (a : α) : ∀ (n : ℕ), length (repeat a n) = n
   | 0 := eq.refl 0
   | (succ i) := congr_arg succ (length_repeat i)
@@ -52,6 +56,7 @@ def firstn : ℕ → list α → list α
 | (succ n) []     := []
 | (succ n) (a::l) := a :: firstn n l
 
+@[simp]
 theorem length_firstn
 : ∀ (i : ℕ) (l : list α), length (firstn i l) = min i (length l)
 | 0        l      := eq.symm (nat.zero_min (length l))

--- a/library/data/list/comb.lean
+++ b/library/data/list/comb.lean
@@ -22,16 +22,19 @@ definition map₂ {α : Type u} {β : Type v} {φ : Type w} (f : α → β → �
 | l [] := []
 | (a::s) (b::t) := f a b :: map₂ s t
 
+@[simp]
 theorem map₂_nil_1 {α : Type u} {β : Type v} {φ : Type w} (f : α → β → φ)
    : Π y, map₂ f nil y = nil
 | [] := eq.refl nil
 | (b::t) := eq.refl nil
 
+@[simp]
 theorem map₂_nil_2 {α : Type u} {β : Type v} {φ : Type w} (f : α → β → φ)
    : Π (x : list α), map₂ f x nil = nil
 | [] := eq.refl nil
 | (b::t) := eq.refl nil
 
+@[simp]
 theorem length_map₂ {α : Type u} {β : Type v} {φ : Type w} (f : α → β → φ)
   : Π x y, length (map₂ f x y) = min (length x) (length y)
 | [] y :=
@@ -59,6 +62,7 @@ definition map_accumr (f : α → σ → σ × β) : list α → σ → (σ × l
   let z := f y (prod.fst r) in
   (prod.fst z, prod.snd z :: prod.snd r)
 
+@[simp]
 theorem length_map_accumr
 : ∀ (f : α → σ → σ × β) (x : list α) (s : σ),
   length (prod.snd (map_accumr f x s)) = length x
@@ -80,6 +84,7 @@ definition map_accumr₂ {α β σ φ : Type} (f : α → β → σ → σ × φ
   let q := f x y (prod.fst r) in
   (prod.fst q, prod.snd q :: (prod.snd r))
 
+@[simp]
 theorem length_map_accumr₂ {α β σ φ : Type}
 : ∀ (f : α → β → σ → σ × φ) x y c,
   length (prod.snd (map_accumr₂ f x y c)) = min (length x) (length y)

--- a/library/init/algebra/field.lean
+++ b/library/init/algebra/field.lean
@@ -32,14 +32,20 @@ instance division_ring_has_div [division_ring α] : has_div α :=
 lemma division_def (a b : α) : a / b = a * b⁻¹ :=
 rfl
 
+@[simp]
 lemma mul_inv_cancel {a : α} (h : a ≠ 0) : a * a⁻¹ = 1 :=
 division_ring.mul_inv_cancel h
 
+@[simp]
 lemma inv_mul_cancel {a : α} (h : a ≠ 0) : a⁻¹ * a = 1 :=
 division_ring.inv_mul_cancel h
 
+@[simp]
+lemma one_div_eq_inv (a : α) : 1 / a = a⁻¹ :=
+one_mul a⁻¹
+
 lemma inv_eq_one_div (a : α) : a⁻¹ = 1 / a :=
-eq.symm $ one_mul (a⁻¹)
+by simp
 
 local attribute [simp]
 division_def mul_comm mul_assoc

--- a/library/init/algebra/functions.lean
+++ b/library/init/algebra/functions.lean
@@ -62,12 +62,15 @@ end
 lemma min_left_comm : ∀ (a b c : α), min a (min b c) = min b (min a c) :=
 left_comm (@min α _) (@min_comm α _) (@min_assoc α _)
 
+@[simp]
 lemma min_self (a : α) : min a a = a :=
 by min_tac a a
 
+@[ematch]
 lemma min_eq_left {a b : α} (h : a ≤ b) : min a b = a :=
 begin apply eq.symm, apply eq_min (le_refl _) h, intros, assumption end
 
+@[ematch]
 lemma min_eq_right {a b : α} (h : b ≤ a) : min a b = b :=
 eq.subst (min_comm b a) (min_eq_left h)
 
@@ -89,6 +92,7 @@ end
 lemma max_left_comm : ∀ (a b c : α), max a (max b c) = max b (max a c) :=
 left_comm (@max α _) (@max_comm α _) (@max_assoc α _)
 
+@[simp]
 lemma max_self (a : α) : max a a = a :=
 by min_tac a a
 

--- a/library/init/data/list/lemmas.lean
+++ b/library/init/data/list/lemmas.lean
@@ -11,31 +11,38 @@ variables {α : Type u} {β : Type v}
 
 namespace list
 
+@[simp]
 lemma nil_append (s : list α) : [] ++ s = s :=
 rfl
 
 lemma cons_append (x : α) (s t : list α) : (x::s) ++ t = x::(s ++ t) :=
 rfl
 
+@[simp]
 lemma map_nil (f : α → β) : map f [] = [] :=
 rfl
 
 lemma map_cons (f : α → β) (a : α) (l : list α) : map f (a :: l) = f a :: map f l :=
 rfl
 
+@[simp]
 lemma length_nil : length (@nil α) = 0 :=
 rfl
 
+@[simp]
 lemma length_cons (x : α) (t : list α) : length (x::t) = length t + 1 :=
 rfl
 
+@[simp]
 lemma nth_zero (a : α) (l : list α) : nth (a :: l) 0 = some a :=
 rfl
 
+@[simp]
 lemma nth_succ (a : α) (l : list α) (n : nat) : nth (a::l) (nat.succ n) = nth l n :=
 rfl
 
 /- list membership -/
+@[simp]
 lemma mem_nil_iff (a : α) : a ∈ [] ↔ false :=
 iff.rfl
 

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -75,9 +75,11 @@ lemma eq_zero_of_add_eq_zero_right : ∀ {n m : ℕ}, n + m = 0 → n = 0
 lemma eq_zero_of_add_eq_zero_left {n m : ℕ} (h : n + m = 0) : m = 0 :=
 @eq_zero_of_add_eq_zero_right m n (nat.add_comm n m ▸ h)
 
+@[simp]
 lemma pred_zero : pred 0 = 0 :=
 rfl
 
+@[simp]
 lemma pred_succ (n : ℕ) : pred (succ n) = n :=
 rfl
 
@@ -577,6 +579,7 @@ instance : semiring nat           := by apply_instance
 instance : ordered_semiring nat   := by apply_instance
 
 /- subtraction -/
+@[simp]
 protected theorem sub_zero (n : ℕ) : n - 0 = n :=
 rfl
 
@@ -594,18 +597,22 @@ protected theorem sub_self : ∀ (n : ℕ), n - n = 0
 | 0        := by rw nat.sub_zero
 | (succ n) := by rw [succ_sub_succ, sub_self n]
 
+@[ematch]
 protected theorem add_sub_add_right : ∀ (n k m : ℕ), (n + k) - (m + k) = n - m
 | n 0        m := by rw [add_zero, add_zero]
 | n (succ k) m := by rw [add_succ, add_succ, succ_sub_succ, add_sub_add_right n k m]
 
+@[ematch]
 protected theorem add_sub_add_left (k n m : ℕ) : (k + n) - (k + m) = n - m :=
 by rw [add_comm k n, add_comm k m, nat.add_sub_add_right]
 
+@[ematch]
 protected theorem add_sub_cancel (n m : ℕ) : n + m - m = n :=
 suffices n + m - (0 + m) = n, from
   by rwa [zero_add] at this,
 by rw [nat.add_sub_add_right, nat.sub_zero]
 
+@[ematch]
 protected theorem add_sub_cancel_left (n m : ℕ) : n + m - n = m :=
 show n + m - (n + 0) = m, from
 by rw [nat.add_sub_add_left, nat.sub_zero]
@@ -709,6 +716,7 @@ lemma sub_eq_sub_min (n m : ℕ) : n - m = n - min n m :=
 if h : n ≥ m then by rewrite [min_eq_right h]
 else by rewrite [sub_eq_zero_of_le (le_of_not_ge h), min_eq_left (le_of_not_ge h), nat.sub_self]
 
+@[simp]
 lemma sub_add_min_cancel (n m : ℕ) : n - m + min n m = n :=
 by rewrite [sub_eq_sub_min, nat.sub_add_cancel (min_le_left n m)]
 

--- a/tests/lean/run/destruct.lean
+++ b/tests/lean/run/destruct.lean
@@ -26,5 +26,5 @@ begin
   intro n,
   destruct n,
    dsimp, intros, note h := lt_irrefl 0, cc,
-   dsimp, intros, subst n, reflexivity
+   dsimp, intros, subst n
 end


### PR DESCRIPTION
@leodemoura The ematch problem we talked about this morning is the one in `bitvec.fill_shr`.  Apparently I was just too tired to add the right ematch annotations.