### PR TITLE
RFC: simp_only

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -570,6 +570,19 @@ meta def simph (hs : parse opt_qexpr_list) (attr_names : parse with_ident_list) 
                (cfg : simp_config := {}) : tactic unit :=
 simp_using_hs hs attr_names ids cfg
 
+/--
+The tactic `simp_only [h_1, ..., h_n]` simplifies the main goal target using only the given `h_i`s.
+
+The tactic `simp_only [h_1, ..., h_n] at h` simplifies the non dependent hypothesis `h : T`. The tactic fails if the target or another hypothesis depends on `h`.
+-/
+meta def simp_only (hs : parse qexpr_list) (loc : parse location) (cfg : simp_config := {}) : tactic unit :=
+do s ← simp_lemmas.append_pexprs simp_lemmas.mk hs,
+   match loc : _ → tactic unit with
+   | [] := simp_goal cfg s
+   | _  := simp_hyps cfg s loc
+   end,
+   try tactic.triv, try (tactic.reflexivity reducible)
+
 meta def simp_intros (ids : parse ident_*) (hs : parse opt_qexpr_list) (attr_names : parse with_ident_list)
                      (wo_ids : parse without_ident_list) (cfg : simp_config := {}) : tactic unit :=
 do s ← mk_simp_set attr_names hs wo_ids,

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -253,6 +253,10 @@ do S ← simp_lemmas.mk_default,
    S ← S^.append hs,
 simplify_goal S cfg >> try triv
 
+meta def simp_only (hs : list expr) (cfg : simp_config := {}) : tactic unit :=
+do S ← (simp_lemmas.mk)^.append hs,
+simplify_goal S cfg >> try triv
+
 meta def dsimp_core (s : simp_lemmas) : tactic unit :=
 target >>= s^.dsimplify >>= change
 
@@ -347,15 +351,23 @@ step $
 do s ← collect_ctx_simps >>= s^.append,
    simp_intro_aux cfg tt s tt ns
 
-meta def simp_at (h : expr) (extra_lemmas : list expr := []) (cfg : simp_config := {}) : tactic unit :=
-do when (expr.is_local_constant h = ff) (fail "tactic simp_at failed, the given expression is not a hypothesis"),
-   htype ← infer_type h,
-   S     ← simp_lemmas.mk_default,
-   S     ← S^.append extra_lemmas,
+private meta def simp_at_core (h : expr) (S : simp_lemmas) (cfg : simp_config := {}) : tactic unit :=
+do htype ← infer_type h,
    (new_htype, heq) ← simplify S htype cfg,
    assert (expr.local_pp_name h) new_htype,
    mk_eq_mp heq h >>= exact,
    try $ clear h
+
+meta def simp_at (h : expr) (extra_lemmas : list expr := []) (cfg : simp_config := {}) : tactic unit :=
+do when (expr.is_local_constant h = ff) (fail "tactic simp_at failed, the given expression is not a hypothesis"),
+   S     ← simp_lemmas.mk_default,
+   S     ← S^.append extra_lemmas,
+   simp_at_core h S cfg
+
+meta def simp_only_at (h : expr) (lemmas : list expr) (cfg : simp_config := {}) : tactic unit :=
+do when (expr.is_local_constant h = ff) (fail "tactic simp_at failed, the given expression is not a hypothesis"),
+   S     ← (simp_lemmas.mk)^.append lemmas,
+   simp_at_core h S cfg
 
 meta def simp_at_using_hs (h : expr) (extra_lemmas : list expr := []) (cfg : simp_config := {}) : tactic unit :=
 do hs ← collect_ctx_simps,

--- a/tests/lean/run/simp_only.lean
+++ b/tests/lean/run/simp_only.lean
@@ -1,0 +1,25 @@
+constants (f : ℕ → ℕ) (a b c : ℕ) (fab : f a = f b) (fbc : f b = f c)
+constants (p : ℕ → Prop) (pfa : p (f a)) (pfb : p (f b)) (pfc :p (f c))
+
+attribute [simp] fbc
+
+example : p (f a) :=
+by simp [fab]; exact pfc
+
+example : p (f a) :=
+by simp_only [fab]; exact pfb
+
+example : p (f a) :=
+by do tactic.simp_only [```(fab)],
+      tactic.applyc ``pfb
+
+example (h : p (f a)) : p (f c) :=
+by simp [fab] at h; assumption
+
+example (h : p (f a)) : p (f b) :=
+by simp_only [fab] at h; assumption
+
+example (h : p (f a)) : p (f b) :=
+by do eh ← tactic.get_local `h,
+      tactic.simp_only_at eh [```(fab)],
+      tactic.assumption


### PR DESCRIPTION
I implemented `simp_only` tactics in `simp_tactic.lean` and `interactive.lean`, but I have a few questions.

1. In `simp_tactic`, `simp_at` takes an optional parameter `extra_lemmas`. Is there any reason not to do the same for `simp`, `dsimp`, and `dsimp_at`, and get rid of `simp_using`?

2. In `interactive`, I added these:
```lean
  simp_only [e1, ..., en]
  simp_only [e1, ..., en] at h
```
Instead, we can use this syntax:
```lean
  simp only [e1, ..., en]
  simp only [e1, ..., en] at h
```
We would add an optional `only` argument to `simp` and give an error if the user uses `only` in combination with `with` or `without`. Is that better?

3. Do we want also want `dsimp_only`, etc.? 