### PR TITLE
RFC: Implement transfer method. Use it for int and dlist

### DIFF
--- a/library/init/algebra/group.lean
+++ b/library/init/algebra/group.lean
@@ -56,6 +56,12 @@ left_cancel_semigroup.mul_left_cancel a b c
 lemma mul_right_cancel [right_cancel_semigroup α] {a b c : α} : a * b = c * b → a = c :=
 right_cancel_semigroup.mul_right_cancel a b c
 
+lemma mul_left_cancel_iff [left_cancel_semigroup α] {a b c : α} : a * b = a * c ↔ b = c :=
+⟨mul_left_cancel, congr_arg _⟩
+
+lemma mul_right_cancel_iff [right_cancel_semigroup α] {a b c : α} : b * a = c * a ↔ b = c :=
+⟨mul_right_cancel, congr_arg _⟩
+
 @[simp] lemma one_mul [monoid α] : ∀ a : α, 1 * a = a :=
 monoid.one_mul
 
@@ -247,6 +253,8 @@ meta def multiplicative_to_additive_pairs : list (name × name) :=
    (`mul_left_inv, `add_left_neg),
    (`mul_left_cancel, `add_left_cancel),
    (`mul_right_cancel, `add_right_cancel),
+   (`mul_left_cancel_iff, `add_left_cancel_iff),
+   (`mul_right_cancel_iff, `add_right_cancel_iff),
    (`inv_mul_cancel_left, `neg_add_cancel_left),
    (`inv_mul_cancel_right, `neg_add_cancel_right),
    (`eq_inv_mul_of_mul_eq, `eq_neg_add_of_add_eq),

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Avigad
 The integers, with addition, multiplication, and subtraction.
 -/
 prelude
-import init.data.nat.lemmas init.relator
+import init.data.nat.lemmas init.meta.transfer
 open nat
 
 /- the type, coercions, and notation -/
@@ -299,132 +299,28 @@ protected lemma rel_mul : (rel_int_nat_nat ⇒ (rel_int_nat_nat ⇒ rel_int_nat_
    int is a ring
 -/
 
-/- addition -/
-
-protected lemma add_comm (a b : ℤ) : a + b = b + a :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  cases (int.left_total_rel_int_nat_nat b) with b' hb,
-  apply (int.rel_eq (int.rel_add ha hb) (int.rel_add hb ha))^.mpr,
-  simp
-end
-
-protected lemma add_zero (a : ℤ) : a + 0 = a :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_add ha int.rel_zero) ha)^.mpr,
-  simp
-end
-
-protected lemma zero_add (a : ℤ) : 0 + a = a :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_add int.rel_zero ha) ha)^.mpr,
-  simp
-end
-
-protected lemma add_assoc (a b c : ℤ) : a + b + c = a + (b + c) :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  cases (int.left_total_rel_int_nat_nat b) with b' hb,
-  cases (int.left_total_rel_int_nat_nat c) with c' hc,
-  apply (int.rel_eq (int.rel_add (int.rel_add ha hb) hc) (int.rel_add ha (int.rel_add hb hc)))^.mpr,
-  simp
-end
-
-/- negation -/
-
-protected lemma add_left_neg (a : ℤ) : -a + a = 0 :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_add (int.rel_neg ha) ha) int.rel_zero)^.mpr,
-  simp
-end
-
-/- multiplication -/
-
-protected lemma mul_comm (a b : ℤ) : a * b = b * a :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  cases (int.left_total_rel_int_nat_nat b) with b' hb,
-  apply (int.rel_eq (int.rel_mul ha hb) (int.rel_mul hb ha))^.mpr,
-  simp
-end
-
-protected lemma mul_assoc (a b c : ℤ) : a * b * c = a * (b * c) :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  cases (int.left_total_rel_int_nat_nat b) with b' hb,
-  cases (int.left_total_rel_int_nat_nat c) with c' hc,
-  apply (int.rel_eq (int.rel_mul (int.rel_mul ha hb) hc) (int.rel_mul ha (int.rel_mul hb hc)))^.mpr,
-  simp [mul_add, add_mul]
-end
-
-protected lemma mul_one (a : ℤ) : a * 1 = a :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_mul ha int.rel_one) ha)^.mpr,
-  simp
-end
-
-protected lemma one_mul (a : ℤ) : 1 * a = a :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_mul int.rel_one ha) ha)^.mpr,
-  simp
-end
-
-protected lemma mul_zero (a : ℤ) : a * 0 = 0 :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_mul ha int.rel_zero) int.rel_zero)^.mpr,
-  simp
-end
-
-protected lemma zero_mul (a : ℤ) : 0 * a = 0 :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  apply (int.rel_eq (int.rel_mul int.rel_zero ha) int.rel_zero)^.mpr,
-  simp
-end
-
-protected lemma distrib_left (a b c : ℤ) : a * (b + c) = a * b + a * c :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  cases (int.left_total_rel_int_nat_nat b) with b' hb,
-  cases (int.left_total_rel_int_nat_nat c) with c' hc,
-  apply (int.rel_eq (int.rel_mul ha (int.rel_add hb hc))
-    (int.rel_add (int.rel_mul ha hb) (int.rel_mul ha hc)))^.mpr,
-  simp [mul_add, add_mul]
-end
-
-protected lemma distrib_right (a b c : ℤ) : (a + b) * c = a * c + b * c :=
-begin
-  cases (int.left_total_rel_int_nat_nat a) with a' ha,
-  cases (int.left_total_rel_int_nat_nat b) with b' hb,
-  cases (int.left_total_rel_int_nat_nat c) with c' hc,
-  apply (int.rel_eq (int.rel_mul (int.rel_add ha hb) hc)
-    (int.rel_add (int.rel_mul ha hc) (int.rel_mul hb hc)))^.mpr,
-  simp [mul_add, add_mul]
-end
+protected meta def transfer : tactic unit := do
+  transfer.transfer [`relator.rel_forall_of_total, `relator.rel_not,
+    `int.rel_eq, `int.rel_zero, `int.rel_one,
+    `int.rel_add, `int.rel_neg, `int.rel_mul]
 
 instance : comm_ring int :=
 { add            := int.add,
-  add_assoc      := int.add_assoc,
+  add_assoc      := begin int.transfer, simp, intros, trivial end,
   zero           := int.zero,
-  zero_add       := int.zero_add,
-  add_zero       := int.add_zero,
+  zero_add       := begin int.transfer, simp, intros, trivial end,
+  add_zero       := begin int.transfer, simp, intros, trivial end,
   neg            := int.neg,
-  add_left_neg   := int.add_left_neg,
-  add_comm       := int.add_comm,
+  add_left_neg   := begin int.transfer, simp, intros, trivial end,
+  add_comm       := begin int.transfer, simp, intros, trivial end,
   mul            := int.mul,
-  mul_assoc      := int.mul_assoc,
+  mul_assoc      := begin int.transfer, simp [add_mul, mul_add], intros, trivial end,
   one            := int.one,
-  one_mul        := int.one_mul,
-  mul_one        := int.mul_one,
-  left_distrib   := int.distrib_left,
-  right_distrib  := int.distrib_right,
-  mul_comm       := int.mul_comm }
+  one_mul        := begin int.transfer, simp, intros, trivial end,
+  mul_one        := begin int.transfer, simp, intros, trivial end,
+  left_distrib   := begin int.transfer, simp [add_mul, mul_add], intros, trivial end,
+  right_distrib  := begin int.transfer, simp [add_mul, mul_add], intros, trivial end,
+  mul_comm       := begin int.transfer, simp, intros, trivial end }
 
 /- Extra instances to short-circuit type class resolution -/
 instance : has_sub int            := by apply_instance
