### PR TITLE
Add a tactic which uses z3 to prove goals

### DIFF
--- a/library/init/meta/format.lean
+++ b/library/init/meta/format.lean
@@ -23,6 +23,7 @@ meta constant format.of_string       : string → format
 meta constant format.of_nat          : nat → format
 meta constant format.flatten         : format → format
 meta constant format.to_string       : format → options → string
+meta constant format.to_buffer       : format → options → string
 meta constant format.of_options      : options → format
 meta constant format.is_nil          : format → bool
 meta constant trace_fmt {α : Type u} : format → (unit → α) → α

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -131,14 +131,18 @@ write h (mk_buffer.append_string s)
 def put_str_ln (h : handle) (s : string) : io unit :=
 put_str h s >> put_str h "\n"
 
-def read_file (s : string) (bin := ff) : io char_buffer :=
-do h ← mk_file_handle s io.mode.read bin,
+def read_to_end (h : handle) : io char_buffer :=
    iterate mk_buffer $ λ r,
      do done ← is_eof h,
      if done then return none
      else do
        c ← read h 1024,
        return $ some (r ++ c)
+
+def read_file (s : string) (bin := ff) : io char_buffer :=
+do h ← mk_file_handle s io.mode.read bin,
+   read_to_end h
+
 end fs
 end io
 

