### PR TITLE
fix(emacs/lean-server): define-fringe-bitmap is only defined in graphics mode

### DIFF
--- a/src/emacs/lean-server.el
+++ b/src/emacs/lean-server.el
@@ -220,8 +220,9 @@
   "Face to highlight pending Lean tasks."
   :group 'lean)
 
-(define-fringe-bitmap 'lean-server-fringe-bitmap
-  (vector) 16 8)
+(if (fboundp 'define-fringe-bitmap)
+  (define-fringe-bitmap 'lean-server-fringe-bitmap
+    (vector) 16 8))
 
 (defface lean-server-task-fringe-face
   '((((class color) (background light))


### PR DESCRIPTION
I received this patch via email.  Apparently you can build emacs without support for the graphical UI, and then the `define-fringe-bitmap` function is not available.