@@ -443,7 +339,7 @@ instance : distrib int            := by apply_instance
 
 protected lemma zero_ne_one : (0 : int) ≠ 1 :=
 begin
-  apply (relator.rel_not (int.rel_eq int.rel_zero int.rel_one))^.mpr,
+  int.transfer,
   apply nat.zero_ne_one
 end
 

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -6,7 +6,7 @@ Authors: Jeremy Avigad
 The integers, with addition, multiplication, and subtraction.
 -/
 prelude
-import init.data.nat.lemmas
+import init.data.nat.lemmas init.relator
 open nat
 
 /- the type, coercions, and notation -/
@@ -57,14 +57,6 @@ match (n - m : nat) with
 | (succ k) := -[1+ k]         -- m < n, and n - m = succ k
 end
 
-private lemma sub_nat_nat_of_sub_eq_zero {m n : ℕ} (h : n - m = 0) :
-  sub_nat_nat m n = of_nat (m - n) :=
-begin unfold sub_nat_nat, rw h, unfold sub_nat_nat._match_1, reflexivity end
-
-private lemma sub_nat_nat_of_sub_eq_succ {m n k : ℕ} (h : n - m = succ k) :
-  sub_nat_nat m n = -[1+ k] :=
-begin unfold sub_nat_nat, rw h, unfold sub_nat_nat._match_1, reflexivity end
-
 protected def neg : ℤ → ℤ
 | (of_nat n) := neg_of_nat n
 | -[1+ n]    := succ n
@@ -106,30 +98,7 @@ protected lemma coe_nat_add_out (m n : ℕ) : ↑m + ↑n = (m + n : ℤ) := rfl
 protected lemma coe_nat_mul_out (m n : ℕ) : ↑m * ↑n = (↑(m * n) : ℤ) := rfl
 protected lemma coe_nat_add_one_out (n : ℕ) : ↑n + (1 : ℤ) = ↑(succ n) := rfl
 
-/- these are only for internal use -/
-
-private lemma of_nat_add_of_nat (m n : nat) : of_nat m + of_nat n = of_nat (m + n) := rfl
-private lemma of_nat_add_neg_succ_of_nat (m n : nat) :
-                of_nat m + -[1+ n] = sub_nat_nat m (succ n) := rfl
-private lemma neg_succ_of_nat_add_of_nat (m n : nat) :
-                -[1+ m] + of_nat n = sub_nat_nat n (succ m) := rfl
-private lemma neg_succ_of_nat_add_neg_succ_of_nat (m n : nat) :
-                -[1+ m] + -[1+ n] = -[1+ succ (m + n)] := rfl
-
-private lemma of_nat_mul_of_nat (m n : nat) : of_nat m * of_nat n = of_nat (m * n) := rfl
-private lemma of_nat_mul_neg_succ_of_nat (m n : nat) :
-                of_nat m * -[1+ n] = neg_of_nat (m * succ n) := rfl
-private lemma neg_succ_of_nat_of_nat (m n : nat) :
-                -[1+ m] * of_nat n = neg_of_nat (succ m * n) := rfl
-private lemma mul_neg_succ_of_nat_neg_succ_of_nat (m n : nat) :
-               -[1+ m] * -[1+ n] = of_nat (succ m * succ n) := rfl
-
-local attribute [simp] of_nat_add_of_nat of_nat_mul_of_nat neg_of_nat_zero neg_of_nat_of_succ
-  neg_neg_of_nat_succ of_nat_add_neg_succ_of_nat neg_succ_of_nat_add_of_nat
-  neg_succ_of_nat_add_neg_succ_of_nat of_nat_mul_neg_succ_of_nat neg_succ_of_nat_of_nat
-  mul_neg_succ_of_nat_neg_succ_of_nat
-
-/- some basic functions and properties -/
+/- injectivity of the constructor functions -/
 
 protected lemma of_nat_inj {m n : ℕ} (h : of_nat m = of_nat n) : m = n :=
 int.no_confusion h id
@@ -146,14 +115,58 @@ of_nat_eq_of_nat_iff m n
 lemma neg_succ_of_nat_inj {m n : ℕ} (h : neg_succ_of_nat m = neg_succ_of_nat n) : m = n :=
 int.no_confusion h id
 
+lemma neg_succ_of_nat_inj_iff {m n : ℕ} : neg_succ_of_nat m = neg_succ_of_nat n ↔ m = n :=
+⟨neg_succ_of_nat_inj, take H, by simp [H]⟩
+
 lemma neg_succ_of_nat_eq (n : ℕ) : -[1+ n] = -(n + 1) := rfl
 
-private lemma sub_nat_nat_of_ge {m n : ℕ} (h : m ≥ n) : sub_nat_nat m n = of_nat (m - n) :=
-sub_nat_nat_of_sub_eq_zero (sub_eq_zero_of_le h)
+/- basic properties of sub_nat_nat -/
 
-private lemma sub_nat_nat_of_lt {m n : ℕ} (h : m < n) : sub_nat_nat m n = -[1+ pred (n - m)] :=
-have n - m = succ (pred (n - m)), from eq.symm (succ_pred_eq_of_pos (nat.sub_pos_of_lt h)),
-by rewrite sub_nat_nat_of_sub_eq_succ this
+private lemma sub_nat_nat_elim (m n : ℕ) (P : ℕ → ℕ → ℤ → Prop)
+  (hp : ∀i n, P (n + i) n (of_nat i))
+  (hn : ∀i m, P m (m + i + 1) (-[1+ i])) :
+  P m n (sub_nat_nat m n) :=
+begin
+  assert H : ∀k, n - m = k → P m n (nat.cases_on k (of_nat (m - n)) (λa, -[1+ a])),
+  { intro k, cases k,
+    { intro e,
+      cases (nat.le.dest (nat.le_of_sub_eq_zero e)) with k h,
+      rw [h^.symm, nat.add_sub_cancel_left],
+      apply hp },
+    { intro heq,
+      assert h : m ≤ n,
+      { exact nat.le_of_lt (nat.lt_of_sub_eq_succ heq) },
+      rw [nat.sub_eq_iff_eq_add h] at heq,
+      rw [heq, add_comm],
+      apply hn } },
+  exact H _ rfl
+end
+
+private lemma sub_nat_nat_add_left {m n : ℕ} :
+  sub_nat_nat (m + n) m = of_nat n :=
+begin
+  dunfold sub_nat_nat,
+  rw [nat.sub_eq_zero_of_le],
+  dunfold sub_nat_nat._match_1,
+  rw [nat.add_sub_cancel_left],
+  apply nat.le_add_right
+end
+
+private lemma sub_nat_nat_add_right {m n : ℕ} :
+  sub_nat_nat m (m + n + 1) = neg_succ_of_nat n :=
+calc sub_nat_nat._match_1 m (m + n + 1) (m + n + 1 - m) =
+        sub_nat_nat._match_1 m (m + n + 1) (m + (n + 1) - m) : by simp
+  ... = sub_nat_nat._match_1 m (m + n + 1) (n + 1) : by rw [nat.add_sub_cancel_left]
+  ... = neg_succ_of_nat n : rfl
+
+private lemma sub_nat_nat_add_add (m n k : ℕ) : sub_nat_nat (m + k) (n + k) = sub_nat_nat m n :=
+sub_nat_nat_elim m n (λm n i, sub_nat_nat (m + k) (n + k) = i)
+  (take i n, have n + i + k = (n + k) + i, by simp,
+    begin rw [this], exact sub_nat_nat_add_left end)
+  (take i m, have m + i + 1 + k = (m + k) + i + 1, by simp,
+    begin rw [this], exact sub_nat_nat_add_right end)
+
+/- nat_abs -/
 
 def nat_abs (a : ℤ) : ℕ := int.cases_on a id succ
 
