### PR TITLE
Proper work-around for lost transient mark in old Emacs versions.

### DIFF
--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -46,7 +46,7 @@
         ;; show current task when not in current file
         (when (and cur-task
                    (not (equal cur-fn (plist-get cur-task :file_name))))
-          (setq display-tasks (cons cur-task display-task)))
+          (setq display-tasks (cons cur-task display-tasks)))
         (mapcar (lambda (task) (apply #'lean-flycheck-parse-task checker buffer cur-fn task))
                 display-tasks))))
 

--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -117,7 +117,8 @@
 
 (defun lean-next-error--handler ()
   (when (lean-info-buffer-active lean-next-error-buffer-name)
-    (let ((errors (or
+    (let ((deactivate-mark) ; keep transient mark
+          (errors (or
                    ;; prefer error of current position, if any
                    (flycheck-overlay-errors-at (point))
                    ;; try errors in current line next

--- a/src/emacs/lean-info.el
+++ b/src/emacs/lean-info.el
@@ -29,15 +29,12 @@
        'common-lisp-indent-function))
 
 (defmacro lean-with-info-output-to-buffer (buffer &rest body)
-  ;; `princ`ing into a different buffer somehow interferes with Transient Mark mode
-  ;; https://github.com/leanprover/lean/issues/1332
-  `(if (not (region-active-p))
-       (let ((buf (get-buffer ,buffer)))
-         (with-current-buffer buf
-           (setq buffer-read-only nil)
-           (erase-buffer)
-           (setq standard-output buf)
-           . ,body))))
+  `(let ((buf (get-buffer ,buffer)))
+     (with-current-buffer buf
+       (setq buffer-read-only nil)
+       (erase-buffer)
+       (setq standard-output buf)
+       . ,body)))
 
 (defun lean-toggle-info-buffer (buffer)
   (-if-let (window (get-buffer-window buffer))

--- a/src/emacs/lean-type.el
+++ b/src/emacs/lean-type.el
@@ -110,13 +110,14 @@
 (defconst lean-show-goal-buffer-name "*Lean Goal*")
 
 (defun lean-show-goal--handler ()
-  (when (lean-info-buffer-active lean-show-goal-buffer-name)
-    (lean-get-info-record-at-point
-     (lambda (info-record)
-       (lean-with-info-output-to-buffer
-        lean-show-goal-buffer-name
-        (-if-let (state (plist-get info-record :state))
-            (princ state)))))))
+  (let ((deactivate-mark)) ; keep transient mark
+    (when (lean-info-buffer-active lean-show-goal-buffer-name)
+      (lean-get-info-record-at-point
+       (lambda (info-record)
+         (lean-with-info-output-to-buffer
+          lean-show-goal-buffer-name
+          (-if-let (state (plist-get info-record :state))
+              (princ state))))))))
 
 (defun lean-toggle-show-goal ()
   "Show goal at the current point."


### PR DESCRIPTION
This uses the work-around described in http://stackoverflow.com/questions/23884218/transient-mark-mode-pre-command-hook-and-with-current-buffer

I have tested it with Emacs 24.5.1, can anybody test with 24.3?

Fixes #1352.