### PR TITLE
fix(kernel/type_checker): disable expression caching in asynchronous proof checking

### DIFF
--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -760,6 +760,7 @@ public:
     }
 
     expr execute() override {
+        scoped_expr_caching disable(false);
         bool memoize = true;
         bool trusted_only = m_decl.is_trusted();
         type_checker checker(m_env, memoize, trusted_only);


### PR DESCRIPTION
This fixes the performance problem I had with the example I posted on slack.

I noticed that we actually never use expression caching, at least with `-j0`: we disable caching in the parser and everything inherits that flag.  (There are tons of other places where we disable it, but none where we enable it.)  @leodemoura Should we just disable expression caching by default?