### PR TITLE
`induction ... generalizing ...` and `case` tactics

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -336,6 +336,7 @@ do e_type ← infer_type e >>= whnf,
    (const I ls) ← return $ get_app_fn e_type,
    return I
 
+precedence `generalizing` : 0
 meta def induction (p : parse texpr) (rec_name : parse using_ident) (ids : parse with_ident_list)
   (revert : parse $ (tk "generalizing" *> ident*)?) : tactic unit :=
 do e ← i_to_expr p,

--- a/src/frontends/lean/token_table.cpp
+++ b/src/frontends/lean/token_table.cpp
@@ -96,7 +96,7 @@ void init_token_table(token_table & t) {
          {"@@", g_max_prec}, {"@", g_max_prec},
          {"sorry", g_max_prec}, {"+", g_plus_prec}, {"->", g_arrow_prec}, {"<-", 0},
          {"match", 0}, {"^.", g_max_prec+1},
-         {"renaming", 0}, {"extends", 0}, {"generalizing", 0}, {nullptr, 0}};
+         {"renaming", 0}, {"extends", 0}, {nullptr, 0}};
 
     char const * commands[] =
         {"theorem", "axiom", "axioms", "variable", "protected", "private",


### PR DESCRIPTION
`induction e generalizing ids` first reverts `ids` and then reintroduces them in each new subgoal. `case n ids` focuses on the `induction/cases` subgoal corresponding to the constructor `n` and optionally renames identifiers introduced by it using `ids`. This is nice not just for documentation, but also for avoiding having to name parameters of eliminated cases, and for reordering cases so that simple ones can be solved with a single final tactic.
See in action at https://github.com/Kha/semantics-lean/commit/23965f9f4fbf085786ce4c6c4fd2e4d6a3f44add#diff-2372531b49c81b52df5a4e3090283065L118