### PR TITLE
[RFC] change precendence of field names to match application

### DIFF
--- a/library/data/bitvec.lean
+++ b/library/data/bitvec.lean
@@ -101,7 +101,7 @@ section arith
 
   protected def mul (x y : bitvec n) : bitvec n :=
   let f := λ r b, cond b (r + r + y) (r + r) in
-  (to_list x).foldl f 0
+  to_list x .foldl f 0
 
   instance : has_mul (bitvec n)  := ⟨bitvec.mul⟩
 end arith

--- a/library/data/hash_map.lean
+++ b/library/data/hash_map.lean
@@ -43,7 +43,7 @@ def find_aux (a : α) : list (Σ a, β a) → option (β a)
   if h : a' = a then some (eq.rec_on h b) else find_aux t
 
 def contains_aux (a : α) (l : list (Σ a, β a)) : bool :=
-(find_aux a l).is_some
+find_aux a l .is_some
 
 def find (m : hash_map α β) (a : α) : option (β a) :=
 match m with
@@ -52,7 +52,7 @@ match m with
 end
 
 def contains (m : hash_map α β) (a : α) : bool :=
-(find m a).is_some
+find m a .is_some
 
 def fold [decidable_eq α] (m : hash_map α β) (d : δ) (f : δ → Π a, β a → δ) : δ :=
 fold_buckets m.buckets d f

--- a/library/init/algebra/field.lean
+++ b/library/init/algebra/field.lean
@@ -126,7 +126,7 @@ eq.symm (eq_one_div_of_mul_eq_one this)
 lemma division_ring.one_div_neg_eq_neg_one_div {a : α} (h : a ≠ 0) : 1 / (- a) = - (1 / a) :=
 have -1 ≠ (0:α), from
   (suppose -1 = 0, absurd (eq.symm (calc
-            1 = -(-1)  : (neg_neg (1:α)).symm
+            1 = -(-1)  : neg_neg (1:α) .symm
           ... = -0     : by rw this
           ... = (0:α)  : neg_zero)) zero_ne_one),
 calc

--- a/library/init/algebra/group.lean
+++ b/library/init/algebra/group.lean
@@ -289,7 +289,7 @@ meta def transport_multiplicative_to_additive : command :=
 let dict := rb_map.of_list multiplicative_to_additive_pairs in
 multiplicative_to_additive_pairs.foldl (λ t ⟨src, tgt⟩, do
   env ← get_env,
-  if (env.get tgt).to_bool = ff
+  if env.get tgt .to_bool = ff
   then t >> transport_with_dict dict src tgt
   else t)
 skip

--- a/library/init/algebra/ring.lean
+++ b/library/init/algebra/ring.lean
@@ -83,13 +83,13 @@ lemma ring.mul_zero [ring α] (a : α) : a * 0 = 0 :=
 have a * 0 + 0 = a * 0 + a * 0, from calc
      a * 0 + 0 = a * (0 + 0)   : by simp
            ... = a * 0 + a * 0 : by rw left_distrib,
-show a * 0 = 0, from (add_left_cancel this).symm
+show a * 0 = 0, from add_left_cancel this .symm
 
 lemma ring.zero_mul [ring α] (a : α) : 0 * a = 0 :=
 have 0 * a + 0 = 0 * a + 0 * a, from calc
   0 * a + 0 = (0 + 0) * a   : by simp
         ... = 0 * a + 0 * a : by rewrite right_distrib,
