### PR TITLE
fix(library/vm): enable bounds checks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ enable_testing()
 option(MULTI_THREAD       "MULTI_THREAD"       ON)
 option(STATIC             "STATIC"             OFF)
 option(SPLIT_STACK        "SPLIT_STACK"        OFF)
+option(VM_UNCHECKED       "VM_UNCHECKED"       OFF)
 option(TCMALLOC           "TCMALLOC"           OFF)
 option(JEMALLOC           "JEMALLOC"           OFF)
 # When OFF we disable JSON support to support older compilers
@@ -98,6 +99,10 @@ if(NOT MULTI_THREAD)
   set(AUTO_THREAD_FINALIZATION OFF)
 else()
   set(LEAN_EXTRA_CXX_FLAGS "${LEAN_EXTRA_CXX_FLAGS} -D LEAN_MULTI_THREAD")
+endif()
+
+if(VM_UNCHECKED)
+  set(LEAN_EXTRA_CXX_FLAGS "${LEAN_EXTRA_CXX_FLAGS} -D LEAN_VM_UNCHECKED")
 endif()
 
 if(AUTO_THREAD_FINALIZATION)

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -3505,8 +3505,9 @@ environment load_external_fn(environment & env, name const & extern_n) {
     }
 }
 
-[[noreturn]] void vm_check_failed(char const *fn, unsigned line, char const *msg) {
-    throw exception(sstream() << "VM check failed at " << fn << ":" << line << ": " << msg);
+[[noreturn]] void vm_check_failed(char const * condition) {
+    throw exception(sstream() << "vm check failed: " << condition
+                              << " (possibly due to incorrect axioms, or sorry)");
 }
 
 class vm_index_manager {

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -58,11 +58,11 @@ public:
 #define LEAN_ALWAYS_INLINE
 #endif
 
-[[noreturn]] void vm_check_failed(char const * fn, unsigned line, char const * msg);
+[[noreturn]] void vm_check_failed(char const * condition);
 #if defined(LEAN_VM_UNCHECKED)
 #define lean_vm_check(cond) lean_assert(cond)
 #else
-#define lean_vm_check(cond) { if (LEAN_UNLIKELY(!(cond))) vm_check_failed(__FILE__, __LINE__, #cond); }
+#define lean_vm_check(cond) { if (LEAN_UNLIKELY(!(cond))) vm_check_failed(#cond); }
 #endif
 
 void display(std::ostream & out, vm_obj const & o);

--- a/src/library/vm/vm_declaration.cpp
+++ b/src/library/vm/vm_declaration.cpp
@@ -52,8 +52,7 @@ bool is_declaration(vm_obj const & o) {
 }
 
 declaration const & to_declaration(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_declaration*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_declaration*>(to_external(o)));
     return static_cast<vm_declaration*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -18,7 +18,6 @@ Author: Leonardo de Moura
 #include "library/vm/vm_name.h"
 #include "library/vm/vm_option.h"
 #include "library/vm/vm_string.h"
-#include "library/vm/vm_level.h"
 #include "library/vm/vm_expr.h"
 #include "library/vm/vm_declaration.h"
 #include "library/vm/vm_exceptional.h"
@@ -39,8 +38,7 @@ bool is_env(vm_obj const & o) {
 }
 
 environment const & to_env(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_environment*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_environment*>(to_external(o)));
     return static_cast<vm_environment*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_exceptional.cpp
+++ b/src/library/vm/vm_exceptional.cpp
@@ -21,8 +21,7 @@ struct vm_throwable : public vm_external {
 };
 
 throwable * to_throwable(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_throwable*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_throwable*>(to_external(o)));
     return static_cast<vm_throwable*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -44,8 +44,7 @@ struct vm_macro_definition : public vm_external {
 };
 
 macro_definition const & to_macro_definition(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_macro_definition*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_macro_definition*>(to_external(o)));
     return static_cast<vm_macro_definition*>(to_external(o))->m_val;
 }
 
@@ -67,8 +66,7 @@ bool is_expr(vm_obj const & o) {
 }
 
 expr const & to_expr(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_expr*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_expr*>(to_external(o)));
     return static_cast<vm_expr*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_format.cpp
+++ b/src/library/vm/vm_format.cpp
@@ -29,8 +29,7 @@ bool is_format(vm_obj const & o) {
 }
 
 format const & to_format(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_format*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_format*>(to_external(o)));
     return static_cast<vm_format*>(to_external(o))->m_val;
 }
 
@@ -125,8 +124,7 @@ struct vm_format_thunk : public vm_external {
 };
 
 std::function<format()> const & to_format_thunk(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_format_thunk*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_format_thunk*>(to_external(o)));
     return static_cast<vm_format_thunk*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_level.cpp
+++ b/src/library/vm/vm_level.cpp
@@ -12,7 +12,6 @@ Author: Leonardo de Moura
 #include "library/vm/vm_name.h"
 #include "library/vm/vm_format.h"
 #include "library/vm/vm_options.h"
