### PR TITLE
Use attribute for registering attributes

### DIFF
--- a/library/init/default.lean
+++ b/library/init/default.lean
@@ -9,8 +9,7 @@ import init.propext init.cc_lemmas init.funext init.category.combinators init.fu
 import init.util init.coe init.wf init.meta init.algebra init.data
 import init.native
 
+@[user_attribute]
 def debugger.attr : user_attribute :=
 { name  := `breakpoint,
   descr := "breakpoint for debugger" }
-
-run_cmd attribute.register `debugger.attr

--- a/library/init/meta/attribute.lean
+++ b/library/init/meta/attribute.lean
@@ -15,7 +15,8 @@ structure user_attribute :=
 
 /- Registers a new user-defined attribute. The argument must be the name of a definition of type
    `user_attribute` or a sub-structure. -/
-meta constant attribute.register : name → command
+meta def attribute.register (decl : name) : command :=
+tactic.set_basic_attribute ``user_attribute decl tt
 
 meta structure caching_user_attribute (α : Type) extends user_attribute :=
 (mk_cache     : list _root_.name → tactic α)

--- a/library/tools/super/prover_state.lean
+++ b/library/tools/super/prover_state.lean
@@ -379,9 +379,9 @@ end
 
 meta def inference := derived_clause → prover unit
 meta structure inf_decl := (prio : ℕ) (inf : inference)
+@[user_attribute]
 meta def inf_attr : user_attribute :=
 ⟨ `super.inf, "inference for the super prover" ⟩
-run_cmd attribute.register `super.inf_attr
 
 meta def seq_inferences : list inference → inference
 | [] := λgiven, return ()

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -399,11 +399,12 @@ declare_definition(parser & p, environment const & env, def_cmd_kind kind, buffe
         new_env = ensure_decl_namespaces(new_env, c_real_name);
     }
 
-    new_env = attrs.apply(new_env, p.ios(), c_real_name);
     new_env = compile_decl(p, new_env, c_name, c_real_name, pos);
     if (doc_string) {
         new_env = add_doc_string(new_env, c_real_name, *doc_string);
     }
+    // note: some attribute handlers rely on the new definition being compiled already
+    new_env = attrs.apply(new_env, p.ios(), c_real_name);
     return mk_pair(new_env, c_real_name);
 }
 

--- a/src/frontends/lean/notation_cmd.cpp
+++ b/src/frontends/lean/notation_cmd.cpp
@@ -830,7 +830,7 @@ void initialize_notation_cmd() {
     register_system_attribute(basic_attribute::with_check(
             "parsing_only", "parsing-only notation declaration",
             [](environment const &, name const &, bool) {
-                throw exception("invalid '[parsing_only]' attribute can only be used in notation declarations");
+                throw exception("invalid '[parsing_only]' attribute, can only be used in notation declarations");
             }));
 }
 void finalize_notation_cmd() {

--- a/tests/lean/caching_user_attribute.lean
+++ b/tests/lean/caching_user_attribute.lean
@@ -1,9 +1,8 @@
+@[user_attribute]
 meta def foo_attr : caching_user_attribute string :=
 { name     := `foo, descr := "bar",
   mk_cache := λ ns, return $ list.join ∘ list.map (list.append "\n" ∘ to_string) $ ns,
   dependencies := [] }
-
-run_cmd attribute.register `foo_attr
 
 attribute [foo] eq.refl eq.mp
 

--- a/tests/lean/run/eval_attr_cache.lean
+++ b/tests/lean/run/eval_attr_cache.lean
@@ -1,5 +1,6 @@
 open tactic
 meta def list_name.to_expr (n : list name) : tactic expr := to_expr (quote n)
+@[user_attribute]
 meta def my_attr : caching_user_attribute (name → bool) :=
 { name         := "my_attr",
   descr        := "my attr",
@@ -10,8 +11,6 @@ meta def my_attr : caching_user_attribute (name → bool) :=
   },
   dependencies := []
 }
-
-run_cmd attribute.register `my_attr
 
 meta def my_tac : tactic unit :=
 do f ← caching_user_attribute.get_cache my_attr,

--- a/tests/lean/user_attribute.lean
+++ b/tests/lean/user_attribute.lean
@@ -1,5 +1,5 @@
+@[user_attribute]
 definition foo_attr : user_attribute := { name := `foo, descr := "bar" }
-run_cmd attribute.register `foo_attr
 
 attribute [foo] eq.refl
 
@@ -9,9 +9,8 @@ run_cmd attribute.get_instances `foo >>= tactic.pp >>= tactic.trace
 #print "---"
 
 -- compound names
+@[user_attribute]
 definition foo_baz_attr : user_attribute := ⟨`foo.baz, "bar"⟩
-
-run_cmd attribute.register `foo_baz_attr
 
 attribute [foo.baz] eq.refl
 
@@ -20,17 +19,17 @@ attribute [foo.baz] eq.refl
 run_cmd attribute.get_instances `foo.baz >>= tactic.pp >>= tactic.trace
 
 -- can't redeclare attributes
+@[user_attribute]
 definition duplicate : user_attribute := ⟨`reducible, "bar"⟩
-run_cmd attribute.register `duplicate
 
 
 -- wrong type
+@[user_attribute]
 definition bar := "bar"
-run_cmd attribute.register `bar
 
 section
   variable x : string
 
+  @[user_attribute]
   definition baz_attr : user_attribute := ⟨`baz, x⟩
-  run_cmd attribute.register `baz_attr
 end

--- a/tests/lean/user_attribute.lean.expected.out
+++ b/tests/lean/user_attribute.lean.expected.out
@@ -7,12 +7,6 @@ eq.refl
 @[foo, foo.baz, refl]
 constructor eq.refl : ∀ {α : Sort u} (a : α), a = a
 [eq.refl]
-user_attribute.lean:24:0: error: an attribute named [reducible] has already been registered
-state:
-⊢ true
-user_attribute.lean:29:0: error: invalid attribute.register argument, must be name of a definition of type user_attribute
-state:
-⊢ true
-user_attribute.lean:35:2: error: invalid attribute.register argument, must be name of a definition of type user_attribute
-state:
-⊢ true
+user_attribute.lean:22:0: error: an attribute named [reducible] has already been registered
+user_attribute.lean:27:0: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:33:2: error: invalid [user_attribute], must be applied to definition of type user_attribute


### PR DESCRIPTION
We could do the same for `vm_monitor.register`. Any others?