### PR TITLE
Extend mk_pattern and match_pattern_core to also output matched universe levels

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -83,8 +83,9 @@ meta def expr.abstract : expr → expr → expr
 | e (expr.local_const n m bi t) := e^.abstract_local n
 | e _                           := e
 
-meta constant expr.instantiate_var  : expr → expr → expr
-meta constant expr.instantiate_vars : expr → list expr → expr
+meta constant expr.instantiate_univ_params : expr → list (name × level) → expr
+meta constant expr.instantiate_var         : expr → expr → expr
+meta constant expr.instantiate_vars        : expr → list expr → expr
 
 meta constant expr.has_var       : expr → bool
 meta constant expr.has_var_idx   : expr → nat → bool

--- a/library/init/meta/match_tactic.lean
+++ b/library/init/meta/match_tactic.lean
@@ -10,29 +10,32 @@ namespace tactic
 meta structure pattern :=
 /- Term to match. -/
 (target : expr)
+/- Set of universes that is instantiated for each successful match. -/
+(uoutput : list level)
 /- Set of terms that is instantiated for each successful match. -/
-(output : list expr)
+(moutput : list expr)
 /- Number of (temporary) universe meta-variables in this pattern. -/
 (nuvars : nat)
 /- Number of (temporary) meta-variables in this pattern. -/
 (nmvars : nat)
 
-/- (mk_pattern ls es t o) creates a new pattern with (length ls) universe meta-variables and (length es) meta-variables.
+/- (mk_pattern ls es t u o) creates a new pattern with (length ls) universe meta-variables and (length es) meta-variables.
    In the produced pattern p, we have that
    - (pattern.target p) is the term t where the universes ls and expressions es have been replaced with temporary meta-variables.
-   - (pattern.output p) is the list o where the universes ls and expressions es have been replaced with temporary meta-variables.
+   - (pattern.uoutput p) is the list u where the universes ls have been replaced with temporary meta-variables.
+   - (pattern.moutput p) is the list o where the universes ls and expressions es have been replaced with temporary meta-variables.
    - (pattern.nuvars p) = length ls
    - (pattern.nmvars p) = length es
 
    The tactic fails if o and the types of es do not contain all universes ls and expressions es. -/
-meta constant mk_pattern : list level → list expr → expr → list expr → tactic pattern
+meta constant mk_pattern : list level → list expr → expr → list level → list expr → tactic pattern
 /- (mk_pattern_core m p e) matches (pattern.target p) and e using transparency m.
    If the matching is successful, then return the instantiation of (pattern.output p).
    The tactic fails if not all (temporary) meta-variables are assigned. -/
-meta constant match_pattern_core : transparency → pattern → expr → tactic (list expr)
+meta constant match_pattern_core : transparency → pattern → expr → tactic (list level × list expr)
 
-meta def match_pattern : pattern → expr → tactic (list expr) :=
-match_pattern_core semireducible
+meta def match_pattern (p : pattern) (e : expr) : tactic (list expr) :=
+fmap prod.snd (match_pattern_core semireducible p e)
 
 open expr
 
@@ -52,7 +55,7 @@ private meta def to_pattern_core : expr → tactic (expr × list expr)
 meta def pexpr_to_pattern (p : pexpr) : tactic pattern :=
 do e ← to_expr p,
    (new_p, xs) ← to_pattern_core e,
-   mk_pattern [] xs new_p xs
+   mk_pattern [] xs new_p [] xs
 
 /- Convert pre-term into a pattern and try to match e.
    Given p of the form (λ x_1 ... x_n, t[x_1, ..., x_n]), a successful

--- a/src/library/vm/vm.cpp
+++ b/src/library/vm/vm.cpp
@@ -102,6 +102,11 @@ vm_obj mk_vm_constructor(unsigned cidx, vm_obj const & o1, vm_obj const & o2, vm
     return mk_vm_constructor(cidx, 4, args);
 }
 
+vm_obj mk_vm_constructor(unsigned cidx, vm_obj const & o1, vm_obj const & o2, vm_obj const & o3, vm_obj const & o4, vm_obj const & o5) {
+    vm_obj args[5] = {o1, o2, o3, o4, o5};
+    return mk_vm_constructor(cidx, 5, args);
+}
+
 vm_obj mk_vm_closure(unsigned fn_idx, unsigned sz, vm_obj const * data) {
     return mk_vm_composite(vm_obj_kind::Closure, fn_idx, sz, data);
 }

--- a/src/library/vm/vm.h
+++ b/src/library/vm/vm.h
@@ -225,6 +225,7 @@ vm_obj mk_vm_constructor(unsigned cidx, vm_obj const &);
 vm_obj mk_vm_constructor(unsigned cidx, vm_obj const &, vm_obj const &);
 vm_obj mk_vm_constructor(unsigned cidx, vm_obj const &, vm_obj const &, vm_obj const &);
 vm_obj mk_vm_constructor(unsigned cidx, vm_obj const &, vm_obj const &, vm_obj const &, vm_obj const &);
