### PR TITLE
fix(frontends/lean/scanner): correctly handle positions in empty files

### DIFF
--- a/src/frontends/lean/module_parser.cpp
+++ b/src/frontends/lean/module_parser.cpp
@@ -61,7 +61,7 @@ module_parser_result module_parser::parse(optional<std::vector<gtask>> const & d
     module_parser_result res;
     if (m_save_info)
         res.m_snapshot_at_end = m_parser.mk_snapshot();
-    res.m_range = {{0, 1}, {0, 1}};
+    res.m_range = {{1, 0}, {1, 0}};
     res.m_cancel = global_cancellation_token();
     res.m_lt = lt.get();
     res.m_next = parse_next_command_like(dependencies);
@@ -71,6 +71,7 @@ module_parser_result module_parser::parse(optional<std::vector<gtask>> const & d
 task<module_parser_result> module_parser::parse_next_command_like(optional<std::vector<gtask>> const & dependencies) {
     auto self = shared_from_this();
     auto begin_pos = m_parser.pos();
+    lean_assert(begin_pos >= pos_info(1, 0));
 
     auto fn = [self, begin_pos] {
         scope_pos_info_provider scope_pip(self->m_parser); // for nested_elaborator_exception::pp
@@ -90,6 +91,7 @@ task<module_parser_result> module_parser::parse_next_command_like(optional<std::
             done = true;
         }
         auto end_pos = self->m_parser.pos();
+        lean_assert(end_pos >= begin_pos);
 
         module_parser_result res;
         if (done || self->m_save_info)

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -691,6 +691,7 @@ scanner::scanner(std::istream & strm, char const * strm_name):
     m_in_notation = false;
     m_last_line = false;
     fetch_line();
+    if (m_sline == 0) m_sline = 1;
     m_line = m_sline;
     m_pos = 0;
 }
@@ -706,6 +707,8 @@ void scanner::skip_to_pos(pos_info const & pos) {
     m_line = m_sline;
     for (unsigned col_idx = 0; col_idx < pos.second; col_idx++)
         next();
+
+    lean_assert(pos == pos_info(get_line(), get_pos()));
 }
 
 std::ostream & operator<<(std::ostream & out, token_kind k) {

--- a/tests/lean/interactive/correct_snapshot_invalidation.input
+++ b/tests/lean/interactive/correct_snapshot_invalidation.input
@@ -6,3 +6,5 @@
 {"seq_num": 5, "command": "sync", "file_name": "f", "content": "inductive foo : nat → nat → Prop\n"}
 {"seq_num": 6, "command": "sync", "file_name": "f", "content": "inductive foo : nat → nat → Prop\n\n"}
 {"seq_num": 7, "command": "sync", "file_name": "f", "content": "inductive foo : nat → nat → Prop\n\n\n"}
+{"seq_num": 8, "command": "sync", "file_name": "f", "content": ""}
+{"seq_num": 9, "command": "sync", "file_name": "f", "content": "import system.io\n"}

--- a/tests/lean/interactive/correct_snapshot_invalidation.input.expected.out
+++ b/tests/lean/interactive/correct_snapshot_invalidation.input.expected.out
@@ -12,3 +12,5 @@
 {"message":"file invalidated","response":"ok","seq_num":5}
 {"message":"file invalidated","response":"ok","seq_num":6}
 {"message":"file invalidated","response":"ok","seq_num":7}
+{"message":"file invalidated","response":"ok","seq_num":8}
+{"message":"file invalidated","response":"ok","seq_num":9}


### PR DESCRIPTION
This fixes the following problem:
 1. Open a new, empty lean file in emacs.
 2. Insert `import system.io` at the top.
 3. Get error that imports need to be at the beginning of the file.