### PR TITLE
Fix equations compilers elim_match: it fails when argument is variable or inaccessible term

### DIFF
--- a/src/library/equations_compiler/elim_match.cpp
+++ b/src/library/equations_compiler/elim_match.cpp
@@ -601,7 +601,7 @@ struct elim_match_fn {
         for (equation const & eqn : P.m_equations) {
             equation new_eqn   = eqn;
             new_eqn.m_patterns = tail(eqn.m_patterns);
-            if (is_var_transition) {
+            if (is_var_transition || is_local(head(eqn.m_patterns))) {
                 new_eqn.m_subst  = add_subst(eqn.m_subst, head(eqn.m_patterns), head(P.m_var_stack));
             }
             new_eqns.push_back(new_eqn);

--- a/tests/lean/run/eqn_compiler_variable_or_inaccessible.lean
+++ b/tests/lean/run/eqn_compiler_variable_or_inaccessible.lean
@@ -1,0 +1,4 @@
+example {α : Type} {p q : α → Prop} {x : α} (h : ∀ y, p y → q y) (hx : q x) :
+  ∀ y, x = y ∨ p y → q y
+| x  (or.inr p)   := h x p
+| ._ (or.inl rfl) := hx


### PR DESCRIPTION
The `elim_match` part of the equations compiler fails when there are two equations, one where the argument is matched against a inaccessible pattern and one where the argument is matched against a variable. An example:
```
example {α : Type} {p q : α → Prop} {x : α} (h : ∀ y, p y → q y) (hx : q x) :
  ∀ y, x = y ∨ p y → q y
| x  (or.inr p)   := h x p
| ._ (or.inl rfl) := hx
```

It looks like when one inaccessible pattern is discovered, all substitutions for the all equations are thrown away. But for /true/ variables the substitution is still needed.

The change in this pull request fixes the problem, and all tests go through. Put it looks like there are not many tests for this part of the equations compiler and I'm not sure if I understand all the invariants for the `problem`s and `equation` in `elim_match`.