@@ -167,235 +180,233 @@ lemma nat_abs_zero : nat_abs (0 : int) = (0 : nat) := rfl
 
 lemma nat_abs_one : nat_abs (1 : int) = (1 : nat) := rfl
 
+/-- Relator between integers and pairs of natural numbers -/
+
+inductive rel_int_nat_nat : ℤ → ℕ × ℕ → Prop
+| pos : ∀{m p}, rel_int_nat_nat (of_nat p) (m + p, m)
+| neg : ∀{m n}, rel_int_nat_nat (neg_succ_of_nat n) (m, m + n + 1)
+
+protected lemma rel_sub_nat_nat {a b : ℕ} : rel_int_nat_nat (sub_nat_nat a b) (a, b) :=
+sub_nat_nat_elim a b (λa b i, rel_int_nat_nat i (a, b))
+  (take i n, rel_int_nat_nat.pos) (take i n, rel_int_nat_nat.neg)
+
+instance right_total_rel_int_nat_nat : relator.right_total rel_int_nat_nat
+| (n, m) := ⟨_, int.rel_sub_nat_nat⟩
+
+instance left_total_rel_int_nat_nat : relator.left_total rel_int_nat_nat
+| (of_nat n) := ⟨(0 + n, 0), rel_int_nat_nat.pos⟩
+| (neg_succ_of_nat n) := ⟨(0, 0 + n + 1), rel_int_nat_nat.neg⟩
+
+instance bi_total_rel_int_nat_nat : relator.bi_total rel_int_nat_nat :=
+⟨int.left_total_rel_int_nat_nat, int.right_total_rel_int_nat_nat⟩
+
+protected lemma rel_neg_of_nat {m} : ∀{n}, rel_int_nat_nat (neg_of_nat n) (m, m + n)
+| 0 := rel_int_nat_nat.pos
+| (nat.succ n) := rel_int_nat_nat.neg
+
+protected lemma rel_eq : (rel_int_nat_nat ⇒ (rel_int_nat_nat ⇒ iff))
+  eq (λa b, a^.1 + b^.2 = b^.1 + a^.2)
+| ._ ._ (@rel_int_nat_nat.pos m p) ._ ._ (@rel_int_nat_nat.pos m' p') :=
+  calc of_nat p = of_nat p'
+        ↔ (m + m') + p = (m + m') + p' : by rw [of_nat_eq_of_nat_iff, add_left_cancel_iff]
+    ... ↔ (m + p) + m' = (m' + p') + m : by simp
+| ._ ._ (@rel_int_nat_nat.pos m p) ._ ._ (@rel_int_nat_nat.neg m' n') :=
+  calc of_nat p = -[1+ n'] ↔ (m' + m) + (n' + p + 1) = (m' + m) + 0 :
+     begin rw [add_left_cancel_iff], apply iff.intro, repeat {intro, contradiction} end
+   ... ↔ (m + p) + (m' + n' + 1) = m' + m : by simp
+| ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.pos m' p') :=
+  calc -[1+ n] = of_nat p' ↔ (m + m') + 0 = (m + m') + (n + p' + 1) :
+     begin rw [add_left_cancel_iff], apply iff.intro, repeat {intro, contradiction} end
+   ... ↔ m + m' = m' + p' + (m + n + 1) : by simp
+| ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.neg m' n') :=
+  calc -[1+ n] = -[1+ n'] ↔ (m + m' + 1) + n' = (m + m' + 1) + n :
+      by rw [neg_succ_of_nat_inj_iff, add_left_cancel_iff, eq_comm]
+    ... ↔ m + (m' + n' + 1) = m' + (m + n + 1) : by simp
+
+/- should this be more general, i.e. ∀{n}, rel_int_nat_nat 0 (n, n) ? -/
+protected lemma rel_zero : rel_int_nat_nat 0 (0, 0) :=
+rel_int_nat_nat.pos
+
+protected lemma rel_one : rel_int_nat_nat 1 (1, 0) :=
+rel_int_nat_nat.pos
+
+protected lemma rel_neg : (rel_int_nat_nat ⇒ rel_int_nat_nat) neg (λa, (a.2, a.1))
+| ._ ._ (@rel_int_nat_nat.pos m p) := int.rel_neg_of_nat
+| ._ ._ (@rel_int_nat_nat.neg m n) := rel_int_nat_nat.pos
+
+protected lemma rel_add : (rel_int_nat_nat ⇒ (rel_int_nat_nat ⇒ rel_int_nat_nat))
+  add (λa b, (a.1 + b.1, a.2 + b.2))
+| ._ ._ (@rel_int_nat_nat.pos m p) ._ ._ (@rel_int_nat_nat.pos m' p') :=
+  have eq : m + p + (m' + p') = m + m' + (p + p'),
+    by simp,
+  show rel_int_nat_nat (of_nat (p + p')) (m + p + (m' + p'), m + m'),
+    begin rw [eq], apply rel_int_nat_nat.pos end
+| ._ ._ (@rel_int_nat_nat.pos m p) ._ ._ (@rel_int_nat_nat.neg m' n') :=
+  have eq1 : m + p + m' = p + (m + m'),
+    by simp,
+  have eq2 : m + (m' + n' + 1) = (n' + 1) + (m + m'),
+    by simp,
+  show rel_int_nat_nat (sub_nat_nat p (n' + 1)) (m + p + m', m + (m' + n' + 1)),
+    begin
+      rw [eq1, eq2, (sub_nat_nat_add_add _ _ (m + m'))^.symm],
+      apply int.rel_sub_nat_nat
+    end
+| ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.pos m' p') :=
+  have eq1 : m + (m' + p') = p' + (m + m'),
+    by simp,
+  have eq2 : (m + n + 1) + m' = (n + 1) + (m + m'),
+    by simp,
+  show rel_int_nat_nat (sub_nat_nat p' (n + 1)) (m + (m' + p'), (m + n + 1) + m'),
+    begin
+      rw [eq1, eq2, (sub_nat_nat_add_add _ _ (m + m'))^.symm],
+      apply int.rel_sub_nat_nat
+    end
+| ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.neg m' n') :=
+  have eq :  (m + n + 1) + (m' + n' + 1) = (m + m') + (n + n' + 1) + 1,
+    by simp,
+  show rel_int_nat_nat -[1+ (n + n' + 1)] (m + m', (m + n + 1) + (m' + n' + 1)),
+    begin rw [eq], apply rel_int_nat_nat.neg end
+
+protected lemma rel_mul : (rel_int_nat_nat ⇒ (rel_int_nat_nat ⇒ rel_int_nat_nat))
+  mul (λa b, (a.1 * b.1 + a.2 * b.2, a.1 * b.2 + a.2 * b.1))
+| ._ ._ (@rel_int_nat_nat.pos m p) ._ ._ (@rel_int_nat_nat.pos m' p') :=
+  have e : (m + p) * (m' + p') + m * m' = (m + p) * m' + m * (m' + p') + p * p',
+    by simp [mul_add, add_mul],
+  show rel_int_nat_nat (of_nat (p * p'))
+      ((m + p) * (m' + p') + m * m', (m + p) * m' + m * (m' + p')),
+    begin rw [e], exact rel_int_nat_nat.pos end
+| ._ ._ (@rel_int_nat_nat.pos m p) ._ ._ (@rel_int_nat_nat.neg m' n') :=
+  have e : (m + p) * (m' + n' + 1) + m * m' = (m + p) * m' + m * (m' + n' + 1) + (p * (n' + 1)),
+    by simp [mul_add, add_mul],
+  show rel_int_nat_nat (of_nat p * -[1+ n'])
+      ((m + p) * m' + m * (m' + n' + 1), (m + p) * (m' + n' + 1) + m * m'),
+    begin rw [e], exact int.rel_neg_of_nat end
+| ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.pos m' p') :=
+  have e : m * m' + (m + n + 1) * (m' + p') = m * (m' + p') + (m + n + 1) * m' + ((n + 1) * p'),
+    by simp [mul_add, add_mul],
+  show rel_int_nat_nat (-[1+ n] * of_nat p')
+      (m * (m' + p') + (m + n + 1) * m',  m * m' + (m + n + 1) * (m' + p')),
+    begin rw [e], exact int.rel_neg_of_nat end
+| ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.neg m' n') :=
+  have e : m * m' + (m + n + 1) * (m' + n' + 1) =
+      m * (m' + n' + 1) + (m + n + 1) * m' + ((n + 1) * (n' + 1)),
+    by simp [mul_add, add_mul],
+  show rel_int_nat_nat (-[1+ n] * -[1+ n'])
+      (m * m' + (m + n + 1) * (m' + n' + 1), m * (m' + n' + 1) + (m + n + 1) * m'),
+    begin rw [e], exact rel_int_nat_nat.pos end
+
 /-
    int is a ring
 -/
 
 /- addition -/
 
-protected lemma add_comm : ∀ a b : ℤ, a + b = b + a
-| (of_nat n) (of_nat m) := by simp
-| (of_nat n) -[1+ m]    := rfl
-| -[1+ n]    (of_nat m) := rfl
-| -[1+ n]    -[1+m]     := by simp
+protected lemma add_comm (a b : ℤ) : a + b = b + a :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  cases (int.left_total_rel_int_nat_nat b) with b' hb,
+  apply (int.rel_eq (int.rel_add ha hb) (int.rel_add hb ha))^.mpr,
+  simp
+end
 
-protected lemma add_zero : ∀ a : ℤ, a + 0 = a
-| (of_nat n) := rfl
-| -[1+ n]   := rfl
+protected lemma add_zero (a : ℤ) : a + 0 = a :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_add ha int.rel_zero) ha)^.mpr,
+  simp
+end
 
 protected lemma zero_add (a : ℤ) : 0 + a = a :=
-int.add_comm a 0 ▸ int.add_zero a
-
-private lemma sub_nat_nat_add_add (m n k : ℕ) : sub_nat_nat (m + k) (n + k) = sub_nat_nat m n :=
-or.elim (le_or_gt n m)
-  (assume h : n ≤ m,
-    have n + k ≤ m + k, from nat.add_le_add_right h k,
-    begin rw [sub_nat_nat_of_ge h, sub_nat_nat_of_ge this, nat.add_sub_add_right] end)
-  (assume h : n > m,
-    have n + k > m + k, from nat.add_lt_add_right h k,
-    by rw [sub_nat_nat_of_lt h, sub_nat_nat_of_lt this, nat.add_sub_add_right])
-
-private lemma sub_nat_nat_sub {m n : ℕ} (h : m ≥ n) (k : ℕ) :
-  sub_nat_nat (m - n) k = sub_nat_nat m (k + n) :=
-calc
-  sub_nat_nat (m - n) k = sub_nat_nat (m - n + n) (k + n) : by rewrite sub_nat_nat_add_add
-                    ... = sub_nat_nat m (k + n)           : by rewrite [nat.sub_add_cancel h]
-
-private lemma sub_nat_nat_add (m n k : ℕ) : sub_nat_nat (m + n) k = of_nat m + sub_nat_nat n k :=
 begin
-  note h := le_or_gt k n,
-  cases h with h' h',
-  { rw [sub_nat_nat_of_ge h'],
-    assert h₂ : k ≤ m + n, exact (le_trans h' (le_add_left _ _)),
-    rw [sub_nat_nat_of_ge h₂], simp,
-    rw nat.add_sub_assoc h' },
-  rw [sub_nat_nat_of_lt h'], simp, rw [succ_pred_eq_of_pos (nat.sub_pos_of_lt h')],
-  transitivity, rw [-nat.sub_add_cancel (le_of_lt h')],
-  apply sub_nat_nat_add_add
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_add int.rel_zero ha) ha)^.mpr,
+  simp
 end
 
-private lemma sub_nat_nat_add_neg_succ_of_nat (m n k : ℕ) :
-    sub_nat_nat m n + -[1+ k] = sub_nat_nat m (n + succ k) :=
+protected lemma add_assoc (a b c : ℤ) : a + b + c = a + (b + c) :=
 begin
-  note h := le_or_gt n m,
-  cases h with h' h',
-  { rw [sub_nat_nat_of_ge h'], simp, rw [sub_nat_nat_sub h', add_comm] },
-  assert h₂ : m < n + succ k, exact nat.lt_of_lt_of_le h' (le_add_right _ _),
-  assert h₃ : m ≤ n + k, exact le_of_succ_le_succ h₂,
-  rw [sub_nat_nat_of_lt h', sub_nat_nat_of_lt h₂], simp,
-  rw [-add_succ, succ_pred_eq_of_pos (nat.sub_pos_of_lt h'), add_succ, succ_sub h₃, pred_succ],
-  rw [add_comm n, nat.add_sub_assoc (le_of_lt h')]
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  cases (int.left_total_rel_int_nat_nat b) with b' hb,
+  cases (int.left_total_rel_int_nat_nat c) with c' hc,
+  apply (int.rel_eq (int.rel_add (int.rel_add ha hb) hc) (int.rel_add ha (int.rel_add hb hc)))^.mpr,
+  simp
 end
-
-private lemma add_assoc_aux1 (m n : ℕ) :
-    ∀ c : ℤ, of_nat m + of_nat n + c = of_nat m + (of_nat n + c)
-| (of_nat k) := by simp
-| -[1+ k]    := by simp [sub_nat_nat_add]
-
-private lemma add_assoc_aux2 (m n k : ℕ) :
-  -[1+ m] + -[1+ n] + of_nat k = -[1+ m] + (-[1+ n] + of_nat k) :=
-begin
-  simp [add_succ], rw [int.add_comm, sub_nat_nat_add_neg_succ_of_nat], simp [add_succ, succ_add]
-end
-
-protected lemma add_assoc : ∀ a b c : ℤ, a + b + c = a + (b + c)
-| (of_nat m) (of_nat n) c          := add_assoc_aux1 _ _ _
-| (of_nat m) b          (of_nat k) := by rw [int.add_comm, -add_assoc_aux1, int.add_comm (of_nat k),
-                                         add_assoc_aux1, int.add_comm b]
-| a          (of_nat n) (of_nat k) := by rw [int.add_comm, int.add_comm a, -add_assoc_aux1,
-                                         int.add_comm a, int.add_comm (of_nat k)]
-| -[1+ m]    -[1+ n]    (of_nat k) := add_assoc_aux2 _ _ _
-| -[1+ m]    (of_nat n) -[1+ k]    := by rw [int.add_comm, -add_assoc_aux2, int.add_comm (of_nat n),
-                                         -add_assoc_aux2, int.add_comm -[1+ m] ]
-| (of_nat m) -[1+ n]    -[1+ k]    := by rw [int.add_comm, int.add_comm (of_nat m),
-                                         int.add_comm (of_nat m), -add_assoc_aux2,
-                                         int.add_comm -[1+ k] ]
-| -[1+ m]    -[1+ n]    -[1+ k]    := by simp [add_succ, neg_of_nat_of_succ]
 
 /- negation -/
 
-private lemma sub_nat_self : ∀ n, sub_nat_nat n n = 0
-| 0        := rfl
-| (succ m) := begin rw [sub_nat_nat_of_sub_eq_zero, nat.sub_self, of_nat_zero], rw nat.sub_self end
-
-local attribute [simp] sub_nat_self
-
-protected lemma add_left_neg : ∀ a : ℤ, -a + a = 0
-| (of_nat 0)        := rfl
-| (of_nat (succ m)) := by simp
-| -[1+ m]           := by simp
+protected lemma add_left_neg (a : ℤ) : -a + a = 0 :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_add (int.rel_neg ha) ha) int.rel_zero)^.mpr,
+  simp
+end
 
 /- multiplication -/
 
-protected lemma mul_comm : ∀ a b : ℤ, a * b = b * a
-| (of_nat m) (of_nat n) := by simp
-| (of_nat m) -[1+ n]    := by simp
-| -[1+ m]    (of_nat n) := by simp
-| -[1+ m]    -[1+ n]    := by simp
+protected lemma mul_comm (a b : ℤ) : a * b = b * a :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  cases (int.left_total_rel_int_nat_nat b) with b' hb,
+  apply (int.rel_eq (int.rel_mul ha hb) (int.rel_mul hb ha))^.mpr,
+  simp
+end
 
-private lemma of_nat_mul_neg_of_nat (m : ℕ) :
-   ∀ n, of_nat m * neg_of_nat n = neg_of_nat (m * n)
-| 0        := rfl
-| (succ n) := begin unfold neg_of_nat, simp end
+protected lemma mul_assoc (a b c : ℤ) : a * b * c = a * (b * c) :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  cases (int.left_total_rel_int_nat_nat b) with b' hb,
+  cases (int.left_total_rel_int_nat_nat c) with c' hc,
+  apply (int.rel_eq (int.rel_mul (int.rel_mul ha hb) hc) (int.rel_mul ha (int.rel_mul hb hc)))^.mpr,
+  simp [mul_add, add_mul]
+end
 
-private lemma neg_of_nat_mul_of_nat (m n : ℕ) :
-    neg_of_nat m * of_nat n = neg_of_nat (m * n) :=
-begin rw int.mul_comm, simp [of_nat_mul_neg_of_nat] end
-
-private lemma neg_succ_of_nat_mul_neg_of_nat (m : ℕ) :
-  ∀ n, -[1+ m] * neg_of_nat n = of_nat (succ m * n)
-| 0        := rfl
-| (succ n) := begin unfold neg_of_nat, simp end
-
-private lemma neg_of_nat_mul_neg_succ_of_nat (m n : ℕ) :
-  neg_of_nat n * -[1+ m] = of_nat (n * succ m) :=
-begin rw int.mul_comm, simp [neg_succ_of_nat_mul_neg_of_nat] end
-
-local attribute [simp] of_nat_mul_neg_of_nat neg_of_nat_mul_of_nat
-  neg_succ_of_nat_mul_neg_of_nat neg_of_nat_mul_neg_succ_of_nat
-
-protected lemma mul_assoc : ∀ a b c : ℤ, a * b * c = a * (b * c)
-| (of_nat m) (of_nat n) (of_nat k) := by simp
-| (of_nat m) (of_nat n) -[1+ k]    := by simp
-| (of_nat m) -[1+ n]    (of_nat k) := by simp
-| (of_nat m) -[1+ n]   -[1+ k]     := by simp
-| -[1+ m]    (of_nat n) (of_nat k) := by simp
-| -[1+ m]    (of_nat n) -[1+ k]    := by simp
-| -[1+ m]    -[1+ n]    (of_nat k) := by simp
-| -[1+ m]    -[1+ n]   -[1+ k]     := by simp
-
-protected lemma mul_one : ∀ (a : ℤ), a * 1 = a
-| (of_nat m) := show of_nat m * of_nat 1 = of_nat m, by simp
-| -[1+ m]    := show -[1+ m] * of_nat 1 = -[1+ m], begin simp, reflexivity end
+protected lemma mul_one (a : ℤ) : a * 1 = a :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_mul ha int.rel_one) ha)^.mpr,
+  simp
+end
 
 protected lemma one_mul (a : ℤ) : 1 * a = a :=
-int.mul_comm a 1 ▸ int.mul_one a
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_mul int.rel_one ha) ha)^.mpr,
+  simp
+end
 
-protected lemma mul_zero : ∀ (a : ℤ), a * 0 = 0
-| (of_nat m) := begin unfold zero, reflexivity end
-| -[1+ m]    := begin unfold zero, reflexivity end
+protected lemma mul_zero (a : ℤ) : a * 0 = 0 :=
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_mul ha int.rel_zero) int.rel_zero)^.mpr,
+  simp
+end
 
 protected lemma zero_mul (a : ℤ) : 0 * a = 0 :=
-int.mul_comm a 0 ▸ int.mul_zero a
-
-private lemma neg_of_nat_eq_sub_nat_nat_zero : ∀ n, neg_of_nat n = sub_nat_nat 0 n
-| 0        := rfl
-| (succ n) := rfl
-
-private lemma of_nat_mul_sub_nat_nat (m n k : ℕ) :
-  of_nat m * sub_nat_nat n k = sub_nat_nat (m * n) (m * k) :=
 begin
-  assert h₀ : m > 0 ∨ 0 = m,
-    exact lt_or_eq_of_le (zero_le _),
-  cases h₀ with h₀ h₀,
-  { note h := nat.lt_or_ge n k,
-    cases h with h h,
-    { assert h' : m * n < m * k,
-        exact nat.mul_lt_mul_of_pos_left h h₀,
-      rw [sub_nat_nat_of_lt h, sub_nat_nat_of_lt h'],
-      simp, rw [succ_pred_eq_of_pos (nat.sub_pos_of_lt h)],
-      rw [-neg_of_nat_of_succ, nat.mul_sub_left_distrib],
-      rw [-succ_pred_eq_of_pos (nat.sub_pos_of_lt h')], reflexivity },
-    assert h' : m * k ≤ m * n,
-      exact mul_le_mul_left _ h,
-    rw [sub_nat_nat_of_ge h, sub_nat_nat_of_ge h'], simp,
-    rw [nat.mul_sub_left_distrib]
-  },
-  assert h₂ : of_nat 0 = 0, exact rfl,
-  subst h₀, simp [h₂, int.zero_mul]
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  apply (int.rel_eq (int.rel_mul int.rel_zero ha) int.rel_zero)^.mpr,
+  simp
 end
 
-private lemma neg_of_nat_add (m n : ℕ) :
-  neg_of_nat m + neg_of_nat n = neg_of_nat (m + n) :=
+protected lemma distrib_left (a b c : ℤ) : a * (b + c) = a * b + a * c :=
 begin
-  cases m,
-  {  cases n,
-    { simp, reflexivity },
-      simp, reflexivity },
-  cases n,
-  { simp, reflexivity },
-  simp [nat.succ_add], reflexivity
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  cases (int.left_total_rel_int_nat_nat b) with b' hb,
+  cases (int.left_total_rel_int_nat_nat c) with c' hc,
+  apply (int.rel_eq (int.rel_mul ha (int.rel_add hb hc))
+    (int.rel_add (int.rel_mul ha hb) (int.rel_mul ha hc)))^.mpr,
+  simp [mul_add, add_mul]
 end
-
-private lemma neg_succ_of_nat_mul_sub_nat_nat (m n k : ℕ) :
-  -[1+ m] * sub_nat_nat n k = sub_nat_nat (succ m * k) (succ m * n) :=
-begin
-  note h := nat.lt_or_ge n k,
-  cases h with h h,
-  { assert h' : succ m * n < succ m * k,
-      exact nat.mul_lt_mul_of_pos_left h (nat.succ_pos m),
-    rw [sub_nat_nat_of_lt h, sub_nat_nat_of_ge (le_of_lt h')],
-    simp [succ_pred_eq_of_pos (nat.sub_pos_of_lt h), nat.mul_sub_left_distrib]},
-  assert h' : n > k ∨ k = n,
-    exact lt_or_eq_of_le h,
-  cases h' with h' h',
-  { assert h₁ : succ m * n > succ m * k,
-      exact nat.mul_lt_mul_of_pos_left h' (nat.succ_pos m),
-    rw [sub_nat_nat_of_ge h, sub_nat_nat_of_lt h₁], simp [nat.mul_sub_left_distrib],
-    rw [nat.mul_comm k, nat.mul_comm n, -succ_pred_eq_of_pos (nat.sub_pos_of_lt h₁),
-        -neg_of_nat_of_succ],
-    reflexivity },
-  subst h', simp, reflexivity
-end
-
-local attribute [simp] of_nat_mul_sub_nat_nat neg_of_nat_add neg_succ_of_nat_mul_sub_nat_nat
-
-protected lemma distrib_left : ∀ a b c : ℤ, a * (b + c) = a * b + a * c
-| (of_nat m) (of_nat n) (of_nat k) := by simp [nat.left_distrib]
-| (of_nat m) (of_nat n) -[1+ k]    := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
-                                            rw -sub_nat_nat_add, reflexivity end
-| (of_nat m) -[1+ n]    (of_nat k) := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
-                                            rw [int.add_comm, -sub_nat_nat_add], reflexivity end
-| (of_nat m) -[1+ n]   -[1+ k]     := begin simp, rw [-nat.left_distrib, succ_add], reflexivity end
-| -[1+ m]    (of_nat n) (of_nat k) := begin simp, rw [-nat.right_distrib, mul_comm] end
-| -[1+ m]    (of_nat n) -[1+ k]    := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
-                                            rw [int.add_comm, -sub_nat_nat_add], reflexivity end
-| -[1+ m]    -[1+ n]    (of_nat k) := begin simp [neg_of_nat_eq_sub_nat_nat_zero],
-                                            rw [-sub_nat_nat_add], reflexivity end
-| -[1+ m]    -[1+ n]   -[1+ k]     := begin simp, rw [-nat.left_distrib, succ_add], reflexivity end
 
 protected lemma distrib_right (a b c : ℤ) : (a + b) * c = a * c + b * c :=
-begin rw [int.mul_comm, int.distrib_left], simp [int.mul_comm] end
+begin
+  cases (int.left_total_rel_int_nat_nat a) with a' ha,
+  cases (int.left_total_rel_int_nat_nat b) with b' hb,
+  cases (int.left_total_rel_int_nat_nat c) with c' hc,
+  apply (int.rel_eq (int.rel_mul (int.rel_add ha hb) hc)
+    (int.rel_add (int.rel_mul ha hc) (int.rel_mul hb hc)))^.mpr,
+  simp [mul_add, add_mul]
+end
 
 instance : comm_ring int :=
 { add            := int.add,
@@ -431,6 +442,9 @@ instance : ring int               := by apply_instance
 instance : distrib int            := by apply_instance
 
 protected lemma zero_ne_one : (0 : int) ≠ 1 :=
-assume h : 0 = 1, succ_ne_zero _ (int.of_nat_inj h)^.symm
+begin
+  apply (relator.rel_not (int.rel_eq int.rel_zero int.rel_one))^.mpr,
+  apply nat.zero_ne_one
+end
 
 end int

--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -93,6 +93,10 @@ def remove_nth : list α → ℕ → list α
 | (x::xs) 0     := xs
 | (x::xs) (i+1) := x :: remove_nth xs i
 
+def remove_all [decidable_eq α] : list α → list α → list α
+| (x :: xs) ys := (if x ∈ ys then remove_all xs ys else x :: remove_all xs ys)
+| [] ys := []
+
 def head [inhabited α] : list α → α
 | []       := default α
 | (a :: l) := a

--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -167,6 +167,10 @@ def zip_with (f : α → β → γ) : list α → list β → list γ
 def zip : list α → list β → list (prod α β) :=
 zip_with prod.mk
 
+def unzip : list (α × β) → list α × list β
+| []            := ([], [])
+| ((a, b) :: t) := match unzip t with (al, bl) := (a::al, b::bl) end
+
 def repeat (a : α) : ℕ → list α
 | 0 := []
 | (succ n) := a :: repeat n

--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -189,6 +189,12 @@ def iota_core : ℕ → list ℕ → list ℕ
 def iota : ℕ → list ℕ :=
 λ n, iota_core n []
 
+def enum_from : ℕ → list α → list (ℕ × α)
+| n [] := nil
+| n (x :: xs) := (n, x) :: enum_from (n + 1) xs
+
+def enum : list α → list (ℕ × α) := enum_from 0
+
 def sum [has_add α] [has_zero α] : list α → α :=
 foldl add zero
 

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -668,6 +668,15 @@ theorem sub_eq_zero_of_le {n m : ℕ} (h : n ≤ m) : n - m = 0 :=
 exists.elim (nat.le.dest h)
   (take k, assume hk : n + k = m, by rw [-hk, sub_self_add])
 
+protected theorem le_of_sub_eq_zero : ∀{n m : ℕ}, n - m = 0 → n ≤ m
+| n 0 H := begin rw [nat.sub_zero] at H, simp [H] end
+| 0 (m+1) H := zero_le _
+| (n+1) (m+1) H := add_le_add_right
+  (le_of_sub_eq_zero begin simp [nat.add_sub_add_right] at H, exact H end) _
+
+protected theorem sub_eq_zero_iff_le {n m : ℕ} : n - m = 0 ↔ n ≤ m :=
+⟨nat.le_of_sub_eq_zero, nat.sub_eq_zero_of_le⟩
+
 theorem succ_sub {m n : ℕ} (h : m ≥ n) : succ m - n  = succ (m - n) :=
 exists.elim (nat.le.dest h)
   (take k, assume hk : n + k = m,
@@ -689,6 +698,14 @@ protected theorem add_sub_assoc {m k : ℕ} (h : k ≤ m) (n : ℕ) : n + m - k 
 exists.elim (nat.le.dest h)
   (take l, assume hl : k + l = m,
     by rw [-hl, nat.add_sub_cancel_left, add_comm k, -add_assoc, nat.add_sub_cancel])
+
+protected lemma sub_eq_iff_eq_add {a b c : ℕ} (ab : b ≤ a) : a - b = c ↔ a = c + b :=
+⟨take c_eq, begin rw [c_eq^.symm, nat.sub_add_cancel ab] end,
+  take a_eq, begin rw [a_eq, nat.add_sub_cancel] end⟩
+
+protected lemma lt_of_sub_eq_succ {m n l : ℕ} (H : m - n = nat.succ l) : n < m :=
+lt_of_not_ge
+  (take (H' : n ≥ m), begin simp [nat.sub_eq_zero_of_le H'] at H, contradiction end)
 
 @[simp] lemma min_zero_left (a : ℕ) : min 0 a = 0 :=
 min_eq_left (zero_le a)

--- a/library/init/data/prod.lean
+++ b/library/init/data/prod.lean
@@ -20,3 +20,11 @@ instance {α : Type u} {β : Type v} [h₁ : decidable_eq α] [h₂ : decidable_
     end
   | (is_false n₁) := is_false (assume h, prod.no_confusion h (λ e₁' e₂', absurd e₁' n₁))
   end
+
+namespace prod
+
+def {u₁ u₂ v₁ v₂} map {α₁ : Type u₁} {α₂ : Type u₂} {β₁ : Type v₁} {β₂ : Type v₂}
+  (f : α₁ → α₂) (g : β₁ → β₂) : α₁ × β₁ → α₂ × β₂
+| (a, b) := (f a, g b)
+
+end prod

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -379,6 +379,9 @@ assume h, h ▸ trivial
 lemma true_eq_false_of_false : false → (true = false) :=
 false.elim
 
+lemma eq_comm {α : Sort u} {a b : α} : a = b ↔ b = a :=
+⟨eq.symm, eq.symm⟩
+
 /- and simp rules -/
 lemma and.imp (hac : a → c) (hbd : b → d) : a ∧ b → c ∧ d :=
 assume ⟨ha, hb⟩, ⟨hac ha, hbd hb⟩

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -133,6 +133,12 @@ meta constant mk_sorry (type : expr) : expr
 /-- Checks whether e is sorry, and returns its type. -/
 meta constant is_sorry (e : expr) : option expr
 
+meta def instantiate_local (n : name) (s : expr) (e : expr) : expr :=
+instantiate_var (abstract_local e n) s
+
+meta def instantiate_locals (s : list (name × expr)) (e : expr) : expr :=
+instantiate_vars (abstract_locals e (list.reverse (list.map prod.fst s))) (list.map prod.snd s)
+
 meta def is_var : expr → bool
 | (var _) := tt
 | _       := ff

--- a/library/init/meta/match_tactic.lean
+++ b/library/init/meta/match_tactic.lean
@@ -103,4 +103,13 @@ do ctx ← local_context,
    new_p ← pexpr_to_pattern p,
    match_hypothesis_core new_p ctx
 
+meta instance : has_to_tactic_format pattern :=
+⟨λp, do
+  t ← pp p^.target,
+  mo ← pp p^.moutput,
+  uo ← pp p^.uoutput,
+  u ← pp p^.nuvars,
+  m ← pp p^.nmvars,
+  return $ to_fmt "pattern.mk (" ++ t ++ ") " ++ uo ++ " " ++ mo ++ " " ++ u ++ " " ++ m ++ "" ⟩
+
 end tactic

--- a/library/init/meta/mk_dec_eq_instance.lean
+++ b/library/init/meta/mk_dec_eq_instance.lean
@@ -125,6 +125,9 @@ do env ← get_env,
            return () },
    mk_dec_eq_instance_core
 
+meta instance binder_info.has_decidable_eq : decidable_eq binder_info :=
+by mk_dec_eq_instance
+
 end tactic
 
 /- instances of types in dependent files -/

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -804,6 +804,13 @@ return $ expr.local_const uniq_name pp_name bi type
 meta def mk_local_def (pp_name : name) (type : expr) : tactic expr :=
 mk_local' pp_name binder_info.default type
 
+meta def mk_local_pis : expr → tactic (list expr × expr)
+| (expr.pi n bi d b) := do
+  p ← mk_local' n bi d,
+  (ps, r) ← mk_local_pis (expr.instantiate_var b p),
+  return ((p :: ps), r)
+| e := return ([], e)
+
 private meta def get_pi_arity_aux : expr → tactic nat
 | (expr.pi n bi d b) :=
   do m     ← mk_fresh_name,

--- a/library/init/meta/transfer.lean
+++ b/library/init/meta/transfer.lean
@@ -1,0 +1,159 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: Johannes Hölzl (CMU)
+-/
+prelude
+import init.meta.tactic init.meta.match_tactic init.relator init.meta.mk_dec_eq_instance
+
+namespace transfer
+open tactic expr list monad
+
+-- FIXME: add trace statements
+
+private meta structure rel_data :=
+(in_type : expr)
+(out_type : expr)
+(relation : expr)
+
+meta instance has_to_tactic_format_rel_data : has_to_tactic_format rel_data :=
+⟨λr, do
+  R ← pp r^.relation,
+  α ← pp r^.in_type,
+  β ← pp r^.out_type,
+  return $ to_fmt "(" ++ R ++ ": rel (" ++ α ++ ") (" ++ β ++ "))" ⟩
+
+private meta structure rule_data :=
+(pr      : expr)
+(uparams : list name)              -- levels not in pat
+(params  : list (expr × bool))     -- fst : local constant, snd = tt → param appears in pattern
+(uargs   : list name)              -- levels not in pat
+(args    : list (expr × rel_data)) -- fst : local constant
+(pat     : pattern)                -- `R c`
+(out     : expr)                   -- right-hand side `d` of rel equation `R c d`
+
+meta instance has_to_tactic_format_rule_data : has_to_tactic_format rule_data :=
+⟨λr, do
+  pr ← pp r^.pr,
+  up ← pp r^.uparams,
+  mp ← pp r^.params,
+  ua ← pp r^.uargs,
+  ma ← pp r^.args,
+  pat ← pp r^.pat^.target,
+  out ← pp r^.out,
+  return $ to_fmt "{ ⟨" ++ pat ++ "⟩ pr: " ++ pr ++ " → " ++ out ++ ", " ++ up ++ " " ++ mp ++ " " ++ ua ++ " " ++ ma ++ " }" ⟩
+
+private meta def get_lift_fun : expr → tactic (list rel_data × expr)
+| e :=
+  do {
+    guardb (is_constant_of (get_app_fn e) `relator.lift_fun),
+    [α, β, γ, δ, R, S] ← return $ get_app_args e,
+    (ps, r) ← get_lift_fun S,
+    return (rel_data.mk α β R :: ps, r)} <|>
+  return ([], e)
+
+private meta def mark_occurences (e : expr) : list expr → list (expr × bool)
+| []       := []
+| (h :: t) := let xs := mark_occurences t in
+  (h, occurs h e || any xs (λ⟨e, oc⟩, oc && occurs h e)) :: xs
+
+private meta def analyse_rule (pr : expr) : tactic rule_data := do
+  -- FIXME(johoelzl): take care of eta contracted terms
+  t ← infer_type pr,
+  (params, app (app r f) g) ← mk_local_pis t,
+  (arg_rels, R) ← get_lift_fun r,
+  args    ← monad.for (enum arg_rels) (λ⟨n, a⟩,
+    prod.mk <$> mk_local_def (mk_simple_name ("a_" ++ to_string n)) a^.in_type <*> pure a),
+  a_vars  ← return $ fmap prod.fst args,
+  p       ← head_beta (app_of_list f a_vars),
+  p_data  ← return $ mark_occurences (app R p) params,
+  p_vars  ← return $ list.map prod.fst (list.filter (λx, ↑x.2) p_data),
+  u'      ← return $ collect_univ_params t,
+  u       ← return $ collect_univ_params (app R p),
+  pat     ← mk_pattern (fmap level.param u) (p_vars ++ a_vars) (app R p) (fmap level.param u) (p_vars ++ a_vars),
+  return $ rule_data.mk pr (list.remove_all u' u) p_data u args pat g
+
+private meta def analyse_decls : list name → tactic (list rule_data) :=
+  monad.mapm (λn, do
+    d ← get_decl n,
+    c ← return d^.univ_params^.length,
+    l ← monad.for (range c) (λ_, level.param <$> mk_fresh_name),
+    analyse_rule (const n l))
+
+private meta def split_params_args : list (expr × bool) → list expr → list (expr × option expr) × list expr
+| ((lc, tt) :: ps) (e :: es) := let (ps', es') := split_params_args ps es in ((lc, some e) :: ps', es')
+| ((lc, ff) :: ps) es        := let (ps', es') := split_params_args ps es in ((lc, none) :: ps', es')
+| _ es := ([], es)
+
+private meta def param_substitutions (ctxt : list expr) :
+  list (expr × option expr) → tactic (list (name × expr) × list expr)
+| (((local_const n _ bi t), s) :: ps) := do
+  (e, m)  ← match s with
+  | (some e) := return (e, [])
+  | none     :=
+    let ctxt' := list.filter (λv, occurs v t) ctxt in
+    let ty := pis ctxt' t in
+    if bi = binder_info.inst_implicit then do
+      guard (bi = binder_info.inst_implicit),
+      ty ← instantiate_mvars ty,
+      e ← mk_instance ty,
+      return (e, [])
+    else do
+      mv ← mk_meta_var ty,
+      return (app_of_list mv ctxt', [mv])
+  end,
+  sb ← return $ instantiate_local n e,
+  ps ← return $ fmap (prod.map sb (fmap sb)) ps,
+  (ms, vs) ← param_substitutions ps,
+  return ((n, e) :: ms, m ++ vs)
+| _ := return ([], [])
+
+/- input expression a type `R a`, it finds a type `b`, s.t. there is a proof of the type `R a b`.
+It return (`a`, pr : `R a b`) -/
+meta def compute_transfer : list rule_data → list expr → expr → tactic (expr × expr × list expr)
+| rds ctxt e := do
+  -- Select matching rule
+  (i, ps, args, ms, rd) ← first (rds^.for (λrd, do
+    (l, m)     ← match_pattern_core semireducible rd^.pat e,
+    level_map  ← monad.for rd^.uparams (λl, prod.mk l <$> mk_meta_univ),
+    inst_univ  ← return $ (λe, instantiate_univ_params e (level_map ++ zip rd^.uargs l)),
+    (ps, args) ← return $ split_params_args (list.map (prod.map inst_univ id) rd^.params) m,
+    (ps, ms)   ← param_substitutions ctxt ps, /- checks type class parameters -/
+    return (instantiate_locals ps ∘ inst_univ, ps, args, ms, rd))),
+
+  (bs, hs, mss) ← monad.for (zip rd^.args args) (λ⟨⟨_, d⟩, e⟩, do
+    -- Argument has function type
+    (args, r) ← get_lift_fun (i d^.relation),
+    ((a_vars, b_vars), (R_vars, bnds)) ← monad.for (enum args) (λ⟨n, arg⟩, do
+      a ← mk_local_def (("a" ++ to_string n) : string) arg^.in_type,
+      b ← mk_local_def (("b" ++ to_string n) : string) arg^.out_type,
+      R ← mk_local_def (("R" ++ to_string n) : string) (arg^.relation a b),
+      return ((a, b), (R, [a, b, R]))) >>= (return ∘ prod.map unzip unzip ∘ unzip),
+    rds'      ← monad.for R_vars analyse_rule,
+
+    -- Transfer argument
+    a           ← return $ i e,
+    a'          ← head_beta (app_of_list a a_vars),
+    (b, pr, ms) ← compute_transfer (rds ++ rds') (ctxt ++ a_vars) (app r a'),
+    b'          ← head_eta (lambdas b_vars b),
+    return (b', [a, b', lambdas (list.join bnds) pr], ms)) >>= (return ∘ prod.map id unzip ∘ unzip),
+
+  -- Combine
+  b  ← head_beta (app_of_list (i rd^.out) bs),
+  pr ← return $ app_of_list (i rd^.pr) (fmap prod.snd ps ++ list.join hs),
+  return (b, pr, ms ++ list.join mss)
+
+meta def transfer (ds : list name) : tactic unit := do
+  rds ← analyse_decls ds,
+  tgt ← target,
+
+  (new_tgt, pr, ms) ← compute_transfer rds [] (const `iff [] tgt),
+  new_pr ← mk_meta_var new_tgt,
+
+  /- Setup final tactic state -/
+  exact (const `iff.mpr [] tgt new_tgt pr new_pr),
+  ms ← monad.for ms (λm, (get_assignment m >> return []) <|> return [m]),
+  gs ← get_goals,
+  set_goals (list.join ms ++ new_pr :: gs)
+
+end transfer

--- a/library/init/relator.lean
+++ b/library/init/relator.lean
@@ -1,0 +1,70 @@
+/-
+Copyright (c) 2017 Johannes Hölzl. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Johannes Hölzl
+
+Relator for functions, pairs, sums, and lists.
+-/
+
+prelude
+import init.core init.data.basic
+
+namespace relator
+universe variables u₁ u₂ v₁ v₂
+
+reserve infixr ` ⇒ `:40
+
+/- TODO(johoelzl):
+ * should we introduce relators of datatypes as recursive function or as inductive
+predicate? For now we stick to the recursor approach.
+ * relation lift for datatypes, Π, Σ, set, and subtype types
+ * proof composition and identity laws
+ * implement method to derive relators from datatype
+-/
+
+section
+variables {α : Type u₁} {β : Type u₂} {γ : Type v₁} {δ : Type v₂}
+variables (R : α → β → Prop) (S : γ → δ → Prop)
+
+def lift_fun (f : α → γ) (g : β → δ) : Prop :=
+∀{a b}, R a b → S (f a) (g b)
+
+infixr ⇒ := lift_fun
+
+end
+
+section
+variables {α : Type u₁} {β : out_param (Type u₂)} (R : out_param (α → β → Prop))
+
+@[class] def right_total := ∀b, ∃a, R a b
+@[class] def left_total := ∀a, ∃b, R a b
+@[class] def bi_total := left_total R ∧ right_total R
+
+end
+
+section
+variables {α : Type u₁} {β : Type u₂} (R : α → β → Prop)
+
+@[class] def left_unique := ∀{a b c}, R a b → R c b → a = c
+@[class] def right_unique := ∀{a b c}, R a b → R a c → b = c
+
+lemma rel_forall_of_total [t : bi_total R] : ((R ⇒ iff) ⇒ iff) (λp, ∀i, p i) (λq, ∀i, q i) :=
+take p q Hrel,
+  ⟨take H b, exists.elim (t^.right b) (take a Rab, (Hrel Rab)^.mp (H _)),
+    take H a, exists.elim (t^.left a) (take b Rab, (Hrel Rab)^.mpr (H _))⟩
+
+lemma left_unique_of_rel_eq {eq' : β → β → Prop} (he : (R ⇒ (R ⇒ iff)) eq eq') : left_unique R
+| a b c (ab : R a b) (cb : R c b) :=
+have eq' b b,
+  from iff.mp (he ab ab) rfl,
+iff.mpr (he ab cb) this
+
+end
+
+lemma rel_imp : (iff ⇒ (iff  ⇒ iff)) implies implies :=
+take p q h r s l, imp_congr h l
+
+lemma rel_not : (iff ⇒ iff) not not :=
+take p q h, not_congr h
+
+end relator

--- a/library/init/relator.lean
+++ b/library/init/relator.lean
@@ -67,4 +67,7 @@ take p q h r s l, imp_congr h l
 lemma rel_not : (iff ⇒ iff) not not :=
 take p q h, not_congr h
 
+instance bi_total_eq {α : Type u₁} : relator.bi_total (@eq α) :=
+⟨take a, ⟨a, rfl⟩, take a, ⟨a, rfl⟩⟩
+
 end relator


### PR DESCRIPTION
This adds a `transfer` method to lean.

It is used to prove that `int` is a commutative ring. For this it transfers along a relation between `int` (i.e. a disjoint sum of nonnegative and negative numbers) and pairs of natural numbers. Using `transfer` the instantiation of `comm_ring int` is much shorter and nicer structured. For example: proving `add_assoc` required a case distinction on all 3 variables, this is now completely gone. Now it requires a proof for each constant (i.e. `zero`, `add`, `mul`, ...) that it is proper wrt to the relation. This turns out to be a straight forward case distinction on the function arguments.

For `dlist` it transfers along the isomorphism between `dlist` and `list`.

This currently only supports _simple_ types. It does not yet support type constructors, i.e. it can not transfer `list (dlist α)` to `list (list α)` or `list int` to `list (nat * nat)`. 