### PR TITLE
perf(library/inductive_compiler): simplification with sizeof lemmas

### DIFF
--- a/library/init/core.lean
+++ b/library/init/core.lean
@@ -488,31 +488,23 @@ From now on, the inductive compiler will automatically generate sizeof instances
 -/
 
 /- Every type `α` has a default has_sizeof instance that just returns 0 for every element of `α` -/
-instance default_has_sizeof (α : Sort u) : has_sizeof α :=
-⟨λ a, nat.zero⟩
+protected def default.sizeof (α : Sort u) : α → nat
+| a := 0
 
-/- TODO(Leo): the [simp.sizeof] annotations are not really necessary.
-   What we need is a robust way of unfolding sizeof definitions. -/
-attribute [simp.sizeof]
-lemma default_has_sizeof_eq (α : Sort u) (a : α) : @sizeof α (default_has_sizeof α) a = 0 :=
-rfl
+instance default_has_sizeof (α : Sort u) : has_sizeof α :=
+⟨default.sizeof α⟩
+
+protected def nat.sizeof : nat → nat
+| n := n
 
 instance : has_sizeof nat :=
-⟨λ a, a⟩
-
-attribute [simp.sizeof]
-lemma sizeof_nat_eq (a : nat) : sizeof a = a :=
-rfl
+⟨nat.sizeof⟩
 
 protected def prod.sizeof {α : Type u} {β : Type v} [has_sizeof α] [has_sizeof β] : (prod α β) → nat
 | ⟨a, b⟩ := 1 + sizeof a + sizeof b
 
 instance (α : Type u) (β : Type v) [has_sizeof α] [has_sizeof β] : has_sizeof (prod α β) :=
 ⟨prod.sizeof⟩
-
-attribute [simp.sizeof]
-lemma sizeof_prod_eq {α : Type u} {β : Type v} [has_sizeof α] [has_sizeof β] (a : α) (b : β) : sizeof (prod.mk a b) = 1 + sizeof a + sizeof b :=
-rfl
 
 protected def sum.sizeof {α : Type u} {β : Type v} [has_sizeof α] [has_sizeof β] : (sum α β) → nat
 | (sum.inl a) := 1 + sizeof a
