### PR TITLE
Add monad laws

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ build_script:
   - C:\msys64\usr\bin\bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/build && ninja && cpack"
 
 test_script:
-  - C:\msys64\usr\bin\bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/build && ctest -j4"
+  - C:\msys64\usr\bin\bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/build && ctest -j4 --output-on-failure"
 
 artifacts:
   - path: build\lean-3.1.1-windows.zip

--- a/.appveyor.yml.in
+++ b/.appveyor.yml.in
@@ -11,7 +11,7 @@ build_script:
   - C:\msys64\usr\bin\bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/build && ninja && cpack"
 
 test_script:
-  - C:\msys64\usr\bin\bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/build && ctest -j4"
+  - C:\msys64\usr\bin\bash -lc "exec 0</dev/null && cd $APPVEYOR_BUILD_FOLDER/build && ctest -j4 --output-on-failure"
 
 artifacts:
   - path: build\lean-@LEAN_VERSION_MAJOR@.@LEAN_VERSION_MINOR@.@LEAN_VERSION_PATCH@-windows.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,9 +112,9 @@ script:
   - cpack
   # TODO(gabriel): add smaller test subset for debug and emscripten builds
   - if [[ $CMAKE_BUILD_TYPE == Release ]]; then
-      yes "A" | ctest -j2;
+      yes "A" | ctest -j2 --output-on-failure;
     else
-      yes "A" | ctest -j2 -I 100,600,10;
+      yes "A" | ctest -j2 -I 100,600,10 --output-on-failure;
     fi
   - if [[ $PACKAGE == TRUE ]]; then make package; fi
   - cd ..

--- a/.travis.yml.in
+++ b/.travis.yml.in
@@ -112,9 +112,9 @@ script:
   - cpack
   # TODO(gabriel): add smaller test subset for debug and emscripten builds
   - if [[ $CMAKE_BUILD_TYPE == Release ]]; then
-      yes "A" | ctest -j2;
+      yes "A" | ctest -j2 --output-on-failure;
     else
-      yes "A" | ctest -j2 -I 100,600,10;
+      yes "A" | ctest -j2 -I 100,600,10 --output-on-failure;
     fi
   - if [[ $PACKAGE == TRUE ]]; then make package; fi
   - cd ..

--- a/library/init/category/applicative.lean
+++ b/library/init/category/applicative.lean
@@ -14,11 +14,31 @@ set_option auto_param.check_exists false
 class applicative (f : Type u → Type v) extends functor f :=
 (pure : Π {α : Type u}, α → f α)
 (seq  : Π {α β : Type u}, f (α → β) → f α → f β)
-(map := λ _ _ x y, seq (pure x) y)
+(infixr ` <$> `:100 := map)
+(infixl ` <*> `:60 := seq)
+(map := λ _ _ x y, pure x <*> y)
+-- ` <* `
 (seq_left : Π {α β : Type u}, f α → f β → f α := λ α β a b, seq (map (const β) a) b)
-(seq_right : Π {α β : Type u}, f α → f β → f β := λ α β a b, seq (map (const α id) a) b)
 (seq_left_eq : ∀ {α β : Type u} (a : f α) (b : f β), seq_left a b = seq (map (const β) a) b . control_laws_tac)
+-- ` *> `
+(seq_right : Π {α β : Type u}, f α → f β → f β := λ α β a b, seq (map (const α id) a) b)
 (seq_right_eq : ∀ {α β : Type u} (a : f α) (b : f β), seq_right a b = seq (map (const α id) a) b . control_laws_tac)
+-- applicative laws
+(pure_seq_eq_map : ∀ {α β : Type u} (g : α → β) (x : f α), pure g <*> x = g <$> x) -- . control_laws_tac)
+(map_pure : ∀ {α β : Type u} (g : α → β) (x : α), g <$> pure x = pure (g x))
+(seq_pure : ∀ {α β : Type u} (g : f (α → β)) (x : α),
+  g <*> pure x = (λ g : α → β, g x) <$> g)
+(seq_assoc : ∀ {α β γ : Type u} (x : f α) (g : f (α → β)) (h : f (β → γ)),
+  h <*> (g <*> x) = (@comp α β γ <$> h) <*> g <*> x)
+-- defaulted functor law
+(map_comp := λ α β γ g h x, calc
+  (h ∘ g) <$> x = pure (h ∘ g) <*> x                        : eq.symm $ pure_seq_eq_map _ _
+            ... = (comp h <$> pure g) <*> x                 : eq.rec rfl $ map_pure (comp h) g
+            ... = pure (@comp α β γ h) <*> pure g <*> x     : eq.rec rfl $ eq.symm $ pure_seq_eq_map (comp h) (pure g)
+            ... = (@comp α β γ <$> pure h) <*> pure g <*> x : eq.rec rfl $ map_pure (@comp α β γ) h
+            ... = pure h <*> (pure g <*> x)                 : eq.symm $ seq_assoc _ _ _
+            ... = h <$> (pure g <*> x)                      : pure_seq_eq_map _ _
+            ... = h <$> g <$> x                             : congr_arg _ $ pure_seq_eq_map _ _)
 end
 
 section
@@ -38,7 +58,12 @@ applicative.seq_left
 @[inline] def seq_right : f α → f β → f β :=
 applicative.seq_right
 
-infixl ` <*> `:2 := seq_app
-infixl ` <* `:2  := seq_left
-infixl ` *> `:2  := seq_right
+infixl ` <*> `:60 := seq_app
+infixl ` <* `:60  := seq_left
+infixl ` *> `:60  := seq_right
+
 end
+
+-- applicative "law" derivable from other laws
+theorem applicative.pure_id_seq {α β : Type u} {f : Type u → Type v} [applicative f] (x : f α) : pure id <*> x = x :=
+eq.trans (applicative.pure_seq_eq_map _ _) (functor.id_map _)

--- a/library/init/category/applicative.lean
+++ b/library/init/category/applicative.lean
@@ -8,12 +8,18 @@ import init.category.functor
 open function
 universes u v
 
+section
+set_option auto_param.check_exists false
+
 class applicative (f : Type u → Type v) extends functor f :=
 (pure : Π {α : Type u}, α → f α)
 (seq  : Π {α β : Type u}, f (α → β) → f α → f β)
+(map := λ _ _ x y, seq (pure x) y)
 (seq_left : Π {α β : Type u}, f α → f β → f α := λ α β a b, seq (map (const β) a) b)
 (seq_right : Π {α β : Type u}, f α → f β → f β := λ α β a b, seq (map (const α id) a) b)
-(map := λ _ _ x y, seq (pure x) y)
+(seq_left_eq : ∀ {α β : Type u} (a : f α) (b : f β), seq_left a b = seq (map (const β) a) b . control_laws_tac)
+(seq_right_eq : ∀ {α β : Type u} (a : f α) (b : f β), seq_right a b = seq (map (const α id) a) b . control_laws_tac)
+end
 
 section
 variables {f : Type u → Type v} [applicative f] {α β : Type u}

--- a/library/init/category/functor.lean
+++ b/library/init/category/functor.lean
@@ -4,13 +4,18 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Luke Nelson, Jared Roesch, Sebastian Ullrich
 -/
 prelude
-import init.core init.function
+import init.core init.function init.meta.name
 open function
 universes u v
+
+section
+set_option auto_param.check_exists false
 
 class functor (f : Type u → Type v) : Type (max u+1 v) :=
 (map : Π {α β : Type u}, (α → β) → f α → f β)
 (map_const : Π {α : Type u} (β : Type u), α → f β → f α := λ α β, map ∘ const β)
+(map_const_eq : ∀ {α β : Type u}, @map_const α β = map ∘ const β . control_laws_tac)
+end
 
 @[inline] def fmap {f : Type u → Type v} [functor f] {α β : Type u} : (α → β) → f α → f β :=
 functor.map

--- a/library/init/category/functor.lean
+++ b/library/init/category/functor.lean
@@ -13,8 +13,13 @@ set_option auto_param.check_exists false
 
 class functor (f : Type u → Type v) : Type (max u+1 v) :=
 (map : Π {α β : Type u}, (α → β) → f α → f β)
+(infixr ` <$> `:100 := map)
+-- ` <$ `
 (map_const : Π {α : Type u} (β : Type u), α → f β → f α := λ α β, map ∘ const β)
 (map_const_eq : ∀ {α β : Type u}, @map_const α β = map ∘ const β . control_laws_tac)
