### PR TITLE
fix(library/metavar_util): do not compress mvar assignments in tmp mode

### DIFF
--- a/src/library/metavar_context.cpp
+++ b/src/library/metavar_context.cpp
@@ -118,6 +118,8 @@ struct metavar_context::interface_impl {
     bool is_assigned(expr const & e) const { return m_ctx.is_assigned(e); }
     optional<expr> get_assignment(expr const & e) const { return m_ctx.get_assignment(e); }
     void assign(expr const & m, expr const & v) { m_ctx.assign(m, v); }
+
+    bool in_tmp_mode() const { return false; }
 };
 
 

--- a/src/library/metavar_util.h
+++ b/src/library/metavar_util.h
@@ -23,6 +23,8 @@ bool is_mvar_core(expr const & e) const;
 bool is_assigned(expr const & e) const;
 optional<expr> get_assignment(expr const & e) const;
 void assign(expr const & m, expr const & v);
+
+bool in_tmp_mode() const;
 */
 
 template<typename CTX>
@@ -87,7 +89,8 @@ level instantiate_mvars(CTX & ctx, level const & l) {
                 if (auto v1 = ctx.get_assignment(l)) {
                     level v2 = instantiate_mvars(ctx, *v1);
                     if (*v1 != v2) {
-                        ctx.assign(l, v2);
+                        if (!ctx.in_tmp_mode())
+                            ctx.assign(l, v2);
                         return some_level(v2);
                     } else {
                         return some_level(*v1);
@@ -134,7 +137,7 @@ class instantiate_mvars_fn : public replace_visitor {
                     return *v1;
                 } else {
                     expr v2 = visit(*v1);
-                    if (v2 != *v1)
+                    if (!m_ctx.in_tmp_mode() && v2 != *v1)
                         m_ctx.assign(m, v2);
                     return v2;
                 }

--- a/tests/lean/run/mvar_backtrack.lean
+++ b/tests/lean/run/mvar_backtrack.lean
@@ -1,0 +1,14 @@
+namespace foo
+open nat
+
+class lt (n : out_param ℕ) (m : ℕ)
+instance succ_lt_succ_of_lt (n m) [lt n m] : lt (succ n) (succ m) := by constructor
+instance zero_lt_succ (m) : lt 0 (succ m) := by constructor
+
+class foo (n : out_param ℕ) (m : ℕ)
+instance (n m) [lt n 10] [lt m n] : foo n m := by constructor
+
+def bar {n} (m) [foo n m] := n
+#eval bar 0
+#eval bar 1
+end foo


### PR DESCRIPTION
Alternative fix for #1519