--- a/library/tools/smt2/attributes.lean
+++ b/library/tools/smt2/attributes.lean
@@ -1,0 +1,5 @@
+def smt2_attribute : user_attribute :=
+{ name := `smt2,
+  descr := "Mark a decalartion as part of the gloabl environment of the smt2 tactic" }
+
+run_cmd register_attribute `smt2_attribute

--- a/library/tools/smt2/attributes.lean
+++ b/library/tools/smt2/attributes.lean
@@ -3,3 +3,4 @@ def smt2_attribute : user_attribute :=
   descr := "Mark a decalartion as part of the gloabl environment of the smt2 tactic" }
 
 run_cmd register_attribute `smt2_attribute
+

--- a/library/tools/smt2/builder.lean
+++ b/library/tools/smt2/builder.lean
@@ -3,7 +3,7 @@ import .syntax
 @[reducible] def smt2.builder (α : Type) := state (list smt2.cmd) α
 
 meta def smt2.builder.to_format {α : Type} (build : smt2.builder α) : format :=
-format.join $ list.map to_fmt $ (build []).snd
+format.join $ list.intersperse "\n" $ (list.map to_fmt $ (build []).snd).reverse
 
 meta instance (α : Type) : has_to_format (smt2.builder α) :=
 ⟨ smt2.builder.to_format ⟩
@@ -11,6 +11,12 @@ meta instance (α : Type) : has_to_format (smt2.builder α) :=
 namespace smt2
 
 namespace builder
+
+def not (t : term) : term :=
+term.apply "not" [t]
+
+def implies (t u : term) : term :=
+term.apply "implies" [t, u]
 
 def add_command (c : cmd) : builder unit := do
 cs ← state.read,
@@ -33,6 +39,9 @@ do push level,
    res ← action,
    pop level,
    return res
+
+def assert (t : term) : builder unit :=
+add_command $ cmd.assert_cmd t
 
 def reset : builder unit :=
 add_command cmd.reset

--- a/library/tools/smt2/builder.lean
+++ b/library/tools/smt2/builder.lean
@@ -42,6 +42,15 @@ term.apply "iff" [t, u]
 def lt (t u : term) : term :=
 term.apply "<" [t, u]
 
+def lte (t u : term) : term :=
+term.apply "<=" [t, u]
+
+def gt (t u : term) : term :=
+term.apply ">" [t, u]
+
+def gte (t u : term) : term :=
+term.apply ">=" [t, u]
+
 def add (t u : term) : term :=
 term.apply "+" [t, u]
 

--- a/library/tools/smt2/builder.lean
+++ b/library/tools/smt2/builder.lean
@@ -18,6 +18,39 @@ term.apply "not" [t]
 def implies (t u : term) : term :=
 term.apply "implies" [t, u]
 
+def and (ts : list term) : term :=
+term.apply "and" ts
+
+def and2 (t u : term) : term :=
+and [t, u]
+
+def or (ts : list term) : term :=
+term.apply "or" ts
+
+def or2 (t u : term) : term :=
+or [t, u]
+
+def iff (t u : term) : term :=
+term.apply "iff" [t, u]
+
+def lt (t u : term) : term :=
+term.apply "<" [t, u]
+
+def add (t u : term) : term :=
+term.apply "+" [t, u]
+
+def sub (t u : term) : term :=
+term.apply "-" [t, u]
+
+def mul (t u : term) : term :=
+term.apply "*" [t, u]
+
+def div (t u : term) : term :=
+term.apply "div" [t, u]
+
+def int_const (i : int) : term :=
+term.const $ special_constant.number i
+
 def add_command (c : cmd) : builder unit := do
 cs ← state.read,
 state.write (c :: cs)
@@ -51,6 +84,9 @@ add_command cmd.exit_cmd
 
 def declare_const (sym : string) (s : sort) : builder unit :=
 add_command $ cmd.declare_const sym s
+
+def declare_sort (sym : string) (arity : nat) : builder unit :=
+add_command $ cmd.declare_sort sym arity
 
 end builder
 

--- a/library/tools/smt2/builder.lean
+++ b/library/tools/smt2/builder.lean
@@ -12,11 +12,17 @@ namespace smt2
 
 namespace builder
 
+def equals (t u : term) : term :=
+term.apply "=" [t, u]
+
 def not (t : term) : term :=
 term.apply "not" [t]
 
 def implies (t u : term) : term :=
 term.apply "implies" [t, u]
+
+def forallq (sym : symbol) (s : sort) (t : term) : term :=
+term.forallq [(sym, s)] t
 
 def and (ts : list term) : term :=
 term.apply "and" ts
@@ -84,6 +90,9 @@ add_command cmd.exit_cmd
 
 def declare_const (sym : string) (s : sort) : builder unit :=
 add_command $ cmd.declare_const sym s
+
+def declare_fun (sym : string) (ps : list sort) (ret : sort) : builder unit :=
+add_command $ cmd.declare_fun sym ps ret
 
 def declare_sort (sym : string) (arity : nat) : builder unit :=
 add_command $ cmd.declare_sort sym arity

--- a/library/tools/smt2/default.lean
+++ b/library/tools/smt2/default.lean
@@ -4,34 +4,113 @@ import .solvers.z3
 import .syntax
 import .builder
 
-meta def smt2 [io.interface] (build : smt2.builder unit) : io string :=
+inductive smt2.response
+| sat
+| unsat
+| other : string → smt2.response
+
+meta def parse_smt2_result (str : string) : smt2.response :=
+    if str = "sat\n"
+    then smt2.response.sat
+    else if str = "unsat\n"
+    then smt2.response.unsat
+    else smt2.response.other str
+
+meta def smt2 [io.interface] (build : smt2.builder unit) : io smt2.response :=
 do z3 ← z3_instance.start,
    io.put_str (to_string $ to_fmt build),
    res ← z3.raw (to_string $ to_fmt build),
-   io.put_str res,
-   return res
+   return $ parse_smt2_result res
 
 open tactic
 open smt2
 open smt2.builder
 
+meta def mangle_name (n : name) : string :=
+    "lean_" ++ n^.to_string_with_sep "-"
+
 meta def reflect_prop (e : expr) : tactic (builder unit) :=
+return $ do let z3_name := mangle_name e.local_uniq_name,
+   declare_const  z3_name "Bool"
+
+meta def reflect_prop_formula' : expr → tactic term
+| ```(¬ %%P) := not <$> (reflect_prop_formula' P)
+| ```(%%P → %% Q) := implies <$> (reflect_prop_formula' P) <*> (reflect_prop_formula' Q)
+| e := if e.is_local_constant
+       then return $ term.qual_id (mangle_name e.local_uniq_name)
+       else tactic.fail $ "unsupported propositional formula : " ++ to_string e
+
+meta def reflect_prop_formula (e : expr) : tactic (builder unit) :=
+do ty ← infer_type e,
+   form ← reflect_prop_formula' ty,
+   return $ assert form
+
+inductive formula_type
+| prop
+| prop_formula
+| unsupported
+
+meta def classify_formula (e : expr) : tactic formula_type :=
 do p ← is_prop e,
    if p
-   then do
-       trace e,
-       n ← mk_fresh_name,
-       return $ declare_const (to_string n) "Bool"
-   else return (return ())
+   then return formula_type.prop
+   else
+     do ty ← infer_type e,
+        sort ← infer_type ty,
+        -- add to our own tracing for this module? look at simplifier?
+        tactic.trace ("type: " ++ to_string ty),
+        tactic.trace ("sort: " ++ to_string sort),
+        if sort = ```(Prop)
+        then return formula_type.prop_formula
+        else return formula_type.unsupported
+
+meta def reflect_local (e : expr) : tactic (builder unit) :=
+do ft ← classify_formula e,
+   match ft with
+   | formula_type.prop := reflect_prop e
+   | formula_type.prop_formula := reflect_prop_formula e
+   | _ := return (return ())
+   end
 
 meta def reflect_context : tactic (builder unit) :=
 do ls ← local_context,
-   bs ← monad.mapm reflect_prop ls,
+   bs ← monad.mapm reflect_local ls,
    return $ list.foldl (λ (a b : builder unit), a >> b) (return ()) bs
 
-meta def reflect : tactic unit :=
+meta def reflect_goal : tactic (builder unit) :=
 do tgt ← target,
-   b ← reflect_context,
-   str ← run_io (λ ioi, @smt2 ioi b),
-   tactic.trace str,
-   return ()
+   ft ← classify_formula tgt,
+   match ft with
+   | formula_type.prop :=
+     do tgt ← target,
+        let n := tgt.local_uniq_name,
+        return $ assert (not $ mangle_name n)
+   | _ :=
+     return $ do declare_const "goal" "Bool",
+        assert (not $ "goal")
+--    | formula_type.prop_formula :=
+--         do ty ← infer_type tgt,
+--            form ← reflect_prop_formula' ty,
+--            return $ assert (not form)
+--    | _ := return (return ())
+   end
+
+
+axiom admit_ax : forall {A : Prop}, A
+
+meta def z3 : tactic unit :=
+do goal_builder ← reflect_goal,
+   ctxt_builder ← reflect_context,
+   resp ← run_io (λ ioi, @smt2 ioi (ctxt_builder >> goal_builder >> check_sat)),
+   match resp with
+   | response.sat := tactic.fail "z3 was unable to prove the goal"
+   | response.other str := tactic.fail $ "encountered unexpected response: `" ++ str ++ "`"
+   | response.unsat := do
+        tgt ← target,
+        fresh_name ← mk_fresh_name,
+        let axiom_name := name.mk_string "z3" (name.mk_string "axioms" fresh_name),
+        -- TODO: generate a minimal unique axiom for each application of the tactic, add_decl (declaration.ax axiom_name [] tgt)
+        sry ← to_expr $ `(sorry),
+        exact sry
+   end
+

--- a/library/tools/smt2/default.lean
+++ b/library/tools/smt2/default.lean
@@ -1,107 +1,154 @@
+-- declare_trace smt2
 import system.io
 import system.process
 import .solvers.z3
 import .syntax
 import .builder
-
-inductive smt2.response
-| sat
-| unsat
-| other : string → smt2.response
-
-meta def parse_smt2_result (str : string) : smt2.response :=
-    if str = "sat\n"
-    then smt2.response.sat
-    else if str = "unsat\n"
-    then smt2.response.unsat
-    else smt2.response.other str
-
-meta def smt2 [io.interface] (build : smt2.builder unit) : io smt2.response :=
-do z3 ← z3_instance.start,
-   io.put_str (to_string $ to_fmt build),
-   res ← z3.raw (to_string $ to_fmt build),
-   return $ parse_smt2_result res
+import .tactic
 
 open tactic
 open smt2
 open smt2.builder
 
+meta structure smt2_state : Type :=
+(sort_map : rb_map expr unit)
+
+meta def smt2_state.initial : smt2_state :=
+⟨ rb_map.mk _ _ ⟩
+
+@[reducible] meta def smt2_m (α : Type) :=
+state_t smt2_state tactic α
+
+meta instance tactic_to_smt2_m (α : Type) : has_coe (tactic α) (smt2_m α) :=
+⟨ fun tc, fun s, do res ← tc, return (res, s) ⟩
+
 meta def mangle_name (n : name) : string :=
-    "lean_" ++ n^.to_string_with_sep "-"
+"lean_" ++ n^.to_string_with_sep "-"
 
-meta def reflect_prop (e : expr) : tactic (builder unit) :=
+meta def ensure_sort (sort : expr) : smt2_m unit :=
+do st ← state_t.read,
+   match st.sort_map.find sort with
+   | some _ := return ()
+   | none :=
+     state_t.write (⟨ st.sort_map.insert sort () ⟩)
+   end
+
+meta def reflect_prop (e : expr) : smt2_m (builder unit) :=
 return $ do let z3_name := mangle_name e.local_uniq_name,
-   declare_const  z3_name "Bool"
+            declare_const  z3_name "Bool"
 
-meta def reflect_prop_formula' : expr → tactic term
+#check eval_expr
+
+meta def as_literal : expr → option int := fun e, none
+
+
+/-- This function is the meat of the tactic, it takes a propositional formula in Lean, and transforms
+   it into a corresponding term in SMT2.
+-/
+meta def reflect_arith_formula : expr → smt2_m term
+| ```(%%a + %%b) := smt2.builder.add <$> reflect_arith_formula a <*> reflect_arith_formula b
+| ```(%%a - %%b) := smt2.builder.sub <$> reflect_arith_formula a <*> reflect_arith_formula b
+| ```(%%a * %%b) := smt2.builder.mul <$> reflect_arith_formula a <*> reflect_arith_formula b
+| ```(%%a / %%b) := smt2.builder.div <$> reflect_arith_formula a <*> reflect_arith_formula b
+| ```(zero : int) := smt2.builder.int_const <$> eval_expr int ```(one : int)
+| ```(one : int) := smt2.builder.int_const <$> eval_expr int ```(one : int)
+| ```(bit0 %%Bits : int) := smt2.builder.int_const <$> eval_expr int ```(bit0 %%Bits : int)
+| ```(bit1 %%Bits : int) := smt2.builder.int_const <$> eval_expr int ```(bit0 %%Bits : int)
+| a :=
+    if a.is_local_constant
+    then return $ term.qual_id (mangle_name a.local_uniq_name)
+    else tactic.fail $ "unsupported arithmetic formula: " ++ to_string a
+
+meta def reflect_prop_formula' : expr → smt2_m term
 | ```(¬ %%P) := not <$> (reflect_prop_formula' P)
-| ```(%%P → %% Q) := implies <$> (reflect_prop_formula' P) <*> (reflect_prop_formula' Q)
-| e := if e.is_local_constant
+| ```(%%P → %%Q) := implies <$> (reflect_prop_formula' P) <*> (reflect_prop_formula' Q)
+| ```(%%P ∧ %%Q) := smt2.builder.and2 <$> (reflect_prop_formula' P) <*> (reflect_prop_formula' Q)
+| ```(%%P ∨ %%Q) := smt2.builder.or2 <$> (reflect_prop_formula' P) <*> (reflect_prop_formula' Q)
+| ```(%%P ↔ %%Q) := smt2.builder.iff <$> (reflect_prop_formula' P) <*> (reflect_prop_formula' Q)
+| ```(%%P < %%Q) :=
+do ty ← infer_type P,
+if (ty = ```(int))
+then smt2.builder.lt <$> (reflect_arith_formula P) <*> (reflect_arith_formula Q)
+else tactic.fail "unknown ordering"
+| e := do tactic.trace ("trace: " ++ to_string e ++ ", " ++ to_string e.local_uniq_name),
+       if e.is_local_constant
        then return $ term.qual_id (mangle_name e.local_uniq_name)
        else tactic.fail $ "unsupported propositional formula : " ++ to_string e
 
-meta def reflect_prop_formula (e : expr) : tactic (builder unit) :=
+meta def reflect_prop_formula (e : expr) : smt2_m (builder unit) :=
 do ty ← infer_type e,
    form ← reflect_prop_formula' ty,
    return $ assert form
 
 inductive formula_type
-| prop
+| const : smt2.sort → formula_type
 | prop_formula
 | unsupported
 
+/-- The goal of this function is to categorize the set of formulas in the hypotheses,
+   and goal, the assumptions this code is written under follow:
+
+   A local constant of the form `(P : Prop)`, must be reflected as declaration
+   in SMT2 that is `(declare-const P Bool)`.
+
+   An occurence of a proof of `P`, `(p : P)`, must be transformed into
+   `(assert P)`. If P is a formula, not an atom, we must transform P into a corresponding
+   SMT2 formula and `(assert P)`.
+-/
 meta def classify_formula (e : expr) : tactic formula_type :=
-do p ← is_prop e,
-   if p
-   then return formula_type.prop
-   else
-     do ty ← infer_type e,
-        sort ← infer_type ty,
-        -- add to our own tracing for this module? look at simplifier?
-        tactic.trace ("type: " ++ to_string ty),
-        tactic.trace ("sort: " ++ to_string sort),
-        if sort = ```(Prop)
+do ty ← infer_type e,
+   prop_sorted ← is_prop ty,
+   if e.is_local_constant
+   then if (ty = ```(Prop))
+        then return $ formula_type.const "Bool"
+        else if (ty = ```(int))
+        then return $ formula_type.const "Int"
+        else if prop_sorted
+        then return formula_type.prop_formula
+        else return formula_type.unsupported
+   else if (ty = ```(Prop))
         then return formula_type.prop_formula
         else return formula_type.unsupported
 
-meta def reflect_local (e : expr) : tactic (builder unit) :=
+meta def reflect_local (e : expr) : smt2_m (builder unit) :=
 do ft ← classify_formula e,
    match ft with
-   | formula_type.prop := reflect_prop e
+   | formula_type.const (sort.id "Bool") := reflect_prop e
+   | formula_type.const (sort.id "Int") :=
+    return $ do let z3_name := mangle_name e.local_uniq_name,
+            declare_const  z3_name "Int"
    | formula_type.prop_formula := reflect_prop_formula e
    | _ := return (return ())
    end
 
-meta def reflect_context : tactic (builder unit) :=
+meta def reflect_context : smt2_m (builder unit) :=
 do ls ← local_context,
    bs ← monad.mapm reflect_local ls,
    return $ list.foldl (λ (a b : builder unit), a >> b) (return ()) bs
 
-meta def reflect_goal : tactic (builder unit) :=
+meta def reflect_goal : smt2_m (builder unit) :=
 do tgt ← target,
    ft ← classify_formula tgt,
+   tactic.trace ("target: " ++ tgt.to_string),
    match ft with
-   | formula_type.prop :=
-     do tgt ← target,
+   | formula_type.const (sort.id "Bool") :=
+     do tactic.trace "variable case",
         let n := tgt.local_uniq_name,
         return $ assert (not $ mangle_name n)
-   | _ :=
-     return $ do declare_const "goal" "Bool",
-        assert (not $ "goal")
---    | formula_type.prop_formula :=
---         do ty ← infer_type tgt,
---            form ← reflect_prop_formula' ty,
---            return $ assert (not form)
---    | _ := return (return ())
+   | formula_type.prop_formula :=
+      do tactic.trace "prop case",
+      (do form ← reflect_prop_formula' tgt, return $ assert (not form))
+   | _ := tactic.fail "unknown goal"
    end
 
-
-axiom admit_ax : forall {A : Prop}, A
-
-meta def z3 : tactic unit :=
+meta def reflect : smt2_m (builder unit) :=
 do goal_builder ← reflect_goal,
    ctxt_builder ← reflect_context,
-   resp ← run_io (λ ioi, @smt2 ioi (ctxt_builder >> goal_builder >> check_sat)),
+   return $ ctxt_builder >> goal_builder >> check_sat
+
+meta def z3 : tactic unit :=
+do (builder, _) ← reflect smt2_state.initial,
+   resp ← run_io (λ ioi, @smt2 ioi builder),
    match resp with
    | response.sat := tactic.fail "z3 was unable to prove the goal"
    | response.other str := tactic.fail $ "encountered unexpected response: `" ++ str ++ "`"

--- a/library/tools/smt2/solvers/z3.lean
+++ b/library/tools/smt2/solvers/z3.lean
@@ -25,6 +25,5 @@ do let z3_stdin := z3.process.stdin,
    let cs := cmd.reverse.to_buffer,
    io.fs.write z3_stdin cs,
    io.fs.close z3_stdin,
-   -- need read all
-   res ← io.fs.read z3_stdout 1024,
+   res ← io.fs.read_to_end z3_stdout,
    return res.to_string

--- a/library/tools/smt2/syntax.lean
+++ b/library/tools/smt2/syntax.lean
@@ -58,7 +58,12 @@ meta def term.to_format : term → format
     format.bracket "(" ")" (
         qual_id.to_format ++ format.space ++ formatted_ts)
 | (term.letb ps ret) := "NYI"
-| _ := "NYI"
+| (term.forallq bs body) :=
+    "(forall (" ++
+    format.join (bs.map (fun ⟨sym, sort⟩, format.bracket "(" ")" $ to_fmt sym ++ " " ++ to_fmt sort)) ++ ") " ++
+    term.to_format body ++ ")"
+| (term.existsq ps ret) := "NYI existsq"
+| (term.annotate _ _) := "NYI annotate"
 
 inductive fun_def : Type
 inductive info_flag : Type
@@ -70,7 +75,7 @@ inductive cmd : Type
 | check_sat : cmd
 | check_sat_assuming : term → cmd -- not complete
 | declare_const : symbol → sort → cmd
-| declare_fun : symbol → list sort → cmd
+| declare_fun : symbol → list sort → sort → cmd
 | declare_sort : symbol → nat → cmd
 | define_fun : fun_def → cmd
 | define_fun_rec : fun_def → cmd
@@ -105,6 +110,8 @@ meta def cmd.to_format : cmd → format
 | (declare_const sym srt) := "(declare-const " ++ sym ++ " " ++ to_fmt srt ++ ")"
 | (assert_cmd t) := "(assert " ++ t.to_format ++ ")"
 | (check_sat) := "(check-sat)"
+| (declare_fun sym ps rs) := "(declare-fun " ++ sym ++
+    format.bracket " (" ")" (format.join $ list.intersperse " " $ list.map to_fmt ps) ++ " " ++ to_fmt rs ++ ")"
 | _ := "NYI"
 
 meta instance : has_to_format cmd :=

--- a/library/tools/smt2/syntax.lean
+++ b/library/tools/smt2/syntax.lean
@@ -7,6 +7,10 @@ inductive special_constant : Type
 | number : int → special_constant
 | string : string → special_constant
 
+meta def special_constant.to_format : special_constant → format
+| (special_constant.number i) := to_fmt (to_string i)
+| (special_constant.string str) := to_fmt str
+
 inductive sort : Type
 | id : identifier → sort
 | apply : identifier → list sort → sort
@@ -48,7 +52,7 @@ instance qual_name_to_term : has_coe qualified_name term :=
 
 meta def term.to_format : term → format
 | (term.qual_id id) := id.to_format
-| (term.const spec_const) := "NYI"
+| (term.const spec_const) := spec_const.to_format
 | (term.apply qual_id ts) :=
     let formatted_ts := format.join $ list.intersperse " "  $ ts.map term.to_format in
     format.bracket "(" ")" (

--- a/library/tools/smt2/syntax.lean
+++ b/library/tools/smt2/syntax.lean
@@ -27,6 +27,13 @@ inductive qualified_name : Type
 | id : identifier → qualified_name
 | qual_id : identifier → sort → qualified_name
 
+meta def qualified_name.to_format : qualified_name → format
+| (qualified_name.id i) := i
+| (qualified_name.qual_id _ _) := "NYI"
+
+instance string_to_qual_name : has_coe string qualified_name :=
+    ⟨ fun str, qualified_name.id str ⟩
+
 inductive term : Type
 | qual_id : qualified_name → term
 | const : special_constant → term
@@ -35,6 +42,19 @@ inductive term : Type
 | forallq : list (symbol × sort) → term → term
 | existsq : list (symbol × sort) → term → term
 | annotate : term → list attr → term
+
+instance qual_name_to_term : has_coe qualified_name term :=
+    ⟨ term.qual_id ⟩
+
+meta def term.to_format : term → format
+| (term.qual_id id) := id.to_format
+| (term.const spec_const) := "NYI"
+| (term.apply qual_id ts) :=
+    let formatted_ts := format.join $ list.intersperse " "  $ ts.map term.to_format in
+    format.bracket "(" ")" (
+        qual_id.to_format ++ format.space ++ formatted_ts)
+| (term.letb ps ret) := "NYI"
+| _ := "NYI"
 
 inductive fun_def : Type
 inductive info_flag : Type
@@ -79,6 +99,8 @@ format.bracket "\"" "\"" (to_fmt s)
 meta def cmd.to_format : cmd → format
 | (echo msg) := "(echo " ++ string_lit msg ++ ")\n"
 | (declare_const sym srt) := "(declare-const " ++ sym ++ " " ++ to_fmt srt ++ ")"
+| (assert_cmd t) := "(assert " ++ t.to_format ++ ")"
+| (check_sat) := "(check-sat)"
 | _ := "NYI"
 
 meta instance : has_to_format cmd :=

--- a/library/tools/smt2/tactic.lean
+++ b/library/tools/smt2/tactic.lean
@@ -1,0 +1,23 @@
+import system.io
+import .builder
+import .syntax
+import .solvers.z3
+
+inductive smt2.response
+| sat
+| unsat
+| other : string → smt2.response
+
+meta def parse_smt2_result (str : string) : smt2.response :=
+if str = "sat\n"
+then smt2.response.sat
+else if str = "unsat\n"
+then smt2.response.unsat
+else smt2.response.other str
+
+-- should probably abstract over solvers
+meta def smt2 [io.interface] (build : smt2.builder unit) : io smt2.response :=
+do z3 ← z3_instance.start,
+io.put_str (to_string $ to_fmt build),
+res ← z3.raw (to_string $ to_fmt build),
+return $ parse_smt2_result res

--- a/library/tools/smt2/tactic.lean
+++ b/library/tools/smt2/tactic.lean
@@ -6,6 +6,7 @@ import .solvers.z3
 inductive smt2.response
 | sat
 | unsat
+| unknown
 | other : string → smt2.response
 
 meta def parse_smt2_result (str : string) : smt2.response :=
@@ -13,11 +14,21 @@ if str = "sat\n"
 then smt2.response.sat
 else if str = "unsat\n"
 then smt2.response.unsat
+else if str = "unknown\n"
+then smt2.response.unknown
 else smt2.response.other str
 
 -- should probably abstract over solvers
-meta def smt2 [io.interface] (build : smt2.builder unit) : io smt2.response :=
+meta def smt2 [io.interface] (build : smt2.builder unit) (log_query : option string := none) : io smt2.response :=
 do z3 ← z3_instance.start,
-io.put_str (to_string $ to_fmt build),
-res ← z3.raw (to_string $ to_fmt build),
-return $ parse_smt2_result res
+   -- maybe we should have a primitive to go from fmt to char buffer
+   let query := to_string $ to_fmt build,
+   -- io.put_str (to_string $ to_fmt build),
+   match log_query with
+   | none := return ()
+   | some fn :=
+     do file ← io.mk_file_handle fn io.mode.write,
+        io.fs.write file (query.reverse.to_buffer)
+   end,
+   res ← z3.raw (to_string $ to_fmt build),
+   return $ parse_smt2_result res

--- a/tests/lean/run/smt2_P_implies_Q_fail.lean
+++ b/tests/lean/run/smt2_P_implies_Q_fail.lean
@@ -1,0 +1,5 @@
+example (P Q : Prop) : P -> Q :=
+begin
+    intros,
+    z3
+end

--- a/tests/lean/run/smt2_arith.lean
+++ b/tests/lean/run/smt2_arith.lean
@@ -1,0 +1,26 @@
+import tools.smt2
+
+lemma arith_simple :
+    forall (x y : int),
+        x < y →
+        x + 1 < y + 1000 :=
+begin
+    intros, z3
+end
+
+lemma arith_wrong :
+    forall (x y : int),
+        x < y →
+        x + 1 < y :=
+begin
+    intros, z3
+end
+
+lemma lt_trans_by_z3 :
+    forall (x y z : int),
+        x < y →
+        y < z →
+        x < z :=
+begin
+    intros, z3
+end

--- a/tests/lean/run/smt2_attribute.lean
+++ b/tests/lean/run/smt2_attribute.lean
@@ -1,0 +1,22 @@
+import tools.smt2
+
+constants f g : Prop → int → int
+attribute [smt2] f
+attribute [smt2] g
+
+constants x y z : int
+attribute [smt2] x
+attribute [smt2] y
+attribute [smt2] z
+
+constants Heq : forall (x x' : Prop) (y : int),
+    (x -> x') ->
+    f x y = g x' y
+
+attribute [smt2] Heq
+
+lemma uninterpreted_functions_with_attr :
+    f (x < 0) ((x + y) +z) = g (x < 0) (z + (y + x)) :=
+begin
+    intros, z3
+end

--- a/tests/lean/run/smt2_de_morgans.lean
+++ b/tests/lean/run/smt2_de_morgans.lean
@@ -1,0 +1,15 @@
+import tools.smt2
+
+lemma negation_of_conj :
+    forall (P Q : Prop),
+        not (P ∧ Q) ↔ not P ∨ not Q :=
+begin
+    intros, z3
+end
+
+lemma negation_of_disj :
+    forall (P Q : Prop),
+        ¬ (P ∨ Q) ↔ ¬ P ∧ ¬ Q :=
+begin
+    intros, z3
+end

--- a/tests/lean/run/smt2_inconsistent_context.lean
+++ b/tests/lean/run/smt2_inconsistent_context.lean
@@ -1,0 +1,7 @@
+import tools.smt2
+
+example (P : Prop) (p : P) (np : not P) : 3 < 1 :=
+begin
+    intros,
+    z3
+end

--- a/tests/lean/run/smt2_p_implies_p.lean
+++ b/tests/lean/run/smt2_p_implies_p.lean
@@ -1,0 +1,7 @@
+import tools.smt2
+
+example (P : Prop) : P → P :=
+begin
+    intros,
+    z3 $ "/tmp/P.smt2"
+end

--- a/tests/lean/run/smt2_uninterp.lean
+++ b/tests/lean/run/smt2_uninterp.lean
@@ -1,0 +1,37 @@
+import tools.smt2
+
+lemma uninterpreted_Props :
+    forall (f g : int → Prop)
+           (x y z : int)
+           (Heq : forall x, f x = g x),
+        f ((x + y) +z) = g (z + (y + x)) :=
+begin
+    intros, z3
+end
+
+lemma uninterpreted_Props_fail :
+    forall (f g : int → Prop)
+           (x y z : int)
+           (Heq : forall x, f x = g x),
+        f ((x + y) +z) = g (z + y) :=
+begin
+    intros, z3
+end
+
+lemma uninterpreted_functions :
+    forall (f g : int → int)
+           (x y z : int)
+           (Heq : forall x, f x = g x),
+        f ((x + y) +z) = g (z + (y + x)) :=
+begin
+    intros, z3
+end
+
+lemma uninterpreted_functions_mixed_sorts :
+    forall (f g : Prop → int → int)
+           (x y z : int)
+           (Heq : forall x y, f x y = g x y),
+        f (x < 0) ((x + y) +z) = g (x < 0) (z + (y + x)) :=
+begin
+    intros, z3 $ some "/tmp/uninterp.smt2"
+end


### PR DESCRIPTION
This is an initial tactic which uses z3 to prove a subset of Lean goals, and uses sorry to finish the proof. 

Currently it supports a limited subset of Lean, it will translate uninterpreted functions, propositional logic & arithmetic into a z3 query.

Doing a clean-up pass right now, but we should merge the initial version. Since we are lacking arithmetic support in Lean currently this might be generally useful. 