### PR TITLE
fix(library/tactic/generalize_tactic): instantiate mvars before calli…

### DIFF
--- a/src/library/tactic/generalize_tactic.cpp
+++ b/src/library/tactic/generalize_tactic.cpp
@@ -17,7 +17,7 @@ vm_obj generalize(transparency_mode m, expr const & e, name const & id, tactic_s
     expr target = ctx.instantiate_mvars(g->get_type());
     expr target_abst = kabstract(ctx, target, e);
     if (closed(target_abst))
-        return mk_tactic_exception("generalize tactic failed, failed to find expression in the targed", s);
+        return mk_tactic_exception("generalize tactic failed, failed to find expression in the target", s);
     expr e_type   = ctx.infer(e);
     expr new_type = mk_pi(id, e_type, target_abst);
     metavar_context mctx = ctx.mctx();

--- a/src/library/tactic/generalize_tactic.cpp
+++ b/src/library/tactic/generalize_tactic.cpp
@@ -13,8 +13,8 @@ namespace lean {
 vm_obj generalize(transparency_mode m, expr const & e, name const & id, tactic_state const & s) {
     optional<metavar_decl> g = s.get_main_goal_decl();
     if (!g) return mk_no_goals_exception(s);
-    expr target = g->get_type();
     type_context ctx = mk_type_context_for(s, m);
+    expr target = ctx.instantiate_mvars(g->get_type());
     expr target_abst = kabstract(ctx, target, e);
     if (closed(target_abst))
         return mk_tactic_exception("generalize tactic failed, failed to find expression in the targed", s);

--- a/tests/lean/run/generalize_inst.lean
+++ b/tests/lean/run/generalize_inst.lean
@@ -1,0 +1,10 @@
+import standard
+
+example : ∃(b : nat), b = 1 ∧ 0 ≤ b :=
+begin
+  apply exists.intro,
+  apply and.intro,
+  apply rfl,
+  generalize 1 z,
+  exact nat.zero_le
+end


### PR DESCRIPTION
…ng kabstract

`kabstract` does not meta variables. When the to-be-generalized term is in the assignment of a metavariable it is currently not generalized. This patch instantiates all meta variables before it calls `kabstract`. 