+-- `functor` is indeed a categorical functor
+(id_map : Π {α : Type u} (x : f α), id <$> x = x)
+(map_comp : Π {α β γ : Type u} (g : α → β) (h : β → γ) (x : f α), (h ∘ g) <$> x = h <$> g <$> x)
 end
 
 @[inline] def fmap {f : Type u → Type v} [functor f] {α β : Type u} : (α → β) → f α → f β :=

--- a/library/init/category/monad.lean
+++ b/library/init/category/monad.lean
@@ -20,9 +20,8 @@ infixl ` >>= `:2 := bind
 infixl ` >> `:2  := has_bind.and_then
 
 class monad (m : Type u → Type v) extends applicative m, has_bind m : Type (max u+1 v) :=
-(seq := λ α β f x, bind f $ λ f, bind x $ λ x, pure (f x))
--- implied by `seq`, but a bit simpler
 (map := λ α β f x, bind x $ λ x, pure (f x))
+(seq := λ α β f x, bind f $ λ f, map f x)
 
 def return {m : Type u → Type v} [monad m] {α : Type u} : α → m α :=
 pure

--- a/library/init/category/monad.lean
+++ b/library/init/category/monad.lean
@@ -7,6 +7,8 @@ prelude
 import init.category.applicative
 universes u v
 
+open function
+
 class has_bind (m : Type u → Type v) :=
 (bind : Π {α β : Type u}, m α → (α → m β) → m β)
 
@@ -16,16 +18,63 @@ has_bind.bind
 @[inline] def has_bind.and_then {α β : Type u} {m : Type u → Type v} [has_bind m] (x : m α) (y : m β) : m β :=
 do x, y
 
-infixl ` >>= `:2 := bind
-infixl ` >> `:2  := has_bind.and_then
+infixl ` >>= `:55 := bind
+infixl ` >> `:55  := has_bind.and_then
+
+section
+set_option auto_param.check_exists false
 
 class monad (m : Type u → Type v) extends applicative m, has_bind m : Type (max u+1 v) :=
-(map := λ α β f x, bind x $ λ x, pure (f x))
-(seq := λ α β f x, bind f $ λ f, map f x)
+(infixr ` <$> `:100 := map)
+(infixl ` <*> `:60 := seq)
+(infixl ` >>= `:55 := bind)
+(map := λ α β f x, x >>= pure ∘ f)
+(seq := λ α β f x, f >>= (<$> x))
+(bind_pure_comp_eq_map : ∀ {α β : Type u} (f : α → β) (x : m α), x >>= pure ∘ f = f <$> x  . control_laws_tac)
+(bind_map_eq_seq : ∀ {α β : Type u} (f : m (α → β)) (x : m α), f >>= (<$> x) = f <*> x  . control_laws_tac)
+-- monad laws
+(pure_bind : ∀ {α β : Type u} (x : α) (f : α → m β), pure x >>= f = f x)
+(bind_assoc : ∀ {α β γ : Type u} (x : m α) (f : α → m β) (g : β → m γ),
+  x >>= f >>= g = x >>= λ x, f x >>= g)
+-- all applicative laws are derivable from the monad laws + id_map
+(pure_seq_eq_map := λ α β g x, eq.trans (eq.symm $ bind_map_eq_seq _ _) (pure_bind _ _))
+(map_pure := λ α β g x, eq.trans (eq.symm $ bind_pure_comp_eq_map _ _) (pure_bind _ _))
+(seq_pure := λ α β g x, calc
+  g <*> pure x = g >>= (<$> pure x)            : eq.symm $ bind_map_eq_seq _ _
+           ... = g >>= λ g : α → β, pure (g x) : congr_arg _ $ funext $ λ g, map_pure _ _
+           ... = (λ g : α → β, g x) <$> g      : bind_pure_comp_eq_map _ _)
+(seq_assoc := λ α β γ x g h, calc
+  h <*> (g <*> x)
+      = h >>= (<$> g <*> x) : eq.symm $ bind_map_eq_seq _ _
+  ... = h >>= λ h, pure (@comp α β γ h) >>= (<$> g) >>= (<$> x) : congr_arg _ $ funext $ λ h, (calc
+    h <$> (g <*> x)
+        = g <*> x >>= pure ∘ h : eq.symm $ bind_pure_comp_eq_map _ _
+    ... = g >>= (<$> x) >>= pure ∘ h                    : eq.rec rfl $ eq.symm $ bind_map_eq_seq g x
+    ... = g >>= λ g, g <$> x >>= pure ∘ h               : bind_assoc _ _ _
+    ... = g >>= λ g, pure (h ∘ g) >>= (<$> x)        : congr_arg _ $ funext $ λ g, (calc
+      g <$> x >>= pure ∘ h
+          = x >>= pure ∘ g >>= pure ∘ h        : eq.rec rfl $ eq.symm $ bind_pure_comp_eq_map g x
+      ... = x >>= λ x, pure (g x) >>= pure ∘ h : bind_assoc _ _ _
+      ... = x >>= λ x, pure (h (g x)) : congr_arg _ $ funext $ λ x, pure_bind _ _
+      ... = (h ∘ g) <$> x : bind_pure_comp_eq_map _ _
+      ... = pure (h ∘ g) >>= (<$> x) : eq.symm $ pure_bind _ _)
+    ... = g >>= pure ∘ (@comp α β γ h) >>= (<$> x) : eq.symm $ bind_assoc _ _ _
+    ... = @comp α β γ h <$> g >>= (<$> x) : eq.rec rfl $ bind_pure_comp_eq_map (comp h) g
+    ... = pure (@comp α β γ h) >>= (<$> g) >>= (<$> x) : eq.rec rfl $ eq.symm $ pure_bind (@comp α β γ h) (<$> g))
+  ... = h >>= (λ h, pure (@comp α β γ h) >>= (<$> g)) >>= (<$> x) : eq.symm $ bind_assoc _ _ _
+  ... = h >>= pure ∘ @comp α β γ >>= (<$> g) >>= (<$> x) : eq.rec rfl $ eq.symm $ bind_assoc h (pure ∘ @comp α β γ) (<$> g)
+  ... = (@comp α β γ <$> h) >>= (<$> g) >>= (<$> x) : eq.rec rfl $ bind_pure_comp_eq_map (@comp α β γ) h
+  ... = ((@comp α β γ <$> h) >>= (<$> g)) <*> x : bind_map_eq_seq _ _
+  ... = (@comp α β γ <$> h) <*> g <*> x : eq.rec rfl $ bind_map_eq_seq (@comp α β γ <$> h) g)
+end
 
-def return {m : Type u → Type v} [monad m] {α : Type u} : α → m α :=
+@[reducible] def return {m : Type u → Type v} [monad m] {α : Type u} : α → m α :=
 pure
 
 /- Identical to has_bind.and_then, but it is not inlined. -/
 def has_bind.seq {α β : Type u} {m : Type u → Type v} [has_bind m] (x : m α) (y : m β) : m β :=
 do x, y
+
+-- monad "law" derivable from other laws
+theorem monad.bind_pure {α β : Type u} {m : Type u → Type v} [monad m] (x : m α) : x >>= pure = x :=
+eq.trans (monad.bind_pure_comp_eq_map _ _ _) (functor.id_map _)

--- a/library/init/category/state.lean
+++ b/library/init/category/state.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.logic init.category.monad init.category.alternative
+import init.meta.tactic
 universes u v
 
 def state (σ α : Type u) : Type u :=

--- a/library/init/classical.lean
+++ b/library/init/classical.lean
@@ -175,22 +175,6 @@ cases_true_false (λ x, x = false ∨ x = true)
   (or.inr rfl)
   (or.inl rfl)
   a
-
-theorem iff.to_eq {a b : Prop} (h : a ↔ b) : a = b :=
-iff.elim (assume h1 h2, propext (iff.intro h1 h2)) h
-
-theorem iff_eq_eq {a b : Prop} : (a ↔ b) = (a = b) :=
-propext (iff.intro
-  (assume h, iff.to_eq h)
-  (assume h, h^.to_iff))
-
-lemma eq_false {a : Prop} : (a = false) = (¬ a) :=
-have (a ↔ false) = (¬ a), from propext (iff_false a),
-eq.subst (@iff_eq_eq a false) this
-
-lemma eq_true {a : Prop} : (a = true) = a :=
-have (a ↔ true) = a, from propext (iff_true a),
-eq.subst (@iff_eq_eq a true) this
 end aux
 
 end classical

