### PR TITLE
Change induction, cases, and apply to return information how they changed the goal

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -312,7 +312,8 @@ do e ← i_to_expr p,
    match rec_name with
    | some n := induction_core semireducible e n ids
    | none   := do I ← get_type_name e, induction_core semireducible e (I <.> "rec") ids
-   end
+   end,
+   return ()
 
 meta def cases (p : qexpr0) (ids : with_ident_list) : tactic unit :=
 do e ← i_to_expr p,

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -317,7 +317,7 @@ do e ← i_to_expr p,
 
 meta def cases (p : qexpr0) (ids : with_ident_list) : tactic unit :=
 do e ← i_to_expr p,
-   if e^.is_local_constant then
+   (if e^.is_local_constant then
      cases_core semireducible e ids
    else do
      x ← mk_fresh_name,
@@ -327,7 +327,8 @@ do e ← i_to_expr p,
            get_local x >>= tactic.revert,
            return ()),
      h ← tactic.intro1,
-     cases_core semireducible h ids
+     cases_core semireducible h ids),
+   return ()
 
 meta def destruct (p : qexpr0) : tactic unit :=
 i_to_expr p >>= tactic.destruct

--- a/library/init/meta/mk_dec_eq_instance.lean
+++ b/library/init/meta/mk_dec_eq_instance.lean
@@ -104,7 +104,7 @@ do I_name ← get_dec_eq_type_name,
    -- Use brec_on if type is recursive.
    -- We store the functional in the variable F.
    if is_recursive env I_name
-   then intro1 >>= (λ x, induction_core semireducible x (I_name <.> "brec_on") (idx_names ++ [v_name, F_name]))
+   then intro1 >>= (λ x, induction_core semireducible x (I_name <.> "brec_on") (idx_names ++ [v_name, F_name]) >> return ())
    else intro v_name >> return (),
 
    -- Apply cases to first element of type (I ...)

--- a/library/init/meta/mk_has_sizeof_instance.lean
+++ b/library/init/meta/mk_has_sizeof_instance.lean
@@ -67,7 +67,7 @@ do I_name ← get_has_sizeof_type_name,
    -- Use brec_on if type is recursive.
    -- We store the functional in the variable F.
    if is_recursive env I_name