@@ -521,55 +513,38 @@ protected def sum.sizeof {α : Type u} {β : Type v} [has_sizeof α] [has_sizeof
 instance (α : Type u) (β : Type v) [has_sizeof α] [has_sizeof β] : has_sizeof (sum α β) :=
 ⟨sum.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_sum_eq_left {α : Type u} {β : Type v} [has_sizeof α] [has_sizeof β] (a : α) : sizeof (@sum.inl α β a) = 1 + sizeof a :=
-rfl
-
-attribute [simp.sizeof]
-lemma sizeof_sum_eq_right {α : Type u} {β : Type v} [has_sizeof α] [has_sizeof β] (b : β) : sizeof (@sum.inr α β b) = 1 + sizeof b :=
-rfl
-
 protected def sigma.sizeof {α : Type u} {β : α → Type v} [has_sizeof α] [∀ a, has_sizeof (β a)] : sigma β → nat
 | ⟨a, b⟩ := 1 + sizeof a + sizeof b
 
 instance (α : Type u) (β : α → Type v) [has_sizeof α] [∀ a, has_sizeof (β a)] : has_sizeof (sigma β) :=
 ⟨sigma.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_sigma_eq {α : Type u} {β : α → Type v} [has_sizeof α] [∀ a, has_sizeof (β a)] (a : α) (b : β a) : sizeof (@sigma.mk α β a b) = 1 + sizeof a + sizeof b :=
-rfl
+protected def unit.sizeof : unit → nat
+| u := 1
 
-instance : has_sizeof unit := ⟨λ u, 1⟩
+instance : has_sizeof unit := ⟨unit.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_unit_eq (u : unit) : sizeof u = 1 :=
-rfl
+protected def punit.sizeof : punit → nat
+| u := 1
 
-instance : has_sizeof punit := ⟨λ u, 1⟩
+instance : has_sizeof punit := ⟨punit.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_punit_eq (u : punit) : sizeof u = 1 :=
-rfl
+protected def bool.sizeof : bool → nat
+| b := 1
 
-instance : has_sizeof bool := ⟨λ u, 1⟩
+instance : has_sizeof bool := ⟨bool.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_bool_eq (b : bool) : sizeof b = 1 :=
-rfl
+protected def pos_num.sizeof : pos_num → nat
+| p := nat.of_pos_num p
 
 instance : has_sizeof pos_num :=
-⟨nat.of_pos_num⟩
+⟨pos_num.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_pos_num_eq (p : pos_num) : sizeof p = nat.of_pos_num p :=
-rfl
+protected def num.sizeof : num → nat
+| n := nat.of_num n
 
 instance : has_sizeof num :=
-⟨nat.of_num⟩
-
-attribute [simp.sizeof]
-lemma sizeof_num_eq (n : num) : sizeof n = nat.of_num n :=
-rfl
+⟨num.sizeof⟩
 
 protected def option.sizeof {α : Type u} [has_sizeof α] : option α → nat
 | none     := 1
@@ -578,14 +553,6 @@ protected def option.sizeof {α : Type u} [has_sizeof α] : option α → nat
 instance (α : Type u) [has_sizeof α] : has_sizeof (option α) :=
 ⟨option.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_option_none_eq (α : Type u) [has_sizeof α] : sizeof (@none α) = 1 :=
-rfl
-
-attribute [simp.sizeof]
-lemma sizeof_option_some_eq {α : Type u} [has_sizeof α] (a : α) : sizeof (some a) = 1 + sizeof a :=
-rfl
-
 protected def list.sizeof {α : Type u} [has_sizeof α] : list α → nat
 | list.nil        := 1
 | (list.cons a l) := 1 + sizeof a + list.sizeof l
@@ -593,15 +560,6 @@ protected def list.sizeof {α : Type u} [has_sizeof α] : list α → nat
 instance (α : Type u) [has_sizeof α] : has_sizeof (list α) :=
 ⟨list.sizeof⟩
 
-attribute [simp.sizeof]
-lemma sizeof_list_nil_eq (α : Type u) [has_sizeof α] : sizeof (@list.nil α) = 1 :=
-rfl
-
-attribute [simp.sizeof]
-lemma sizeof_list_cons_eq {α : Type u} [has_sizeof α] (a : α) (l : list α) : sizeof (list.cons a l) = 1 + sizeof a + sizeof l :=
-rfl
-
-attribute [simp.sizeof]
 lemma nat_add_zero (n : nat) : n + 0 = n := rfl
 
 /- Combinator calculus -/

--- a/src/library/constructions/has_sizeof.h
+++ b/src/library/constructions/has_sizeof.h
@@ -14,6 +14,7 @@ namespace lean {
 environment mk_has_sizeof(environment const & env, name const & ind_name);
 
 name mk_has_sizeof_name(name const & ind_name);
+name mk_sizeof_name(name const & ind_name);
 name mk_sizeof_spec_name(name const & ir_name);
 name simp_sizeof_attribute_name();
 simp_lemmas get_sizeof_simp_lemmas(environment const & env, transparency_mode m);

--- a/src/library/inductive_compiler/compiler.cpp
+++ b/src/library/inductive_compiler/compiler.cpp
@@ -19,7 +19,7 @@ Author: Daniel Selsam
 namespace lean {
 environment add_inner_inductive_declaration(environment const & env, options const & opts,
                                             name_map<implicit_infer_kind> implicit_infer_map,
-                                            ginductive_decl const & decl, bool is_trusted) {
+                                            ginductive_decl & decl, bool is_trusted) {
     lean_assert(decl.get_inds().size() == decl.get_intro_rules().size());
     if (optional<environment> new_env = add_nested_inductive_decl(env, opts, implicit_infer_map, decl, is_trusted)) {
         return register_ginductive_decl(*new_env, decl, ginductive_kind::NESTED);

--- a/src/library/inductive_compiler/compiler.h
+++ b/src/library/inductive_compiler/compiler.h
@@ -13,7 +13,7 @@ Author: Daniel Selsam
 namespace lean {
 environment add_inner_inductive_declaration(environment const & env, options const & opts,
                                             name_map<implicit_infer_kind> implicit_infer_map,
-                                            ginductive_decl const & decl, bool is_trusted);
+                                            ginductive_decl & decl, bool is_trusted);
 
 void initialize_inductive_compiler();
 void finalize_inductive_compiler();

--- a/src/library/inductive_compiler/ginductive_decl.h
+++ b/src/library/inductive_compiler/ginductive_decl.h
@@ -7,6 +7,7 @@ Author: Daniel Selsam
 #pragma once
 #include "kernel/environment.h"
 #include "kernel/find_fn.h"
+#include "library/tactic/simp_lemmas.h"
 
 namespace lean {
 
@@ -16,6 +17,8 @@ class ginductive_decl {
     buffer<expr> m_params;
     buffer<expr> m_inds;
     buffer<buffer<expr> > m_intro_rules;
+
+    optional<simp_lemmas> m_sizeof_lemmas;
 public:
     ginductive_decl() {}
     ginductive_decl(unsigned nest_depth, buffer<name> const & lp_names, buffer<expr> const & params):
@@ -23,6 +26,14 @@ public:
     ginductive_decl(unsigned nest_depth, buffer<name> const & lp_names, buffer<expr> const & params,
                     buffer<expr> const & inds, buffer<buffer<expr> > const & intro_rules):
         m_nest_depth(nest_depth), m_lp_names(lp_names), m_params(params), m_inds(inds), m_intro_rules(intro_rules) {}
+
+    void set_sizeof_lemmas(simp_lemmas const & sizeof_lemmas) {
+        lean_assert(!m_sizeof_lemmas);
+        m_sizeof_lemmas = optional<simp_lemmas>(sizeof_lemmas);
+    }
+
+    bool has_sizeof_lemmas() const { return static_cast<bool>(m_sizeof_lemmas); }
+    simp_lemmas get_sizeof_lemmas() const { return *m_sizeof_lemmas; }
 
     unsigned get_nest_depth() const { return m_nest_depth; }
     bool is_mutual() const { return m_inds.size() > 1; }

--- a/src/library/inductive_compiler/mutual.h
+++ b/src/library/inductive_compiler/mutual.h
@@ -12,7 +12,7 @@ Author: Daniel Selsam
 namespace lean {
 environment add_mutual_inductive_decl(environment const & env, options const & opts,
                                       name_map<implicit_infer_kind> const & implicit_infer_map,
-                                      ginductive_decl const & mut_decl, bool is_trusted);
+                                      ginductive_decl & mut_decl, bool is_trusted);
 
 void initialize_inductive_compiler_mutual();
 void finalize_inductive_compiler_mutual();

--- a/src/library/inductive_compiler/nested.h
+++ b/src/library/inductive_compiler/nested.h
@@ -12,7 +12,7 @@ Author: Daniel Selsam
 namespace lean {
 optional<environment> add_nested_inductive_decl(environment const & env, options const & opts,
                                                 name_map<implicit_infer_kind> const & implicit_infer_map,
-                                                ginductive_decl const & decl, bool is_trusted);
+                                                ginductive_decl & decl, bool is_trusted);
 
 void initialize_inductive_compiler_nested();
 void finalize_inductive_compiler_nested();

--- a/src/library/local_context.cpp
+++ b/src/library/local_context.cpp
@@ -187,7 +187,7 @@ local_decl const & local_context::get_local_decl(name const & n) const {
     if (local_decl const * r = m_name2local_decl.find(n))
         return *r;
     else
-        throw exception("unknow local constant");
+        throw exception(sstream() << "unknown local constant: " << n);
 }
 
 local_decl const & local_context::get_local_decl(expr const & e) const {

--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -907,6 +907,7 @@ optional<expr> simplify_core_fn::prove_by_simp(name const & rel, expr const & e)
             return some_expr(mk_true_intro());
         }
     }
+    lean_simp_trace(m_ctx, name({"simplify", "failure"}), tout() << "proof stuck at: " << r.get_new() << "\n";);
     return none_expr();
 }
 

--- a/tests/lean/1279.lean.expected.out
+++ b/tests/lean/1279.lean.expected.out
@@ -23,7 +23,7 @@ A B C : source^.Obj,
 f : source^.Hom A B,
 g : source^.Hom B C
 ⊢ source^.Obj
-1279.lean:8:10: warning: declaration 'Functor.has_sizeof_inst' uses sorry
+1279.lean:8:10: warning: declaration 'Functor.sizeof' uses sorry
 1279.lean:8:10: warning: declaration 'Functor.mk.sizeof_spec' uses sorry
 1279.lean:8:10: warning: declaration 'Functor.functoriality' uses sorry
 1279.lean:8:10: warning: declaration 'Functor.rec_on' uses sorry

--- a/tests/lean/run/converter.lean
+++ b/tests/lean/run/converter.lean
@@ -27,7 +27,7 @@ by conversion $
 
 set_option trace.app_builder true
 
-attribute [simp] sizeof_nat_eq
+@[simp] lemma sizeof_nat_eq (n : ℕ) : sizeof n = n := rfl
 
 example (a b c : nat) : (λ x, g (f x (sizeof x))) = (λ x, 0) :=
 by conversion $

--- a/tests/lean/run/mutual_inductive.lean
+++ b/tests/lean/run/mutual_inductive.lean
@@ -12,8 +12,6 @@ check @foo.rec
 check @bar.rec
 check @foo.has_sizeof_inst
 check @bar.has_sizeof_inst
-check @foo.mk.sizeof_spec
-check @bar.mk.sizeof_spec
 end X1
 
 namespace X2
@@ -30,8 +28,6 @@ check @foo.rec
 check @bar.rec
 check @foo.has_sizeof_inst
 check @bar.has_sizeof_inst
-check @foo.mk.sizeof_spec
-check @bar.mk.sizeof_spec
 end X2
 
 namespace X3
@@ -48,8 +44,6 @@ check @foo.rec
 check @bar.rec
 check @foo.has_sizeof_inst
 check @bar.has_sizeof_inst
-check @foo.mk.sizeof_spec
-check @bar.mk.sizeof_spec
 end X3
 
 namespace X4
@@ -71,9 +65,6 @@ check @rig.rec
 check @foo.has_sizeof_inst
 check @bar.has_sizeof_inst
 check @rig.has_sizeof_inst
-check @foo.mk.sizeof_spec
-check @bar.mk.sizeof_spec
-check @rig.mk.sizeof_spec
 end X4
 
 namespace X5
@@ -95,10 +86,6 @@ check @rig.rec
 check @foo.has_sizeof_inst
 check @bar.has_sizeof_inst
 check @rig.has_sizeof_inst
-check @foo.mk.sizeof_spec
-check @bar.mk.sizeof_spec
-check @rig.mk.sizeof_spec
-check @rig.put.sizeof_spec
 end X5
 
 namespace X6


### PR DESCRIPTION
This commit makes `tests/lean/run/nested_inductive.lean` 10x faster.

There were 3 performance issues:
1. `sizeof` was getting reduced in the simplifier, exposing recursors
2. the `sizeof` simp sets all had the same head symbol
3. `sizeof` simp sets were being constructed from scratch at every level of nesting

We fix as follows:
1. `sizeof` is irreducible inside the simplifier calls
2. we manually unfold `sizeof xs` to expose e.g. `list.sizeof xs` inside both the simplifier and the LHS of every `sizeof` simp rule we create. 
3. we pass the `sizeof` lemmas around the inductive compiler, accumulating the new `sizeof` lemmas as we go