--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 -/
 prelude
-import init.logic init.data.nat.basic init.category.monad
+import init.logic init.data.nat.basic
 open decidable list
 
 universes u v w
@@ -224,6 +224,3 @@ join (map b a)
 @[inline] def ret {α : Type u} (a : α) : list α :=
 [a]
 end list
-
-instance : monad list :=
-{map := @list.map, pure := @list.ret, bind := @list.bind}

--- a/library/init/data/list/instances.lean
+++ b/library/init/data/list/instances.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 -/
 prelude
-import init.category.monad init.category.alternative init.data.list.basic
 import init.meta.mk_dec_eq_instance
 open list
 

--- a/library/init/data/list/instances.lean
+++ b/library/init/data/list/instances.lean
@@ -10,38 +10,39 @@ open list
 
 universes u v
 
+local attribute [simp] map join ret list.append append_nil
+
 section
 variables {α : Type u} {β : Type v} (x : α) (xs ys : list α) (f : α → list β)
 
+private lemma nil_bind : list.bind nil f = nil :=
+by simp [list.bind]
+
 private lemma cons_bind : list.bind (x :: xs) f = f x ++ list.bind xs f :=
-by dsimp [list.bind, join]; apply rfl
+by simp [list.bind]
 
 private lemma append_bind : list.bind (xs ++ ys) f = list.bind xs f ++ list.bind ys f :=
 begin
-  induction xs with x xs ih,
-  { apply rfl },
-  { simp [cons_bind, ih] },
+  induction xs,
+  { refl },
+  { simph [cons_bind] }
 end
 end
+
+local attribute [simp] nil_bind cons_bind append_bind
 
 instance : monad list :=
 {pure := @list.ret, bind := @list.bind,
  id_map := begin
    intros _ xs, induction xs with x xs ih,
-   { apply rfl },
-   { dsimp [list.bind, map, join, ret, append, list.append],
-     dsimp [list.bind, map, join, ret] at ih,
-     rw ih }
+   { refl },
+   { dsimp at ih, dsimp, simph }
  end,
- pure_bind := begin
-   intros,
-   dsimp [list.bind, ret, map, join],
-   apply append_nil
- end,
+ pure_bind := by simp_intros,
  bind_assoc := begin
-   intros _ _ _ xs _ _, induction xs with x xs ih,
-   { apply rfl },
-   { simp [cons_bind, append_bind, ih] },
+   intros _ _ _ xs _ _, induction xs,
+   { refl },
+   { simph }
  end}
 
 instance : alternative list :=

--- a/library/init/data/option/basic.lean
+++ b/library/init/data/option/basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.logic init.category
+import init.logic init.category.monad init.category.alternative
 open decidable
 
 universes u v
@@ -53,58 +53,3 @@ instance {α : Type u} [d : decidable_eq α] : decidable_eq (option α)
   | (is_false n) := is_false (λ h, option.no_confusion h (λ e, absurd e n))
   end
 
-@[inline] def option_bind {α : Type u} {β : Type v} : option α → (α → option β) → option β
-| none     b := none
-| (some a) b := b a
-
-instance : monad option :=
-{pure := @some, bind := @option_bind}
-
-def option_orelse {α : Type u} : option α → option α → option α
-| (some a) o         := some a
-| none     (some a)  := some a
-| none     none      := none
-
-instance : alternative option :=
-{ option.monad with
-  failure := @none,
-  orelse  := @option_orelse }
-
-def option_t (m : Type u → Type v) [monad m] (α : Type u) : Type v :=
-m (option α)
-
-@[inline] def option_t_bind {m : Type u → Type v} [monad m] {α β : Type u} (a : option_t m α) (b : α → option_t m β)
-                               : option_t m β :=
-show m (option β), from
-do o ← a,
-   match o with
-   | none     := return none
-   | (some a) := b a
-   end
-
-@[inline] def option_t_return {m : Type u → Type v} [monad m] {α : Type u} (a : α) : option_t m α :=
-show m (option α), from
-return (some a)
-
-instance {m : Type u → Type v} [monad m] : monad (option_t m) :=
-{pure := @option_t_return m _, bind := @option_t_bind m _}
-
-def option_t_orelse {m : Type u → Type v} [monad m] {α : Type u} (a : option_t m α) (b : option_t m α) : option_t m α :=
-show m (option α), from
-do o ← a,
-   match o with
-   | none     := b
-   | (some v) := return (some v)
-   end
-
-def option_t_fail {m : Type u → Type v} [monad m] {α : Type u} : option_t m α :=
-show m (option α), from
-return none
-
-instance {m : Type u → Type v} [monad m] : alternative (option_t m) :=
-{ option_t.monad with
-  failure := @option_t_fail m _,
-  orelse  := @option_t_orelse m _ }
-
-def option_t.lift {m : Type u → Type v} [monad m] {α : Type u} (a : m α) : option_t m α :=
-(some <$> a : m (option α))

--- a/library/init/data/option/instances.lean
+++ b/library/init/data/option/instances.lean
@@ -5,6 +5,8 @@ Authors: Leonardo de Moura
 -/
 prelude
 import .basic
+import init.meta.tactic
+
 
 universes u v
 
@@ -13,7 +15,10 @@ universes u v
 | (some a) b := b a
 
 instance : monad option :=
-{pure := @some, bind := @option_bind}
+{pure := @some, bind := @option_bind,
+ id_map := λ α x, option.rec rfl (λ x, rfl) x,
+ pure_bind := λ α β x f, rfl,
+ bind_assoc := λ α β γ x f g, option.rec rfl (λ x, rfl) x}
 
 def option_orelse {α : Type u} : option α → option α → option α
 | (some a) o         := some a
@@ -24,42 +29,3 @@ instance : alternative option :=
 { option.monad with
   failure := @none,
   orelse  := @option_orelse }
-
-def option_t (m : Type u → Type v) [monad m] (α : Type u) : Type v :=
-m (option α)
-
-@[inline] def option_t_bind {m : Type u → Type v} [monad m] {α β : Type u} (a : option_t m α) (b : α → option_t m β)
-                               : option_t m β :=
-show m (option β), from
-do o ← a,
-   match o with
-   | none     := return none
-   | (some a) := b a
-   end
-
-@[inline] def option_t_return {m : Type u → Type v} [monad m] {α : Type u} (a : α) : option_t m α :=
-show m (option α), from
-return (some a)
-
-instance {m : Type u → Type v} [monad m] : monad (option_t m) :=
-{pure := @option_t_return m _, bind := @option_t_bind m _}
-
-def option_t_orelse {m : Type u → Type v} [monad m] {α : Type u} (a : option_t m α) (b : option_t m α) : option_t m α :=
-show m (option α), from
-do o ← a,
-   match o with
-   | none     := b
-   | (some v) := return (some v)
-   end
-
-def option_t_fail {m : Type u → Type v} [monad m] {α : Type u} : option_t m α :=
-show m (option α), from
-return none
-
-instance {m : Type u → Type v} [monad m] : alternative (option_t m) :=
-{ option_t.monad with
-  failure := @option_t_fail m _,
-  orelse  := @option_t_orelse m _ }
-
-def option_t.lift {m : Type u → Type v} [monad m] {α : Type u} (a : m α) : option_t m α :=
-(some <$> a : m (option α))

