### PR TITLE
fix(library/tactic/kabstract.cpp): only use replace_fn cache if repla…

### DIFF
--- a/src/library/tactic/kabstract.cpp
+++ b/src/library/tactic/kabstract.cpp
@@ -176,7 +176,7 @@ expr kabstract(type_context & ctx, expr const & e, expr const & t, occurrences c
                 }
             }
             return none_expr();
-        });
+        }, occs.is_all());
 }
 
 bool kdepends_on(type_context & ctx, expr const & e, expr const & t) {

--- a/tests/lean/run/kabstract_cache.lean
+++ b/tests/lean/run/kabstract_cache.lean
@@ -1,0 +1,7 @@
+open tactic
+
+example {α : Type} (f : α → α → α) (a b : α) (H₁ : a = b) (H₂ : f b a = a) :
+let c := a in f c c = c :=
+by do dsimp,
+      get_local `H₁ >>= rewrite_core reducible tt tt (occurrences.pos [1]) ff,
+      get_local `H₂ >>= exact


### PR DESCRIPTION
…cing all occs

