### PR TITLE
Better field notation info

### DIFF
--- a/src/frontends/lean/builtin_exprs.cpp
+++ b/src/frontends/lean/builtin_exprs.cpp
@@ -1066,10 +1066,10 @@ static expr parse_proj(parser_state & p, unsigned, expr const * args, pos_info c
             /* failed to elaborate or infer type */
             throw ex;
         }
-        expr fn       = get_app_fn(lhs_type);
+        expr fn = get_app_fn(lhs_type);
         if (is_constant(fn)) {
-            ex.m_token_info.m_struct  = const_name(fn);
             ex.m_token_info.m_context = break_at_pos_exception::token_context::field;
+            ex.m_token_info.m_struct  = const_name(fn);
         }
         throw;
     }

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -914,8 +914,8 @@ expr elaborator::visit_const_core(expr const & e) {
 void elaborator::save_identifier_info(expr const & f) {
     if (!m_no_info && m_uses_infom && get_pos_info_provider() && (is_constant(f) || is_local(f))) {
         if (auto p = get_pos_info_provider()->get_pos_info(f)) {
-            m_info.add_identifier_info(p->first, p->second, is_constant(f) ? const_name(f) : local_pp_name(f));
-            m_info.add_type_info(p->first, p->second, infer_type(f));
+            m_info.add_identifier_info(*p, is_constant(f) ? const_name(f) : local_pp_name(f));
+            m_info.add_type_info(*p, infer_type(f));
         }
     }
 }
@@ -3729,11 +3729,11 @@ static vm_obj tactic_save_type_info(vm_obj const & _e, vm_obj const & ref, vm_ob
     type_context ctx = mk_type_context_for(s);
     try {
         expr type = ctx.infer(e);
-        get_global_info_manager()->add_type_info(pos->first, pos->second, type);
+        get_global_info_manager()->add_type_info(*pos, type);
         if (is_constant(e))
-            get_global_info_manager()->add_identifier_info(pos->first, pos->second, const_name(e));
+            get_global_info_manager()->add_identifier_info(*pos, const_name(e));
         else if (is_local(e))
-            get_global_info_manager()->add_identifier_info(pos->first, pos->second, local_pp_name(e));
+            get_global_info_manager()->add_identifier_info(*pos, local_pp_name(e));
     } catch (exception & ex) {
         return tactic::mk_exception(ex, s);
     }

--- a/src/frontends/lean/info_manager.h
+++ b/src/frontends/lean/info_manager.h
@@ -73,7 +73,6 @@ class info_manager : public log_entry_cell {
     std::string m_file_name;
     rb_map<unsigned, line_info_data_set, unsigned_cmp> m_line_data;
 
-    line_info_data_set get_line_info_set(unsigned l) const;
     void add_info(pos_info pos, info_data data);
 public:
     info_manager() {}
@@ -88,6 +87,8 @@ public:
     /* Takes type info from global declaration with the given name. */
     void add_const_info(environment const & env, pos_info pos, name const & full_id);
     void add_vm_obj_format_info(pos_info pos, environment const & env, vm_obj const & thunk);
+
+    line_info_data_set get_line_info_set(unsigned l) const;
 
     void instantiate_mvars(metavar_context const & mctx);
     void merge(info_manager const & info);

--- a/src/frontends/lean/info_manager.h
+++ b/src/frontends/lean/info_manager.h
@@ -73,8 +73,8 @@ class info_manager : public log_entry_cell {
     std::string m_file_name;
     rb_map<unsigned, line_info_data_set, unsigned_cmp> m_line_data;
 
-    void add_info(unsigned l, unsigned c, info_data data);
     line_info_data_set get_line_info_set(unsigned l) const;
+    void add_info(pos_info pos, info_data data);
 public:
     info_manager() {}
     info_manager(std::string const & file_name) : m_file_name(file_name) {}
@@ -83,16 +83,18 @@ public:
 
     bool empty() const { return m_line_data.empty(); }
 
-    void add_type_info(unsigned l, unsigned c, expr const & e);
-    void add_identifier_info(unsigned l, unsigned c, name const & full_id);
-    void add_vm_obj_format_info(unsigned l, unsigned c, environment const & env, vm_obj const & thunk);
+    void add_type_info(pos_info pos, expr const & e);
+    void add_identifier_info(pos_info pos, name const & full_id);
+    /* Takes type info from global declaration with the given name. */
+    void add_const_info(environment const & env, pos_info pos, name const & full_id);
+    void add_vm_obj_format_info(pos_info pos, environment const & env, vm_obj const & thunk);
 
     void instantiate_mvars(metavar_context const & mctx);
     void merge(info_manager const & info);
 
 #ifdef LEAN_JSON
-    void get_info_record(environment const & env, options const & o, io_state const & ios, unsigned line,
-                         unsigned col, json & record, std::function<bool (info_data const &)> pred = {}) const;
+    void get_info_record(environment const & env, options const & o, io_state const & ios, pos_info pos,
+                         json & record, std::function<bool (info_data const &)> pred = {}) const;
 #endif
 };
 

--- a/src/frontends/lean/interactive.cpp
+++ b/src/frontends/lean/interactive.cpp
@@ -129,7 +129,14 @@ void report_info(environment const & env, options const & opts, io_state const &
                     record["tactic_param_idx"] = *idx;
                 has_token_info = true;
                 break;
-            default:
+            case break_at_pos_exception::token_context::field: {
+                auto name = e.m_token_info.m_struct + e.m_token_info.m_token;
+                record["full-id"] = name.to_string();
+                add_source_info(env, name, record);
+                if (auto doc = get_doc_string(env, name))
+                    record["doc"] = *doc;
+                interactive_report_type(env, opts, env.get(name).get_type(), record);
+            } default:
                 break;
         }
     }

--- a/src/frontends/lean/interactive.cpp
+++ b/src/frontends/lean/interactive.cpp
@@ -137,14 +137,12 @@ void report_info(environment const & env, options const & opts, io_state const &
     for (auto & infom : info_managers) {
         if (infom.get_file_name() == m_mod_info.m_mod) {
             if (e.m_goal_pos) {
-                infom.get_info_record(env, opts, ios, e.m_goal_pos->first,
-                                      e.m_goal_pos->second, record, [](info_data const & d) {
+                infom.get_info_record(env, opts, ios, *e.m_goal_pos, record, [](info_data const & d) {
                             return dynamic_cast<vm_obj_format_info const *>(d.raw());
                         });
             }
             if (!has_token_info)
-                infom.get_info_record(env, opts, ios, e.m_token_info.m_pos.first,
-                                      e.m_token_info.m_pos.second, record);
+                infom.get_info_record(env, opts, ios, e.m_token_info.m_pos, record);
         }
     }
 

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -1913,8 +1913,7 @@ expr parser::parse_id() {
     name id = check_id_next("", break_at_pos_exception::token_context::expr);
     expr e = id_to_expr(id, p);
     if (is_constant(e) && get_global_info_manager()) {
-        get_global_info_manager()->add_identifier_info(p.first, p.second, const_name(e));
-        get_global_info_manager()->add_type_info(p.first, p.second, m_env.get(const_name(e)).get_type());
+        get_global_info_manager()->add_const_info(m_env, p, const_name(e));
     }
     return e;
 }

--- a/src/frontends/lean/print_cmd.cpp
+++ b/src/frontends/lean/print_cmd.cpp
@@ -392,8 +392,7 @@ bool print_id_info(parser & p, message_builder & out, name const & id, bool show
     if (auto c = head_opt(cs))
         if (!tail(cs))
             if (auto infom = get_global_info_manager()) {
-                infom->add_identifier_info(pos.first, pos.second, *c);
-                infom->add_type_info(pos.first, pos.second, p.env().get(*c).get_type());
+                infom->add_const_info(p.env(), pos, *c);
             }
 
     if (found) return true;

--- a/tests/lean/interactive/field_info.lean
+++ b/tests/lean/interactive/field_info.lean
@@ -2,3 +2,12 @@ def f (n : ℕ) := n^.to_string
                   --^ "command": "info"
 def g (l : list ℕ) := l^.all
                        --^ "command": "info"
+
+-- elaborated, not locally inferable
+def h : list ℕ → (ℕ → bool) → bool :=
+λ l, (l ++ l)^.all
+              --^ "command": "info"
+
+-- not elaborated, locally inferable
+def j := (list.nil^.all
+                   --^ "command": "info"

--- a/tests/lean/interactive/field_info.lean.expected.out
+++ b/tests/lean/interactive/field_info.lean.expected.out
@@ -1,3 +1,6 @@
+{"msgs":[{"caption":"","file_name":"f","pos_col":40,"pos_line":13,"severity":"error","text":"invalid expression, `)` expected"}],"response":"all_messages"}
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"record":{"full-id":"nat.to_string","source":,"type":"ℕ → string"},"response":"ok","seq_num":2}
 {"record":{"full-id":"list.all","source":,"type":"Π {α : Type}, list α → (α → bool) → bool"},"response":"ok","seq_num":4}
+{"record":{"full-id":"list.all","source":,"type":"Π {α : Type}, list α → (α → bool) → bool"},"response":"ok","seq_num":9}
+{"record":{"full-id":"list.all","source":,"type":"Π {α : Type u}, list α → (α → bool) → bool"},"response":"ok","seq_num":13}


### PR DESCRIPTION
Fixes the issue reported by @digama0 and adds info records in the inverse case in which elaboration of the declaration failed but local inference of the LHS succeeds.