--- a/library/init/data/option/instances.lean
+++ b/library/init/data/option/instances.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+prelude
+import .basic
+
+universes u v
+
+@[inline] def option_bind {α : Type u} {β : Type v} : option α → (α → option β) → option β
+| none     b := none
+| (some a) b := b a
+
+instance : monad option :=
+{pure := @some, bind := @option_bind}
+
+def option_orelse {α : Type u} : option α → option α → option α
+| (some a) o         := some a
+| none     (some a)  := some a
+| none     none      := none
+
+instance : alternative option :=
+{ option.monad with
+  failure := @none,
+  orelse  := @option_orelse }
+
+def option_t (m : Type u → Type v) [monad m] (α : Type u) : Type v :=
+m (option α)
+
+@[inline] def option_t_bind {m : Type u → Type v} [monad m] {α β : Type u} (a : option_t m α) (b : α → option_t m β)
+                               : option_t m β :=
+show m (option β), from
+do o ← a,
+   match o with
+   | none     := return none
+   | (some a) := b a
+   end
+
+@[inline] def option_t_return {m : Type u → Type v} [monad m] {α : Type u} (a : α) : option_t m α :=
+show m (option α), from
+return (some a)
+
+instance {m : Type u → Type v} [monad m] : monad (option_t m) :=
+{pure := @option_t_return m _, bind := @option_t_bind m _}
+
+def option_t_orelse {m : Type u → Type v} [monad m] {α : Type u} (a : option_t m α) (b : option_t m α) : option_t m α :=
+show m (option α), from
+do o ← a,
+   match o with
+   | none     := b
+   | (some v) := return (some v)
+   end
+
+def option_t_fail {m : Type u → Type v} [monad m] {α : Type u} : option_t m α :=
+show m (option α), from
+return none
+
+instance {m : Type u → Type v} [monad m] : alternative (option_t m) :=
+{ option_t.monad with
+  failure := @option_t_fail m _,
+  orelse  := @option_t_orelse m _ }
+
+def option_t.lift {m : Type u → Type v} [monad m] {α : Type u} (a : m α) : option_t m α :=
+(some <$> a : m (option α))

--- a/library/init/data/option_t.lean
+++ b/library/init/data/option_t.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+prelude
+import init.meta.interactive
+
+universes u v
+
+def option_t (m : Type u → Type v) [monad m] (α : Type u) : Type v :=
+m (option α)
+
+@[inline] def option_t_bind {m : Type u → Type v} [monad m] {α β : Type u} (a : option_t m α) (b : α → option_t m β)
+                               : option_t m β :=
+show m (option β), from
+do o ← a,
+   match o with
+   | none     := return none
+   | (some a) := b a
+   end
+
+@[inline] def option_t_return {m : Type u → Type v} [monad m] {α : Type u} (a : α) : option_t m α :=
+show m (option α), from
+return (some a)
+
+instance {m : Type u → Type v} [monad m] : monad (option_t m) :=
+{pure := @option_t_return m _, bind := @option_t_bind m _,
+ id_map := begin
+   intros,
+   dsimp [option_t_bind],
+   assert h : option_t_bind._match_1 option_t_return = @pure m _ (option α),
+   { apply funext, intro s, cases s, apply rfl, apply rfl },
+   { rw h, apply @monad.bind_pure _ (option α) m },
+ end,
+ pure_bind := begin
+   intros,
+   dsimp [option_t_bind, option_t_return],
+   dsimp [return, pure, bind], -- TODO: fix signature of `pure_bind`
+   rw [monad.pure_bind], apply rfl
+ end,
+ bind_assoc := begin
+   intros,
+   dsimp [option_t_bind, option_t_return, bind],
+   rw [monad.bind_assoc],
+   apply congr_arg, apply funext, intro x,
+   cases x,
+   { dsimp [option_t_bind._match_1, return, pure],
+     rw [monad.pure_bind], apply rfl },
+   { apply rfl }
+ end}
+
+def option_t_orelse {m : Type u → Type v} [monad m] {α : Type u} (a : option_t m α) (b : option_t m α) : option_t m α :=
+show m (option α), from
+do o ← a,
+   match o with
+   | none     := b
+   | (some v) := return (some v)
+   end
+
+def option_t_fail {m : Type u → Type v} [monad m] {α : Type u} : option_t m α :=
+show m (option α), from
+return none
+
+instance {m : Type u → Type v} [monad m] : alternative (option_t m) :=
+{ @option_t.monad m _ with
+  failure := @option_t_fail m _,
+  orelse  := @option_t_orelse m _ }
+
+def option_t.lift {m : Type u → Type v} [monad m] {α : Type u} (a : m α) : option_t m α :=
+(some <$> a : m (option α))

--- a/library/init/data/set.lean
+++ b/library/init/data/set.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.logic init.category.functor
+import init.meta.tactic
 
 universes u v
 def set (α : Type u) := α → Prop

--- a/library/init/data/set.lean
+++ b/library/init/data/set.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.tactic
+import init.meta.interactive
 
 universes u v
 def set (α : Type u) := α → Prop
@@ -74,6 +74,18 @@ def image (f : α → β) (s : set α) : set β :=
 {b | ∃ a, a ∈ s ∧ f a = b}
 
 instance : functor set :=
-{map := @set.image}
+{map := @set.image,
+ id_map := begin
+   intros _ s, apply funext, intro b,
+   dsimp [image, set_of],
+   exact propext ⟨λ ⟨b', ⟨_, _⟩⟩, ‹b' = b› ▸ ‹s b'›,
+                  λ _, ⟨b, ⟨‹s b›, rfl⟩⟩⟩,
+ end,
+ map_comp := begin
+   intros, apply funext, intro c,
+   dsimp [image, set_of],
+   exact propext ⟨λ ⟨a, ⟨h₁, h₂⟩⟩, ⟨g a, ⟨⟨a, ⟨h₁, rfl⟩⟩, h₂⟩⟩,
+                  λ ⟨b, ⟨⟨a, ⟨h₁, h₂⟩⟩, h₃⟩⟩, ⟨a, ⟨h₁, h₂^.symm ▸ h₃⟩⟩⟩
+ end}
 
 end set

--- a/library/init/meta/comp_value_tactics.lean
+++ b/library/init/meta/comp_value_tactics.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.tactic
+import init.meta.tactic init.data.option.instances
 
 meta constant mk_nat_val_ne_proof : expr → expr → option expr
 meta constant mk_nat_val_lt_proof : expr → expr → option expr

--- a/library/init/meta/converter.lean
+++ b/library/init/meta/converter.lean
@@ -70,7 +70,9 @@ protected meta def bind {α β : Type} (c₁ : conv α) (c₂ : α → conv β) 
 meta instance : monad conv :=
 { map  := @conv.map,
   pure := @conv.pure,
-  bind := @conv.bind }
+  bind := @conv.bind,
+  id_map := undefined, pure_bind := undefined, bind_assoc := undefined,
+  bind_pure_comp_eq_map := undefined, bind_map_eq_seq := undefined }
 
 meta instance : alternative conv :=
 { conv.monad with

--- a/library/init/meta/exceptional.lean
+++ b/library/init/meta/exceptional.lean
@@ -51,4 +51,6 @@ end exceptional
 
 meta instance : monad exceptional :=
 {pure := @exceptional.return, bind := @exceptional.bind,
- map_const_eq := undefined, seq_left_eq := undefined, seq_right_eq := undefined}
+ map_const_eq := undefined, seq_left_eq := undefined, seq_right_eq := undefined,
+ id_map := undefined, pure_bind := undefined, bind_assoc := undefined,
+ bind_pure_comp_eq_map := undefined, bind_map_eq_seq := undefined}

--- a/library/init/meta/exceptional.lean
+++ b/library/init/meta/exceptional.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.category.monad init.meta.format
+import init.category.monad init.meta.format init.util
 /-
 Remark: we use a function that produces a format object as the exception information.
 Motivation: the formatting object may be big, and we may create it on demand.
@@ -50,4 +50,5 @@ exception α (λ u, f)
 end exceptional
 
 meta instance : monad exceptional :=
-{pure := @exceptional.return, bind := @exceptional.bind}
+{pure := @exceptional.return, bind := @exceptional.bind,
+ map_const_eq := undefined, seq_left_eq := undefined, seq_right_eq := undefined}

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.level
+import init.meta.level init.category.monad
 
 structure pos :=
 (line   : nat)

--- a/library/init/meta/format.lean
+++ b/library/init/meta/format.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.options
+import init.meta.options init.function
 
 universes u v
 

--- a/library/init/meta/interaction_monad.lean
+++ b/library/init/meta/interaction_monad.lean
@@ -69,7 +69,9 @@ interaction_monad_bind t₁ (λ a, t₂)
 
 meta instance interaction_monad.monad : monad m :=
 {map := @interaction_monad_fmap, pure := @interaction_monad_return, bind := @interaction_monad_bind,
- map_const_eq := undefined, seq_left_eq := undefined, seq_right_eq := undefined}
+ map_const_eq := undefined, seq_left_eq := undefined, seq_right_eq := undefined,
+ id_map := undefined, pure_bind := undefined, bind_assoc := undefined,
+ bind_pure_comp_eq_map := undefined, bind_map_eq_seq := undefined}
 
 meta def interaction_monad.mk_exception {α : Type u} {β : Type v} [has_to_format β] (msg : β) (ref : option expr) (s : state) : result state α :=
 exception (some (λ _, to_fmt msg)) none s