-   then intro `_v >>= (λ x, induction_core semireducible x (I_name <.> "brec_on") [v_name, F_name])
+   then intro `_v >>= (λ x, induction_core semireducible x (I_name <.> "brec_on") [v_name, F_name] >> return ())
    else intro v_name >> return (),
    arg_names : list (list name) ← mk_constructors_arg_names I_name `_p,
    get_local v_name >>= λ v, cases_using v (join arg_names),

--- a/library/init/meta/relation_tactics.lean
+++ b/library/init/meta/relation_tactics.lean
@@ -14,7 +14,7 @@ do tgt ← target,
    env ← get_env,
    r   ← return $ get_app_fn tgt,
    match (op_for env (const_name r)) with
-   | (some refl) := mk_const refl >>= apply_core t tt ff tt
+   | (some refl) := mk_const refl >>= apply_core t tt ff tt >> return ()
    | none        := fail $ tac_name ++ " tactic failed, target is not a relation application with the expected property."
    end
 

--- a/library/init/meta/smt/smt_tactic.lean
+++ b/library/init/meta/smt/smt_tactic.lean
@@ -361,7 +361,7 @@ meta def add_lemmas_from_facts : smt_tactic unit :=
 get_facts >>= add_lemmas_from_facts_core
 
 meta def induction (e : expr) (rec : name) (ids : list name) : smt_tactic unit :=
-slift (tactic.induction e rec ids)
+slift (tactic.induction e rec ids >> return ()) -- pass on the information?
 
 end smt_tactic
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -413,8 +413,13 @@ meta constant abstract_hash : expr → tactic nat
 meta constant abstract_weight : expr → tactic nat
 meta constant abstract_eq     : expr → expr → tactic bool
 /- (induction_core m H rec ns) induction on H using recursor rec, names for the new hypotheses
-   are retrieved from ns. If ns does not have sufficient names, then use the internal binder names in the recursor. -/
-meta constant induction_core : transparency → expr → name → list name → tactic unit
+   are retrieved from ns. If ns does not have sufficient names, then use the internal binder names
+   in the recursor.
+   It returns for each new goal a list of new hypotheses and a list of substitutions for hypotheses
+   depending on H. The substitutions map internal names to their replacement terms. If the
+   replacement is again a hypothesis the user name stays the same. The internal names are only valid
+   in the original goal, not in the type context of the new goal. -/
+meta constant induction_core : transparency → expr → name → list name → tactic (list (list expr × list (name × expr)))
 /- (cases_core m H ns) apply cases_on recursor, names for the new hypotheses are retrieved from ns.
    H must be a local constant -/
 meta constant cases_core     : transparency → expr → list name → tactic unit
@@ -866,7 +871,7 @@ cases_core semireducible H []
 meta def cases_using : expr → list name → tactic unit :=
 cases_core semireducible
 
-meta def induction : expr → name → list name → tactic unit :=
+meta def induction : expr → name → list name → tactic (list (list expr × list (name × expr))) :=
 induction_core semireducible
 
 meta def destruct (e : expr) : tactic unit :=

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -421,8 +421,12 @@ meta constant abstract_eq     : expr → expr → tactic bool
    in the original goal, not in the type context of the new goal. -/
 meta constant induction_core : transparency → expr → name → list name → tactic (list (list expr × list (name × expr)))
 /- (cases_core m H ns) apply cases_on recursor, names for the new hypotheses are retrieved from ns.
-   H must be a local constant -/
-meta constant cases_core     : transparency → expr → list name → tactic unit
+   H must be a local constant.
+   It returns for each new goal the name of the constructor, a list of new hypotheses, and a list of
+   substitutions for hypotheses depending on H. The number of new goals may be smaller than the
+   number of constructors. Some goals may be discarded when the indices to not match.
+   See `induction_core` for information on the list of substitutions. -/
+meta constant cases_core     : transparency → expr → list name → tactic (list (name × list expr × list (name × expr)))
 /- (destruct_core m e) similar to cases tactic, but does not revert/intro/clear hypotheses. -/
 meta constant destruct_core    : transparency → expr → tactic unit
 /- (generalize_core m e n) -/
@@ -865,10 +869,10 @@ do tgt : expr ← target,
    fail "tactic by_contradiction failed, target is not a negation nor a decidable proposition (remark: when 'local attribute classical.prop_decidable [instance]' is used all propositions are decidable)",
    intro H
 
-meta def cases (H : expr) : tactic unit :=
+meta def cases (H : expr) : tactic (list (name × list expr × list (name × expr))) :=
 cases_core semireducible H []
 
-meta def cases_using : expr → list name → tactic unit :=
+meta def cases_using : expr → list name → tactic (list (name × list expr × list (name × expr))) :=
 cases_core semireducible
 
 meta def induction : expr → name → list name → tactic (list (list expr × list (name × expr))) :=

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -391,8 +391,9 @@ meta constant set_goals     : list expr → tactic unit
    the unification is performed using the given transparency mode.
    If approx is tt, then fallback to first-order unification, and approximate context during unification.
    If all is tt, then all unassigned meta-variables are added as new goals.
-   If insts is tt, then use type class resolution to instantiate unassigned meta-variables. -/
-meta constant apply_core    : transparency → bool → bool → bool → expr → tactic unit
+   If insts is tt, then use type class resolution to instantiate unassigned meta-variables.
+   It returns a list of all introduced meta variables, even the assigned ones. -/
+meta constant apply_core    : transparency → bool → bool → bool → expr → tactic (list expr)
 /- Create a fresh meta universe variable. -/
 meta constant mk_meta_univ  : tactic level
 /- Create a fresh meta-variable with the given type.
@@ -781,11 +782,11 @@ meta def now : tactic unit :=
 do n ← num_goals,
    when (n ≠ 0) (fail "now tactic failed, there are unsolved goals")
 
-meta def apply : expr → tactic unit :=
-apply_core semireducible tt ff tt
+meta def apply (e : expr) : tactic unit :=
+do apply_core semireducible tt ff tt e, return ()
 
-meta def fapply : expr → tactic unit :=
-apply_core semireducible tt tt tt
+meta def fapply (e : expr) : tactic unit :=
+do apply_core semireducible tt tt tt e, return ()
 
 /- Try to solve the main goal using type class resolution. -/
 meta def apply_instance : tactic unit :=

--- a/src/library/vm/vm_list.cpp
+++ b/src/library/vm/vm_list.cpp
@@ -32,6 +32,8 @@ vm_obj to_obj(list<name> const & ls) { return list_to_obj(ls); }
 vm_obj to_obj(list<level> const & ls) { return list_to_obj(ls); }
 vm_obj to_obj(list<expr> const & ls) { return list_to_obj(ls); }
 
+vm_obj to_obj(list<list<expr>> const & ls) { return list_to_obj(ls); }
+
 vm_obj to_obj(buffer<name> const & ls) { return to_obj(to_list(ls)); }
 vm_obj to_obj(buffer<level> const & ls) { return to_obj(to_list(ls)); }
 vm_obj to_obj(buffer<expr> const & ls) { return to_obj(to_list(ls)); }
@@ -104,6 +106,13 @@ unsigned list_cases_on(vm_obj const & o, buffer<vm_obj> & data) {
 
 vm_obj to_obj(list<unsigned> const & ls) {
     return to_vm_list(ls, [&](unsigned n) { return mk_vm_nat(n); });
+}
+
+vm_obj to_obj(buffer<vm_obj> const & ls) {
+    vm_obj obj = mk_vm_nil();
+    for (unsigned i = ls.size(); i > 0; i--)
+        obj = mk_vm_cons(ls[i - 1], obj);
+    return obj;
 }
 
 void initialize_vm_list() {

--- a/src/library/vm/vm_list.h
+++ b/src/library/vm/vm_list.h
@@ -26,6 +26,7 @@ list<expr> to_list_expr(vm_obj const & o);
 void to_buffer_expr(vm_obj const & o, buffer<expr> & r);
 vm_obj to_obj(buffer<expr> const & ls);
 vm_obj to_obj(list<expr> const & ls);
+vm_obj to_obj(list<list<expr>> const & ls);
 
 template<typename A, typename F>
 vm_obj to_vm_list(list<A> const & ls, F const & fn) {
@@ -34,6 +35,7 @@ vm_obj to_vm_list(list<A> const & ls, F const & fn) {
 }
 
 vm_obj to_obj(list<unsigned> const & ls);
+vm_obj to_obj(buffer<vm_obj> const & ls);
 
 /* Helper functions for accessing (list A) when A is not expr, name nor level */
 inline bool is_nil(vm_obj const & o) { return is_simple(o); }

--- a/tests/lean/interactive/do_info.lean.expected.out
+++ b/tests/lean/interactive/do_info.lean.expected.out
@@ -1,7 +1,7 @@
 {"msg":{"caption":"trace output","file_name":"f","pos_col":3,"pos_line":4,"severity":"information","text":"a b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ a = ?m_1\n\na b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ ?m_1 = c\n"},"response":"additional_message"}
 {"message":"file invalidated","response":"ok","seq_num":0}
-{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":521},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
+{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":526},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
 {"record":{"full-id":"tactic.transitivity","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":30},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":9}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":619},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":624},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
 {"record":{"full-id":"tactic.symmetry","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":27},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":14}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":619},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":624},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}

--- a/tests/lean/interactive/do_info.lean.expected.out
+++ b/tests/lean/interactive/do_info.lean.expected.out
@@ -1,7 +1,7 @@
 {"msg":{"caption":"trace output","file_name":"f","pos_col":3,"pos_line":4,"severity":"information","text":"a b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ a = ?m_1\n\na b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ ?m_1 = c\n"},"response":"additional_message"}
 {"message":"file invalidated","response":"ok","seq_num":0}
-{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":530},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
+{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":531},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
 {"record":{"full-id":"tactic.transitivity","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":30},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":9}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":628},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":629},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
 {"record":{"full-id":"tactic.symmetry","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":27},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":14}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":628},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":629},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}

--- a/tests/lean/interactive/do_info.lean.expected.out
+++ b/tests/lean/interactive/do_info.lean.expected.out
@@ -1,7 +1,7 @@
 {"msg":{"caption":"trace output","file_name":"f","pos_col":3,"pos_line":4,"severity":"information","text":"a b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ a = ?m_1\n\na b c : ℕ,\nh : a = b,\na_1 : c = b\n⊢ ?m_1 = c\n"},"response":"additional_message"}
 {"message":"file invalidated","response":"ok","seq_num":0}
-{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":526},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
+{"record":{"full-id":"tactic.intro","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":530},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"name → tactic expr"},"response":"ok","seq_num":6}
 {"record":{"full-id":"tactic.transitivity","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":30},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":9}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":624},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":628},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":12}
 {"record":{"full-id":"tactic.symmetry","source":{"column":9,"file":"/library/init/meta/relation_tactics.lean","line":27},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":14}
-{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":624},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}
+{"record":{"full-id":"tactic.assumption","source":{"column":9,"file":"/library/init/meta/tactic.lean","line":628},"state":"a b c : ℕ\n⊢ a = b → c = b → a = c","type":"tactic unit"},"response":"ok","seq_num":16}


### PR DESCRIPTION
`induction` and `cases` return now information about added hypotheses and how they modified existing hypotheses. `apply` returns *all* generated mvars.

With this we do not need to analyze the applied rules beforehand, also we do not need to generate names used by `induction` and `cases`. It is also easy to check that the result is as expected (i.e. `do [[a, b]] <- cases r`).

For `apply` it may be important to know which mvars where generated and which ones are available in the generated subgoals. For some cases it can be hard to predict which mvars are assigned. This change should allow an easier map of rule parameters to subgoals.