### PR TITLE
feat(library/init/meta/vm): add decidable_eq for vm_obj_kind

### DIFF
--- a/library/init/meta/vm.lean
+++ b/library/init/meta/vm.lean
@@ -5,6 +5,7 @@ Authors: Leonardo de Moura
 -/
 prelude
 import init.meta.tactic init.data.option.basic
+import init.meta.mk_dec_eq_instance
 
 meta constant vm_obj : Type
 
@@ -13,6 +14,9 @@ inductive vm_obj_kind
 | name | level | expr | declaration
 | environment | tactic_state | format
 | options | other
+
+instance vm_obj_kind_dec_eq : decidable_eq vm_obj_kind :=
+    by tactic.mk_dec_eq_instance
 
 namespace vm_obj
 meta constant kind            : vm_obj → vm_obj_kind


### PR DESCRIPTION
This was nice to have when writing a simple vm_monitor. 