### PR TITLE
feat(shell/server): limit full message updates to once every 200ms

### DIFF
--- a/src/library/versioned_msg_buf.h
+++ b/src/library/versioned_msg_buf.h
@@ -36,6 +36,8 @@ protected:
     std::vector<message> get_messages_core();
     std::vector<name> get_nonempty_buckets_core();
 
+    unique_lock<mutex> get_lock() { return unique_lock<mutex>(m_mutex); }
+
 public:
     versioned_msg_buf() {}
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -4,5 +4,5 @@ add_library(util OBJECT debug.cpp name.cpp name_set.cpp fresh_name.cpp
   stackinfo.cpp lean_path.cpp serializer.cpp lbool.cpp
   bitap_fuzzy_search.cpp init_module.cpp thread.cpp memory_pool.cpp
   utf8.cpp name_map.cpp list_fn.cpp null_ostream.cpp file_lock.cpp
-  task_queue.cpp
+  task_queue.cpp timer.cpp
   small_object_allocator.cpp subscripted_name_set.cpp process.cpp)

--- a/src/util/timer.cpp
+++ b/src/util/timer.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Gabriel Ebner
+*/
+#include "util/timer.h"
+
+#if defined(LEAN_MULTI_THREAD)
+namespace lean {
+
+constexpr chrono::steady_clock::duration accuracy = chrono::milliseconds(10);
+
+single_timer::single_timer() : m_thread(std::bind(&single_timer::worker, this)) {}
+single_timer::~single_timer() {
+    {
+        unique_lock<mutex> lock(m_mutex);
+        m_shutting_down = true;
+    }
+    m_timer_changed.notify_one();
+    m_thread.join();
+}
+
+void single_timer::worker() {
+    unique_lock<mutex> lock(m_mutex);
+    while (!m_shutting_down) {
+        auto now = chrono::steady_clock::now();
+        if (m_time && *m_time <= now + accuracy) {
+            m_time = optional<chrono::steady_clock::time_point>();
+            if (auto cb = std::move(m_cb)) {
+                lock.unlock();
+                cb();
+                lock.lock();
+            }
+        } else if (m_time) {
+            m_timer_changed.wait_for(lock, *m_time - now);
+        } else {
+            m_timer_changed.wait(lock);
+        }
+    }
+}
+
+void single_timer::set(chrono::steady_clock::time_point const & time, callback const & cb, bool overwrite) {
+    unique_lock<mutex> lock(m_mutex);
+    if (overwrite || !m_time) {
+        m_time = optional<chrono::steady_clock::time_point>(time);
+        m_cb = cb;
+        m_timer_changed.notify_one();
+    }
+}
+
+void single_timer::reset() {
+    unique_lock<mutex> lock(m_mutex);
+    m_time = optional<chrono::steady_clock::time_point>();
+    m_cb = nullptr;
+    m_timer_changed.notify_one();
+}
+
+}
+#endif

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Gabriel Ebner
+*/
+#pragma once
+#include "util/thread.h"
+#include "util/optional.h"
+
+namespace lean {
+
+#if defined(LEAN_MULTI_THREAD)
+class single_timer {
+public:
+    using callback = std::function<void()>;
+
+private:
+    mutex m_mutex;
+    condition_variable m_timer_changed;
+    bool m_shutting_down;
+
+    optional<chrono::steady_clock::time_point> m_time;
+    callback m_cb;
+
+    lthread m_thread;
+
+    void worker();
+
+public:
+    single_timer();
+    ~single_timer();
+
+    void set(chrono::steady_clock::time_point const &, callback const & cb, bool overwrite = true);
+    void reset();
+};
+#else
+class single_timer {};
+#endif
+
+}


### PR DESCRIPTION
Should fix #1364.

With this change we only send 22 full updates instead of 1500, and only 4M instead of 200M.