-show 0 * a = 0, from  (add_left_cancel this).symm
+show 0 * a = 0, from add_left_cancel this .symm
 
 instance ring.to_semiring [s : ring α] : semiring α :=
 { s with
@@ -174,13 +174,13 @@ section integral_domain
   lemma eq_of_mul_eq_mul_right {a b c : α} (ha : a ≠ 0) (h : b * a = c * a) : b = c :=
   have b * a - c * a = 0, from sub_eq_zero_of_eq h,
   have (b - c) * a = 0,   by rw [mul_sub_right_distrib, this],
-  have b - c = 0,         from (eq_zero_or_eq_zero_of_mul_eq_zero this).resolve_right ha,
+  have b - c = 0,         from eq_zero_or_eq_zero_of_mul_eq_zero this .resolve_right ha,
   eq_of_sub_eq_zero this
 
   lemma eq_of_mul_eq_mul_left {a b c : α} (ha : a ≠ 0) (h : a * b = a * c) : b = c :=
   have a * b - a * c = 0, from sub_eq_zero_of_eq h,
   have a * (b - c) = 0,   by rw [mul_sub_left_distrib, this],
-  have b - c = 0,         from (eq_zero_or_eq_zero_of_mul_eq_zero this).resolve_left ha,
+  have b - c = 0,         from eq_zero_or_eq_zero_of_mul_eq_zero this .resolve_left ha,
   eq_of_sub_eq_zero this
 
   lemma eq_zero_of_mul_eq_self_right {a b : α} (h₁ : b ≠ 1) (h₂ : a * b = a) : a = 0 :=
@@ -191,7 +191,7 @@ section integral_domain
     h₁ this,
   have a * b - a = 0,   by simp [h₂],
   have a * (b - 1) = 0, by rwa [mul_sub_left_distrib, mul_one],
-    show a = 0, from (eq_zero_or_eq_zero_of_mul_eq_zero this).resolve_right hb
+    show a = 0, from eq_zero_or_eq_zero_of_mul_eq_zero this .resolve_right hb
 
   lemma eq_zero_of_mul_eq_self_left {a b : α} (h₁ : b ≠ 1) (h₂ : b * a = a) : a = 0 :=
   eq_zero_of_mul_eq_self_right h₁ (by rwa mul_comm at h₂)

--- a/library/init/classical.lean
+++ b/library/init/classical.lean
@@ -17,10 +17,10 @@ noncomputable theorem indefinite_description {α : Sort u} (p : α → Prop) :
 λ h, choice (let ⟨x, px⟩ := h in ⟨⟨x, px⟩⟩)
 
 noncomputable def some {α : Sort u} {p : α → Prop} (h : ∃ x, p x) : α :=
-(indefinite_description p h).val
+indefinite_description p h .val
 
 theorem some_spec {α : Sort u} {p : α → Prop} (h : ∃ x, p x) : p (some h) :=
-(indefinite_description p h).property
+indefinite_description p h .property
 
 /- Diaconescu's theorem: using function extensionality and propositional extensionality,
    we can get excluded middle from this. -/
@@ -75,7 +75,7 @@ theorem exists_true_of_nonempty {α : Sort u} (h : nonempty α) : ∃ x : α, tr
 nonempty.elim h (take x, ⟨x, trivial⟩)
 
 noncomputable def inhabited_of_nonempty {α : Sort u} (h : nonempty α) : inhabited α :=
-⟨(indefinite_description _ (exists_true_of_nonempty h)).val⟩
+⟨indefinite_description _ (exists_true_of_nonempty h) .val⟩
 
 noncomputable def inhabited_of_exists {α : Sort u} {p : α → Prop} (h : ∃ x, p x) :
   inhabited α :=
@@ -113,12 +113,12 @@ end
 /- the Hilbert epsilon function -/
 
 noncomputable def epsilon {α : Sort u} [h : nonempty α] (p : α → Prop) : α :=
-(strong_indefinite_description p h).val
+strong_indefinite_description p h .val
 
 theorem epsilon_spec_aux {α : Sort u} (h : nonempty α) (p : α → Prop) (hex : ∃ y, p y) :
     p (@epsilon α h p) :=
-have aux : (∃ y, p y) → p ((strong_indefinite_description p h).val),
-  from (strong_indefinite_description p h).property,
+have aux : (∃ y, p y) → p (strong_indefinite_description p h .val),
+  from strong_indefinite_description p h .property,
 aux hex
 
 theorem epsilon_spec {α : Sort u} {p : α → Prop} (hex : ∃ y, p y) :

--- a/library/init/data/fin/ops.lean
+++ b/library/init/data/fin/ops.lean
@@ -72,23 +72,23 @@ instance decidable_le : ∀ (a b : fin n), decidable (a ≤ b)
 | ⟨a, _⟩ ⟨b, _⟩ := by apply nat.decidable_le
 
 lemma add_def (a b : fin n) : (a + b).val = (a.val + b.val) % n :=
-show (fin.add a b).val = (a.val + b.val) % n, from
+show fin.add a b .val = (a.val + b.val) % n, from
 by cases a; cases b; simp [fin.add]
 
 lemma mul_def (a b : fin n) : (a * b).val = (a.val * b.val) % n :=
-show (fin.mul a b).val = (a.val * b.val) % n, from
+show fin.mul a b .val = (a.val * b.val) % n, from
 by cases a; cases b; simp [fin.mul]
 
 lemma sub_def (a b : fin n) : (a - b).val = a.val - b.val :=
-show (fin.sub a b).val = a.val - b.val, from
+show fin.sub a b .val = a.val - b.val, from
 by cases a; cases b; simp [fin.sub]
 
 lemma mod_def (a b : fin n) : (a % b).val = a.val % b.val :=
-show (fin.mod a b).val = a.val % b.val, from
+show fin.mod a b .val = a.val % b.val, from
 by cases a; cases b; simp [fin.mod]
 
 lemma div_def (a b : fin n) : (a / b).val = a.val / b.val :=
-show (fin.div a b).val = a.val / b.val, from
+show fin.div a b .val = a.val / b.val, from
 by cases a; cases b; simp [fin.div]
 
 lemma lt_def (a b : fin n) : (a < b) = (a.val < b.val) :=

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -248,7 +248,7 @@ protected lemma rel_add : (rel_int_nat_nat ⇒ (rel_int_nat_nat ⇒ rel_int_nat_
     by simp,
   show rel_int_nat_nat (sub_nat_nat p (n' + 1)) (m + p + m', m + (m' + n' + 1)),
     begin
-      rw [eq1, eq2, (sub_nat_nat_add_add _ _ (m + m')).symm],
+      rw [eq1, eq2, sub_nat_nat_add_add _ _ (m + m') .symm],
       apply int.rel_sub_nat_nat
     end
 | ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.pos m' p') :=
@@ -258,7 +258,7 @@ protected lemma rel_add : (rel_int_nat_nat ⇒ (rel_int_nat_nat ⇒ rel_int_nat_
     by simp,
   show rel_int_nat_nat (sub_nat_nat p' (n + 1)) (m + (m' + p'), (m + n + 1) + m'),
     begin
-      rw [eq1, eq2, (sub_nat_nat_add_add _ _ (m + m')).symm],
+      rw [eq1, eq2, sub_nat_nat_add_add _ _ (m + m') .symm],
       apply int.rel_sub_nat_nat
     end
 | ._ ._ (@rel_int_nat_nat.neg m n) ._ ._ (@rel_int_nat_nat.neg m' n') :=

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -61,7 +61,7 @@ end
 
 lemma le_of_coe_nat_le_coe_nat {m n : ℕ} (h : (↑m : ℤ) ≤ ↑n) : m ≤ n :=
 le.elim h (take k, assume hk : ↑m + ↑k = ↑n,
-  have m + k = n, from int.coe_nat_inj ((int.coe_nat_add m k).trans hk),
+  have m + k = n, from int.coe_nat_inj (int.coe_nat_add m k .trans hk),
   nat.le.intro this)
 
 lemma coe_nat_le_coe_nat_iff (m n : ℕ) : (↑m : ℤ) ≤ ↑n ↔ m ≤ n :=
@@ -84,10 +84,10 @@ lemma coe_nat_lt_coe_nat_iff (n m : ℕ) : (↑n : ℤ) < ↑m ↔ n < m :=
 begin rw [lt_iff_add_one_le, -int.coe_nat_succ, coe_nat_le_coe_nat_iff], reflexivity end
 
 lemma lt_of_coe_nat_lt_coe_nat {m n : ℕ} (h : (↑m : ℤ) < ↑n) : m < n :=
-(coe_nat_lt_coe_nat_iff  _ _).mp h
+coe_nat_lt_coe_nat_iff  _ _ .mp h
 
 lemma coe_nat_lt_coe_nat_of_lt {m n : ℕ} (h : m < n) : (↑m : ℤ) < ↑n :=
-(coe_nat_lt_coe_nat_iff _ _).mpr h
+coe_nat_lt_coe_nat_iff _ _ .mpr h
 
 /- show that the integers form an ordered additive group -/
 

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -1068,7 +1068,7 @@ begin
   cases lt_or_ge p (b^succ w) with h₁ h₁,
   -- base case: p < b^succ w
   { assert h₂ : p / b < b^w,
-    { apply (div_lt_iff_lt_mul p _ b_pos).mpr,
+    { apply div_lt_iff_lt_mul p _ b_pos .mpr,
       simp at h₁, simp [h₁] },
     rw [mod_eq_of_lt h₁,mod_eq_of_lt h₂], simp [mod_add_div], },
   -- step: p ≥ b^succ w
@@ -1081,7 +1081,7 @@ begin
     rw [mod_eq_sub_mod h₄ h₁,IH _ h₂,pow_succ],
     apply congr, apply congr_arg,
     { assert h₃ : p / b ≥ b^w,
-      { apply (le_div_iff_mul_le _ p b_pos).mpr, simp [h₅] },
+      { apply le_div_iff_mul_le _ p b_pos .mpr, simp [h₅] },
       simp [nat.sub_mul_div _ _ _ b_pos h₅,mod_eq_sub_mod h₄ h₃] },
     { simp [nat.sub_mul_mod p (b^w) _ b_pos h₅] } }
 end

--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -512,9 +512,9 @@ iff.trans iff.comm (iff_false a)
 iff_true_intro iff.rfl
 
 @[congr] lemma iff_congr (h₁ : a ↔ c) (h₂ : b ↔ d) : (a ↔ b) ↔ (c ↔ d) :=
-(iff_iff_implies_and_implies a b).trans
-  ((and_congr (imp_congr h₁ h₂) (imp_congr h₂ h₁)).trans
-    (iff_iff_implies_and_implies c d).symm)
+iff_iff_implies_and_implies a b .trans
+  (and_congr (imp_congr h₁ h₂) (imp_congr h₂ h₁)) .trans
+    (iff_iff_implies_and_implies c d .symm)
 
 /- implies simp rule -/
 @[simp] lemma implies_true_iff (α : Sort u) : (α → true) ↔ true :=
@@ -671,7 +671,7 @@ section
   else is_true (assume h, absurd h hp)
 
   instance [decidable p] [decidable q] : decidable (p ↔ q) :=
-  decidable_of_decidable_of_iff and.decidable (iff_iff_implies_and_implies p q).symm
+  decidable_of_decidable_of_iff and.decidable (iff_iff_implies_and_implies p q .symm)
 end
 
 instance {α : Sort u} [decidable_eq α] (a b : α) : decidable (a ≠ b) :=

--- a/library/init/meta/environment.lean
+++ b/library/init/meta/environment.lean
@@ -98,7 +98,7 @@ end
 
 /-- Return true if 'n' has been declared in the current file -/
 meta def in_current_file (env : environment) (n : name) : bool :=
-(env.decl_olean n).is_none && env.contains n
+env.decl_olean n .is_none && env.contains n
 
 meta def is_definition (env : environment) (n : name) : bool :=
 match env.get n with

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -118,7 +118,7 @@ private meta def parser_desc_aux : expr → tactic (list format)
 meta def param_desc : expr → tactic format
 | ```(parse %%p) := join <$> parser_desc_aux p
 | ```(opt_param %%t ._) := (++ "?") <$> pp t
-| e := if is_constant e ∧ (const_name e).components.ilast = `itactic
+| e := if is_constant e ∧ const_name e .components.ilast = `itactic
   then return $ to_fmt "{ tactic }"
   else paren <$> pp e
 end interactive

--- a/library/init/meta/name.lean
+++ b/library/init/meta/name.lean
@@ -61,7 +61,7 @@ private def name.components' : name -> list name
 | (mk_numeral v n)         := mk_numeral v anonymous :: name.components' n
 
 def name.components (n : name) : list name :=
-(name.components' n).reverse
+name.components' n .reverse
 
 def name.to_string : name → string :=
 name.to_string_with_sep "."

--- a/library/init/meta/smt/congruence_closure.lean
+++ b/library/init/meta/smt/congruence_closure.lean
@@ -71,7 +71,7 @@ meta def in_singlenton_eqc (s : cc_state) (e : expr) : bool :=
 s.next e = e
 
 meta def eqc_size (s : cc_state) (e : expr) : nat :=
-(s.eqc_of e).length
+s.eqc_of e .length
 
 meta def fold_eqc_core {α} (s : cc_state) (f : α → expr → α) (first : expr) : expr → α → α
 | c a :=

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -22,7 +22,7 @@ meta def step {α : Type} (tac : smt_tactic α) : smt_tactic unit :=
 tac >> solve_goals
 
 meta def istep {α : Type} (line : nat) (col : nat) (tac : smt_tactic α) : smt_tactic unit :=
-λ ss ts, (@scope_trace _ line col ((tac >> solve_goals) ss ts)).clamp_pos line col
+λ ss ts, @scope_trace _ line col ((tac >> solve_goals) ss ts) .clamp_pos line col
 
 meta def execute (tac : smt_tactic unit) : tactic unit :=
 using_smt tac

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -192,7 +192,7 @@ do s ← read,
 
 meta def get_decl (n : name) : tactic declaration :=
 do s ← read,
-   (env s).get n
+   env s .get n
 
 meta def trace {α : Type u} [has_to_tactic_format α] (a : α) : tactic unit :=
 do fmt ← pp a,
@@ -461,7 +461,7 @@ meta def step {α : Type u} (t : tactic α) : tactic unit :=
 t >>[tactic] cleanup
 
 meta def istep {α : Type u} (line col : ℕ) (t : tactic α) : tactic unit :=
-λ s, (@scope_trace _ line col (step t s)).clamp_pos line col
+λ s, @scope_trace _ line col (step t s) .clamp_pos line col
 
 meta def is_prop (e : expr) : tactic bool :=
 do t ← infer_type e,

--- a/library/init/propext.lean
+++ b/library/init/propext.lean
@@ -12,13 +12,13 @@ constant propext {a b : Prop} : (a ↔ b) → a = b
 universes u v
 
 lemma forall_congr_eq {a : Sort u} {p q : a → Prop} (h : ∀ x, p x = q x) : (∀ x, p x) = ∀ x, q x :=
-propext (forall_congr (λ a, (h a).to_iff))
+propext (forall_congr (λ a, h a .to_iff))
 
 lemma imp_congr_eq {a b c d : Prop} (h₁ : a = c) (h₂ : b = d) : (a → b) = (c → d) :=
 propext (imp_congr h₁.to_iff h₂.to_iff)
 
 lemma imp_congr_ctx_eq {a b c d : Prop} (h₁ : a = c) (h₂ : c → (b = d)) : (a → b) = (c → d) :=
-propext (imp_congr_ctx h₁.to_iff (λ hc, (h₂ hc).to_iff))
+propext (imp_congr_ctx h₁.to_iff (λ hc, h₂ hc .to_iff))
 
 lemma eq_true_intro {a : Prop} (h : a) : a = true :=
 propext (iff_true_intro h)

--- a/library/init/relator.lean
+++ b/library/init/relator.lean
@@ -50,8 +50,8 @@ variables {α : Type u₁} {β : Type u₂} (R : α → β → Prop)
 
 lemma rel_forall_of_total [t : bi_total R] : ((R ⇒ iff) ⇒ iff) (λp, ∀i, p i) (λq, ∀i, q i) :=
 take p q Hrel,
-  ⟨take H b, exists.elim (t.right b) (take a Rab, (Hrel Rab).mp (H _)),
-    take H a, exists.elim (t.left a) (take b Rab, (Hrel Rab).mpr (H _))⟩
+  ⟨take H b, exists.elim (t.right b) (take a Rab, Hrel Rab .mp (H _)),
+    take H a, exists.elim (t.left a) (take b Rab, Hrel Rab .mpr (H _))⟩
 
 lemma left_unique_of_rel_eq {eq' : β → β → Prop} (he : (R ⇒ (R ⇒ iff)) eq eq') : left_unique R
 | a b c (ab : R a b) (cb : R c b) :=

--- a/library/tools/debugger/util.lean
+++ b/library/tools/debugger/util.lean
@@ -16,7 +16,7 @@ def split_core : string → string → list string
 | []      r  := [r.reverse]
 
 def split (s : string) : list string :=
-(split_core s []).reverse
+split_core s [] .reverse
 
 def to_qualified_name_core : string → string → name
 | []      r := if r = "" then name.anonymous else mk_simple_name r.reverse

--- a/library/tools/smt2/builder.lean
+++ b/library/tools/smt2/builder.lean
@@ -3,7 +3,7 @@ import .syntax
 @[reducible] def smt2.builder (α : Type) := state (list smt2.cmd) α
 
 meta def smt2.builder.to_format {α : Type} (build : smt2.builder α) : format :=
-format.join $ list.map to_fmt $ (build []).snd
+format.join $ list.map to_fmt $ build [] .snd
 
 meta instance (α : Type) : has_to_format (smt2.builder α) :=
 ⟨ smt2.builder.to_format ⟩

--- a/library/tools/super/cdcl_solver.lean
+++ b/library/tools/super/cdcl_solver.lean
@@ -101,7 +101,7 @@ meta def initial (local_false : expr) : state := {
 }
 
 meta def watches_for (st : state) (pl : prop_lit) : watch_map :=
-(st.watches.find pl).get_or_else (rb_map.mk _ _)
+st.watches.find pl .get_or_else (rb_map.mk _ _)
 
 end state
 

--- a/library/tools/super/clause.lean
+++ b/library/tools/super/clause.lean
@@ -175,7 +175,7 @@ pp (do l ← c.1.get_lits, [l.to_formula])
 meta instance : has_to_tactic_format clause := ⟨tactic_format⟩
 
 meta def is_maximal (gt : expr → expr → bool) (c : clause) (i : nat) : bool :=
-list.empty (list.filter (λj, gt (get_lit c j).formula (get_lit c i).formula) (range c.num_lits))
+list.empty (list.filter (λj, gt (get_lit c j .formula) (get_lit c i .formula)) (range c.num_lits))
 
 meta def normalize (c : clause) : tactic clause := do
 opened  ← open_constn c (num_binders c),
@@ -237,12 +237,12 @@ private meta def distinct' (local_false : expr) : list expr → expr → clause
       proof_wo_dups := foldl (λproof (h' : expr),
                               instantiate_var (abstract_local proof h'.local_uniq_name) h)
                          proof dups in
-    (distinct' rest proof_wo_dups).close_const h
+    distinct' rest proof_wo_dups .close_const h
 
 meta def distinct (c : clause) : tactic clause := do
 (qf, vs) ← c.open_constn c.num_quants,
 (fls, hs) ← qf.open_constn qf.num_lits,
-return $ (distinct' c.local_false hs fls.proof).close_constn vs
+return $ distinct' c.local_false hs fls.proof .close_constn vs
 
 end clause
 

--- a/library/tools/super/clause_ops.lean
+++ b/library/tools/super/clause_ops.lean
@@ -15,10 +15,10 @@ meta def on_left_at {m} [monad m] (c : clause) (i : ℕ)
                     -- f gets a type and returns a list of proofs of that type
                     (f : expr → m (list (list expr × expr))) : m (list clause) := do
 op ← c.open_constn (c.num_quants + i),
-@guard tactic _ (op.1.get_lit 0).is_neg _,
-new_hyps ← f (op.1.get_lit 0).formula,
+@guard tactic _ (op.1.get_lit 0 .is_neg) _,
+new_hyps ← f $ op.1.get_lit 0 .formula,
 return $ new_hyps.map (λnew_hyp,
-  (op.1.inst new_hyp.2).close_constn (op.2 ++ new_hyp.1))
+  op.1.inst new_hyp.2 .close_constn (op.2 ++ new_hyp.1))
 
 meta def on_left_at_dn {m} [monad m] [alternative m] (c : clause) (i : ℕ)
                     [has_monad_lift_t tactic m]
@@ -26,22 +26,23 @@ meta def on_left_at_dn {m} [monad m] [alternative m] (c : clause) (i : ℕ)
                     (f : expr → m (list (list expr × expr))) : m (list clause) := do
 qf ← c.open_constn c.num_quants,
 op ← qf.1.open_constn c.num_lits,
-lci ← (op.2.nth i).to_monad,
-@guard tactic _ (qf.1.get_lit i).is_neg _,
-h ← mk_local_def `h $ imp (qf.1.get_lit i).formula c.local_false,
+lci ← op.2.nth i .to_monad,
+@guard tactic _ (qf.1.get_lit i .is_neg) _,
+h ← mk_local_def `h $ imp (qf.1.get_lit i .formula) c.local_false,
 new_hyps ← f h,
 return $ new_hyps.map $ λnew_hyp,
-  (((clause.mk 0 0 new_hyp.2 c.local_false c.local_false).close_const h).inst
-               (op.1.close_const lci).proof).close_constn
-  (qf.2 ++ op.2.remove_nth i ++ new_hyp.1)
+  clause.mk 0 0 new_hyp.2 c.local_false c.local_false
+    .close_const h
+    .inst (op.1.close_const lci .proof)
+    .close_constn (qf.2 ++ op.2.remove_nth i ++ new_hyp.1)
 
 meta def on_right_at {m} [monad m] (c : clause) (i : ℕ)
                      [has_monad_lift_t tactic m]
                      -- f gets a hypothesis and returns a list of proofs of false
                      (f : expr → m (list (list expr × expr))) : m (list clause) := do
 op ← c.open_constn (c.num_quants + i),
-@guard tactic _ ((op.1.get_lit 0).is_pos) _,
-h ← mk_local_def `h (op.1.get_lit 0).formula,
+@guard tactic _ (op.1.get_lit 0 .is_pos) _,
+h ← mk_local_def `h $ op.1.get_lit 0 .formula,
 new_hyps ← f h,
 return $ new_hyps.map (λnew_hyp,
   (op.1.inst (lambdas [h] new_hyp.2)).close_constn (op.2 ++ new_hyp.1))
@@ -51,13 +52,13 @@ meta def on_right_at' {m} [monad m] (c : clause) (i : ℕ)
                      -- f gets a hypothesis and returns a list of proofs
                      (f : expr → m (list (list expr × expr))) : m (list clause) := do
 op ← c.open_constn (c.num_quants + i),
-@guard tactic _ ((op.1.get_lit 0).is_pos) _,
-h ← mk_local_def `h (op.1.get_lit 0).formula,
+@guard tactic _ (op.1.get_lit 0 .is_pos) _,
+h ← mk_local_def `h $ op.1.get_lit 0 .formula,
 new_hyps ← f h,
-for new_hyps (λnew_hyp, do
+for new_hyps $ λnew_hyp, do
   type ← infer_type new_hyp.2,
   nh ← mk_local_def `nh $ imp type c.local_false,
-  return $ (op.1.inst (lambdas [h] (app nh new_hyp.2))).close_constn (op.2 ++ new_hyp.1 ++ [nh]))
+  return $ op.1.inst (lambdas [h] (app nh new_hyp.2)) .close_constn (op.2 ++ new_hyp.1 ++ [nh])
 
 meta def on_first_right (c : clause) (f : expr → tactic (list (list expr × expr))) : tactic (list clause) :=
 first $ do i ← list.range c.num_lits, [on_right_at c i f]

--- a/library/tools/super/equality.lean
+++ b/library/tools/super/equality.lean
@@ -11,7 +11,7 @@ namespace super
 meta def try_unify_eq_l (c : clause) (i : nat) : tactic clause := do
 guard $ clause.literal.is_neg (clause.get_lit c i),
 qf ← clause.open_metan c c.num_quants,
-match is_eq (qf.1.get_lit i).formula with
+match is_eq $ qf.1.get_lit i .formula with
 | none := failed
 | some (lhs, rhs) := do
 unify lhs rhs,

--- a/library/tools/super/factoring.lean
+++ b/library/tools/super/factoring.lean
@@ -23,7 +23,7 @@ unify_lit (qf.get_lit i) (qf.get_lit j),
 qfi ← qf.inst_mvars, guard $ clause.is_maximal gt qfi i,
 -- construct proof
 (at_j, cs) ← qf.open_constn j, hyp_i ← cs.nth i,
-let qf' := (at_j.inst hyp_i).close_constn cs,
+let qf' := at_j.inst hyp_i .close_constn cs,
 -- instantiate meta-variables and replace remaining meta-variables by quantifiers
 clause.meta_closure mvars qf'
 

--- a/library/tools/super/prover_state.lean
+++ b/library/tools/super/prover_state.lean
@@ -218,7 +218,7 @@ return { id := id, c := c, selected := [], assertions := ass, sc := sc }
 
 meta def add_inferred (c : derived_clause) : prover unit := do
 c' ← c.c.normalize, c' ← return { c with c := c' },
-register_consts_in_precedence (contained_funsyms c'.c.type).values,
+register_consts_in_precedence (contained_funsyms c'.c.type .values),
 state ← state_t.read,
 state_t.write { state with newly_derived := c' :: state.newly_derived }
 
@@ -331,7 +331,7 @@ do active ← get_active, for' active.values $ λac, do
 
 meta def move_passive_to_locked : prover unit :=
 do passive ← flip monad.lift state_t.read $ λst, st.passive, for' passive.to_list $ λpc, do
-  c_val ← sat_eval_assertions pc.2.assertions,
+  c_val ← sat_eval_assertions (pc.2.assertions),
   if ¬c_val then do
     state_t.modify $ λst, { st with
       passive := st.passive.erase pc.1,
@@ -422,7 +422,7 @@ meta def empty (local_false : expr) : prover_state :=
 
 meta def initial (local_false : expr) (clauses : list clause) : tactic prover_state := do
 after_setup ← for' clauses (λc,
-  let in_sos := ((contained_lconsts c.proof).erase local_false.local_uniq_name).size = 0 in
+  let in_sos := contained_lconsts c.proof .erase local_false.local_uniq_name .size = 0 in
   do mk_derived c { priority := score.prio.immediate, in_sos := in_sos,
                     age := 0, cost := 0 } >>= add_inferred
 ) $ empty local_false,

--- a/library/tools/super/resolution.lean
+++ b/library/tools/super/resolution.lean
@@ -19,14 +19,14 @@ meta def try_resolve : tactic clause := do
 qf1 ← c1.open_metan c1.num_quants,
 qf2 ← c2.open_metan c2.num_quants,
 -- FIXME: using default transparency unifies m*n with (x*y*z)*w here ???
-unify (qf1.1.get_lit i1).formula (qf2.1.get_lit i2).formula transparency.reducible,
+unify (qf1.1.get_lit i1 .formula) (qf2.1.get_lit i2 .formula) transparency.reducible,
 qf1i ← qf1.1.inst_mvars,
 guard $ clause.is_maximal gt qf1i i1,
 op1 ← qf1.1.open_constn i1,
 op2 ← qf2.1.open_constn c2.num_lits,
-a_in_op2 ← (op2.2.nth i2).to_monad,
+a_in_op2 ← op2.2.nth i2 .to_monad,
 clause.meta_closure (qf1.2 ++ qf2.2) $
-  (op1.1.inst (op2.1.close_const a_in_op2).proof).close_constn (op1.2 ++ op2.2.remove_nth i2)
+  op1.1.inst (op2.1.close_const a_in_op2 .proof) .close_constn (op1.2 ++ op2.2.remove_nth i2)
 
 meta def try_add_resolvent : prover unit := do
 c' ← try_resolve gt ac1.c ac2.c i1 i2,

--- a/library/tools/super/selection.lean
+++ b/library/tools/super/selection.lean
@@ -23,11 +23,11 @@ end
 meta def selection21 : selection_strategy :=
 simple_selection_strategy $ λgt c,
 let maximal_lits := list.filter_maximal (λi j,
-  gt (c.get_lit i).formula (c.get_lit j).formula) (list.range c.num_lits) in
+  gt (c.get_lit i .formula) (c.get_lit j .formula)) (list.range c.num_lits) in
 if list.length maximal_lits = 1 then maximal_lits else
-let neg_lits := list.filter (λi, (c.get_lit i).is_neg) (list.range c.num_lits),
+let neg_lits := list.filter (λi, c.get_lit i .is_neg) (list.range c.num_lits),
     maximal_neg_lits := list.filter_maximal (λi j,
-      gt (c.get_lit i).formula (c.get_lit j).formula) neg_lits in
+      gt (c.get_lit i .formula) (c.get_lit j .formula)) neg_lits in
 if ¬maximal_neg_lits.empty then
   list.taken 1 maximal_neg_lits
 else
@@ -36,15 +36,15 @@ else
 meta def selection22 : selection_strategy :=
 simple_selection_strategy $ λgt c,
 let maximal_lits := list.filter_maximal (λi j,
-  gt (c.get_lit i).formula (c.get_lit j).formula) (list.range c.num_lits),
-  maximal_lits_neg := list.filter (λi, (c.get_lit i).is_neg) maximal_lits in
+  gt (c.get_lit i .formula) (c.get_lit j .formula)) (list.range c.num_lits),
+  maximal_lits_neg := list.filter (λi, c.get_lit i .is_neg) maximal_lits in
 if ¬maximal_lits_neg.empty then
   list.taken 1 maximal_lits_neg
 else
   maximal_lits
 
 meta def clause_weight (c : derived_clause) : nat :=
-(c.c.get_lits.for (λl, expr_size l.formula + if l.is_pos then 10 else 1)).sum
+c.c.get_lits.for (λl, expr_size l.formula + if l.is_pos then 10 else 1) .sum
 
 meta def find_minimal_by (passive : rb_map clause_id derived_clause)
                          {A} [has_ordering A]

--- a/library/tools/super/splitting.lean
+++ b/library/tools/super/splitting.lean
@@ -12,13 +12,13 @@ private meta def find_components : list expr → list (list (expr × ℕ)) → l
 | (e::es) comps :=
   let (contain_e, do_not_contain_e) :=
       partition (λc : list (expr × ℕ), c.exists_ $ λf,
-        (abstract_local f.1 e.local_uniq_name).has_var) comps in
+        abstract_local f.1 e.local_uniq_name .has_var) comps in
     find_components es $ list.join contain_e :: do_not_contain_e
 | _ comps := comps
 
 meta def get_components (hs : list expr) : list (list expr) :=
-(find_components hs (hs.zip_with_index.map $ λh, [h])).map $ λc,
-(sort_on (λh : expr × ℕ, h.2) c).map $ λh, h.1
+find_components hs (hs.zip_with_index.map $ λh, [h]) .map $ λc,
+sort_on (λh : expr × ℕ, h.2) c .map $ λh, h.1
 
 meta def extract_assertions : clause → prover (clause × list expr) | c :=
 if c.num_lits = 0 then return (c, [])
@@ -56,7 +56,7 @@ return $ { empty_clause with proof := p }.close_constn hs
 meta def splitting_inf : inf_decl := inf_decl.mk 30 $ take given, do
 lf ← flip monad.lift state_t.read $ λst, st.local_false,
 op ← given.c.open_constn given.c.num_binders,
-if list.bor (given.c.get_lits.map $ λl, (is_local_not lf l.formula).is_some) then return () else
+if list.bor (given.c.get_lits.map $ λl, is_local_not lf l.formula .is_some) then return () else
 let comps := get_components op.2 in
 if comps.length < 2 then return () else do
 splitting_clause ← mk_splitting_clause op.1 comps,

--- a/library/tools/super/subsumption.lean
+++ b/library/tools/super/subsumption.lean
@@ -21,7 +21,7 @@ meta def try_subsume (small large : clause) : tactic unit := do
 small_open ← clause.open_metan small (clause.num_quants small),
 large_open ← clause.open_constn large (clause.num_quants large),
 guard $ small.num_lits ≤ large.num_lits,
-try_subsume_core small_open.1.get_lits large_open.1.get_lits
+try_subsume_core (small_open.1.get_lits) (large_open.1.get_lits)
 
 meta def does_subsume (small large : clause) : tactic bool :=
 (try_subsume small large >> return tt) <|> return ff

--- a/library/tools/super/superposition.lean
+++ b/library/tools/super/superposition.lean
@@ -57,11 +57,11 @@ match is_eq e with
 end
 
 meta def try_sup : tactic clause := do
-guard $ (c1.get_lit i1).is_pos,
+guard $ c1.get_lit i1 .is_pos,
 qf1 ← c1.open_metan c1.num_quants,
 qf2 ← c2.open_metan c2.num_quants,
-(rwr_from, rwr_to) ← (is_eq_dir (qf1.1.get_lit i1).formula ltr).to_monad,
-atom ← return (qf2.1.get_lit i2).formula,
+(rwr_from, rwr_to) ← is_eq_dir (qf1.1.get_lit i1 .formula) ltr .to_monad,
+atom ← return (qf2.1.get_lit i2 .formula),
 eq_type ← infer_type rwr_from,
 atom_at_pos ← return $ get_position atom pos,
 atom_at_pos_type ← infer_type atom_at_pos,
@@ -75,7 +75,7 @@ if lt_in_termorder
 rwr_ctx_varn ← mk_fresh_name,
 abs_rwr_ctx ← return $
   lam rwr_ctx_varn binder_info.default eq_type
-  (if (qf2.1.get_lit i2).is_neg
+  (if qf2.1.get_lit i2 .is_neg
    then replace_position (mk_var 0) atom pos
    else imp (replace_position (mk_var 0) atom pos) c2.local_false),
 lf_univ ← infer_univ c1.local_false,
@@ -83,16 +83,16 @@ univ ← infer_univ eq_type,
 atom_univ ← infer_univ atom,
 op1 ← qf1.1.open_constn i1,
 op2 ← qf2.1.open_constn c2.num_lits,
-hi2 ← (op2.2.nth i2).to_monad,
+hi2 ← op2.2.nth i2 .to_monad,
 new_atom ← whnf_no_delta $ app abs_rwr_ctx rwr_to',
 new_hi2 ← return $ local_const hi2.local_uniq_name `H binder_info.default new_atom,
 new_fin_prf ←
   return $ app_of_list (const congr_ax [lf_univ, univ, atom_univ]) [c1.local_false, eq_type, rwr_from, rwr_to,
-            abs_rwr_ctx, (op2.1.close_const hi2).proof, new_hi2],
-clause.meta_closure (qf1.2 ++ qf2.2) $ (op1.1.inst new_fin_prf).close_constn (op1.2 ++ op2.2.update_nth i2 new_hi2)
+            abs_rwr_ctx, op2.1.close_const hi2 .proof, new_hi2],
+clause.meta_closure (qf1.2 ++ qf2.2) $ op1.1.inst new_fin_prf .close_constn (op1.2 ++ op2.2.update_nth i2 new_hi2)
 
 meta def rwr_positions (c : clause) (i : nat) : list (list ℕ) :=
-get_rwr_positions (c.get_lit i).formula
+get_rwr_positions $ c.get_lit i .formula
 
 meta def try_add_sup : prover unit :=
 (do c' ← try_sup gt ac1.c ac2.c i1 i2 pos ltr ff congr_ax,
@@ -102,8 +102,8 @@ meta def try_add_sup : prover unit :=
 meta def superposition_back_inf : inference :=
 take given, do active ← get_active, sequence' $ do
   given_i ← given.selected,
-  guard (given.c.get_lit given_i).is_pos,
-  option.to_monad $ is_eq (given.c.get_lit given_i).formula,
+  guard $ given.c.get_lit given_i .is_pos,
+  option.to_monad $ is_eq $ given.c.get_lit given_i .formula,
   other ← rb_map.values active,
   guard $ ¬given.sc.in_sos ∨ ¬other.sc.in_sos,
   other_i ← other.selected,
@@ -118,8 +118,8 @@ take given, do active ← get_active, sequence' $ do
   other ← rb_map.values active,
   guard $ ¬given.sc.in_sos ∨ ¬other.sc.in_sos,
   other_i ← other.selected,
-  guard (other.c.get_lit other_i).is_pos,
-  option.to_monad $ is_eq (other.c.get_lit other_i).formula,
+  guard $ other.c.get_lit other_i .is_pos,
+  option.to_monad $ is_eq $ other.c.get_lit other_i .formula,
   pos ← rwr_positions given.c given_i,
   [do try_add_sup gt other given other_i given_i pos tt ``super.sup_ltr,
       try_add_sup gt other given other_i given_i pos ff ``super.sup_rtl]

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2015,9 +2015,9 @@ unsigned parser::curr_lbp() const {
         return 0;
     case token_kind::Identifier:     case token_kind::Numeral:
     case token_kind::Decimal:        case token_kind::String:
-    case token_kind::Char:
+    case token_kind::Char: case token_kind::FieldName:
         return get_max_prec();
-    case token_kind::FieldNum: case token_kind::FieldName:
+    case token_kind::FieldNum:
         return get_max_prec()+1;
     }
     lean_unreachable(); // LCOV_EXCL_LINE


### PR DESCRIPTION
This was the second part of my projection syntax suggestion on slack. I'm posting this here mainly to have concrete data supporting the change. We can close this PR if we don't want to adopt the change.

I propose to change the precedence of the field-name token to match that of application.  At the moment we allow the following code:
```lean
(env s).get n
list.range x .succ -- parsed as (list.range (nat.succ x))
```
I find the second one particularly confusing as the space suggests that they are different arguments.  With this change, the code would look as follows:
```lean
env s .get n
list.range (x .succ) -- or: list.range x.succ
```

Practically speaking, this PR removes 158 parentheses in the standard library, often greatly increasing readability.  This is a particularly striking example:
```diff
 return $ new_hyps.map $ λnew_hyp,
-  (((clause.mk 0 0 new_hyp.2 c.local_false c.local_false).close_const h).inst
-               (op.1.close_const lci).proof).close_constn
-  (qf.2 ++ op.2.remove_nth i ++ new_hyp.1)
+  clause.mk 0 0 new_hyp.2 c.local_false c.local_false
+    .close_const h
+    .inst (op.1.close_const lci .proof)
+    .close_constn (qf.2 ++ op.2.remove_nth i ++ new_hyp.1)
```

Disadvantages:
 * `x .succ` is parsed differently than `x.succ`
 * It does not play well with the `.2` projections, since they are always parsed as tokens (and keep their old precedence).  This could be fixed by scanning `x.2.get` as a single name, and resolving the `.2` in the `id_to_expr` function.