### PR TITLE
Recover from almost all elaboration errors using sorry

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2725,7 +2725,7 @@ expr elaborator::visit(expr const & e, optional<expr> const & expected_type) {
     flet<unsigned> inc_depth(m_depth, m_depth+1);
     trace_elab_detail(tout() << "[" << m_depth << "] visiting\n" << e << "\n";
                       if (expected_type) tout() << "expected type:\n" << instantiate_mvars(*expected_type) << "\n";);
-    return recover_expr_from_exception(expected_type, e, [&] {
+    return recover_expr_from_exception(expected_type, e, [&] () -> expr {
         if (is_placeholder(e)) {
             return visit_placeholder(e, expected_type);
         } else if (is_have_expr(e)) {

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -296,7 +296,8 @@ class inductive_cmd_fn {
     void elaborate_inductive_decls(buffer<expr> const & params, buffer<expr> const & inds, buffer<buffer<expr> > const & intro_rules,
                                    buffer<expr> & new_params, buffer<expr> & new_inds, buffer<buffer<expr> > & new_intro_rules) {
         options opts = m_p.get_options();
-        elaborator elab(m_env, opts, local_pp_name(inds[0]), metavar_context(), local_context());
+        bool recover_from_errors = true;
+        elaborator elab(m_env, opts, local_pp_name(inds[0]), metavar_context(), local_context(), recover_from_errors);
 
         buffer<expr> params_no_inds;
         for (expr const & p : params) {
@@ -357,6 +358,7 @@ class inductive_cmd_fn {
         elab.finalize(all_exprs, implicit_lp_names, true, false);
         m_env = elab.env();
         m_lp_names.append(implicit_lp_names);
+        if (elab.has_errors()) m_p.set_error();
 
         new_params.clear();
         new_inds.clear();

--- a/src/frontends/lean/print_cmd.cpp
+++ b/src/frontends/lean/print_cmd.cpp
@@ -360,7 +360,7 @@ bool print_id_info(parser & p, message_builder & out, name const & id, bool show
             try {
                 if (show_value)
                     print_definition(env, out, c, pos);
-            } catch (exception & ex) {
+            } catch (std::exception & ex) {
                 out << "[incorrect proof]\n";
                 bool use_pos = false;
                 out.set_exception(ex, use_pos);

--- a/src/frontends/lean/tactic_evaluator.cpp
+++ b/src/frontends/lean/tactic_evaluator.cpp
@@ -19,9 +19,17 @@ Author: Leonardo de Moura
 #include "frontends/lean/tactic_notation.h"
 
 namespace lean {
-[[noreturn]] void throw_unsolved_tactic_state(tactic_state const & ts, format const & fmt, expr const & ref) {
+elaborator_exception unsolved_tactic_state(tactic_state const & ts, format const & fmt, expr const & ref) {
     format msg = fmt + line() + format("state:") + line() + ts.pp();
-    throw elaborator_exception(ref, msg);
+    return elaborator_exception(ref, msg);
+}
+
+elaborator_exception unsolved_tactic_state(tactic_state const & ts, char const * msg, expr const & ref) {
+    return unsolved_tactic_state(ts, format(msg), ref);
+}
+
+[[noreturn]] void throw_unsolved_tactic_state(tactic_state const & ts, format const & fmt, expr const & ref) {
+    throw unsolved_tactic_state(ts, fmt, ref);
 }
 
 [[noreturn]] void throw_unsolved_tactic_state(tactic_state const & ts, char const * msg, expr const & ref) {

--- a/src/frontends/lean/tactic_evaluator.h
+++ b/src/frontends/lean/tactic_evaluator.h
@@ -9,6 +9,8 @@ Author: Leonardo de Moura
 #include "frontends/lean/info_manager.h"
 
 namespace lean {
+elaborator_exception unsolved_tactic_state(tactic_state const & ts, format const & fmt, expr const & ref);
+elaborator_exception unsolved_tactic_state(tactic_state const & ts, char const * msg, expr const & ref);
 [[noreturn]] void throw_unsolved_tactic_state(tactic_state const & ts, format const & fmt, expr const & ref);
 [[noreturn]] void throw_unsolved_tactic_state(tactic_state const & ts, char const * msg, expr const & ref);
 

--- a/src/frontends/smt2/parser.cpp
+++ b/src/frontends/smt2/parser.cpp
@@ -398,7 +398,7 @@ private:
     bool parse_commands() {
         scan();
 
-        // TODO(dhs): for now we will not recover from any errors
+        // TODO(dhs): for now we will not recoverable_error from any errors
         while (true) {
             switch (curr_kind()) {
             case scanner::token_kind::LEFT_PAREN:

--- a/src/library/tactic/elaborate.cpp
+++ b/src/library/tactic/elaborate.cpp
@@ -26,7 +26,8 @@ vm_obj tactic_to_expr_core(vm_obj const & relaxed, vm_obj const & qe, vm_obj con
     try {
         environment env = s.env();
         auto e = to_expr(qe);
-        elaborator elab(env, s.get_options(), s.decl_name(), mctx, g->get_context());
+        bool recover_from_errors = false;
+        elaborator elab(env, s.get_options(), s.decl_name(), mctx, g->get_context(), recover_from_errors);
         expr r = elab.elaborate(resolve_names(env, g->get_context(), e));
         if (!to_bool(relaxed))
             elab.ensure_no_unassigned_metavars(r);

--- a/tests/lean/1162.lean.expected.out
+++ b/tests/lean/1162.lean.expected.out
@@ -1,3 +1,3 @@
+1162.lean:10:12: error: equation compiler error, equation #2 has not been used in the compilation, note that the left-hand-side of equation #1 is a variable
 1162.lean:7:4: warning: declaration 'ppday' uses sorry
 1162.lean:7:4: warning: declaration 'ppday.equations._eqn_1' uses sorry
-1162.lean:10:12: error: equation compiler error, equation #2 has not been used in the compilation, note that the left-hand-side of equation #1 is a variable

--- a/tests/lean/1279.lean.expected.out
+++ b/tests/lean/1279.lean.expected.out
@@ -6,3 +6,29 @@ has type
   source^.Hom A B
 but is expected to have type
   source^.Hom C ?m_1
+1279.lean:12:55: error: type mismatch at application
+  target^.compose (onMorphisms g) (onMorphisms f)
+term
+  onMorphisms f
+has type
+  target^.Hom (onObjects A) (onObjects B)
+but is expected to have type
+  target^.Hom (onObjects C) (onObjects ?m_1)
+1279.lean:12:33: error: don't know how to synthesize placeholder
+context:
+source target : Category,
+onObjects : source^.Obj → target^.Obj,
+onMorphisms : Π ⦃A B : source^.Obj⦄, source^.Hom A B → target^.Hom (onObjects A) (onObjects B),
+A B C : source^.Obj,
+f : source^.Hom A B,
+g : source^.Hom B C
+⊢ source^.Obj
+1279.lean:8:10: warning: declaration 'Functor.has_sizeof_inst' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.mk.sizeof_spec' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.functoriality' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.rec_on' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.induction_on' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.destruct' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.cases_on' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.no_confusion_type' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.no_confusion' uses sorry

--- a/tests/lean/1293.lean.expected.out
+++ b/tests/lean/1293.lean.expected.out
@@ -18,3 +18,15 @@ state:
 foo : ?m_1,
 trivial : ?m_2
 ⊢ ?m_3
+1293.lean:13:8: error: don't know how to synthesize placeholder
+context:
+⊢ Sort ?
+1293.lean:13:12: error: don't know how to synthesize placeholder
+context:
+foo : sorry
+⊢ Sort ?
+1293.lean:13:8: error: don't know how to synthesize placeholder
+context:
+foo : sorry,
+trivial : sorry
+⊢ Sort ?

--- a/tests/lean/858.lean.expected.out
+++ b/tests/lean/858.lean.expected.out
@@ -1,4 +1,3 @@
 858.lean:2:18: error: don't know how to synthesize placeholder
 context:
 ⊢ Sort ?
-858.lean:2:18: error: elaborator failed

--- a/tests/lean/aux_decl_zeta.lean.expected.out
+++ b/tests/lean/aux_decl_zeta.lean.expected.out
@@ -1,5 +1,3 @@
-aux_decl_zeta.lean:5:11: warning: declaration 'f' uses sorry
-aux_decl_zeta.lean:5:11: warning: declaration 'f.equations._eqn_1' uses sorry
 aux_decl_zeta.lean:11:48: error: equation compiler failed to create auxiliary declaration 'f._match_1', auxiliary declaration has references to let-declarations (possible solution: use 'set_option eqn_compiler.zeta true')
 nested exception message:
 type mismatch at application
@@ -10,3 +8,6 @@ has type
   vec ℕ n
 but is expected to have type
   vec ℕ 10
+aux_decl_zeta.lean:5:11: warning: declaration 'f._main' uses sorry
+aux_decl_zeta.lean:5:11: warning: declaration 'f._main.equations._eqn_1' uses sorry
+aux_decl_zeta.lean:5:11: warning: declaration 'f.equations._eqn_1' uses sorry

--- a/tests/lean/bad_error1.lean.expected.out
+++ b/tests/lean/bad_error1.lean.expected.out
@@ -4,3 +4,17 @@ given argument
   n
 expected argument
   m
+bad_error1.lean:4:22: error: unexpected argument at application
+  nat.bit1_ne_bit0 sorry m
+given argument
+  m
+expected argument
+  n
+bad_error1.lean:4:13: error: type mismatch at application
+  ne.symm (nat.bit1_ne_bit0 sorry sorry)
+term
+  nat.bit1_ne_bit0 sorry sorry
+has type
+  bit1 sorry ≠ bit0 sorry
+but is expected to have type
+  bit1 m ≠ bit0 n

--- a/tests/lean/bad_error2.lean.expected.out
+++ b/tests/lean/bad_error2.lean.expected.out
@@ -15,3 +15,5 @@ _match : (∃ (k_1 : ℕ), k + n + k_1 = k + m) → n ≤ m,
 w : ℕ,
 hw : (λ (k_1 : ℕ), k + n + k_1 = k + m) w
 ⊢ n + w = m
+bad_error2.lean:3:8: warning: declaration 'this._match_1' uses sorry
+bad_error2.lean:3:8: warning: declaration 'this._match_1.equations._eqn_1' uses sorry

--- a/tests/lean/bad_error3.lean.expected.out
+++ b/tests/lean/bad_error3.lean.expected.out
@@ -1,4 +1,14 @@
 bad_error3.lean:1:33: error: type expected at
   p 0
+bad_error3.lean:3:0: error: tactic failed, there are unsolved goals
+state:
+p : ℕ → ℕ → Prop
+⊢ sorry
 bad_error3.lean:5:32: error: type expected at
   p 0
+bad_error3.lean:7:0: error: tactic failed, there are unsolved goals
+state:
+p : ℕ → ℕ → Prop
+⊢ sorry
+bad_error3.lean:5:4: warning: declaration 'ex' uses sorry
+bad_error3.lean:5:4: warning: declaration 'ex.equations._eqn_1' uses sorry

--- a/tests/lean/bad_error4.lean.expected.out
+++ b/tests/lean/bad_error4.lean.expected.out
@@ -1,5 +1,3 @@
-bad_error4.lean:4:11: warning: declaration 'bar' uses sorry
-bad_error4.lean:4:11: warning: declaration 'bar.equations._eqn_1' uses sorry
 bad_error4.lean:5:0: error: type mismatch at application
   {f := λ (a : unit) (b : delayed[?m_1]), delayed[?m_3]}
 term
@@ -8,3 +6,5 @@ has type
   Π (a : unit) (b : delayed[?m_1]), delayed[?m_2]
 but is expected to have type
   unit → unit
+bad_error4.lean:4:11: warning: declaration 'bar' uses sorry
+bad_error4.lean:4:11: warning: declaration 'bar.equations._eqn_1' uses sorry

--- a/tests/lean/bad_error5.lean.expected.out
+++ b/tests/lean/bad_error5.lean.expected.out
@@ -1,3 +1,3 @@
+bad_error5.lean:13:10: error: _tactic._val_3: trying to evaluate sorry
 bad_error5.lean:9:11: warning: declaration 'V' uses sorry
 bad_error5.lean:9:11: warning: declaration 'V.equations._eqn_1' uses sorry
-bad_error5.lean:9:0: error: _tactic._val_3: trying to evaluate sorry

--- a/tests/lean/bad_inaccessible.lean.expected.out
+++ b/tests/lean/bad_inaccessible.lean.expected.out
@@ -1,13 +1,13 @@
+bad_inaccessible.lean:3:5: error: invalid use of inaccessible term, it is not fixed by other arguments
 bad_inaccessible.lean:2:11: warning: declaration 'f1' uses sorry
 bad_inaccessible.lean:2:11: warning: declaration 'f1.equations._eqn_1' uses sorry
-bad_inaccessible.lean:3:5: error: invalid use of inaccessible term, it is not fixed by other arguments
-bad_inaccessible.lean:5:11: warning: declaration 'f2' uses sorry
-bad_inaccessible.lean:5:11: warning: declaration 'f2.equations._eqn_1' uses sorry
 bad_inaccessible.lean:6:7: error: invalid use of inaccessible term, the provided term is
   b
 but is expected to be
   a
-bad_inaccessible.lean:12:11: warning: declaration 'foo' uses sorry
-bad_inaccessible.lean:12:11: warning: declaration 'foo.equations._eqn_1' uses sorry
+bad_inaccessible.lean:5:11: warning: declaration 'f2' uses sorry
+bad_inaccessible.lean:5:11: warning: declaration 'f2.equations._eqn_1' uses sorry
 bad_inaccessible.lean:14:3: error: invalid use of inaccessible term, it is not completely fixed by other arguments
   .?m_1 + 1
+bad_inaccessible.lean:12:11: warning: declaration 'foo' uses sorry
+bad_inaccessible.lean:12:11: warning: declaration 'foo.equations._eqn_1' uses sorry

--- a/tests/lean/bad_inaccessible2.lean.expected.out
+++ b/tests/lean/bad_inaccessible2.lean.expected.out
@@ -1,5 +1,3 @@
-bad_inaccessible2.lean:29:11: warning: declaration 'map_head' uses sorry
-bad_inaccessible2.lean:29:11: warning: declaration 'map_head.equations._eqn_1' uses sorry
 bad_inaccessible2.lean:31:2: error: type mismatch at application
   map_head (cons a va) (cons b vb)
 term
@@ -8,3 +6,6 @@ has type
   vec .?m_1 (n + 1)
 but is expected to have type
   vec A .(.?m_2 + 1)
+bad_inaccessible2.lean:31:46: error: ill-formed match/equations expression
+bad_inaccessible2.lean:29:11: warning: declaration 'map_head' uses sorry
+bad_inaccessible2.lean:29:11: warning: declaration 'map_head.equations._eqn_1' uses sorry

--- a/tests/lean/choice_expl.lean.expected.out
+++ b/tests/lean/choice_expl.lean.expected.out
@@ -5,3 +5,4 @@ choice_expl.lean:15:6: error: ambiguous overload, possible interpretations
   N1.pr a b
 Additional information:
 choice_expl.lean:15:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1

--- a/tests/lean/cls_err.lean.expected.out
+++ b/tests/lean/cls_err.lean.expected.out
@@ -1,5 +1,5 @@
-cls_err.lean:12:13: warning: declaration 'tst' uses sorry
-cls_err.lean:12:13: warning: declaration 'tst.equations._eqn_1' uses sorry
 cls_err.lean:13:2: error: failed to synthesize type class instance for
 A : Type u
 ⊢ H A
+cls_err.lean:12:13: warning: declaration 'tst' uses sorry
+cls_err.lean:12:13: warning: declaration 'tst.equations._eqn_1' uses sorry

--- a/tests/lean/coe1.lean.expected.out
+++ b/tests/lean/coe1.lean.expected.out
@@ -11,6 +11,7 @@ has type
   real
 but is expected to have type
   int
+sorry : ?M_1
 ↑i + x : real
 x + ↑n : real
 coe1.lean:35:8: error: type mismatch at application
@@ -21,6 +22,7 @@ has type
   real
 but is expected to have type
   ℕ
+sorry : ?M_1
 ↑n + x : real
 ↑i + x : real
 ↑n + x : real

--- a/tests/lean/coe2.lean.expected.out
+++ b/tests/lean/coe2.lean.expected.out
@@ -11,6 +11,7 @@ has type
   real
 but is expected to have type
   int
+sorry : ?M_1
 i + x : real
 x + n : real
 coe2.lean:37:8: error: type mismatch at application
@@ -21,4 +22,5 @@ has type
   real
 but is expected to have type
   ℕ
+sorry : ?M_1
 n + x : real

--- a/tests/lean/crash.lean.expected.out
+++ b/tests/lean/crash.lean.expected.out
@@ -1,10 +1,20 @@
-crash.lean:6:11: error: don't know how to synthesize placeholder
-context:
-P : Prop
-⊢ Sort ?
 crash.lean:9:17: error: invalid have-expression, expression
   H
 has type
   P
 but is expected to have type
   ¬P
+crash.lean:10:12: error: don't know how to synthesize placeholder
+context:
+P : Prop,
+H : P,
+H' : ¬P
+⊢ Sort ?
+crash.lean:10:12: error: don't know how to synthesize placeholder
+context:
+P : Prop,
+H : P,
+H' : ¬P
+⊢ sorry
+crash.lean:6:11: warning: declaration 'crash' uses sorry
+crash.lean:6:11: warning: declaration 'crash.equations._eqn_1' uses sorry

--- a/tests/lean/ctx.lean.expected.out
+++ b/tests/lean/ctx.lean.expected.out
@@ -8,4 +8,3 @@ p1 p2 : A × B
 ⊢ ℕ
 ctx.lean:2:11: warning: declaration 'foo' uses sorry
 ctx.lean:2:11: warning: declaration 'foo.equations._eqn_1' uses sorry
-ctx.lean:3:0: error: elaborator failed

--- a/tests/lean/def1.lean.expected.out
+++ b/tests/lean/def1.lean.expected.out
@@ -7,5 +7,3 @@ but is expected to have type
 Additional information:
 def1.lean:5:16: context: the inferred motive for the eliminator-like application is
   λ (_x : A), f _x = f c
-def1.lean:5:3: context: the inferred motive for the eliminator-like application is
-  λ (_x : A), f a = f c

--- a/tests/lean/def4.lean.expected.out
+++ b/tests/lean/def4.lean.expected.out
@@ -7,6 +7,7 @@ has type
   ℕ
 but is expected to have type
   A
+sorry : ?M_1
 g : A → A
 def4.lean:17:8: error: type mismatch at application
   g 0
@@ -16,6 +17,7 @@ has type
   ℕ
 but is expected to have type
   A
+sorry : ?M_1
 f : Π (A : Type u_1), A → A
 f ℕ 0 : ℕ
 g 0 : ℕ

--- a/tests/lean/elab1.lean.expected.out
+++ b/tests/lean/elab1.lean.expected.out
@@ -3,4 +3,6 @@
 elab1.lean:13:6: error: invalid '@', function is overloaded, use fully qualified names (overloads: boo.subst, foo.subst)
 elab1.lean:15:6: error: invalid '@@', function is overloaded, use fully qualified names (overloads: boo.subst, foo.subst)
 elab1.lean:19:6: error: invalid overloaded application, elaborator has special support for 'eq.subst' (it is handled as an "eliminator"), but this kind of constant cannot be overloaded (solution: use fully qualified names) (overloads: eq.subst, boo.subst, foo.subst)
+sorry : ?M_1
 elab1.lean:25:6: error: invalid 'eq.subst' application, elaborator has special support for this kind of application (it is handled as an "eliminator"), but the expected type must be known
+sorry : ?M_1

--- a/tests/lean/elab11.lean.expected.out
+++ b/tests/lean/elab11.lean.expected.out
@@ -3,6 +3,7 @@ elab11.lean:6:6: error: ambiguous overload, possible interpretations
   boo.f 1
 Additional information:
 elab11.lean:6:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 bla.f 1 : ℕ
 boo.f 1 : bool
 elab11.lean:16:7: error: none of the overloads are applicable
@@ -41,3 +42,4 @@ has type
   bool
 but is expected to have type
   string
+sorry : string

--- a/tests/lean/elab12.lean.expected.out
+++ b/tests/lean/elab12.lean.expected.out
@@ -1,16 +1,31 @@
 elab12.lean:1:30: error: type expected at
   0
+elab12.lean:1:38: error: function expected at
+  rfl
+Additional information:
+elab12.lean:1:38: context: switched to simple application elaboration procedure because failed to use expected type to elaborate it, error message
+  too many arguments
+elab12.lean:2:2: error: function expected at
+  H
+λ (a : ℕ), have H : sorry, from sorry, sorry : ∀ (a : ℕ), a = a
 elab12.lean:4:42: error: function expected at
   rfl
 Additional information:
 elab12.lean:4:42: context: switched to simple application elaboration procedure because failed to use expected type to elaborate it, error message
   too many arguments
+elab12.lean:5:2: error: function expected at
+  H
+λ (a : ℕ), have H : a = a, from sorry, sorry : ∀ (a : ℕ), a = a
 elab12.lean:7:44: error: invalid have-expression, expression
   a + 0
 has type
   ℕ
 but is expected to have type
   a = a
+elab12.lean:8:2: error: function expected at
+  H
+λ (a : ℕ), have H : a = a, from sorry, sorry : ∀ (a : ℕ), a = a
 elab12.lean:11:2: error: function expected at
   H
+λ (a : ℕ), have H : a = a, from rfl, sorry : ∀ (a : ℕ), a = a
 λ (a : ℕ), have H : a = a, from rfl, H : ∀ (a : ℕ), a = a

--- a/tests/lean/elab2.lean.expected.out
+++ b/tests/lean/elab2.lean.expected.out
@@ -7,4 +7,5 @@ has type
   bool
 but is expected to have type
   nat
+sorry : ?M_1
 @bla.{0 0} nat bool (@zero.{0} nat nat.has_zero) (@zero.{0} nat nat.has_zero) bool.tt : nat

--- a/tests/lean/elab4.lean.expected.out
+++ b/tests/lean/elab4.lean.expected.out
@@ -13,11 +13,13 @@ function expected at
   boo.f 0 1 2
 Additional information:
 elab4.lean:13:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 elab4.lean:15:6: error: ambiguous overload, possible interpretations
   foo.f 0 1
   boo.f 0 1
 Additional information:
 elab4.lean:15:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 foo.f bool.tt 2 : bool
 bla.f bool.tt bool.ff bool.tt : bool → bool
 elab4.lean:21:6: error: ambiguous overload, possible interpretations
@@ -25,4 +27,5 @@ elab4.lean:21:6: error: ambiguous overload, possible interpretations
   foo.f bool.tt bool.ff
 Additional information:
 elab4.lean:21:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 foo.f 0 1 : ℕ

--- a/tests/lean/elab4b.lean.expected.out
+++ b/tests/lean/elab4b.lean.expected.out
@@ -12,13 +12,16 @@ function expected at
   f 0 1 2
 Additional information:
 elab4b.lean:9:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 elab4b.lean:11:6: error: ambiguous overload, possible interpretations
   foo.f 0 1
   boo.f 0 1
 Additional information:
 elab4b.lean:11:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 elab4b.lean:13:6: error: ambiguous overload, possible interpretations
   bla.f bool.tt bool.ff
   foo.f bool.tt bool.ff
 Additional information:
 elab4b.lean:13:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1

--- a/tests/lean/elab_error_recovery.lean
+++ b/tests/lean/elab_error_recovery.lean
@@ -1,0 +1,21 @@
+def half_baked : ℕ → ℕ
+| 3  := 2
+-- type mismatches
+| 0  := 1 + ""
+-- placeholders
+| 5  := _ + 4
+-- missing typeclass instances
+| 42 := if 2 ∈ 3 then 3 else _
+-- exceptions during tactic evaluation
+| 7  := by do undefined
+-- nested elaboration errors
+| _  := begin exact [] end
+
+print half_baked._main
+
+eval    half_baked 3
+eval    half_baked 5
+vm_eval half_baked 3
+
+-- type errors in binders
+check ∀ x : nat.zero, x = x

--- a/tests/lean/elab_error_recovery.lean.expected.out
+++ b/tests/lean/elab_error_recovery.lean.expected.out
@@ -1,0 +1,58 @@
+elab_error_recovery.lean:4:10: error: type mismatch at application
+  1 + ""
+term
+  ""
+has type
+  string
+but is expected to have type
+  ℕ
+elab_error_recovery.lean:8:13: error: failed to synthesize type class instance for
+half_baked : ℕ → ℕ
+⊢ has_mem ℕ ℕ
+elab_error_recovery.lean:8:8: error: failed to synthesize type class instance for
+half_baked : ℕ → ℕ
+⊢ decidable (2 ∈ 3)
+elab_error_recovery.lean:10:11: error: undefined
+elab_error_recovery.lean:12:14: error: invalid type ascription, expression has type
+  list ?m_1
+but is expected to have type
+  ℕ
+state:
+half_baked : ℕ → ℕ,
+_x : ℕ
+⊢ ℕ
+elab_error_recovery.lean:12:23: error: failed
+state:
+half_baked : ℕ → ℕ,
+_x : ℕ
+⊢ ℕ
+elab_error_recovery.lean:6:8: error: don't know how to synthesize placeholder
+context:
+half_baked : ℕ → ℕ
+⊢ ℕ
+elab_error_recovery.lean:8:29: error: don't know how to synthesize placeholder
+context:
+half_baked : ℕ → ℕ
+⊢ ℕ
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main.equations._eqn_1' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main.equations._eqn_2' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main.equations._eqn_3' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main.equations._eqn_4' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main.equations._eqn_5' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked._main.equations._eqn_6' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked.equations._eqn_2' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked.equations._eqn_3' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked.equations._eqn_4' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked.equations._eqn_5' uses sorry
+elab_error_recovery.lean:1:4: warning: declaration 'half_baked.equations._eqn_6' uses sorry
+def half_baked._main : ℕ → ℕ :=
+λ (a : ℕ),
+  ite (a = 3) 2
+    (ite (a = 0) (1 + sorry) (ite (a = 5) (sorry + 4) (ite (a = 42) (ite (2 ∈ 3) 3 sorry) (ite (a = 7) sorry sorry))))
+2
+nat.succ (nat.succ (nat.succ (nat.succ sorry)))
+2
+elab_error_recovery.lean:21:12: error: type expected at
+  0
+∀ (x : sorry), x = x : Prop

--- a/tests/lean/empty.lean.expected.out
+++ b/tests/lean/empty.lean.expected.out
@@ -1,5 +1,4 @@
-empty.lean:6:25: warning: declaration 'v2' uses sorry
-empty.lean:6:25: warning: definition 'v2' was incorrectly marked as noncomputable
-empty.lean:6:25: warning: declaration 'v2.equations._eqn_1' uses sorry
 empty.lean:6:39: error: failed to synthesize type class instance for
 ⊢ nonempty Empty
+empty.lean:6:25: warning: declaration 'v2' uses sorry
+empty.lean:6:25: warning: declaration 'v2.equations._eqn_1' uses sorry

--- a/tests/lean/emptyc_errors.lean.expected.out
+++ b/tests/lean/emptyc_errors.lean.expected.out
@@ -3,9 +3,19 @@ context:
 A : Type u,
 x : A
 ⊢ has_mem A ?m_1
-emptyc_errors.lean:4:52: error: don't know how to synthesize placeholder
+emptyc_errors.lean:4:54: error: don't know how to synthesize placeholder
 context:
 A : Type u,
 x : A
-⊢ has_mem A ?m_1
-emptyc_errors.lean:4:52: error: elaborator failed
+⊢ Type ?
+emptyc_errors.lean:4:54: error: don't know how to synthesize placeholder
+context:
+A : Type u,
+x : A
+⊢ has_emptyc sorry
+emptyc_errors.lean:5:0: error: type mismatch, expression
+  λ (h : x ∈ ∅), h
+has type
+  x ∈ ∅ → x ∈ ∅
+but is expected to have type
+  x ∉ ∅

--- a/tests/lean/eqn_compiler_error_msg.lean.expected.out
+++ b/tests/lean/eqn_compiler_error_msg.lean.expected.out
@@ -1,2 +1,3 @@
 eqn_compiler_error_msg.lean:5:2: error: invalid function application in pattern, it cannot be reduced to a constructor (possible solution, mark term as inaccessible using '.( )')
   .p + .n
+eqn_compiler_error_msg.lean:5:24: error: ill-formed match/equations expression

--- a/tests/lean/eqn_hole.lean.expected.out
+++ b/tests/lean/eqn_hole.lean.expected.out
@@ -2,14 +2,14 @@ eqn_hole.lean:3:7: error: don't know how to synthesize placeholder
 context:
 f : ℕ → ℕ
 ⊢ ℕ
+eqn_hole.lean:2:11: error: invalid non-exhaustive set of equations (use 'set_option trace.eqn_compiler.elim_match true' for additional details)
 eqn_hole.lean:2:11: warning: declaration 'f' uses sorry
 eqn_hole.lean:2:11: warning: declaration 'f.equations._eqn_1' uses sorry
-eqn_hole.lean:3:7: error: elaborator failed
 eqn_hole.lean:8:13: error: don't know how to synthesize placeholder
 context:
 g : ℕ → ℕ,
 n : ℕ
 ⊢ ℕ
+eqn_hole.lean:6:11: error: support for well-founded recursion has not been implemented yet, use 'set_option trace.eqn_compiler true' for additional information
 eqn_hole.lean:6:11: warning: declaration 'g' uses sorry
 eqn_hole.lean:6:11: warning: declaration 'g.equations._eqn_1' uses sorry
-eqn_hole.lean:8:13: error: elaborator failed

--- a/tests/lean/error_full_names.lean.expected.out
+++ b/tests/lean/error_full_names.lean.expected.out
@@ -1,5 +1,8 @@
 error_full_names.lean:4:6: error: failed to synthesize type class instance for
 ⊢ has_zero nat
+error_full_names.lean:4:8: error: failed to synthesize type class instance for
+⊢ has_add nat
+0 + nat.zero : nat
 error_full_names.lean:8:6: error: type mismatch at application
   nat.succ nat.zero
 term
@@ -8,3 +11,4 @@ has type
   nat
 but is expected to have type
   ℕ
+sorry : ?M_1

--- a/tests/lean/error_pos.lean.expected.out
+++ b/tests/lean/error_pos.lean.expected.out
@@ -1,15 +1,25 @@
 error_pos.lean:1:39: error: type expected at
   B
+error_pos.lean:1:8: warning: declaration '_example' uses sorry
 error_pos.lean:4:43: error: type expected at
   B
 error_pos.lean:9:39: error: type expected at
   B
+λ (A : Type) (B : A → Type) (b : sorry), true : Π (A : Type), (A → Type) → sorry → Prop
 error_pos.lean:11:35: error: type expected at
   B
+λ (A : Type) (B : A → Type), sorry → true : Π (A : Type), (A → Type) → Prop
 error_pos.lean:13:42: error: type expected at
   B
+λ (A : Type) (B : A → Type) (b : sorry), b : Π (A : Type), (A → Type) → sorry → sorry
 error_pos.lean:15:105: error: invalid let-expression, expression
   a₁
+has type
+  B
+but is expected to have type
+  A
+error_pos.lean:15:133: error: invalid let-expression, expression
+  a₂
 has type
   B
 but is expected to have type

--- a/tests/lean/eval_expr_error.lean.expected.out
+++ b/tests/lean/eval_expr_error.lean.expected.out
@@ -1,5 +1,11 @@
-eval_expr_error.lean:3:9: warning: declaration 'tst1' uses sorry
 eval_expr_error.lean:5:8: error: invalid eval_expr, type must be a closed expression
+eval_expr_error.lean:5:4: error: don't know how to synthesize placeholder
+context:
+A : Type,
+tst1 : tactic unit,
+a : expr
+⊢ Type
+eval_expr_error.lean:3:9: warning: declaration 'tst1' uses sorry
 eval_expr_error.lean:8:0: error: invalid eval_expr, type mismatch
 state:
 ⊢ true

--- a/tests/lean/field_access.lean.expected.out
+++ b/tests/lean/field_access.lean.expected.out
@@ -3,10 +3,12 @@ field_access.lean:5:7: error: invalid projection, structure expected
   l
 has type
   list ℕ
+sorry : ?M_1
 field_access.lean:7:12: error: invalid projection, structure has only 2 field(s)
   (1, 2)
 which has type
   ?m_1 × ?m_2
+sorry : ?M_1
 field_access.lean:10:1: error: invalid '~>' notation, 'forr' is not a valid "field" because environment does not contain 'list.forr'
   l
 which has type

--- a/tests/lean/hole_in_fn.lean.expected.out
+++ b/tests/lean/hole_in_fn.lean.expected.out
@@ -4,4 +4,3 @@ n : ℕ
 ⊢ ℕ
 hole_in_fn.lean:5:11: warning: declaration 'f' uses sorry
 hole_in_fn.lean:5:11: warning: declaration 'f.equations._eqn_1' uses sorry
-hole_in_fn.lean:6:13: error: elaborator failed

--- a/tests/lean/hole_issue2.lean.expected.out
+++ b/tests/lean/hole_issue2.lean.expected.out
@@ -11,12 +11,8 @@ h : ⟦l₁⟧ ⊆ ⟦l₂⟧,
 w : A,
 hw : ¬list.count w l₁ ≤ list.count w l₂
 ⊢ false
-hole_issue2.lean:18:25: warning: declaration 'decidable_subbag_1' uses sorry
-hole_issue2.lean:18:25: warning: declaration 'decidable_subbag_1.equations._eqn_1' uses sorry
-hole_issue2.lean:22:74: error: elaborator failed
-Additional information:
-hole_issue2.lean:19:0: context: the inferred motive for the eliminator-like application is
-  λ (_x _x_1 : bag A), decidable (_x ⊆ _x_1)
+hole_issue2.lean:18:25: warning: declaration 'decidable_subbag_1._match_1' uses sorry
+hole_issue2.lean:18:25: warning: declaration 'decidable_subbag_1._match_1.equations._eqn_1' uses sorry
 hole_issue2.lean:29:65: error: don't know how to synthesize placeholder
 context:
 A : Type,
@@ -26,12 +22,8 @@ _match : Π (b : bool), subcount l₁ l₂ = b → decidable (⟦l₁⟧ ⊆ ⟦
 H : subcount l₁ l₂ = ff,
 h : ⟦l₁⟧ ⊆ ⟦l₂⟧
 ⊢ ∀ (a : A), ¬list.count a l₁ ≤ list.count a l₂ → false
-hole_issue2.lean:25:25: warning: declaration 'decidable_subbag_2' uses sorry
-hole_issue2.lean:25:25: warning: declaration 'decidable_subbag_2.equations._eqn_1' uses sorry
-hole_issue2.lean:29:65: error: elaborator failed
-Additional information:
-hole_issue2.lean:26:0: context: the inferred motive for the eliminator-like application is
-  λ (_x _x_1 : bag A), decidable (_x ⊆ _x_1)
+hole_issue2.lean:25:25: warning: declaration 'decidable_subbag_2._match_1' uses sorry
+hole_issue2.lean:25:25: warning: declaration 'decidable_subbag_2._match_1.equations._eqn_1' uses sorry
 hole_issue2.lean:36:28: error: don't know how to synthesize placeholder
 context:
 A : Type,
@@ -41,9 +33,5 @@ _match : Π (b : bool), subcount l₁ l₂ = b → decidable (⟦l₁⟧ ⊆ ⟦
 H : subcount l₁ l₂ = ff,
 h : ⟦l₁⟧ ⊆ ⟦l₂⟧
 ⊢ false
-hole_issue2.lean:32:25: warning: declaration 'decidable_subbag_3' uses sorry
-hole_issue2.lean:32:25: warning: declaration 'decidable_subbag_3.equations._eqn_1' uses sorry
-hole_issue2.lean:36:28: error: elaborator failed
-Additional information:
-hole_issue2.lean:33:0: context: the inferred motive for the eliminator-like application is
-  λ (_x _x_1 : bag A), decidable (_x ⊆ _x_1)
+hole_issue2.lean:32:25: warning: declaration 'decidable_subbag_3._match_1' uses sorry
+hole_issue2.lean:32:25: warning: declaration 'decidable_subbag_3._match_1.equations._eqn_1' uses sorry

--- a/tests/lean/inaccessible.lean.expected.out
+++ b/tests/lean/inaccessible.lean.expected.out
@@ -1,15 +1,27 @@
-inaccessible.lean:13:11: warning: declaration 'inv_3' uses sorry
-inaccessible.lean:13:11: warning: declaration 'inv_3.equations._eqn_1' uses sorry
 inaccessible.lean:14:10: error: function expected at
   mk
+inaccessible.lean:14:2: error: invalid occurrence of macro expression in pattern (possible solution, mark term as inaccessible using '.( )')
+  sorry
+inaccessible.lean:14:17: error: ill-formed match/equations expression
+inaccessible.lean:13:11: warning: declaration 'inv_3' uses sorry
+inaccessible.lean:13:11: warning: declaration 'inv_3.equations._eqn_1' uses sorry
 inaccessible.lean:17:11: error: invalid inaccessible annotation, it cannot be used around functions in applications
 inaccessible.lean:25:12: error: invalid pattern, 'a' already appeared in this pattern
-inaccessible.lean:27:11: warning: declaration 'inv_7' uses sorry
-inaccessible.lean:27:11: warning: declaration 'inv_7.equations._eqn_1' uses sorry
 inaccessible.lean:28:3: error: function expected at
   f
+inaccessible.lean:28:2: error: type mismatch at application
+  inv_7 sorry (mk b)
+term
+  mk b
+has type
+  imf .?m_3 (.?m_3 b)
+but is expected to have type
+  imf f sorry
+inaccessible.lean:28:16: error: ill-formed match/equations expression
+inaccessible.lean:27:11: warning: declaration 'inv_7' uses sorry
+inaccessible.lean:27:11: warning: declaration 'inv_7.equations._eqn_1' uses sorry
 inaccessible.lean:31:4: error: invalid pattern, 'a' already appeared in this pattern
-inaccessible.lean:80:11: warning: declaration 'map_6' uses sorry
-inaccessible.lean:80:11: warning: declaration 'map_6.equations._eqn_1' uses sorry
 inaccessible.lean:82:3: error: invalid use of inaccessible term, it is not completely fixed by other arguments
   .?m_1 + 1
+inaccessible.lean:80:11: warning: declaration 'map_6' uses sorry
+inaccessible.lean:80:11: warning: declaration 'map_6.equations._eqn_1' uses sorry

--- a/tests/lean/inaccessible2.lean.expected.out
+++ b/tests/lean/inaccessible2.lean.expected.out
@@ -1,8 +1,13 @@
+inaccessible2.lean:5:7: error: invalid occurrence of 'inaccessible' annotation, it must only occur in patterns
+inaccessible2.lean:5:4: error: invalid use of inaccessible term, the provided term is
+  f sorry
+but is expected to be
+  f a
 inaccessible2.lean:4:11: warning: declaration 'inv_1' uses sorry
 inaccessible2.lean:4:11: warning: declaration 'inv_1.equations._eqn_1' uses sorry
-inaccessible2.lean:5:7: error: invalid occurrence of 'inaccessible' annotation, it must only occur in patterns
 inaccessible2.lean:8:10: error: invalid pattern, must be an application, constant, variable, type ascription or inaccessible term
 inaccessible2.lean:11:11: error: invalid pattern, must be an application, constant, variable, type ascription or inaccessible term
+inaccessible2.lean:14:9: error: invalid pattern, in a constructor application, the parameters of the inductive datatype must be marked as inaccessible
+inaccessible2.lean:14:20: error: ill-formed match/equations expression
 inaccessible2.lean:13:11: warning: declaration 'symm' uses sorry
 inaccessible2.lean:13:11: warning: declaration 'symm.equations._eqn_1' uses sorry
-inaccessible2.lean:14:9: error: invalid pattern, in a constructor application, the parameters of the inductive datatype must be marked as inaccessible

--- a/tests/lean/inst_error.lean.expected.out
+++ b/tests/lean/inst_error.lean.expected.out
@@ -2,3 +2,4 @@ inst_error.lean:1:38: error: failed to synthesize type class instance for
 A : Type,
 a b c : A
 ⊢ decidable (a = b ∧ a = c)
+λ (A : Type) (a b c : A), ite (a = b ∧ a = c) tt ff : Π (A : Type), A → A → A → bool

--- a/tests/lean/instance_cache1.lean.expected.out
+++ b/tests/lean/instance_cache1.lean.expected.out
@@ -3,15 +3,19 @@ A : Type ?,
 a : A,
 this : has_add A
 ⊢ has_add A
-instance_cache1.lean:5:11: warning: declaration 'f2' uses sorry
-instance_cache1.lean:5:11: warning: declaration 'f2.equations._eqn_1' uses sorry
+instance_cache1.lean:1:11: warning: declaration 'f1' uses sorry
+instance_cache1.lean:1:11: warning: declaration 'f1.equations._eqn_1' uses sorry
 instance_cache1.lean:6:7: error: failed to synthesize type class instance for
 A : Type ?,
 a : A,
 s : has_add A
 ⊢ has_add A
+instance_cache1.lean:5:11: warning: declaration 'f2' uses sorry
+instance_cache1.lean:5:11: warning: declaration 'f2.equations._eqn_1' uses sorry
 instance_cache1.lean:9:19: error: failed to synthesize type class instance for
 A : Type ?,
 a : A,
 s : has_add A
 ⊢ has_add A
+instance_cache1.lean:8:11: warning: declaration 'f3' uses sorry
+instance_cache1.lean:8:11: warning: declaration 'f3.equations._eqn_1' uses sorry

--- a/tests/lean/instance_cache_bug1.lean.expected.out
+++ b/tests/lean/instance_cache_bug1.lean.expected.out
@@ -1,3 +1,4 @@
 instance_cache_bug1.lean:5:8: error: failed to synthesize type class instance for
 ⊢ has_add A
 a + a : A
+a + a : A

--- a/tests/lean/interactive/complete_tactic.lean.expected.out
+++ b/tests/lean/interactive/complete_tactic.lean.expected.out
@@ -1,4 +1,5 @@
 {"msg":{"caption":"","file_name":"f","pos_col":14,"pos_line":1,"severity":"error","text":"assumption tactic failed\nstate:\n⊢ ?m_1"},"response":"additional_message"}
+{"msg":{"caption":"","file_name":"f","pos_col":8,"pos_line":1,"severity":"error","text":"don't know how to synthesize placeholder\ncontext:\n⊢ Sort ?"},"response":"additional_message"}
 {"msg":{"caption":"","file_name":"f","pos_col":66,"pos_line":5,"severity":"error","text":"invalid expression, unexpected token"},"response":"additional_message"}
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"prefix":"","response":"ok","seq_num":2}

--- a/tests/lean/interactive/test_single.sh
+++ b/tests/lean/interactive/test_single.sh
@@ -10,17 +10,22 @@ else
     INTERACTIVE=$3
 fi
 
+DIFF=diff
+if diff --color --help >/dev/null 2>&1; then
+  DIFF="diff --color";
+fi
+
 ./run_single.sh $1 $f > "$f.produced.out"
 
 if test -f "$f.expected.out"; then
-    if diff --ignore-all-space "$f.produced.out" "$f.expected.out"; then
+    if $DIFF -u --ignore-all-space "$f.expected.out" "$f.produced.out"; then
         echo "-- checked"
         exit 0
     else
         echo "ERROR: file $f.produced.out does not match $f.expected.out"
         if [ $INTERACTIVE == "yes" ]; then
             meld "$f.produced.out" "$f.expected.out"
-            if diff --ignore-all-space "$f.produced.out" "$f.expected.out"; then
+            if $DIFF --ignore-all-space "$f.expected.out" "$f.produced.out"; then
                 echo "-- mismatch was fixed"
             fi
         fi

--- a/tests/lean/let1.lean.expected.out
+++ b/tests/lean/let1.lean.expected.out
@@ -12,3 +12,10 @@ has type
   Π (p q : bool), p → q → Π (c : bool), (p → q → c) → c
 but is expected to have type
   Π (p q : bool), p → q → and q p
+let bool : Type := Prop,
+    and : bool → bool → Prop := λ (p q : bool), Π (c : bool), (p → q → c) → c,
+    and_intro : Π (p q : bool), p → q → and q p := sorry,
+    and_elim_left : Π (p q : bool), and p q → p := λ (p q : bool) (H : and p q), H p (λ (H1 : p) (H2 : q), H1),
+    and_elim_right : Π (p q : bool), and p q → q := λ (p q : bool) (H : and p q), H q (λ (H1 : p) (H2 : q), H2)
+in and_intro :
+  ∀ (p q : Prop), p → q → (λ (p q : Prop), ∀ (c : Prop), (p → q → c) → c) q p

--- a/tests/lean/minimize_errors.lean.expected.out
+++ b/tests/lean/minimize_errors.lean.expected.out
@@ -1,11 +1,11 @@
-minimize_errors.lean:1:4: warning: declaration 'f' uses sorry
-minimize_errors.lean:1:4: warning: declaration 'f.equations._eqn_1' uses sorry
 minimize_errors.lean:2:0: error: type mismatch, expression
   λ (a : ℕ), a
 has type
   ℕ → ℕ
 but is expected to have type
   ℕ → ℕ → ℕ
+minimize_errors.lean:1:4: warning: declaration 'f' uses sorry
+minimize_errors.lean:1:4: warning: declaration 'f.equations._eqn_1' uses sorry
 f : ℕ → ℕ → ℕ
 g : ℕ → ℕ → ℕ
 def g : ℕ → ℕ → ℕ :=

--- a/tests/lean/mismatch.lean.expected.out
+++ b/tests/lean/mismatch.lean.expected.out
@@ -6,3 +6,4 @@ has type
   num
 but is expected to have type
   ℕ
+sorry : ?M_1

--- a/tests/lean/nary_overload.lean.expected.out
+++ b/tests/lean/nary_overload.lean.expected.out
@@ -3,6 +3,7 @@ nary_overload.lean:16:6: error: ambiguous overload, possible interpretations
   [a, b, c]
 Additional information:
 nary_overload.lean:16:6: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 [a, b, c] : vec A
 [a, b, c] : lst A
 @vec.cons A a (@vec.cons A b (@vec.cons A c (@vec.nil A))) : vec.{0} A

--- a/tests/lean/no_meta_rec_inst.lean.expected.out
+++ b/tests/lean/no_meta_rec_inst.lean.expected.out
@@ -1,6 +1,6 @@
-no_meta_rec_inst.lean:4:9: warning: declaration 'n_has_false' uses sorry
 no_meta_rec_inst.lean:5:3: error: tactic.mk_instance failed to generate instance for
   has_false ℕ
 state:
 n_has_false : has_false ℕ
 ⊢ has_false ℕ
+no_meta_rec_inst.lean:4:9: warning: declaration 'n_has_false' uses sorry

--- a/tests/lean/non_exhaustive_error.lean.expected.out
+++ b/tests/lean/non_exhaustive_error.lean.expected.out
@@ -1,3 +1,3 @@
+non_exhaustive_error.lean:2:11: error: invalid non-exhaustive set of equations (use 'set_option trace.eqn_compiler.elim_match true' for additional details)
 non_exhaustive_error.lean:2:11: warning: declaration 'f' uses sorry
 non_exhaustive_error.lean:2:11: warning: declaration 'f.equations._eqn_1' uses sorry
-non_exhaustive_error.lean:2:11: error: invalid non-exhaustive set of equations (use 'set_option trace.eqn_compiler.elim_match true' for additional details)

--- a/tests/lean/notation_error_pos.lean.expected.out
+++ b/tests/lean/notation_error_pos.lean.expected.out
@@ -1,9 +1,19 @@
 notation_error_pos.lean:6:6: error: failed to synthesize type class instance for
 ⊢ has_one string
+notation_error_pos.lean:6:6: error: failed to synthesize type class instance for
+⊢ has_add string
+"a" + 1 : string
 notation_error_pos.lean:8:6: error: failed to synthesize type class instance for
 ⊢ has_one string
+notation_error_pos.lean:8:6: error: failed to synthesize type class instance for
+⊢ has_add string
+"a" + 1 : string
 notation_error_pos.lean:10:6: error: failed to synthesize type class instance for
 ⊢ has_one string
+notation_error_pos.lean:10:6: error: failed to synthesize type class instance for
+⊢ has_add string
+1 + "a" : string
 notation_error_pos.lean:12:6: error: failed to synthesize type class instance for
 x : string
 ⊢ has_add string
+λ (x : string), x + "b" : string → string

--- a/tests/lean/num2.lean.expected.out
+++ b/tests/lean/num2.lean.expected.out
@@ -1,5 +1,11 @@
 o : N
 z : N
 eq a gz : Prop
+num2.lean:24:7: error: failed to synthesize type class instance for
+⊢ has_zero G
+num2.lean:24:6: error: invalid type ascription, expression has type
+  N
+but is expected to have type
+  G
 eq gz a : Prop
 eq b z : Prop

--- a/tests/lean/num3.lean.expected.out
+++ b/tests/lean/num3.lean.expected.out
@@ -1,3 +1,7 @@
 @eq N a z : Prop
+num3.lean:14:10: error: invalid type ascription, expression has type
+  N
+but is expected to have type
+  num
 @eq num 2 1 : Prop
 @eq num 2 1 : Prop

--- a/tests/lean/over_notation.lean.expected.out
+++ b/tests/lean/over_notation.lean.expected.out
@@ -22,5 +22,6 @@ but is expected to have type
   nat
 Additional information:
 over_notation.lean:11:9: context: switched to basic overload resolution where arguments are elaborated without any information about the expected type because expected type was not available
+sorry : ?M_1
 f 1 (f 2 (f 3 0)) : nat
 g "a" (g "b" (g "c" "")) : string

--- a/tests/lean/private_structure.lean.expected.out
+++ b/tests/lean/private_structure.lean.expected.out
@@ -20,4 +20,5 @@ private_structure.lean:32:6: error: unknown identifier 'point.y'
 def foo.bla : Type :=
 point
 private_structure.lean:37:7: error: invalid constructor ⟨...⟩, type is a private inductive datatype
+sorry : foo.bla
 foo.mk : foo.bla

--- a/tests/lean/proj_notation.lean.expected.out
+++ b/tests/lean/proj_notation.lean.expected.out
@@ -13,15 +13,18 @@ proj_notation.lean:34:18: error: invalid '~>' notation, 'fst' is not a valid "fi
   c
 which has type
   car
+λ (c : car), sorry : Π (c : car), delayed[?M_1]
 proj_notation.lean:36:19: error: invalid projection, index must be greater than 0
 proj_notation.lean:38:18: error: invalid projection, structure has only 2 field(s)
   c
 which has type
   car
+λ (c : car), sorry : Π (c : car), delayed[?M_1]
 proj_notation.lean:40:18: error: invalid projection, structure expected
   n
 has type
   ℕ
+λ (n : ℕ), sorry : Π (n : ℕ), delayed[?M_1]
 p^.fst : ℕ
 p^.snd : ℕ
 λ (c : car), (c^.pos)^.y : car → ℕ

--- a/tests/lean/set_attr1.lean.expected.out
+++ b/tests/lean/set_attr1.lean.expected.out
@@ -1,6 +1,6 @@
-set_attr1.lean:13:11: warning: declaration 'ex2' uses sorry
-set_attr1.lean:13:11: warning: declaration 'ex2.equations._eqn_1' uses sorry
 set_attr1.lean:14:3: error: tactic failed, there are unsolved goals
 state:
 n : ℕ
 ⊢ f n = n + 1
+set_attr1.lean:13:11: warning: declaration 'ex2' uses sorry
+set_attr1.lean:13:11: warning: declaration 'ex2.equations._eqn_1' uses sorry

--- a/tests/lean/slow_error.lean.expected.out
+++ b/tests/lean/slow_error.lean.expected.out
@@ -6,3 +6,4 @@ has type
   string
 but is expected to have type
   caching_user_attribute string
+sorry : ?M_1

--- a/tests/lean/structure_instance_bug.lean.expected.out
+++ b/tests/lean/structure_instance_bug.lean.expected.out
@@ -1,3 +1,3 @@
+structure_instance_bug.lean:11:0: error: invalid structure value {...}, field 'B' is implicit and must not be provided
 structure_instance_bug.lean:10:11: warning: declaration 'foo3' uses sorry
 structure_instance_bug.lean:10:11: warning: declaration 'foo3.equations._eqn_1' uses sorry
-structure_instance_bug.lean:11:0: error: invalid structure value {...}, field 'B' is implicit and must not be provided

--- a/tests/lean/structure_instance_bug2.lean.expected.out
+++ b/tests/lean/structure_instance_bug2.lean.expected.out
@@ -1,3 +1,3 @@
+structure_instance_bug2.lean:4:0: error: invalid structure instance, 'default_smt_pre_config' is not the name of a structure type
 structure_instance_bug2.lean:3:4: warning: declaration 'my_pre_config1' uses sorry
 structure_instance_bug2.lean:3:4: warning: declaration 'my_pre_config1.equations._eqn_1' uses sorry
-structure_instance_bug2.lean:4:0: error: invalid structure instance, 'default_smt_pre_config' is not the name of a structure type

--- a/tests/lean/t10.lean.expected.out
+++ b/tests/lean/t10.lean.expected.out
@@ -7,6 +7,7 @@ has type
   B
 but is expected to have type
   N
+sorry : ?M_1
 [x, y, z, x, y, y] : list
 [x] : list
 [] : list


### PR DESCRIPTION
This is a (non-exhaustive) list of errors that we can now recover from:
```lean
def half_baked : ℕ → ℕ
| 3  := 2
-- type mismatches
| 0  := 1 + ""
-- placeholders
| 5  := _ + 4
-- missing type-class instances
| 42 := if 2 ∈ 3 then 3 else _
-- exceptions during tactic evaluation
| 7  := by do undefined
-- nested elaboration errors
| _  := begin exact [] end
```
This is the elaborated term:
```lean
λ (a : ℕ),
  ite (a = 3) 2
    (ite (a = 0) (1 + sorry)
      (ite (a = 5) (sorry + 4)
        (ite (a = 42) (ite (2 ∈ 3) 3 sorry)
          (ite (a = 7) sorry sorry))))
```
The resulting definition gets added to the environment, and `vm_eval half_baked 3` returns 2, as expected.

The approach is pretty much as in described in #1358.  We only try do error recovery outside backtracking points, and set a boolean flag when backtracking is possible.  If error recovery is enabled, we try to return sorry instead of throwing an exception whenever possible.  In addition, the `visit` method catches exceptions and turns them into sorry as well.

There are still a few rough edges:
 * Missing type class instances are reported more than once.  That is, `x + y + z + w` generates 3 error messages about the missing has_add instance.
 * Partial applications are not sorry-padded, but completely replaced by sorry.  For example, `3 + (nat.add 4)` is elaborated to `3 + sorry` instead of `3 + (4 + sorry)`.  This situation is probably common in partial inputs, so we should keep it in mind for autocompletion.
 * Metavariables are solved using sorry in `ensure_no_unassigned_metavars`.  This is probably not the right place to do it, but I think it is the right time during elaboration.
 * The additional information in `visit_elim_app` is not added to the error in error-recovery mode.