-#include "library/vm/vm_list.h"
 
 namespace lean {
 struct vm_level : public vm_external {
@@ -29,8 +28,7 @@ bool is_level(vm_obj const & o) {
 }
 
 level const & to_level(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_level*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_level*>(to_external(o)));
     return static_cast<vm_level*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_list.cpp
+++ b/src/library/vm/vm_list.cpp
@@ -45,8 +45,7 @@ list<A> to_list_ ## A(vm_obj const & o) {                               \
     } else if (is_constructor(o)) {                                     \
         return list<A>(ToA(cfield(o, 0)), to_list_ ## A(cfield(o, 1))); \
     } else {                                                            \
-        lean_assert(is_external(o));                                    \
-        lean_assert(dynamic_cast<vm_list<A>*>(to_external(o)));         \
+        lean_vm_check(dynamic_cast<vm_list<A>*>(to_external(o)));       \
         return static_cast<vm_list<A>*>(to_external(o))->m_val;         \
     }                                                                   \
 }
@@ -63,8 +62,7 @@ void to_buffer_ ## A(vm_obj const & o, buffer<A> & r) {                 \
         r.push_back(ToA(cfield(o, 0)));                                 \
         to_buffer_ ## A(cfield(o, 1), r);                               \
     } else {                                                            \
-        lean_assert(is_external(o));                                    \
-        lean_assert(dynamic_cast<vm_list<A>*>(to_external(o)));         \
+        lean_vm_check(dynamic_cast<vm_list<A>*>(to_external(o)));       \
         to_buffer(static_cast<vm_list<A>*>(to_external(o))->m_val, r);  \
     }                                                                   \
 }
@@ -91,7 +89,6 @@ unsigned list_cases_on(vm_obj const & o, buffer<vm_obj> & data) {
         data.append(csize(o), cfields(o));
         return 1;
     } else {
-        lean_assert(is_external(o));
         if (auto l = dynamic_cast<vm_list<name>*>(to_external(o))) {
             return list_cases_on_core(l->m_val, data);
         } else if (auto l = dynamic_cast<vm_list<expr>*>(to_external(o))) {

--- a/src/library/vm/vm_name.cpp
+++ b/src/library/vm/vm_name.cpp
@@ -28,8 +28,7 @@ bool is_name(vm_obj const & o) {
 }
 
 name const & to_name(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_name*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_name *>(to_external(o)));
     return static_cast<vm_name*>(to_external(o))->m_val;
 }
 

--- a/src/library/vm/vm_options.cpp
+++ b/src/library/vm/vm_options.cpp
@@ -21,14 +21,13 @@ struct vm_options : public vm_external {
     virtual vm_external * clone(vm_clone_fn const &) override { return new (get_vm_allocator().allocate(sizeof(vm_options))) vm_options(m_val); }
 };
 
-options const & to_options(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_options*>(to_external(o)));
-    return static_cast<vm_options*>(to_external(o))->m_val;
-}
-
 bool is_options(vm_obj const & o) {
     return is_external(o) && dynamic_cast<vm_options*>(to_external(o));
+}
+
+options const & to_options(vm_obj const & o) {
+    lean_vm_check(dynamic_cast<vm_options*>(to_external(o)));
+    return static_cast<vm_options*>(to_external(o))->m_val;
 }
 
 vm_obj to_obj(options const & n) {

--- a/src/library/vm/vm_rb_map.cpp
+++ b/src/library/vm/vm_rb_map.cpp
@@ -73,8 +73,7 @@ vm_external * vm_rb_map_ts_copy::clone(vm_clone_fn const & fn) {
 }
 
 vm_obj_map const & to_map(vm_obj const & o) {
-    lean_assert(is_external(o));
-    lean_assert(dynamic_cast<vm_rb_map*>(to_external(o)));
+    lean_vm_check(dynamic_cast<vm_rb_map*>(to_external(o)));
     return static_cast<vm_rb_map*>(to_external(o))->m_map;
 }
 

--- a/src/library/vm/vm_task.cpp
+++ b/src/library/vm/vm_task.cpp
@@ -68,7 +68,7 @@ bool is_task(vm_obj const & o) {
 }
 
 task_result<ts_vm_obj> const & to_task(vm_obj const & o) {
-    lean_assert(is_task(o));
+    lean_vm_check(dynamic_cast<vm_task *>(to_external(o)));
     return static_cast<vm_task*>(to_external(o))->m_val;
 }
 


### PR DESCRIPTION
With bounds checks enabled, ~the changes in this PR improve the VM performance between 5% and 20%~, as measured on these benchmarks: https://gist.github.com/gebner/f2377acc1810ed2b56be851432039ccf

Even in the worst case, the bounds checks are now only 3% slower.

Summary of the benchmarks:
```
==> without_checks.txt <==  (ignore this one, benchmarking mistake)
list_rev_bench 1200: 2.35025 secs
lpo_bench 10000: 1.91253 secs
struct_perm_bench 10000000: 3.11673 secs

==> without_checks_new.txt <==
list_rev_bench 1200: 2.02882 secs
lpo_bench 10000: 1.58234 secs
struct_perm_bench 10000000: 2.91412 secs

==> with_checks.txt <==
list_rev_bench 1200: 2.09339 secs
lpo_bench 10000: 1.58201 secs
struct_perm_bench 10000000: 2.99373 secs
```