### PR TITLE
Allow VM code to create tasks

### DIFF
--- a/library/data/bitvec.lean
+++ b/library/data/bitvec.lean
@@ -40,7 +40,7 @@ section shift
 
   local attribute [ematch] nat.add_sub_assoc sub_le le_of_not_ge sub_eq_zero_of_le
   def fill_shr (x : bitvec n) (i : ℕ) (fill : bool) : bitvec n :=
-  bitvec.cong (begin [smt] by_cases (i ≤ n), eblast end) $
+  bitvec.cong (by async { begin [smt] by_cases (i ≤ n), eblast end }) $
     repeat fill (min n i) ++ₜ taken (n-i) x
 
   -- unsigned shift right

--- a/library/init/meta/async_tactic.lean
+++ b/library/init/meta/async_tactic.lean
@@ -1,0 +1,58 @@
+prelude
+import init.meta.tactic
+import init.meta.interactive
+
+namespace tactic
+
+private meta def run_or_fail {α} (s : tactic_state) (tac : tactic α) : α :=
+match tac s with
+| (tactic_result.success a s) := a
+| (tactic_result.exception .α fmt _ s') :=
+  undefined_core $ to_string $ fmt () ++ format.line ++ to_fmt s'
+end
+
+meta def run_async {α : Type} (tac : tactic α) : tactic (task α) := do
+s ← read, return $ task.delay $ λ _,
+  match tac s with
+  | (tactic_result.success a s) := a
+  | (tactic_result.exception .α fmt _ s') :=
+    undefined_core $ to_string $ fmt () ++ format.line ++ to_fmt s'
+  end
+
+private meta def get_undeclared_const (env : environment) (base : name) : ℕ → name | i :=
+let n := base <.> ("_aux_" ++ to_string i) in
+if ¬env^.contains n then n
+else get_undeclared_const (i+1)
+
+meta def new_aux_decl_name : tactic name := do
+env ← get_env, n ← decl_name,
+return $ get_undeclared_const env n 1
+
+meta def prove_goal_async (tac : tactic unit) : tactic unit := do
+ctx ← local_context, revert_lst ctx,
+tgt ← target, tgt ← instantiate_mvars tgt,
+env ← get_env, tgt ← return $ env^.unfold_untrusted_macros tgt,
+when tgt^.has_meta_var (fail $ "goal contains metavariables"),
+params ← return tgt^.collect_univ_params,
+lemma_name ← new_aux_decl_name,
+proof ← run_async (do
+  goal_meta ← mk_meta_var tgt,
+  set_goals [goal_meta],
+  monad.for' ctx (λc, intro c^.local_pp_name),
+  tac,
+  proof ← instantiate_mvars goal_meta,
+  proof ← return $ env^.unfold_untrusted_macros proof,
+  when proof^.has_meta_var $ fail "async proof failed: contains metavariables",
+  return proof),
+add_decl $ declaration.thm lemma_name params tgt proof,
+exact (expr.const lemma_name (params^.for level.param))
+
+namespace interactive
+open interactive.types
+
+/-- Proves the first goal asynchronously as a separate lemma. -/
+meta def async (tac : itactic) : tactic unit :=
+prove_goal_async tac
+
+end interactive
+end tactic

--- a/library/init/meta/decl_cmds.lean
+++ b/library/init/meta/decl_cmds.lean
@@ -36,17 +36,17 @@ e^.replace (λ e d,
    creates the declaration
         lemma g_lemma : forall a, g a > 0 := ... -/
 meta def copy_decl_updating_type (replacements : name_map name) (src_decl_name : name) (new_decl_name : name) : command :=
-do env       ← get_env,
-   decl      ← returnex $ env^.get src_decl_name,
-   new_type  ← return $ apply_replacement replacements decl^.type,
-   new_value ← return $ expr.const src_decl_name (decl^.univ_params^.for level.param),
-   add_decl (((decl^.to_definition^.update_type new_type)^.update_name new_decl_name)^.update_value new_value),
-   return ()
+do env  ← get_env,
+   decl ← returnex $ env^.get src_decl_name,
+   decl ← return $ decl^.update_name $ new_decl_name,
+   decl ← return $ decl^.update_type $ apply_replacement replacements decl^.type,
+   decl ← return $ decl^.update_value $ expr.const src_decl_name (decl^.univ_params^.for level.param),
+   add_decl decl
 
 meta def copy_decl_using (replacements : name_map name) (src_decl_name : name) (new_decl_name : name) : command :=
-do env       ← get_env,
-   decl      ← returnex $ env^.get src_decl_name,
-   new_type  ← return $ apply_replacement replacements decl^.type,
-   new_value ← return $ task.map (apply_replacement replacements) decl^.value_task,
-   add_decl (((decl^.to_definition^.update_type new_type)^.update_name new_decl_name)^.update_value_task new_value),
-   return ()
+do env  ← get_env,
+   decl ← returnex $ env^.get src_decl_name,
+   decl ← return $ decl^.update_name $ new_decl_name,
+   decl ← return $ decl^.update_type $ apply_replacement replacements decl^.type,
+   decl ← return $ decl^.map_value $ apply_replacement replacements,
+   add_decl decl

--- a/library/init/meta/decl_cmds.lean
+++ b/library/init/meta/decl_cmds.lean
@@ -47,6 +47,6 @@ meta def copy_decl_using (replacements : name_map name) (src_decl_name : name) (
 do env       ← get_env,
    decl      ← returnex $ env^.get src_decl_name,
    new_type  ← return $ apply_replacement replacements decl^.type,
-   new_value ← return $ apply_replacement replacements decl^.value,
-   add_decl (((decl^.to_definition^.update_type new_type)^.update_name new_decl_name)^.update_value new_value),
+   new_value ← return $ task.map (apply_replacement replacements) decl^.value_task,
+   add_decl (((decl^.to_definition^.update_type new_type)^.update_name new_decl_name)^.update_value_task new_value),
    return ()

--- a/library/init/meta/declaration.lean
+++ b/library/init/meta/declaration.lean
@@ -80,6 +80,11 @@ meta def declaration.value : declaration → expr
 | (declaration.thm n ls t v) := v^.get
 | _ := default expr
 
+meta def declaration.value_task : declaration → task expr
+| (declaration.defn n ls t v h tr) := task.pure v
+| (declaration.thm n ls t v) := v
+| _ := task.pure (default expr)
+
 meta def declaration.update_type : declaration → expr → declaration
 | (declaration.defn n ls t v h tr) new_t := declaration.defn n ls new_t v h tr
 | (declaration.thm n ls t v)       new_t := declaration.thm n ls new_t v
@@ -95,6 +100,11 @@ meta def declaration.update_name : declaration → name → declaration
 meta def declaration.update_value : declaration → expr → declaration
 | (declaration.defn n ls t v h tr) new_v := declaration.defn n ls t new_v h tr
 | (declaration.thm n ls t v)       new_v := declaration.thm n ls t (task.pure new_v)
+| d                                new_v := d
+
+meta def declaration.update_value_task : declaration → task expr → declaration
+| (declaration.defn n ls t v h tr) new_v := declaration.defn n ls t new_v^.get h tr
+| (declaration.thm n ls t v)       new_v := declaration.thm n ls t new_v
 | d                                new_v := d
 
 meta def declaration.to_definition : declaration → declaration

--- a/library/init/meta/declaration.lean
+++ b/library/init/meta/declaration.lean
@@ -107,6 +107,11 @@ meta def declaration.update_value_task : declaration → task expr → declarati
 | (declaration.thm n ls t v)       new_v := declaration.thm n ls t new_v
 | d                                new_v := d
 
+meta def declaration.map_value : declaration → (expr → expr) → declaration
+| (declaration.defn n ls t v h tr) f := declaration.defn n ls t (f v) h tr
+| (declaration.thm n ls t v)       f := declaration.thm n ls t (task.map f v)
+| d                                f := d
+
 meta def declaration.to_definition : declaration → declaration
 | (declaration.cnst n ls t tr) := declaration.defn n ls t (default expr) reducibility_hints.abbrev tr
 | (declaration.ax n ls t)      := declaration.thm n ls t (task.pure (default expr))

--- a/library/init/meta/default.lean
+++ b/library/init/meta/default.lean
@@ -14,3 +14,4 @@ import init.meta.mk_dec_eq_instance init.meta.mk_inhabited_instance
 import init.meta.simp_tactic init.meta.set_get_option_tactics
 import init.meta.interactive init.meta.converter init.meta.vm
 import init.meta.comp_value_tactics init.meta.smt
+import init.meta.async_tactic

--- a/library/init/meta/environment.lean
+++ b/library/init/meta/environment.lean
@@ -80,6 +80,8 @@ meta constant decl_olean : environment → name → option string
 meta constant decl_pos_info : environment → name → option (nat × nat)
 open expr
 
+meta constant unfold_untrusted_macros : environment → expr → expr
+
 meta def is_constructor_app (env : environment) (e : expr) : bool :=
 is_constant (get_app_fn e) && is_constructor env (const_name (get_app_fn e))
 

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -89,6 +89,8 @@ meta constant expr.copy_pos_info : expr → expr → expr
 meta constant expr.is_internal_cnstr : expr → option unsigned
 meta constant expr.get_nat_value : expr → option nat
 
+meta constant expr.collect_univ_params : expr → list name
+
 namespace expr
 open decidable
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -405,6 +405,9 @@ try $ do
   prio ← has_attribute attr_name src,
   set_basic_attribute_core attr_name tgt p (some prio)
 
+/-- Name of the declaration currently being elaborated. -/
+meta constant decl_name : tactic name
+
 /- (save_type_info e ref) save (typeof e) at position associated with ref -/
 meta constant save_type_info : expr → expr → tactic unit
 meta constant save_info_thunk : nat → nat → (unit → format) → tactic unit

--- a/library/init/meta/task.lean
+++ b/library/init/meta/task.lean
@@ -1,9 +1,23 @@
 prelude
+import init.category
+
 meta constant {u} task : Type u → Type (max u 1)
 
 namespace task
 
 meta constant {u} get {α : Type u} (t : task α) : α
-meta constant {u} pure {α : Type u} (t : α) : task α
+protected meta constant {u} pure {α : Type u} (t : α) : task α
+protected meta constant {u v} map {α : Type u} {β : Type v} (f : α → β) (t : task α) : task β
+protected meta constant {u} flatten {α : Type u} : task (task α) → task α
+
+protected meta def {u v} bind {α : Type u} {β : Type v} (t : task α) (f : α → task β) : task β :=
+task.flatten (task.map f t)
+
+meta instance : monad task :=
+{ map := @task.map, bind := @task.bind, ret := @task.pure }
+
+@[inline]
+meta def {u} delay {α : Type u} (f : unit → α) : task α :=
+task.map f (return ())
 
 end task

--- a/src/api/parser.cpp
+++ b/src/api/parser.cpp
@@ -56,7 +56,7 @@ lean_bool lean_parse_expr(lean_env env, lean_ios ios, char const * str, lean_exp
     parser p(_env, _ios, mk_dummy_loader(), in, strname, use_exceptions);
     expr e = p.parse_expr();
     expr _e; level_param_names _ps;
-    std::tie(_e, _ps) = p.elaborate(list<expr>(), e);
+    std::tie(_e, _ps) = p.elaborate(strname, list<expr>(), e);
     *new_expr = of_expr(new expr(_e));
     *new_ps   = of_list_name(new list<name>(_ps));
     LEAN_CATCH;

--- a/src/frontends/lean/builtin_cmds.cpp
+++ b/src/frontends/lean/builtin_cmds.cpp
@@ -163,7 +163,7 @@ environment end_scoped_cmd(parser & p) {
 
 environment check_cmd(parser & p) {
     expr e; level_param_names ls;
-    std::tie(e, ls) = parse_local_expr(p);
+    std::tie(e, ls) = parse_local_expr(p, "_check");
     type_checker tc(p.env(), true, false);
     expr type = tc.check(e, ls);
     auto out              = p.mk_message(p.cmd_pos(), INFORMATION);
@@ -184,7 +184,7 @@ environment eval_cmd(parser & p) {
         whnf = true;
     }
     expr e; level_param_names ls;
-    std::tie(e, ls) = parse_local_expr(p);
+    std::tie(e, ls) = parse_local_expr(p, "_eval");
     expr r;
     if (whnf) {
         type_checker tc(p.env(), true, false);
@@ -380,10 +380,10 @@ static expr convert_metavars(metavar_context & ctx, expr const & e) {
 static environment unify_cmd(parser & p) {
     environment const & env = p.env();
     expr e1; level_param_names ls1;
-    std::tie(e1, ls1) = parse_local_expr(p);
+    std::tie(e1, ls1) = parse_local_expr(p, "_unify");
     p.check_token_next(get_comma_tk(), "invalid #unify command, proper usage \"#unify e1, e2\"");
     expr e2; level_param_names ls2;
-    std::tie(e2, ls2) = parse_local_expr(p);
+    std::tie(e2, ls2) = parse_local_expr(p, "_unify");
     metavar_context mctx;
     local_context   lctx;
     e1 = convert_metavars(mctx, e1);
@@ -436,7 +436,7 @@ static void vm_eval_core(vm_state & s, name const & main, optional<vm_obj> const
 static environment vm_eval_cmd(parser & p) {
     auto pos = p.pos();
     expr e; level_param_names ls;
-    std::tie(e, ls) = parse_local_expr(p);
+    std::tie(e, ls) = parse_local_expr(p, "_eval");
     if (has_metavar(e))
         throw parser_error("invalid vm_eval command, expression contains metavariables", pos);
     type_context tc(p.env(), transparency_mode::All);
@@ -533,7 +533,7 @@ static environment run_command_cmd(parser & p) {
     tactic               = mk_app(mk_constant(get_pre_monad_and_then_name()), tactic, try_triv);
     expr val             = mk_typed_expr(mk_true(), mk_by(tactic));
     bool check_unassigned = false;
-    elaborate(env, opts, mctx, local_context(), val, check_unassigned);
+    elaborate(env, opts, "_run_command", mctx, local_context(), val, check_unassigned);
     return env;
 }
 

--- a/src/frontends/lean/builtin_exprs.cpp
+++ b/src/frontends/lean/builtin_exprs.cpp
@@ -830,7 +830,7 @@ static expr parse_proj(parser & p, unsigned, expr const * args, pos_info const &
         try {
             metavar_context mctx;
             bool check_unassigned = false;
-            lhs = p.elaborate(mctx, lhs, check_unassigned).first;
+            lhs = p.elaborate({}, mctx, lhs, check_unassigned).first;
             type_checker tc(p.env(), true, false);
             lhs_type = tc.infer(lhs);
         } catch (exception &) {

--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -49,7 +49,7 @@ void decl_attributes::parse_core(parser & p, bool compact) {
             auto pos = p.pos();
             expr pre_val = p.parse_expr();
             pre_val = mk_typed_expr(mk_constant(get_num_name()), pre_val);
-            expr val = p.elaborate(list<expr>(), pre_val).first;
+            expr val = p.elaborate("_attribute", list<expr>(), pre_val).first;
             val = normalize(p.env(), val);
             if (optional<mpz> mpz_val = to_num_core(val)) {
                 if (!mpz_val->is_unsigned_int())

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -266,7 +266,7 @@ static environment variable_cmd_core(parser & p, variable_kind k, decl_modifiers
     }
     level_param_names new_ls;
     list<expr> ctx = p.locals_to_context();
-    std::tie(type, new_ls) = p.elaborate_type(ctx, type);
+    std::tie(type, new_ls) = p.elaborate_type("_variable", ctx, type);
     if (k == variable_kind::Variable || k == variable_kind::Parameter)
         update_local_levels(p, new_ls, k == variable_kind::Variable);
     return declare_var(p, p.env(), n, append(ls, new_ls), type, k, bi, pos, modifiers);
@@ -369,7 +369,7 @@ static environment variables_cmd_core(parser & p, variable_kind k, decl_modifier
         level_param_names new_ls;
         expr new_type;
         check_command_period_open_binder_or_eof(p);
-        std::tie(new_type, new_ls) = p.elaborate_type(ctx, type);
+        std::tie(new_type, new_ls) = p.elaborate_type("_variables", ctx, type);
         if (k == variable_kind::Variable || k == variable_kind::Parameter)
             update_local_levels(p, new_ls, k == variable_kind::Variable);
         new_ls = append(ls, new_ls);

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -157,7 +157,7 @@ environment mutual_definition_cmd_core(parser & p, def_cmd_kind kind, decl_modif
     buffer<expr> fns, params;
     declaration_info_scope scope(p, kind, modifiers);
     expr val = parse_mutual_definition(p, lp_names, fns, params);
-    elaborator elab(p.env(), p.get_options(), metavar_context(), local_context());
+    elaborator elab(p.env(), p.get_options(), local_pp_name(fns[0]), metavar_context(), local_context());
     buffer<expr> new_params;
     elaborate_params(elab, params, new_params);
     val = replace_locals_preserving_pos_info(val, params, new_params);
@@ -650,7 +650,7 @@ public:
         auto_reporting_info_manager_scope scope4(get_module_id(), m_use_info_manager);
 
         try {
-            elaborator elab(m_decl_env, m_opts, m_mctx, m_lctx);
+            elaborator elab(m_decl_env, m_opts, local_pp_name(m_fn), m_mctx, m_lctx);
             expr val, type;
             std::tie(val, type) = elaborate_proof(elab);
             if (is_equations_result(val))
@@ -721,7 +721,7 @@ public:
         auto_reporting_info_manager_scope scope4(get_module_id(), m_use_info_manager);
 
         try {
-            elaborator elab(m_decl_env, m_opts, m_mctx, m_lctx);
+            elaborator elab(m_decl_env, m_opts, "example", m_mctx, m_lctx);
 
             expr val, type;
             std::tie(val, type) = elab.elaborate_with_type(m_val, mlocal_type(m_fn));
@@ -778,7 +778,7 @@ environment single_definition_cmd_core(parser & p, def_cmd_kind kind, decl_modif
     if (p.get_break_at_pos())
         return p.env();
 
-    elaborator elab(p.env(), p.get_options(), metavar_context(), local_context());
+    elaborator elab(p.env(), p.get_options(), local_pp_name(fn), metavar_context(), local_context());
     buffer<expr> new_params;
     elaborate_params(elab, params, new_params);
     elab.set_instance_fingerprint();

--- a/src/frontends/lean/elaborator.h
+++ b/src/frontends/lean/elaborator.h
@@ -10,6 +10,7 @@ Author: Leonardo de Moura
 #include "library/local_context.h"
 #include "library/type_context.h"
 #include "library/tactic/tactic_state.h"
+#include "library/tactic/elaborate.h"
 #include "frontends/lean/elaborator_exception.h"
 #include "frontends/lean/info_manager.h"
 
@@ -34,6 +35,7 @@ private:
     };
     environment       m_env;
     options           m_opts;
+    name              m_decl_name;
     type_context      m_ctx;
     info_manager      m_info;
 
@@ -248,7 +250,7 @@ private:
     void finalize_core(sanitize_param_names_fn & S, buffer<expr> & es,
                        bool check_unassigned, bool to_simple_metavar, bool collect_local_ctx);
 public:
-    elaborator(environment const & env, options const & opts, metavar_context const & mctx, local_context const & lctx);
+    elaborator(environment const & env, options const & opts, name const & decl_name, metavar_context const & mctx, local_context const & lctx);
     ~elaborator();
     metavar_context const & mctx() const { return m_ctx.mctx(); }
     local_context const & lctx() const { return m_ctx.lctx(); }
@@ -303,12 +305,14 @@ public:
     }
 };
 
-pair<expr, level_param_names> elaborate(environment & env, options const & opts,
+pair<expr, level_param_names> elaborate(environment & env, options const & opts, name const & decl_name,
                                         metavar_context & mctx, local_context const & lctx,
                                         expr const & e, bool check_unassigend);
 
-expr nested_elaborate(environment & env, options const & opts, metavar_context & mctx, local_context const & lctx,
-                      expr const & e, bool relaxed);
+/** \brief Translated local constants (and undefined constants) occurring in \c e into
+    local constants provided by \c ctx.
+    Throw exception is \c ctx does not contain the local constant. */
+expr resolve_names(environment const & env, local_context const & lctx, expr const & e);
 
 void initialize_elaborator();
 void finalize_elaborator();

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -289,7 +289,7 @@ class inductive_cmd_fn {
     void elaborate_inductive_decls(buffer<expr> const & params, buffer<expr> const & inds, buffer<buffer<expr> > const & intro_rules,
                                    buffer<expr> & new_params, buffer<expr> & new_inds, buffer<buffer<expr> > & new_intro_rules) {
         options opts = m_p.get_options();
-        elaborator elab(m_env, opts, metavar_context(), local_context());
+        elaborator elab(m_env, opts, local_pp_name(inds[0]), metavar_context(), local_context());
 
         buffer<expr> params_no_inds;
         for (expr const & p : params) {

--- a/src/frontends/lean/notation_cmd.cpp
+++ b/src/frontends/lean/notation_cmd.cpp
@@ -47,7 +47,7 @@ static unsigned parse_precedence_core(parser & p) {
         parser::local_scope scope(p, env);
         expr pre_val = p.parse_expr(get_max_prec());
         pre_val  = mk_typed_expr(mk_constant(get_num_name()), pre_val);
-        expr val = p.elaborate(list<expr>(), pre_val).first;
+        expr val = p.elaborate("notation", list<expr>(), pre_val).first;
         val = normalize(p.env(), val);
         if (optional<mpz> mpz_val = to_num_core(val)) {
             if (!mpz_val->is_unsigned_int())

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -805,47 +805,43 @@ level parser::parse_level(unsigned rbp) {
     return left;
 }
 
-pair<expr, level_param_names> parser::elaborate(metavar_context & mctx, local_context_adapter const & adapter,
+pair<expr, level_param_names> parser::elaborate(name const & decl_name,
+                                                metavar_context & mctx, local_context_adapter const & adapter,
                                                 expr const & e, bool check_unassigned) {
     expr tmp_e  = adapter.translate_to(e);
     pair<expr, level_param_names> r =
-        ::lean::elaborate(m_env, get_options(), mctx, adapter.lctx(), tmp_e, check_unassigned);
+        ::lean::elaborate(m_env, get_options(), decl_name, mctx, adapter.lctx(), tmp_e, check_unassigned);
     expr new_e = r.first;
     new_e      = adapter.translate_from(new_e);
     return mk_pair(new_e, r.second);
 }
 
-pair<expr, level_param_names> parser::elaborate(metavar_context & mctx, list<expr> const & lctx, expr const & e, bool check_unassigned) {
+pair<expr, level_param_names> parser::elaborate(name const & decl_name, metavar_context & mctx, list<expr> const & lctx, expr const & e, bool check_unassigned) {
     local_context_adapter adapter(lctx);
-    return elaborate(mctx, adapter, e, check_unassigned);
+    return elaborate(decl_name, mctx, adapter, e, check_unassigned);
 }
 
-pair<expr, level_param_names> parser::elaborate(metavar_context & mctx, expr const & e, bool check_unassigned) {
+pair<expr, level_param_names> parser::elaborate(name const & decl_name, metavar_context & mctx, expr const & e, bool check_unassigned) {
     local_context_adapter adapter(m_local_decls);
-    return elaborate(mctx, adapter, e, check_unassigned);
+    return elaborate(decl_name, mctx, adapter, e, check_unassigned);
 }
 
-pair<expr, level_param_names> parser::elaborate(expr const & e) {
+pair<expr, level_param_names> parser::elaborate(name const & decl_name, list<expr> const & ctx, expr const & e) {
     metavar_context mctx;
-    return elaborate(mctx, list<expr>(), e, true);
+    return elaborate(decl_name, mctx, ctx, e, true);
 }
 
-pair<expr, level_param_names> parser::elaborate(list<expr> const & ctx, expr const & e) {
-    metavar_context mctx;
-    return elaborate(mctx, ctx, e, true);
-}
-
-pair<expr, level_param_names> parser::elaborate_type(list<expr> const & ctx, expr const & e) {
+pair<expr, level_param_names> parser::elaborate_type(name const & decl_name, list<expr> const & ctx, expr const & e) {
     metavar_context mctx;
     expr Type  = copy_tag(e, mk_sort(mk_level_placeholder()));
     expr new_e = copy_tag(e, mk_typed_expr(Type, e));
-    return elaborate(mctx, ctx, new_e, true);
+    return elaborate(decl_name, mctx, ctx, new_e, true);
 }
 
-pair<expr, level_param_names> parser::elaborate_type(metavar_context & mctx, expr const & e) {
+pair<expr, level_param_names> parser::elaborate_type(name const & decl_name, metavar_context & mctx, expr const & e) {
     expr Type  = copy_tag(e, mk_sort(mk_level_placeholder()));
     expr new_e = copy_tag(e, mk_typed_expr(Type, e));
-    return elaborate(mctx, new_e, true);
+    return elaborate(decl_name, mctx, new_e, true);
 }
 
 [[ noreturn ]] void throw_invalid_open_binder(pos_info const & pos) {

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -506,18 +506,17 @@ public:
     expr const & get_undef_id(unsigned i) const { return m_undef_ids[i]; }
 
 private:
-    pair<expr, level_param_names> elaborate(metavar_context & mctx, local_context_adapter const & adapter,
+    pair<expr, level_param_names> elaborate(name const & decl_name, metavar_context & mctx, local_context_adapter const & adapter,
                                             expr const & e, bool check_unassigned = true);
 
 public:
     local_context_adapter mk_local_context_adapter() { return local_context_adapter(m_local_decls); }
-    pair<expr, level_param_names> elaborate(expr const & e);
-    pair<expr, level_param_names> elaborate(metavar_context & mctx, expr const & e, bool check_unassigned = true);
-    pair<expr, level_param_names> elaborate(metavar_context & mctx, list<expr> const & lctx, expr const & e, bool check_unassigned);
-    pair<expr, level_param_names> elaborate(list<expr> const & ctx, expr const & e);
-    pair<expr, level_param_names> elaborate_type(list<expr> const & lctx, expr const & e);
+    pair<expr, level_param_names> elaborate(name const & decl_name, metavar_context & mctx, expr const & e, bool check_unassigned = true);
+    pair<expr, level_param_names> elaborate(name const & decl_name, metavar_context & mctx, list<expr> const & lctx, expr const & e, bool check_unassigned);
+    pair<expr, level_param_names> elaborate(name const & decl_name, list<expr> const & ctx, expr const & e);
+    pair<expr, level_param_names> elaborate_type(name const & decl_name, list<expr> const & lctx, expr const & e);
     /* Elaborate \c e as a type using the given metavariable context, and using m_local_decls as the local context */
-    pair<expr, level_param_names> elaborate_type(metavar_context & mctx, expr const & e);
+    pair<expr, level_param_names> elaborate_type(name const & decl_name, metavar_context & mctx, expr const & e);
 
     expr mk_sorry(pos_info const & p);
     bool used_sorry() const { return m_used_sorry; }

--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -389,7 +389,7 @@ struct structure_cmd_fn {
         expr tmp       = Pi_as_is(ctx, Pi(tmp_locals, m_type, m_p), m_p);
         level_param_names new_ls;
         expr new_tmp;
-        std::tie(new_tmp, new_ls) = m_p.elaborate_type(list<expr>(), tmp);
+        std::tie(new_tmp, new_ls) = m_p.elaborate_type(m_name, list<expr>(), tmp);
         levels new_meta_ls = map2<level>(new_ls, [&](name const &) { return m_ctx.mk_univ_metavar_decl(); });
         new_tmp = instantiate_univ_params(new_tmp, new_ls, new_meta_ls);
         new_tmp = update_locals(new_tmp, ctx);
@@ -682,7 +682,7 @@ struct structure_cmd_fn {
         level_param_names new_ls;
         expr new_tmp;
         metavar_context mctx      = m_ctx.mctx();
-        std::tie(new_tmp, new_ls) = m_p.elaborate_type(mctx, tmp);
+        std::tie(new_tmp, new_ls) = m_p.elaborate_type(m_name, mctx, tmp);
         m_ctx.set_mctx(mctx);
         for (auto new_l : new_ls)
             m_level_names.push_back(new_l);

--- a/src/frontends/lean/util.cpp
+++ b/src/frontends/lean/util.cpp
@@ -262,19 +262,19 @@ level mk_result_level(buffer<level> const & r_lvls) {
     }
 }
 
-std::tuple<expr, level_param_names> parse_local_expr(parser & p, metavar_context & mctx, bool relaxed) {
+std::tuple<expr, level_param_names> parse_local_expr(parser & p, name const & decl_name, metavar_context & mctx, bool relaxed) {
     expr e = p.parse_expr();
     p.declare_sorry_if_used();
     bool check_unassigend = !relaxed;
     expr new_e; level_param_names ls;
-    std::tie(new_e, ls) = p.elaborate(mctx, e, check_unassigend);
+    std::tie(new_e, ls) = p.elaborate(decl_name, mctx, e, check_unassigend);
     level_param_names new_ls = to_level_param_names(collect_univ_params(new_e));
     return std::make_tuple(new_e, new_ls);
 }
 
-std::tuple<expr, level_param_names> parse_local_expr(parser & p, bool relaxed) {
+std::tuple<expr, level_param_names> parse_local_expr(parser & p, name const & decl_name, bool relaxed) {
     metavar_context mctx;
-    return parse_local_expr(p, mctx, relaxed);
+    return parse_local_expr(p, decl_name, mctx, relaxed);
 }
 
 optional<name> is_uniquely_aliased(environment const & env, name const & n) {

--- a/src/frontends/lean/util.h
+++ b/src/frontends/lean/util.h
@@ -84,7 +84,7 @@ expr Pi_as_is(expr const & local, expr const & e);
 level mk_result_level(buffer<level> const & r_lvls);
 
 /** \brief Auxiliary function for check/eval/find_decl */
-std::tuple<expr, level_param_names> parse_local_expr(parser & p, bool relaxed = true);
+std::tuple<expr, level_param_names> parse_local_expr(parser & p, name const & decl_name, bool relaxed = true);
 
 optional<name> is_uniquely_aliased(environment const & env, name const & n);
 

--- a/src/frontends/smt2/parser.cpp
+++ b/src/frontends/smt2/parser.cpp
@@ -478,7 +478,7 @@ private:
 
         metavar_context mctx;
         expr goal_mvar = mctx.mk_metavar_decl(lctx(), mk_constant(get_false_name()));
-        vm_obj s = to_obj(mk_tactic_state_for_metavar(env(), ios().get_options(), mctx, goal_mvar));
+        vm_obj s = to_obj(mk_tactic_state_for_metavar(env(), ios().get_options(), "check-sat", mctx, goal_mvar));
 
         vm_state state(env(), ios().get_options());
         scope_vm_state scope(state);

--- a/src/library/mt_task_queue.cpp
+++ b/src/library/mt_task_queue.cpp
@@ -307,6 +307,7 @@ void mt_task_queue::wait(generic_task_result const & t) {
     }
     while (!unwrap(t)->has_evaluated()) {
         if (g_current_task) {
+            // std::cerr << "waiting: " << g_current_task->description() <<  " -> " << t.description() << std::endl;
             scoped_add<int> inc_required(m_required_workers, +1);
             if (m_sleeping_workers == 0) {
                 spawn_worker();

--- a/src/library/tactic/cases_tactic.cpp
+++ b/src/library/tactic/cases_tactic.cpp
@@ -56,7 +56,7 @@ struct cases_tactic_fn {
 
     /* throw exception that stores the intermediate state */
     [[ noreturn ]] void throw_exception(expr const & mvar, char const * msg) {
-        throw cases_tactic_exception(mk_tactic_state_for_metavar(m_env, m_opts, m_mctx, mvar), msg);
+        throw cases_tactic_exception(mk_tactic_state_for_metavar(m_env, m_opts, "cases", m_mctx, mvar), msg);
     }
 
     #define lean_cases_trace(MVAR, CODE) lean_trace(name({"tactic", "cases"}), type_context TMP_CTX = mk_type_context_for(MVAR); scope_trace_env _scope1(m_env, TMP_CTX); CODE)
@@ -232,7 +232,7 @@ struct cases_tactic_fn {
     }
 
     format pp_goal(expr const & mvar) {
-        tactic_state tmp = mk_tactic_state_for_metavar(m_env, m_opts, m_mctx, mvar);
+        tactic_state tmp = mk_tactic_state_for_metavar(m_env, m_opts, "cases", m_mctx, mvar);
         return tmp.pp_goal(mvar);
     }
 

--- a/src/library/tactic/dsimplify.cpp
+++ b/src/library/tactic/dsimplify.cpp
@@ -295,12 +295,12 @@ class tactic_dsimplify_fn : public dsimplify_core_fn {
 
 public:
     tactic_dsimplify_fn(type_context & ctx, defeq_canonizer::state & dcs, unsigned max_steps, bool visit_instances,
-                        vm_obj const & a, vm_obj const & pre, vm_obj const & post):
+                        vm_obj const & a, vm_obj const & pre, vm_obj const & post, tactic_state const & s):
         dsimplify_core_fn(ctx, dcs, max_steps, visit_instances),
         m_a(a),
         m_pre(pre),
         m_post(post),
-        m_s(mk_tactic_state_for(ctx.env(), ctx.get_options(), ctx.mctx(), ctx.lctx(), mk_true())) {
+        m_s(s) {
     }
 
     vm_obj const & get_a() const { return m_a; }
@@ -314,7 +314,7 @@ vm_obj tactic_dsimplify_core(vm_obj const &, vm_obj const & a,
         type_context ctx = mk_type_context_for(s, transparency_mode::Reducible);
         defeq_can_state dcs = s.dcs();
         tactic_dsimplify_fn F(ctx, dcs, force_to_unsigned(max_steps, std::numeric_limits<unsigned>::max()),
-                              to_bool(visit_instances), a, pre, post);
+                              to_bool(visit_instances), a, pre, post, s);
         expr new_e = F(to_expr(e));
         tactic_state new_s = set_mctx_dcs(s, F.mctx(), dcs);
         return mk_tactic_success(mk_vm_pair(F.get_a(), to_obj(new_e)), new_s);

--- a/src/library/tactic/elaborate.h
+++ b/src/library/tactic/elaborate.h
@@ -13,20 +13,6 @@ expr mk_by(expr const & e);
 bool is_by(expr const & e);
 expr const & get_by_arg(expr const & e);
 
-/* Elaboration function.
-   \remark The boolean flag indicates whether metavariables should be tolerated in the result or not.
-   \remark The metavariable context is input/output. */
-typedef std::function<expr(environment &, options const &, metavar_context &, local_context const &, expr const &, bool)> elaborate_fn;
-
-/** \brief Auxiliary function for setting the thread local elaboration
-    procedure used by the tactic framework. */
-class scope_elaborate_fn {
-    elaborate_fn const * m_old;
-public:
-    scope_elaborate_fn(elaborate_fn const &);
-    ~scope_elaborate_fn();
-};
-
 void initialize_elaborate();
 void finalize_elaborate();
 }

--- a/src/library/tactic/subst_tactic.cpp
+++ b/src/library/tactic/subst_tactic.cpp
@@ -34,7 +34,7 @@ bool check_hypothesis_in_context(metavar_context const & mctx, expr const & mvar
 expr subst(environment const & env, options const & opts, transparency_mode const & m, metavar_context & mctx,
            expr const & mvar, expr const & H, bool symm, hsubstitution * subst) {
     #define lean_subst_trace(CODE) lean_trace(name({"tactic", "subst"}), CODE)
-#define lean_subst_trace_state(MVAR, MSG) lean_trace(name({"tactic", "subst"}), tactic_state S = mk_tactic_state_for_metavar(env, opts, mctx, MVAR); type_context TMP_CTX = mk_type_context_for(S, m); scope_trace_env _scope1(env, TMP_CTX); tout() << MSG << S.pp_core() << "\n";)
+#define lean_subst_trace_state(MVAR, MSG) lean_trace(name({"tactic", "subst"}), tactic_state S = mk_tactic_state_for_metavar(env, opts, "subst", mctx, MVAR); type_context TMP_CTX = mk_type_context_for(S, m); scope_trace_env _scope1(env, TMP_CTX); tout() << MSG << S.pp_core() << "\n";)
 
     lean_subst_trace_state(mvar, "initial:\n");
     lean_assert(mctx.get_metavar_decl(mvar));

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -18,6 +18,7 @@ Author: Leonardo de Moura
 #include "library/module.h"
 #include "library/documentation.h"
 #include "library/scoped_ext.h"
+#include "library/unfold_macros.h"
 #include "library/vm/vm_environment.h"
 #include "library/vm/vm_exceptional.h"
 #include "library/vm/vm_format.h"

--- a/src/library/tactic/tactic_state.h
+++ b/src/library/tactic/tactic_state.h
@@ -20,6 +20,7 @@ class tactic_state_cell {
     MK_LEAN_RC();
     environment     m_env;
     options         m_options;
+    name            m_decl_name;
     metavar_context m_mctx;
     list<expr>      m_goals;
     expr            m_main;
@@ -27,9 +28,11 @@ class tactic_state_cell {
     friend class tactic_state;
     void dealloc();
 public:
-    tactic_state_cell(environment const & env, options const & o, metavar_context const & ctx, list<expr> const & gs,
+    tactic_state_cell(environment const & env, options const & o, name const & decl_name,
+                      metavar_context const & ctx, list<expr> const & gs,
                       expr const & main, defeq_can_state const & s):
-        m_rc(0), m_env(env), m_options(o), m_mctx(ctx), m_goals(gs), m_main(main), m_defeq_can_state(s) {}
+        m_rc(0), m_env(env), m_options(o), m_decl_name(decl_name),
+        m_mctx(ctx), m_goals(gs), m_main(main), m_defeq_can_state(s) {}
 };
 
 class tactic_state {
@@ -41,7 +44,8 @@ private:
     explicit tactic_state(tactic_state_cell * ptr):m_ptr(ptr) { if (m_ptr) m_ptr->inc_ref(); }
     format pp_goal(formatter_factory const & fmtf, expr const & g) const;
 public:
-    tactic_state(environment const & env, options const & o, metavar_context const & ctx, list<expr> const & gs,
+    tactic_state(environment const & env, options const & o, name const & decl_name,
+                 metavar_context const & ctx, list<expr> const & gs,
                  expr const & main, defeq_can_state const & s);
     tactic_state(tactic_state const & s):m_ptr(s.m_ptr) { if (m_ptr) m_ptr->inc_ref(); }
     tactic_state(tactic_state && s):m_ptr(s.m_ptr) { s.m_ptr = nullptr; }
@@ -55,6 +59,7 @@ public:
     metavar_context const & mctx() const { lean_assert(m_ptr); return m_ptr->m_mctx; }
     list<expr> const & goals() const { lean_assert(m_ptr); return m_ptr->m_goals; }
     expr const & main() const { lean_assert(m_ptr); return m_ptr->m_main; }
+    name const & decl_name() const { lean_assert(m_ptr); return m_ptr->m_decl_name; }
     defeq_can_state const & get_defeq_canonizer_state() const { return m_ptr->m_defeq_can_state; }
     defeq_can_state const & dcs() const { return get_defeq_canonizer_state(); }
 
@@ -80,11 +85,12 @@ inline optional<tactic_state> none_tactic_state() { return optional<tactic_state
 inline optional<tactic_state> some_tactic_state(tactic_state const & e) { return optional<tactic_state>(e); }
 inline optional<tactic_state> some_tactic_state(tactic_state && e) { return optional<tactic_state>(std::forward<tactic_state>(e)); }
 
-tactic_state mk_tactic_state_for(environment const & env, options const & opts, metavar_context mctx,
+tactic_state mk_tactic_state_for(environment const & env, options const & opts, name const & decl_name, metavar_context mctx,
                                  local_context const & lctx, expr const & type);
-tactic_state mk_tactic_state_for(environment const & env, options const & opts,
+tactic_state mk_tactic_state_for(environment const & env, options const & opts, name const & decl_name,
                                  local_context const & lctx, expr const & type);
-tactic_state mk_tactic_state_for_metavar(environment const & env, options const & opts, metavar_context const & mctx, expr const & mvar);
+tactic_state mk_tactic_state_for_metavar(environment const & env, options const & opts, name const & decl_name,
+                                         metavar_context const & mctx, expr const & mvar);
 
 tactic_state set_options(tactic_state const & s, options const & o);
 tactic_state set_env(tactic_state const & s, environment const & env);

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -184,7 +184,7 @@ vm_obj caching_user_attribute_get_cache(vm_obj const &, vm_obj const & vm_attr, 
     lean_trace("user_attributes_cache", tout() << "recomputing cache for [" << attr.get_name() << "]\n";);
     buffer<name> instances;
     attr.get_instances(env, instances);
-    tactic_state s0 = mk_tactic_state_for(env, options(), local_context(), mk_true());
+    tactic_state s0 = mk_tactic_state_for(env, options(), {}, local_context(), mk_true());
     vm_obj result = invoke(cache_handler, to_obj(to_list(instances)), to_obj(s0));
     if (is_tactic_success(result)) {
         user_attr_cache::entry entry;

--- a/src/library/tactic/vm_monitor.cpp
+++ b/src/library/tactic/vm_monitor.cpp
@@ -161,7 +161,7 @@ vm_obj vm_obj_to_tactic_state(vm_obj const & o) {
     if (is_tactic_state(o))
         return o;
     else
-        return to_obj(mk_tactic_state_for(environment(), options(), local_context(), mk_Prop()));
+        return to_obj(mk_tactic_state_for(environment(), options(), {}, local_context(), mk_Prop()));
 }
 
 vm_obj vm_obj_to_format(vm_obj const & o) {

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -395,7 +395,7 @@ ts_vm_obj::ts_vm_obj(vm_obj const & o) {
 }
 
 ts_vm_obj::data::~data() {
-    steal_ptr(m_root);
+    if (!is_simple(m_root)) steal_ptr(m_root);
     for (vm_obj_cell * cell : m_objs) {
         switch (cell->kind()) {
         case vm_obj_kind::Simple:

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include <string>
+#include "library/unfold_macros.h"
 #include "kernel/type_checker.h"
 #include "kernel/inductive/inductive.h"
 #include "library/standard_kernel.h"
@@ -227,6 +228,10 @@ vm_obj environment_is_projection(vm_obj const & env, vm_obj const & n) {
     }
 }
 
+vm_obj environment_unfold_untrusted_macros(vm_obj const & env, vm_obj const & e) {
+    return to_obj(unfold_untrusted_macros(to_env(env), to_expr(e)));
+}
+
 void initialize_vm_environment() {
     DECLARE_VM_BUILTIN(name({"environment", "mk_std"}),                environment_mk_std);
     DECLARE_VM_BUILTIN(name({"environment", "trust_lvl"}),             environment_trust_lvl);
@@ -252,6 +257,7 @@ void initialize_vm_environment() {
     DECLARE_VM_BUILTIN(name({"environment", "trans_for"}),             environment_trans_for);
     DECLARE_VM_BUILTIN(name({"environment", "decl_olean"}),            environment_decl_olean);
     DECLARE_VM_BUILTIN(name({"environment", "decl_pos_info"}),         environment_decl_pos_info);
+    DECLARE_VM_BUILTIN(name({"environment", "unfold_untrusted_macros"}), environment_unfold_untrusted_macros);
 }
 
 void finalize_vm_environment() {

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -6,6 +6,7 @@ Author: Leonardo de Moura
 */
 #include <string>
 #include <iostream>
+#include <library/locals.h>
 #include "kernel/expr.h"
 #include "kernel/free_vars.h"
 #include "kernel/instantiate.h"
@@ -377,6 +378,13 @@ vm_obj expr_get_nat_value(vm_obj const & o) {
     }
 }
 
+vm_obj expr_collect_univ_params(vm_obj const & o) {
+    list<name> param_list;
+    collect_univ_params(to_expr(o), name_set()).for_each(
+            [&] (name const & n) { param_list = cons(n, param_list); });
+    return to_obj(param_list);
+}
+
 // TODO(Leo): move to a different file
 vm_obj vm_mk_nat_val_ne_proof(vm_obj const & a, vm_obj const & b) {
     return to_obj(mk_nat_val_ne_proof(to_expr(a), to_expr(b)));
@@ -443,6 +451,7 @@ void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "lower_vars"}),       expr_lower_vars);
     DECLARE_VM_BUILTIN(name({"expr", "hash"}),             expr_hash);
     DECLARE_VM_BUILTIN(name({"expr", "copy_pos_info"}),    expr_copy_pos_info);
+    DECLARE_VM_BUILTIN(name({"expr", "collect_univ_params"}), expr_collect_univ_params);
     DECLARE_VM_CASES_BUILTIN(name({"expr", "cases_on"}),   expr_cases_on);
 
     DECLARE_VM_BUILTIN(name("mk_nat_val_ne_proof"),        vm_mk_nat_val_ne_proof);

--- a/src/library/vm/vm_task.cpp
+++ b/src/library/vm/vm_task.cpp
@@ -8,6 +8,11 @@ Author: Gabriel Ebner
 #include <string>
 #include <iostream>
 #include <vector>
+#include "library/trace.h"
+#include "library/type_context.h"
+#include "frontends/lean/info_manager.h"
+#include "frontends/lean/elaborator.h"
+#include "library/tactic/elaborate.h"
 #include "library/vm/vm.h"
 #include "library/vm/vm_string.h"
 #include "library/vm/vm_expr.h"
@@ -45,8 +50,8 @@ static task_result<B> mk_map_task(task_result<A> const & in, Fn const & fn) {
 };
 
 struct vm_task : public vm_external {
-    task_result<vm_obj> m_val;
-    vm_task(task_result<vm_obj> const & v) : m_val(v) {}
+    task_result<ts_vm_obj> m_val;
+    vm_task(task_result<ts_vm_obj> const & v) : m_val(v) {}
     virtual ~vm_task() {}
     virtual void dealloc() override { this->~vm_task(); get_vm_allocator().deallocate(sizeof(vm_task), this); }
     virtual vm_external * ts_clone(vm_clone_fn const &) override {
@@ -62,34 +67,105 @@ bool is_task(vm_obj const & o) {
     return is_external(o) && dynamic_cast<vm_task *>(to_external(o));
 }
 
-task_result<vm_obj> & to_task(vm_obj const & o) {
+task_result<ts_vm_obj> const & to_task(vm_obj const & o) {
     lean_assert(is_task(o));
     return static_cast<vm_task*>(to_external(o))->m_val;
 }
 
-vm_obj to_obj(task_result<vm_obj> const & n) {
+vm_obj to_obj(task_result<ts_vm_obj> const & n) {
     return mk_vm_external(new (get_vm_allocator().allocate(sizeof(vm_task))) vm_task(n));
 }
 
 vm_obj to_obj(task_result<expr> const & n) {
-    return to_obj(mk_map_task<vm_obj>(n, [] (expr const & e) { return to_obj(e); }));
+    return to_obj(mk_map_task<ts_vm_obj>(n, [] (expr const & e) { return ts_vm_obj(to_obj(e)); }));
 }
 
 task_result<expr> to_expr_task(vm_obj const & o) {
-    return mk_map_task<expr>(to_task(o), [] (vm_obj const & o) { return to_expr(o); });
+    return mk_map_task<expr>(to_task(o), [] (ts_vm_obj const & o) { return to_expr(o.to_vm_obj()); });
 }
 
 vm_obj vm_task_get(vm_obj const &, vm_obj const & t) {
-    return to_task(t).get();
+    return to_task(t).get().to_vm_obj();
 }
 
 vm_obj vm_task_pure(vm_obj const &, vm_obj const & t) {
-    return to_obj(mk_pure_task_result(t, "task.pure"));
+    return to_obj(mk_pure_task_result(ts_vm_obj(t), "task.pure"));
+}
+
+struct vm_map_task : public task<ts_vm_obj> {
+    environment m_env;
+    options m_opts;
+    bool m_use_infom;
+    ts_vm_obj m_fn;
+    task_result<ts_vm_obj> m_arg;
+
+public:
+    vm_map_task(environment const & env, options const & opts, bool use_infom,
+                 ts_vm_obj const & fn, task_result<ts_vm_obj> const & arg) :
+            m_env(env), m_opts(opts), m_use_infom(use_infom), m_fn(fn), m_arg(arg) {}
+
+    void description(std::ostream & out) const override {
+        out << "task.map";
+    }
+
+    std::vector<generic_task_result> get_dependencies() override {
+        return {m_arg};
+    }
+
+    ts_vm_obj execute() override {
+        // Tracing
+        type_context tc(m_env);
+        scope_trace_env scope_trace(m_env, m_opts, tc);
+
+        // Info manager
+        auto_reporting_info_manager_scope scope_infom(get_module_id(), m_use_infom);
+
+        vm_state state(m_env, m_opts);
+        scope_vm_state scope_vm(state);
+        return ts_vm_obj(state.invoke(m_fn.to_vm_obj(), m_arg.get().to_vm_obj()));
+    }
+};
+
+struct vm_flatten_task : public task<ts_vm_obj> {
+    task_result<ts_vm_obj> m_task;
+
+public:
+    vm_flatten_task(task_result<ts_vm_obj> const & t) : m_task(t) {}
+
+    void description(std::ostream & out) const override {
+        out << "task.flatten";
+    }
+
+    bool is_tiny() const override { return true; }
+
+    std::vector<generic_task_result> get_dependencies() override {
+        std::vector<generic_task_result> deps = { m_task };
+        if (auto res = m_task.peek())
+            deps.push_back(to_task(res->to_vm_obj()));
+        return deps;
+    }
+
+    ts_vm_obj execute() override {
+        return to_task(m_task.get().to_vm_obj()).get();
+    }
+};
+
+vm_obj vm_task_map(vm_obj const &, vm_obj const &, vm_obj const & fn, vm_obj const & t) {
+    return to_obj(get_global_task_queue()->submit<vm_map_task>(
+            get_vm_state().env(), get_vm_state().get_options(),
+            get_global_info_manager() != nullptr,
+            ts_vm_obj(fn), to_task(t)));
+}
+
+vm_obj vm_task_flatten(vm_obj const &, vm_obj const & t) {
+    return to_obj(get_global_task_queue()->submit<vm_flatten_task>(to_task(t)));
 }
 
 void initialize_vm_task() {
     DECLARE_VM_BUILTIN(name({"task", "get"}),  vm_task_get);
     DECLARE_VM_BUILTIN(name({"task", "pure"}), vm_task_pure);
+    DECLARE_VM_BUILTIN(name({"task", "map"}),  vm_task_map);
+    DECLARE_VM_BUILTIN(name({"task", "flatten"}), vm_task_flatten);
 }
 
 void finalize_vm_task() {

--- a/src/library/vm/vm_task.h
+++ b/src/library/vm/vm_task.h
@@ -8,11 +8,11 @@ Author: Gabriel Ebner
 #include "library/vm/vm.h"
 
 namespace lean {
-vm_obj to_obj(task_result<vm_obj> const & n);
+vm_obj to_obj(task_result<ts_vm_obj> const & n);
 vm_obj to_obj(task_result<expr> const & n);
 bool is_task(vm_obj const & o);
 task_result<expr> to_expr_task(vm_obj const & o);
-task_result<vm_obj> & to_task(vm_obj const & o);
+task_result<ts_vm_obj> const & to_task(vm_obj const & o);
 
 void initialize_vm_task();
 void finalize_vm_task();

--- a/tests/lean/interactive/do_info.lean.expected.out
+++ b/tests/lean/interactive/do_info.lean.expected.out
@@ -1,7 +1,7 @@
 {"msg":{"caption":"trace output","file_name":"f","pos_col":0,"pos_line":3,"severity":"information","text":"a b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ a = ?m_1\n\na b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ ?m_1 = c\n"},"response":"additional_message"}
 {"message":"file invalidated","response":"ok","seq_num":0}
-{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":456},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
+{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":459},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
 {"record":{"full-id":"tactic.transitivity","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":30},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":9}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":563},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":566},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
 {"record":{"full-id":"tactic.symmetry","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":27},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":14}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":563},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":566},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}

--- a/tests/lean/task.lean
+++ b/tests/lean/task.lean
@@ -1,0 +1,12 @@
+import data.vector
+
+run_command tactic.run_async (tactic.trace
+  "trace message from a different task")
+
+def {u} foo {α : Type u} {n : ℕ} : vector α (0+n) → vector α n :=
+if n = 0 then
+  λ v, cast (by async { simp }) v
+else
+  λ v, cast (by async { simp }) v
+
+print foo

--- a/tests/lean/task.lean.expected.out
+++ b/tests/lean/task.lean.expected.out
@@ -1,0 +1,4 @@
+trace message from a different task
+def foo : Π {α : Type u} {n : ℕ}, vector α (0 + n) → vector α n :=
+λ {α : Type u} {n : ℕ},
+  ite (n = 0) (λ (v : vector α (0 + n)), cast (foo._aux_1 v) v) (λ (v : vector α (0 + n)), cast (foo._aux_2 v) v)


### PR DESCRIPTION
In the category of "cool things we can do with the tactic monad", we can now define a tactic combinator in Lean that replaces the current goal with a lemma and proves it asynchronously in a different thread:
```lean
  def fill_shr (x : bitvec n) (i : ℕ) (fill : bool) : bitvec n :=
  bitvec.cong (by async { begin [smt] by_cases (i ≤ n), eblast end }) $
    repeat fill (min n i) ++ₜ taken (n-i) x
```

However I stumbled into a major issue: `rb_map` is not thread-safe, even with `ts_vm_obj`.  I think the reason is that we do not clone the comparison function, any ideas on how to solve that @leodemoura?