### PR TITLE
feat(library/vm/vm_aux): add vm code for sorry

### DIFF
--- a/library/init/util.lean
+++ b/library/init/util.lean
@@ -17,3 +17,7 @@ f ()
 /- This function has a native implementation that shows the VM call stack. -/
 def trace_call_stack {α : Type} (f : unit → α) : α :=
 f ()
+
+meta constant {u} undefined_core {α : Type u} (message : string) : α
+
+meta def {u} undefined {α : Type u} : α := undefined_core "undefined"

--- a/src/library/vm/vm_aux.cpp
+++ b/src/library/vm/vm_aux.cpp
@@ -32,10 +32,22 @@ vm_obj vm_trace_call_stack(vm_obj const &, vm_obj const & fn) {
     return invoke(fn, mk_vm_unit());
 }
 
+vm_obj vm_sorry(vm_obj const &) {
+    auto & s = get_vm_state();
+    throw exception(sstream() << s.call_stack_fn(s.call_stack_size() - 1)
+                              << ": trying to evaluate sorry");
+}
+
+vm_obj vm_undefined_core(vm_obj const &, vm_obj const & message) {
+    throw exception(to_string(message));
+}
+
 void initialize_vm_aux() {
     DECLARE_VM_BUILTIN("timeit", vm_timeit);
     DECLARE_VM_BUILTIN("trace",  vm_trace);
     DECLARE_VM_BUILTIN("trace_call_stack", vm_trace_call_stack);
+    DECLARE_VM_BUILTIN("sorry", vm_sorry);
+    DECLARE_VM_BUILTIN("undefined_core", vm_undefined_core);
 }
 
 void finalize_vm_aux() {

--- a/tests/lean/bad_error5.lean.expected.out
+++ b/tests/lean/bad_error5.lean.expected.out
@@ -1,1 +1,1 @@
-bad_error5.lean:13:10: error: code generation failed, VM does not have code for 'sorry'
+bad_error5.lean:9:0: error: _tactic: trying to evaluate sorry

--- a/tests/lean/vm_sorry.lean
+++ b/tests/lean/vm_sorry.lean
@@ -1,0 +1,12 @@
+def half_baked : bool → ℕ
+| tt := 42
+| ff := sorry
+
+vm_eval (half_baked tt)
+vm_eval (half_baked ff)
+
+meta def my_partial_fun : bool → ℕ
+| tt := 42
+| ff := undefined
+
+vm_eval (my_partial_fun ff)

--- a/tests/lean/vm_sorry.lean.expected.out
+++ b/tests/lean/vm_sorry.lean.expected.out
@@ -1,0 +1,3 @@
+42
+vm_sorry.lean:6:0: error: _main._val_1: trying to evaluate sorry
+vm_sorry.lean:12:0: error: undefined


### PR DESCRIPTION
When we are going to have error recovery in the parser where we replace parts with sorry, it will be nice to use these half-broken functions in VM code.