--- a/library/init/meta/interaction_monad.lean
+++ b/library/init/meta/interaction_monad.lean
@@ -68,7 +68,8 @@ meta def interaction_monad_orelse {α : Type u} (t₁ t₂ : m α) : m α :=
 interaction_monad_bind t₁ (λ a, t₂)
 
 meta instance interaction_monad.monad : monad m :=
-{map := @interaction_monad_fmap, pure := @interaction_monad_return, bind := @interaction_monad_bind}
+{map := @interaction_monad_fmap, pure := @interaction_monad_return, bind := @interaction_monad_bind,
+ map_const_eq := undefined, seq_left_eq := undefined, seq_right_eq := undefined}
 
 meta def interaction_monad.mk_exception {α : Type u} {β : Type v} [has_to_format β] (msg : β) (ref : option expr) (s : state) : result state α :=
 exception (some (λ _, to_fmt msg)) none s

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -40,7 +40,7 @@ meta def without_ident_list := (tk "without" *> ident*) <|> return []
 meta def location := (tk "at" *> ident*) <|> return []
 meta def qexpr_list := list_of (qexpr 0)
 meta def opt_qexpr_list := qexpr_list <|> return []
-meta def qexpr_list_or_texpr := qexpr_list <|> return <$> texpr
+meta def qexpr_list_or_texpr := qexpr_list <|> list.ret <$> texpr
 end types
 
 /-- Use `desc` as the interactive description of `p`. -/
@@ -66,13 +66,13 @@ private meta def parser_desc_aux : expr → tactic (list format)
 | ```(ident)  := return ["id"]
 | ```(ident_) := return ["id"]
 | ```(qexpr) := return ["expr"]
-| ```(tk %%c) := return <$> to_fmt <$> eval_expr string c
+| ```(tk %%c) := list.ret <$> to_fmt <$> eval_expr string c
 | ```(cur_pos) := return []
 | ```(return ._) := return []
 | ```(._ <$> %%p) := parser_desc_aux p
 | ```(skip_info %%p) := parser_desc_aux p
 | ```(set_goal_info_pos %%p) := parser_desc_aux p
