### PR TITLE
fix(emacs/lean-input): remove overloading of \b abbreviation

### DIFF
--- a/src/emacs/lean-input.el
+++ b/src/emacs/lean-input.el
@@ -627,7 +627,7 @@ order for the change to take effect."
   ;; Musical symbols.
 
   ("note" . ,(lean-input-to-string-list "♩♪♫♬"))
-  ("b"    . ("♭"))
+  ("flat" . ("♭"))
   ("#"    . ("♯"))
 
   ;; Other punctuation and symbols.


### PR DESCRIPTION
We use `\b` for β and ♭, and I find it annoying that typing `\b` selects one of
the two in a seemingly random way.  AFAICT β is much more commonly used, so
I've renamed the abbreviation for ♭ to `\flat`.