+vm_obj mk_vm_constructor(unsigned cidx, vm_obj const &, vm_obj const &, vm_obj const &, vm_obj const &, vm_obj const &);
 /* TODO(Leo, Jared): delete native closures that take environment as argument */
 vm_obj mk_native_closure(environment const & env, name const & n, unsigned sz, vm_obj const * args);
 vm_obj mk_native_closure(environment const & env, name const & n, std::initializer_list<vm_obj const> args);

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -258,6 +258,18 @@ vm_obj expr_replace(vm_obj const & e, vm_obj const & fn) {
     return to_obj(r);
 }
 
+vm_obj expr_instantiate_univ_params(vm_obj const & e, vm_obj const & nls) {
+  list<name> names = to_list<name>(nls, [](vm_obj const & p) {
+    lean_assert(csize(p) == 2);
+    return to_name(cfield(p, 0));
+  } );
+  list<level> levels = to_list<level>(nls, [](vm_obj const & p) {
+    lean_assert(csize(p) == 2);
+    return to_level(cfield(p, 1));
+  } );
+  return to_obj(instantiate_univ_params(to_expr(e), names, levels));
+}
+
 vm_obj expr_instantiate_var(vm_obj const & e, vm_obj const & v) {
     return to_obj(instantiate(to_expr(e), to_expr(v)));
 }
@@ -452,6 +464,7 @@ void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "lex_lt"}),           expr_lex_lt);
     DECLARE_VM_BUILTIN(name({"expr", "fold"}),             expr_fold);
     DECLARE_VM_BUILTIN(name({"expr", "replace"}),          expr_replace);
+    DECLARE_VM_BUILTIN(name({"expr", "instantiate_univ_params"}), expr_instantiate_univ_params);
     DECLARE_VM_BUILTIN(name({"expr", "instantiate_var"}),  expr_instantiate_var);
     DECLARE_VM_BUILTIN(name({"expr", "instantiate_vars"}), expr_instantiate_vars);
     DECLARE_VM_BUILTIN(name({"expr", "abstract_local"}),   expr_abstract_local);

--- a/tests/lean/run/do_match_else.lean
+++ b/tests/lean/run/do_match_else.lean
@@ -11,8 +11,8 @@ by do
   H ← get_local `H >>= infer_type,
   (lhs, rhs) ← match_eq H,
   nat_add : expr ← mk_const `nat.add,
-  p : pattern    ← mk_pattern [] [a, b] (app2 nat_add a b) [app2 nat_add b a, a, b],
-  trace (pattern.output p),
+  p : pattern    ← mk_pattern [] [a, b] (app2 nat_add a b) [] [app2 nat_add b a, a, b],
+  trace (pattern.moutput p),
   [v₁, v₂, v₃] ← match_pattern p lhs | failed,
   trace v₁, trace v₂, trace v₃,
   constructor

--- a/tests/lean/run/match_pattern1.lean
+++ b/tests/lean/run/match_pattern1.lean
@@ -6,8 +6,8 @@ example (a b c x y : nat) (H : nat.add (nat.add x y) y = 0) : true :=
 by do
   a ← get_local `a, b ← get_local `b, c ← get_local `c,
   nat_add : expr ← mk_const `nat.add,
-  p : pattern    ← mk_pattern [] [a, b] (app_of_list nat_add [a, b]) [app_of_list nat_add [b, a], a, b],
-  trace (pattern.output p),
+  p : pattern    ← mk_pattern [] [a, b] (app_of_list nat_add [a, b]) [] [app_of_list nat_add [b, a], a, b],
+  trace (pattern.moutput p),
   H ← get_local `H >>= infer_type,
   lhs_rhs ← match_eq H,
   out     ← match_pattern p (prod.fst lhs_rhs),

--- a/tests/lean/run/match_pattern2.lean
+++ b/tests/lean/run/match_pattern2.lean
@@ -18,7 +18,7 @@ do env ← get_env,
    ls  : list level   ← return $ map level.param (declaration.univ_params d),
    (some type)        ← return $ declaration.instantiate_type_univ_params d ls | failed,
    (es, lhs, rhs)     ← pattern_telescope type [],
-   p   : pattern      ← mk_pattern ls es lhs [rhs, app_of_list (expr.const n ls) es],
+   p   : pattern      ← mk_pattern ls es lhs [] [rhs, app_of_list (expr.const n ls) es],
    return p
 
 open nat


### PR DESCRIPTION
This extends `tactic.mk_pattern` and `tactic.match_pattern_core` to also output matched universe levels. And add a `expr.instantiate_univ_params` to instantiate them later on.

I did not yet adapt `match_pattern`, for my purposes `match_pattern_core` is enough. But if people need it, it can be changed. We could try to support universes in `to_pattern_core`. An option would be to create local (universe) constants for (universe) meta variables in the lambdas.

I renamed `pattern.output` to `pattern.moutput`. Should I keep it like this, or is `output` preferred.