-| ```(with_desc %%desc %%p) := return <$> eval_expr format desc
+| ```(with_desc %%desc %%p) := list.ret <$> eval_expr format desc
 | ```(%%p₁ <*> %%p₂) := do
   f₁ ← parser_desc_aux p₁,
   f₂ ← parser_desc_aux p₂,
@@ -306,7 +306,7 @@ meta def rw_rules : parser rw_rules_t :=
 (tk "[" *>
  rw_rules_t.mk <$> sep_by (skip_info (tk ",")) (set_goal_info_pos $ rw_rule_p (qexpr 0))
                <*> (some <$> cur_pos <* set_goal_info_pos (tk "]")))
-<|> rw_rules_t.mk <$> (return <$> rw_rule_p texpr) <*> return none
+<|> rw_rules_t.mk <$> (list.ret <$> rw_rule_p texpr) <*> return none
 
 private meta def rw_core (m : transparency) (rs : parse rw_rules) (loc : parse location) : tactic unit :=
 match loc with

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -685,5 +685,11 @@ meta def delta : parse ident* → parse location → tactic unit
 | cs [] := do new_cs ← to_qualified_names cs, tactic.delta new_cs
 | cs hs := do new_cs ← to_qualified_names cs, delta_hyps new_cs hs
 
+meta def apply_opt_param : tactic unit :=
+tactic.apply_opt_param
+
+meta def apply_auto_param : tactic unit :=
+tactic.apply_auto_param
+
 end interactive
 end tactic

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -507,7 +507,9 @@ private meta def simp_lemmas.append_pexprs : simp_lemmas → list pexpr → tact
 private meta def mk_simp_set (attr_names : list name) (hs : list pexpr) (ex : list name) : tactic simp_lemmas :=
 do s₀ ← join_user_simp_lemmas attr_names,
    s₁ ← simp_lemmas.append_pexprs s₀ hs,
-   return $ simp_lemmas.erase s₁ ex
+   -- add equational lemmas, if any
+   ex ← ex^.mfor (λ n, list.cons n <$> get_eqn_lemmas_for tt n),
+   return $ simp_lemmas.erase s₁ $ ex^.join
 
 private meta def simp_goal (cfg : simp_config) : simp_lemmas → tactic unit
 | s := do

--- a/library/init/meta/lean/parser.lean
+++ b/library/init/meta/lean/parser.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Sebastian Ullrich
 -/
 prelude
-import init.data.option.basic init.category.monad init.category.alternative
-import init.meta.pexpr init.meta.interaction_monad
+import init.meta.tactic
 
 namespace lean
 

--- a/library/init/meta/rec_util.lean
+++ b/library/init/meta/rec_util.lean
@@ -6,7 +6,7 @@ Authors: Leonardo de Moura
 Helper tactic for showing that a type has decidable equality.
 -/
 prelude
-import init.meta.tactic
+import init.meta.tactic init.data.option.instances
 
 namespace tactic
 open expr

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura
 prelude
 import init.meta.tactic init.meta.attribute init.meta.constructor_tactic
 import init.meta.relation_tactics init.meta.occurrences init.meta.quote
+import init.data.option.instances
 
 open tactic
 

--- a/library/init/meta/smt/smt_tactic.lean
+++ b/library/init/meta/smt/smt_tactic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
+import init.category
 import init.meta.simp_tactic
 import init.meta.smt.congruence_closure
 import init.meta.smt.ematch

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -993,6 +993,12 @@ rfl
 
 meta def control_laws_tac := whnf_target >> intros >> to_expr ``(rfl) >>= exact
 
+meta def unsafe_monad_from_pure_bind {m : Type u → Type v}
+  (pure : Π {α : Type u}, α → m α)
+  (bind : Π {α β : Type u}, m α → (α → m β) → m β) : monad m :=
+{pure := @pure, bind := @bind,
+ id_map := undefined, pure_bind := undefined, bind_assoc := undefined}
+
 meta instance : monad task :=
 {map := @task.map, bind := @task.bind, pure := @task.pure,
  id_map := undefined, pure_bind := undefined, bind_assoc := undefined,

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -988,3 +988,13 @@ run_cmd do
 
 lemma id_locked_eq {α : Type u} (a : α) : id_locked α a = a :=
 rfl
+
+/- Install monad laws tactic and use it to prove some instances. -/
+
+meta def control_laws_tac := whnf_target >> intros >> to_expr ``(rfl) >>= exact
+
+meta instance : monad task :=
+{map := @task.map, bind := @task.bind, pure := @task.pure}
+
+instance : monad list :=
+{map := @list.map, pure := @list.ret, bind := @list.bind}

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -950,6 +950,17 @@ end
 meta def add_meta_definition (n : name) (lvls : list name) (type value : expr) : tactic unit :=
 add_decl (declaration.defn n lvls type value reducibility_hints.abbrev ff)
 
+meta def apply_opt_param : tactic unit :=
+do ```(opt_param %%t %%v) ← target,
+   exact v
+
+meta def apply_auto_param : tactic unit :=
+do ```(auto_param %%type %%tac_name_expr) ← target,
+   change type,
+   tac_name ← eval_expr name tac_name_expr,
+   tac ← eval_expr (tactic unit) (expr.const tac_name []),
+   tac
+
 end tactic
 
 notation [parsing_only] `command`:max := tactic unit

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -994,7 +994,6 @@ rfl
 meta def control_laws_tac := whnf_target >> intros >> to_expr ``(rfl) >>= exact
 
 meta instance : monad task :=
-{map := @task.map, bind := @task.bind, pure := @task.pure}
-
-instance : monad list :=
-{map := @list.map, pure := @list.ret, bind := @list.bind}
+{map := @task.map, bind := @task.bind, pure := @task.pure,
+ id_map := undefined, pure_bind := undefined, bind_assoc := undefined,
+ bind_pure_comp_eq_map := undefined}

--- a/library/init/meta/task.lean
+++ b/library/init/meta/task.lean
@@ -1,5 +1,5 @@
 prelude
-import init.category
+import init.logic
 
 meta constant {u} task : Type u → Type u
 
@@ -13,11 +13,8 @@ protected meta constant {u} flatten {α : Type u} : task (task α) → task α
 protected meta def {u v} bind {α : Type u} {β : Type v} (t : task α) (f : α → task β) : task β :=
 task.flatten (task.map f t)
 
-meta instance : monad task :=
-{ map := @task.map, bind := @task.bind, pure := @task.pure }
-
 @[inline]
 meta def {u} delay {α : Type u} (f : unit → α) : task α :=
-task.map f (return ())
+task.map f (task.pure ())
 
 end task

--- a/library/init/meta/transfer.lean
+++ b/library/init/meta/transfer.lean
@@ -5,6 +5,7 @@ Author: Johannes Hölzl (CMU)
 -/
 prelude
 import init.meta.tactic init.meta.match_tactic init.relator init.meta.mk_dec_eq_instance
+import init.data.list.instances
 
 namespace transfer
 open tactic expr list monad

--- a/library/init/meta/vm.lean
+++ b/library/init/meta/vm.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.tactic init.data.option.basic
+import init.meta.tactic init.data.option_t
 import init.meta.mk_dec_eq_instance
 
 meta constant vm_obj : Type
@@ -77,7 +77,9 @@ meta constant vm_core.ret {α : Type} : α → vm_core α
 meta constant vm_core.bind {α β : Type} : vm_core α → (α → vm_core β) → vm_core β
 
 meta instance : monad vm_core :=
-{map := @vm_core.map, pure := @vm_core.ret, bind := @vm_core.bind}
+{map := @vm_core.map, pure := @vm_core.ret, bind := @vm_core.bind,
+ id_map := undefined, pure_bind := undefined, bind_assoc := undefined,
+ bind_pure_comp_eq_map := undefined, bind_map_eq_seq := undefined}
 
 @[reducible] meta def vm (α : Type) : Type := option_t vm_core α
 

--- a/library/init/native/result.lean
+++ b/library/init/native/result.lean
@@ -5,7 +5,7 @@ Authors: Jared Roesch
 -/
 prelude
 
-import init.category.monad
+import init.meta.tactic
 
 namespace native
 

--- a/library/init/propext.lean
+++ b/library/init/propext.lean
@@ -25,3 +25,19 @@ propext (iff_true_intro h)
 
 lemma eq_false_intro {a : Prop} (h : ¬a) : a = false :=
 propext (iff_false_intro h)
+
+theorem iff.to_eq {a b : Prop} (h : a ↔ b) : a = b :=
+propext h
+
+theorem iff_eq_eq {a b : Prop} : (a ↔ b) = (a = b) :=
+propext (iff.intro
+  (assume h, iff.to_eq h)
+  (assume h, h^.to_iff))
+
+lemma eq_false {a : Prop} : (a = false) = (¬ a) :=
+have (a ↔ false) = (¬ a), from propext (iff_false a),
+eq.subst (@iff_eq_eq a false) this
+
+lemma eq_true {a : Prop} : (a = true) = a :=
+have (a ↔ true) = a, from propext (iff_true a),
+eq.subst (@iff_eq_eq a true) this

--- a/library/init/util.lean
+++ b/library/init/util.lean
@@ -32,6 +32,6 @@ f ()
 meta def try_for {α : Type u} (max : nat) (f : thunk α) : option α :=
 some (f ())
 
-meta constant undefined_core {α : Type u} (message : string) : α
+meta constant undefined_core {α : Sort u} (message : string) : α
 
-meta def undefined {α : Type u} : α := undefined_core "undefined"
+meta def undefined {α : Sort u} : α := undefined_core "undefined"

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -33,8 +33,7 @@ structure io.file_system (m : Type → Type → Type) :=
 
 class io.interface :=
 (m        : Type → Type → Type)
-(return   : Π e α, α → m e α)
-(bind     : Π e α β, m e α → (α → m e β) → m e β)
+(monad    : Π e, monad (m e))
 (catch    : Π e₁ e₂ α, m e₁ α → (e₁ → m e₂ α) → m e₂ α)
 (fail     : Π e α, e → m e α)
 (term     : io.terminal m)
@@ -49,15 +48,13 @@ io.interface.m e α
 io_core io.error α
 
 instance io_core_is_monad (e : Type) : monad (io_core e) :=
-{ pure := io.interface.return e,
-  bind := io.interface.bind e }
+io.interface.monad e
 
 protected def io.fail {α : Type} (s : string) : io α :=
 io.interface.fail io.error α (io.error.other s)
 
 instance : monad_fail io :=
-{ pure := io.interface.return io.error,
-  bind := io.interface.bind io.error,
+{ io_core_is_monad io.error with
   fail := @io.fail _ }
 
 namespace io

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -1540,8 +1540,11 @@ expr elaborator::visit_base_app_simple(expr const & _fn, arg_mask amask, buffer<
     type = instantiate_mvars(type_before_whnf);
 
     buffer<expr> eta_args;
-    if (optional<expr> new_type = process_optional_and_auto_params(type, ref, eta_args, new_args))
-        type = *new_type;
+    if (amask == arg_mask::Default) {
+        /* We ignore optional/auto params when `@` is used */
+        if (optional<expr> new_type = process_optional_and_auto_params(type, ref, eta_args, new_args))
+            type = *new_type;
+    }
 
     expr r = Fun(eta_args, mk_app(fn, new_args.size(), new_args.data()));
     if (expected_type) {

--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -672,7 +672,8 @@ struct structure_cmd_fn {
                 parse_field_block(binder_info());
             } else {
                 binder_info bi = m_p.parse_binder_info();
-                parse_field_block(bi);
+                if (!m_p.parse_local_notation_decl())
+                    parse_field_block(bi);
                 m_p.parse_close_binder_info(bi);
             }
         }

--- a/src/frontends/lean/structure_cmd.cpp
+++ b/src/frontends/lean/structure_cmd.cpp
@@ -846,7 +846,8 @@ struct structure_cmd_fn {
         buffer<expr> field_wo_defaults;
         for (field_decl const & decl : m_fields) field_wo_defaults.push_back(decl.local);
         r         = Pi(m_params, Pi(field_wo_defaults, r, m_p), m_p);
-        return infer_implicit_params(r, m_params.size(), m_mk_infer);
+        r         = infer_implicit_params(r, m_params.size(), m_mk_infer);
+        return unfold_untrusted_macros(m_env, r);
     }
 
     expr mk_intro_type_no_params() {

--- a/src/kernel/kernel_exception.cpp
+++ b/src/kernel/kernel_exception.cpp
@@ -9,9 +9,14 @@ Author: Leonardo de Moura
 #include "util/sstream.h"
 #include "kernel/scope_pos_info_provider.h"
 #include "kernel/kernel_exception.h"
+#include "kernel/error_msgs.h"
 
 namespace lean {
 format kernel_exception::pp(formatter const &) const { return format(what()); }
+
+format definition_type_mismatch_exception::pp(formatter const & fmt) const {
+    return pp_def_type_mismatch(fmt, m_decl.get_name(), m_decl.get_type(), m_given_type, true);
+}
 
 class generic_kernel_exception : public kernel_exception {
 protected:

--- a/src/kernel/kernel_exception.h
+++ b/src/kernel/kernel_exception.h
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #pragma once
 #include "kernel/environment.h"
 #include "kernel/ext_exception.h"
+#include "kernel/scope_pos_info_provider.h"
 
 namespace lean {
 class environment;
@@ -21,6 +22,19 @@ public:
     environment const & get_environment() const { return m_env; }
     virtual format pp(formatter const & fmt) const override;
     virtual throwable * clone() const override { return new kernel_exception(m_env, m_msg.c_str()); }
+    virtual void rethrow() const override { throw *this; }
+};
+
+class definition_type_mismatch_exception : public kernel_exception {
+    declaration m_decl;
+    expr m_given_type;
+public:
+    definition_type_mismatch_exception(environment const & env, declaration const & decl, expr const & given_type):
+            kernel_exception(env), m_decl(decl), m_given_type(given_type) {}
+    expr const & get_given_type() const { return m_given_type; }
+    virtual optional<pos_info> get_pos() const override { return get_pos_info(m_decl.get_value()); }
+    virtual format pp(formatter const & fmt) const override;
+    virtual throwable * clone() const override { return new definition_type_mismatch_exception(m_env, m_decl, m_given_type); }
     virtual void rethrow() const override { throw *this; }
 };
 

--- a/src/kernel/type_checker.cpp
+++ b/src/kernel/type_checker.cpp
@@ -735,9 +735,7 @@ static void check_definition(environment const & env, declaration const & d, typ
     check_no_mlocal(env, d.get_name(), d.get_value(), false);
     expr val_type = checker.check(d.get_value(), d.get_univ_params());
     if (!checker.is_def_eq(val_type, d.get_type())) {
-        throw_kernel_exception(env, d.get_value(), [=](formatter const &fmt) {
-            return pp_def_type_mismatch(fmt, d.get_name(), d.get_type(), val_type, true);
-        });
+        throw definition_type_mismatch_exception(env, d, val_type);
     }
 }
 

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -364,6 +364,7 @@ name const * g_unification_hint_mk = nullptr;
 name const * g_unit = nullptr;
 name const * g_unit_cases_on = nullptr;
 name const * g_unit_star = nullptr;
+name const * g_unsafe_monad_from_pure_bind = nullptr;
 name const * g_user_attribute = nullptr;
 name const * g_vm_monitor = nullptr;
 name const * g_weak_order = nullptr;
@@ -735,6 +736,7 @@ void initialize_constants() {
     g_unit = new name{"unit"};
     g_unit_cases_on = new name{"unit", "cases_on"};
     g_unit_star = new name{"unit", "star"};
+    g_unsafe_monad_from_pure_bind = new name{"unsafe_monad_from_pure_bind"};
     g_user_attribute = new name{"user_attribute"};
     g_vm_monitor = new name{"vm_monitor"};
     g_weak_order = new name{"weak_order"};
@@ -1107,6 +1109,7 @@ void finalize_constants() {
     delete g_unit;
     delete g_unit_cases_on;
     delete g_unit_star;
+    delete g_unsafe_monad_from_pure_bind;
     delete g_user_attribute;
     delete g_vm_monitor;
     delete g_weak_order;
@@ -1478,6 +1481,7 @@ name const & get_unification_hint_mk_name() { return *g_unification_hint_mk; }
 name const & get_unit_name() { return *g_unit; }
 name const & get_unit_cases_on_name() { return *g_unit_cases_on; }
 name const & get_unit_star_name() { return *g_unit_star; }
+name const & get_unsafe_monad_from_pure_bind_name() { return *g_unsafe_monad_from_pure_bind; }
 name const & get_user_attribute_name() { return *g_user_attribute; }
 name const & get_vm_monitor_name() { return *g_vm_monitor; }
 name const & get_weak_order_name() { return *g_weak_order; }

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -366,6 +366,7 @@ name const & get_unification_hint_mk_name();
 name const & get_unit_name();
 name const & get_unit_cases_on_name();
 name const & get_unit_star_name();
+name const & get_unsafe_monad_from_pure_bind_name();
 name const & get_user_attribute_name();
 name const & get_vm_monitor_name();
 name const & get_weak_order_name();

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -359,6 +359,7 @@ unification_hint.mk
 unit
 unit.cases_on
 unit.star
+unsafe_monad_from_pure_bind
 user_attribute
 vm_monitor
 weak_order

--- a/src/library/tactic/elaborate.cpp
+++ b/src/library/tactic/elaborate.cpp
@@ -53,8 +53,6 @@ vm_obj tactic_to_expr_core(vm_obj const & qe, vm_obj const & relaxed, vm_obj con
         } else {
             return tactic::mk_success(to_obj(r), set_env_mctx(s, env, mctx));
         }
-    } catch (failed_to_synthesize_placeholder_exception & ex) {
-        return tactic::mk_exception(ex, ex.get_tactic_state());
     } catch (elaborator_exception & ex) {
         return tactic::mk_exception(ex, s);
     } catch (exception & ex) {

--- a/src/library/tactic/elaborator_exception.cpp
+++ b/src/library/tactic/elaborator_exception.cpp
@@ -12,6 +12,10 @@ throwable * elaborator_exception::clone() const {
     return new elaborator_exception(m_pos, m_fmt);
 }
 
+format failed_to_synthesize_placeholder_exception::pp() const {
+    return m_fmt + line() + format("context:") + line() + m_state.pp();
+}
+
 throwable * nested_elaborator_exception::clone() const {
     return new nested_elaborator_exception(m_pos, m_fmt, m_exception);
 }

--- a/src/library/tactic/elaborator_exception.h
+++ b/src/library/tactic/elaborator_exception.h
@@ -34,6 +34,7 @@ public:
     virtual void rethrow() const override { throw *this; }
     expr const & get_mvar() const { return m_mvar; }
     tactic_state const & get_tactic_state() const { return m_state; }
+    virtual format pp() const override;
 };
 
 class nested_elaborator_exception : public elaborator_exception {

--- a/src/library/tactic/eval.cpp
+++ b/src/library/tactic/eval.cpp
@@ -7,6 +7,7 @@ Author: Leonardo de Moura
 #include "util/fresh_name.h"
 #include "kernel/type_checker.h"
 #include "kernel/kernel_exception.h"
+#include "kernel/error_msgs.h"
 #include "library/vm/vm.h"
 #include "library/vm/vm_expr.h"
 #include "library/compiler/vm_compiler.h"
@@ -29,13 +30,25 @@ static vm_obj eval(expr const & A, expr a, tactic_state const & s) {
         vm_state & S = get_vm_state();
         environment aux_env = S.env();
         name eval_aux_name = mk_tagged_fresh_name("_eval_expr");
-        /* We use nested_exception_without_pos to make sure old position information nested in 'a' is used
-           in type error messages. */
         try {
             auto cd = check(aux_env, mk_definition(aux_env, eval_aux_name, {}, A, a, true, false));
             aux_env = aux_env.add(cd);
+        } catch (definition_type_mismatch_exception & ex) {
+            expr given_type = ex.get_given_type();
+            return tactic::mk_exception([=]() {
+                io_state_stream ios = tout();
+                formatter fmt = ios.get_formatter();
+
+                format expected_fmt, given_fmt;
+                std::tie(expected_fmt, given_fmt) = pp_until_different(fmt, A, given_type);
+                return format("type error at eval_expr, argument has type '") + given_fmt +
+                    compose(line(), format("but is expected to have type")) +
+                    expected_fmt;
+            }, s);
         } catch (kernel_exception & ex) {
-            return tactic::mk_exception(nested_exception_without_pos("eval_expr failed due to type error", ex), s);
+            /* We use nested_exception_without_pos to make sure old position information nested in 'a' is not used
+               in type error messages. */
+            return tactic::mk_exception(nested_exception_without_pos("eval_expr failed", ex), s);
         }
         try {
             aux_env = vm_compile(aux_env, aux_env.get(eval_aux_name));

--- a/src/library/unfold_macros.cpp
+++ b/src/library/unfold_macros.cpp
@@ -29,7 +29,7 @@ class unfold_untrusted_macros_fn : public replace_visitor_with_tc {
         expr r = update_macro(e, new_args.size(), new_args.data());
         if (!m_trust_lvl || def.trust_level() >= *m_trust_lvl) {
             if (optional<expr> new_r = m_ctx.expand_macro(r)) {
-                return *new_r;
+                return visit(*new_r);
             } else {
                 throw generic_exception(e, "failed to expand macro");
             }

--- a/src/library/vm/vm_io.cpp
+++ b/src/library/vm/vm_io.cpp
@@ -281,11 +281,11 @@ static vm_obj mk_fs() {
     return mk_vm_constructor(0, 11, fields);
 }
 
-static vm_obj io_return(vm_obj const &, vm_obj const &, vm_obj const & a, vm_obj const &) {
+static vm_obj io_return(vm_obj const &, vm_obj const & a, vm_obj const &) {
     return mk_io_result(a);
 }
 
-static vm_obj io_bind(vm_obj const & /* e */, vm_obj const & /* α */, vm_obj const & /* β */, vm_obj const & a, vm_obj const & b, vm_obj const &) {
+static vm_obj io_bind(vm_obj const & /* α */, vm_obj const & /* β */, vm_obj const & a, vm_obj const & b, vm_obj const &) {
     vm_obj r = invoke(a, mk_vm_unit());
     if (cidx(r) == 0) {
         vm_obj v = cfield(r, 0);
@@ -295,9 +295,10 @@ static vm_obj io_bind(vm_obj const & /* e */, vm_obj const & /* α */, vm_obj co
     }
 }
 
-static vm_obj io_monad(vm_obj const &, vm_obj const &) {
-    return get_vm_state().invoke(get_unsafe_monad_from_pure_bind_name(),
-                                 {mk_vm_simple(0), mk_native_closure(io_return), mk_native_closure(io_bind)});
+static vm_obj io_monad(vm_obj const &) {
+    vm_state & S = get_vm_state();
+    vm_obj const & mk_unsafe_monad = S.get_constant(get_unsafe_monad_from_pure_bind_name());
+    return invoke(mk_unsafe_monad, mk_vm_simple(0), mk_native_closure(io_return), mk_native_closure(io_bind));
 }
 
 static vm_obj io_catch(vm_obj const &, vm_obj const &, vm_obj const &, vm_obj const & a, vm_obj const & b, vm_obj const &) {

--- a/src/library/vm/vm_io.cpp
+++ b/src/library/vm/vm_io.cpp
@@ -295,6 +295,11 @@ static vm_obj io_bind(vm_obj const & /* e */, vm_obj const & /* α */, vm_obj co
     }
 }
 
+static vm_obj io_monad(vm_obj const &, vm_obj const &) {
+    return get_vm_state().invoke(get_unsafe_monad_from_pure_bind_name(),
+                                 {mk_vm_simple(0), mk_native_closure(io_return), mk_native_closure(io_bind)});
+}
+
 static vm_obj io_catch(vm_obj const &, vm_obj const &, vm_obj const &, vm_obj const & a, vm_obj const & b, vm_obj const &) {
     vm_obj r = invoke(a, mk_vm_unit());
     if (cidx(r) == 1) {
@@ -316,24 +321,22 @@ static vm_obj io_m(vm_obj const &, vm_obj const &) {
 /*
 structure io.interface :=
 (m        : Type → Type → Type)
-(return   : ∀ e α, α → m e α)
-(bind     : ∀ e α β, m e α → (α → m e β) → m e β)
+(monad    : Π e, monad (m e))
 (catch    : ∀ e₁ e₂ α, m e₁ α → (e₁ → m e₂ α) → m e₂ α)
 (fail     : ∀ e α, e → m e α)
 (term     : io.terminal m)
 (fs       : io.file_system m)
 */
 vm_obj mk_io_interface() {
-    vm_obj fields[7] = {
+    vm_obj fields[6] = {
         mk_native_closure(io_m), /* TODO(Leo): delete after we improve code generator */
-        mk_native_closure(io_return),
-        mk_native_closure(io_bind),
+        mk_native_closure(io_monad),
         mk_native_closure(io_catch),
         mk_native_closure(io_fail),
         mk_terminal(),
         mk_fs()
     };
-    return mk_vm_constructor(0, 7, fields);
+    return mk_vm_constructor(0, 6, fields);
 }
 
 optional<vm_obj> is_io_result(vm_obj const & o) {

--- a/tests/lean/858.lean.expected.out
+++ b/tests/lean/858.lean.expected.out
@@ -1,1 +1,3 @@
 858.lean:2:18: error: don't know how to synthesize placeholder
+context:
+⊢ Sort ?

--- a/tests/lean/auto_quote_error.lean.expected.out
+++ b/tests/lean/auto_quote_error.lean.expected.out
@@ -1,6 +1,11 @@
 auto_quote_error.lean:5:29: error: don't know how to synthesize placeholder
-state:
+context:
 a b c : ℕ,
 h1 : a = b,
 h2 : b = c
 ⊢ b = c
+state:
+a b c : ℕ,
+h1 : a = b,
+h2 : b = c
+⊢ c = a

--- a/tests/lean/auto_quote_error2.lean.expected.out
+++ b/tests/lean/auto_quote_error2.lean.expected.out
@@ -27,8 +27,13 @@ a_1 : a = b,
 a_2 : b = c
 ⊢ a = ?m_1
 auto_quote_error2.lean:37:22: error: don't know how to synthesize placeholder
-state:
+context:
 a b c : ℕ,
 h1 : a = b,
 h2 : b = c
 ⊢ b = c
+state:
+a b c : ℕ,
+h1 : a = b,
+h2 : b = c
+⊢ a = c

--- a/tests/lean/run/apply_auto_opt.lean
+++ b/tests/lean/run/apply_auto_opt.lean
@@ -1,0 +1,26 @@
+def p (a : nat) (b := tt) : nat :=
+a + cond b 1 2
+
+def q (a b : nat) (h : a ≠ b . tactic.contradiction) : nat :=
+a + b
+
+def val1 : nat :=
+begin
+  apply @p,
+  exact 2,
+  apply_opt_param
+end
+
+example : val1 = 3 :=
+rfl
+
+def val2 : nat :=
+begin
+  fapply @q,
+  exact 1,
+  exact 0,
+  apply_auto_param
+end
+
+example : val2 = 1 :=
+rfl

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -364,6 +364,7 @@ run_cmd script_check_id `unification_hint.mk
 run_cmd script_check_id `unit
 run_cmd script_check_id `unit.cases_on
 run_cmd script_check_id `unit.star
+run_cmd script_check_id `unsafe_monad_from_pure_bind
 run_cmd script_check_id `user_attribute
 run_cmd script_check_id `vm_monitor
 run_cmd script_check_id `weak_order

--- a/tests/lean/run/check_monad_mk.lean
+++ b/tests/lean/run/check_monad_mk.lean
@@ -1,0 +1,3 @@
+#check @monad.mk
+#check @functor.mk
+#check @applicative.mk

--- a/tests/lean/run/isabelle.lean
+++ b/tests/lean/run/isabelle.lean
@@ -33,8 +33,7 @@ protected meta def failure {α} : lazy_tactic α :=
 λ s, nil
 
 meta instance : monad lazy_tactic :=
-{ pure := @lazy_tactic.return,
-  bind := @lazy_tactic.bind }
+unsafe_monad_from_pure_bind @lazy_tactic.return @lazy_tactic.bind
 
 meta instance : alternative lazy_tactic :=
 { lazy_tactic.monad with

--- a/tests/lean/tactic_error_pos.lean.expected.out
+++ b/tests/lean/tactic_error_pos.lean.expected.out
@@ -8,17 +8,27 @@ h1 : p,
 h2 : q
 ⊢ p ∧ q
 tactic_error_pos.lean:9:19: error: don't know how to synthesize placeholder
-state:
+context:
 p q : Prop,
 h1 : p,
 h2 : q
 ⊢ p
+state:
+p q : Prop,
+h1 : p,
+h2 : q
+⊢ p ∧ q
 tactic_error_pos.lean:15:29: error: don't know how to synthesize placeholder
-state:
+context:
 p q : Prop,
 h1 : p,
 h2 : q
 ⊢ p
+state:
+p q : Prop,
+h1 : p,
+h2 : q
+⊢ p ∧ q
 tactic_error_pos.lean:23:0: error: tactic failed, there are unsolved goals
 state:
 p q : Prop,

--- a/tests/lean/type_error_at_eval_expr.lean.expected.out
+++ b/tests/lean/type_error_at_eval_expr.lean.expected.out
@@ -1,6 +1,6 @@
 type_error_at_eval_expr.lean:3:0: error: eval_expr failed due to type error
 nested exception message:
-type mismatch at definition '_eval_expr.16.440', has type
+type mismatch at definition '_eval_expr.16.500', has type
   list ℕ
 but is expected to have type
   ℕ

--- a/tests/lean/type_error_at_eval_expr.lean.expected.out
+++ b/tests/lean/type_error_at_eval_expr.lean.expected.out
@@ -1,6 +1,4 @@
-type_error_at_eval_expr.lean:3:0: error: eval_expr failed due to type error
-nested exception message:
-type mismatch at definition '_eval_expr.16.500', has type
+type_error_at_eval_expr.lean:3:0: error: type error at eval_expr, argument has type '
   list ℕ
 but is expected to have type
   ℕ


### PR DESCRIPTION
* add invariants to `functor`, `applicative`, and `monad`
* default as many superclass laws as possible - when given only `pure` and `bind`, the proof obligations break down to just 1 functor law and 2 monad laws
* prove non-meta instances correct, use `undefined` for meta ones
* extend `structure` a bit to make things easier

The instance proofs aren't exactly pretty - I wildly switched between `dsimp`, `simp`, and `rw` depending on what worked in a given context.

I tried to fix `io` by constructing an unsafe `monad` instance in C++ via Lean, but there's still some VM error left. There are also a few other tests I have broken somehow.