### PR TITLE
[WIP, RFC, Preview] Linting Framework

### DIFF
--- a/library/init/default.lean
+++ b/library/init/default.lean
@@ -16,7 +16,3 @@ def debugger.attr : user_attribute :=
 
 meta structure linter :=
 (lint : declaration → tactic unit)
-
-@[linter] meta def my_lint : linter :=
-⟨ fun d, tactic.trace "foobar" ⟩
-

--- a/library/init/default.lean
+++ b/library/init/default.lean
@@ -8,11 +8,9 @@ import init.core init.logic init.category init.data.basic
 import init.propext init.cc_lemmas init.funext init.category.combinators init.function init.classical
 import init.util init.coe init.wf init.meta init.algebra init.data
 import init.native
+import init.linter
 
 @[user_attribute]
 def debugger.attr : user_attribute :=
 { name  := `breakpoint,
   descr := "breakpoint for debugger" }
-
-meta structure linter :=
-(lint : declaration → tactic unit)

--- a/library/init/default.lean
+++ b/library/init/default.lean
@@ -13,3 +13,10 @@ import init.native
 def debugger.attr : user_attribute :=
 { name  := `breakpoint,
   descr := "breakpoint for debugger" }
+
+meta structure linter :=
+(lint : declaration → tactic unit)
+
+@[linter] meta def my_lint : linter :=
+⟨ fun d, tactic.trace "foobar" ⟩
+

--- a/library/init/linter.lean
+++ b/library/init/linter.lean
@@ -1,0 +1,11 @@
+prelude
+
+import init.data.option.basic
+import init.meta.declaration
+import init.meta.tactic
+
+meta constant pos_info_provider : Type
+meta constant pos_info_provider.expr_pos : pos_info_provider → option pos
+
+meta structure linter :=
+(lint : pos_info_provider → declaration → tactic unit)

--- a/library/init/linter.lean
+++ b/library/init/linter.lean
@@ -9,3 +9,33 @@ meta constant pos_info_provider.expr_pos : pos_info_provider → option pos
 
 meta structure linter :=
 (lint : pos_info_provider → declaration → tactic unit)
+
+open tactic
+
+meta def linter.get_decl_pos (d : declaration) : tactic pos :=
+do env ← get_env,
+   match env.decl_pos d.to_name with
+   | none := failed
+   | some pos := return pos
+   end
+
+-- A lint for warning about declaration naming conventions.
+private def name_str_is_accepted_style (s : string) : bool :=
+if (64 < s.head.to_nat) && (s.head.to_nat < 91)
+then bool.ff
+else bool.tt
+
+private def name_is_accepted_style : name → bool
+| (name.mk_numeral i n) := name_is_accepted_style n
+| (name.mk_string str n) := name_str_is_accepted_style str.reverse &&
+                            name_is_accepted_style n
+| (name.anonymous) := bool.tt
+
+private meta def warn_decl_name (pos_prov : pos_info_provider) (decl : declaration) : tactic unit :=
+let name := decl.to_name in
+if name_is_accepted_style name
+then do pos ← linter.get_decl_pos decl, save_info_thunk pos (fun u, to_fmt $ "foooo bar")
+else trace $ "warning: `" ++ to_string name ++ "` violates style guidelines"
+
+@[linter] private meta def warn_decl_names : linter :=
+⟨ warn_decl_name ⟩

--- a/library/init/meta/pexpr.lean
+++ b/library/init/meta/pexpr.lean
@@ -4,11 +4,31 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
+
 import init.meta.expr
+
 universe u
 
+-- meta inductive equations (f : () -> Type) : Type
+-- | empty {} : equations
+-- | equation : (f ())  → equations
+
 /- Quoted expressions. They can be converted into expressions by using a tactic. -/
-meta constant pexpr : Type
+meta inductive pexpr : Type
+| var         : nat → pexpr
+| sort        : level → pexpr
+| const       : name → list level → pexpr
+| mvar        : name → pexpr → pexpr
+| local_const : name → name → binder_info → pexpr → pexpr
+| app         : pexpr → pexpr → pexpr
+| lam         : name → binder_info → pexpr → pexpr → pexpr
+| pi          : name → binder_info → pexpr → pexpr → pexpr
+| elet        : name → pexpr → pexpr → pexpr → pexpr
+| macro       : macro_def → ∀ n, (fin n → pexpr) → pexpr
+-- | prenum      : int → pexpr
+| prenum      : nat → pexpr
+| equations   : list (pexpr × pexpr) → pexpr
+
 protected meta constant pexpr.of_expr  : expr → pexpr
 protected meta constant pexpr.subst    : pexpr → pexpr → pexpr
 

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -32,6 +32,7 @@ Author: Leonardo de Moura
 #include "library/compiler/vm_compiler.h"
 #include "library/compiler/rec_fn_macro.h"
 #include "library/tactic/eqn_lemmas.h"
+#include "library/linter.h"
 #include "frontends/lean/parser.h"
 #include "frontends/lean/tokens.h"
 #include "frontends/lean/elaborator.h"
@@ -308,9 +309,18 @@ static certified_declaration check(parser & p, environment const & env, name con
                 msg.get_text_stream().get_stream()
                     << "type checking time of " << c_name << " took " << display_profiling_time{duration} << "\n";
                 msg.report();
-            });
+        });
+
+        if (linting_enabled(p.get_options())) {
+            lint_declaration(env, d);
+        }
+
         return ::lean::check(env, d);
     } else {
+        if (linting_enabled(p.get_options())) {
+            lint_declaration(env, d);
+        }
+
         return ::lean::check(env, d);
     }
 }

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -394,7 +394,7 @@ declare_definition(parser & p, environment const & env, def_cmd_kind kind, buffe
     }
 
     if (linting_enabled(p.get_options())) {
-        lint_declaration(env, p, def);
+        lint_declaration(new_env, p, def);
     }
 
     new_env = compile_decl(p, new_env, c_name, c_real_name, pos);

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -394,7 +394,7 @@ declare_definition(parser & p, environment const & env, def_cmd_kind kind, buffe
     }
 
     if (linting_enabled(p.get_options())) {
-        lint_declaration(new_env, p, def);
+        lint_declaration(new_env, def);
     }
 
     new_env = compile_decl(p, new_env, c_name, c_real_name, pos);

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -311,16 +311,8 @@ static certified_declaration check(parser & p, environment const & env, name con
                 msg.report();
         });
 
-        if (linting_enabled(p.get_options())) {
-            lint_declaration(env, d);
-        }
-
         return ::lean::check(env, d);
     } else {
-        if (linting_enabled(p.get_options())) {
-            lint_declaration(env, d);
-        }
-
         return ::lean::check(env, d);
     }
 }
@@ -399,6 +391,10 @@ declare_definition(parser & p, environment const & env, def_cmd_kind kind, buffe
 
     if (!modifiers.m_is_private) {
         new_env = ensure_decl_namespaces(new_env, c_real_name);
+    }
+
+    if (linting_enabled(p.get_options())) {
+        lint_declaration(env, def);
     }
 
     new_env = compile_decl(p, new_env, c_name, c_real_name, pos);

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -394,7 +394,7 @@ declare_definition(parser & p, environment const & env, def_cmd_kind kind, buffe
     }
 
     if (linting_enabled(p.get_options())) {
-        lint_declaration(env, def);
+        lint_declaration(env, p, def);
     }
 
     new_env = compile_decl(p, new_env, c_name, c_real_name, pos);

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -21,4 +21,4 @@ add_library(library OBJECT deep_copy.cpp expr_lt.cpp io_state.cpp
   eval_helper.cpp
   messages.cpp message_builder.cpp module_mgr.cpp comp_val.cpp
   documentation.cpp check.cpp arith_instance.cpp parray.cpp process.cpp
-  pipe.cpp handle.cpp profiling.cpp)
+  pipe.cpp handle.cpp profiling.cpp linter.cpp)

--- a/src/library/init_module.cpp
+++ b/src/library/init_module.cpp
@@ -53,6 +53,7 @@ Author: Leonardo de Moura
 #include "library/check.h"
 #include "library/parray.h"
 #include "library/profiling.h"
+#include "library/linter.h"
 
 namespace lean {
 void initialize_library_core_module() {
@@ -117,9 +118,11 @@ void initialize_library_module() {
     initialize_check();
     initialize_congr_lemma();
     initialize_parray();
+    initialize_linter();
 }
 
 void finalize_library_module() {
+    finalize_linter();
     finalize_parray();
     finalize_congr_lemma();
     finalize_check();

--- a/src/library/linter.cpp
+++ b/src/library/linter.cpp
@@ -26,8 +26,7 @@ buffer<name> get_linters(environment const & env) {
     return ns;
 }
 
-void lint_declaration(environment const &env, pos_info_provider const &prov,
-                      declaration const &decl) {
+void lint_declaration(environment const &env, declaration const &decl) {
     auto opts = get_global_ios().get_options();
     vm_state S(env, opts);
     scope_vm_state scoped(S);
@@ -39,8 +38,8 @@ void lint_declaration(environment const &env, pos_info_provider const &prov,
     for (auto linter_name : linter_names) {
         // NB: because we currently have 1 field inductive, this requires no unboxing
         auto linter_fn = S.get_constant(linter_name);
-        vm_obj linter_result = S.invoke(linter_fn, to_obj(prov), to_obj(decl), to_obj(tac_st));
-        if (is_constructor(linter_result) && cidx(linter_result) == 0) {
+        vm_obj linter_result = S.invoke(linter_fn, to_obj(decl), to_obj(tac_st));
+        if (tactic::is_result_success(linter_result)) {
             return; // to_format(cfield(linter_result ,0));
         } else if (auto except = tactic::is_exception(S, linter_result)) {
             auto msg = std::get<0>(*except);

--- a/src/library/linter.cpp
+++ b/src/library/linter.cpp
@@ -36,7 +36,15 @@ void lint_declaration(environment const & env, declaration const & decl) {\
     for (auto linter_name : linter_names) {
         // NB: because we currently have 1 field inductive, this requires no unboxing
         auto linter_fn = S.get_constant(linter_name);
-        vm_obj result = S.invoke(linter_fn, to_obj(decl), to_obj(tac_st));
+        vm_obj linter_result = S.invoke(linter_fn, to_obj(decl), to_obj(tac_st));
+        if (is_constructor(linter_result) && cidx(linter_result) == 0) {
+            return; // to_format(cfield(linter_result ,0));
+        } else if (auto except = tactic::is_exception(S, linter_result)) {
+            auto msg = std::get<0>(*except);
+            throw lean::exception((sstream() << msg).str());
+        } else {
+            lean_unreachable();
+        }
     }
 }
 

--- a/src/library/linter.cpp
+++ b/src/library/linter.cpp
@@ -61,7 +61,6 @@ void initialize_linter() {
             "linter", "a declaration linter",
             [](environment const & env, name const & decl_name, bool) {
                 auto decl = env.find(decl_name);
-                std::cout << "in linter check" << decl->get_type() << std::endl;
                 // throw exception("invalid '[parsing_only]' attribute, can only be used in notation declarations");
             }));
 

--- a/src/library/linter.cpp
+++ b/src/library/linter.cpp
@@ -1,0 +1,64 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Jared Roesch
+*/
+
+#include "library/attribute_manager.h"
+#include "library/tactic/tactic_state.h"
+#include "library/vm/vm_declaration.h"
+#include "util/sexpr/option_declarations.h"
+
+#ifndef LEAN_DEFAULT_LINTER
+#define LEAN_DEFAULT_LINTER true
+#endif
+
+namespace lean {
+
+static lean::name * g_linter = nullptr;
+
+buffer<name> get_linters(environment const & env) {
+    buffer<name> ns;
+    get_attribute(env, *g_linter).get_instances(env, ns);
+    return ns;
+}
+
+void lint_declaration(environment const & env, declaration const & decl) {\
+    auto opts = get_global_ios().get_options();
+    vm_state S(env, opts);
+    scope_vm_state scoped(S);
+
+    local_context lctx;
+    tactic_state tac_st = mk_tactic_state_for(env, opts, {"Linter"}, lctx, mk_constant("true"));
+
+    auto linter_names = get_linters(env);
+    for (auto linter_name : linter_names) {
+        // NB: because we currently have 1 field inductive, this requires no unboxing
+        auto linter_fn = S.get_constant(linter_name);
+        vm_obj result = S.invoke(linter_fn, to_obj(decl), to_obj(tac_st));
+    }
+}
+
+bool linting_enabled(options const & opts) {
+    return opts.get_bool(*g_linter, LEAN_DEFAULT_LINTER);
+}
+
+void initialize_linter() {
+    g_linter = new name{"linter"};
+
+    register_system_attribute(basic_attribute::with_check(
+            "linter", "a declaration linter",
+            [](environment const & env, name const & decl_name, bool) {
+                auto decl = env.find(decl_name);
+                std::cout << "in linter check" << decl->get_type() << std::endl;
+                // throw exception("invalid '[parsing_only]' attribute, can only be used in notation declarations");
+            }));
+
+    register_bool_option(*g_linter, LEAN_DEFAULT_LINTER, "(linter) enable the linting framework");
+}
+
+void finalize_linter() {
+    delete g_linter;
+}
+}

--- a/src/library/linter.h
+++ b/src/library/linter.h
@@ -1,0 +1,19 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Jared Roesch
+*/
+#pragma once
+
+#include "kernel/declaration.h"
+#include "util/sexpr/options.h"
+
+namespace lean {
+
+void lint_declaration(environment const & env, declaration const & decl);
+bool linting_enabled(options const & opts);
+void initialize_linter();
+void finalize_linter();
+
+}

--- a/src/library/linter.h
+++ b/src/library/linter.h
@@ -11,7 +11,8 @@ Author: Jared Roesch
 
 namespace lean {
 
-void lint_declaration(environment const & env, declaration const & decl);
+
+void lint_declaration(environment const &, pos_info_provider const & prov, declaration const & decl);
 bool linting_enabled(options const & opts);
 void initialize_linter();
 void finalize_linter();

--- a/src/library/linter.h
+++ b/src/library/linter.h
@@ -12,7 +12,7 @@ Author: Jared Roesch
 namespace lean {
 
 
-void lint_declaration(environment const &, pos_info_provider const & prov, declaration const & decl);
+void lint_declaration(environment const &, declaration const & decl);
 bool linting_enabled(options const & opts);
 void initialize_linter();
 void finalize_linter();

--- a/src/library/vm/CMakeLists.txt
+++ b/src/library/vm/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(vm OBJECT vm.cpp optimize.cpp vm_nat.cpp vm_string.cpp vm_aux.cpp vm_io.cpp vm_name.cpp
   vm_options.cpp vm_format.cpp vm_rb_map.cpp vm_level.cpp vm_expr.cpp vm_exceptional.cpp
   vm_declaration.cpp vm_environment.cpp vm_list.cpp vm_pexpr.cpp vm_task.cpp
-  vm_native.cpp vm_int.cpp init_module.cpp vm_parser.cpp vm_array.cpp vm_pos_info.cpp)
+  vm_native.cpp vm_int.cpp init_module.cpp vm_parser.cpp vm_array.cpp vm_pos_info.cpp
+  vm_pos_info_provider.cpp)

--- a/src/library/vm/init_module.cpp
+++ b/src/library/vm/init_module.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Leonardo de Moura
@@ -24,6 +24,7 @@ Author: Leonardo de Moura
 #include "library/vm/vm_task.h"
 #include "library/vm/vm_parser.h"
 #include "library/vm/vm_array.h"
+#include "library/vm/vm_pos_info_provider.h"
 
 namespace lean {
 void initialize_vm_core_module() {
@@ -47,9 +48,11 @@ void initialize_vm_core_module() {
     initialize_vm_environment();
     initialize_vm_parser();
     initialize_vm_array();
+    initialize_vm_pos_info_provider();
 }
 
 void finalize_vm_core_module() {
+    finalize_vm_pos_info_provider();
     finalize_vm_array();
     finalize_vm_parser();
     finalize_vm_environment();

--- a/src/library/vm/vm_int.h
+++ b/src/library/vm/vm_int.h
@@ -11,6 +11,9 @@ namespace lean {
 int to_int(vm_obj const & o);
 optional<int> try_to_int(vm_obj const & o);
 int force_to_int(vm_obj const & o, int def);
+vm_obj mk_vm_int(int n);
+vm_obj mk_vm_int(unsigned n);
+vm_obj mk_vm_int(mpz const & n);
 void initialize_vm_int();
 void finalize_vm_int();
 }

--- a/src/library/vm/vm_pexpr.cpp
+++ b/src/library/vm/vm_pexpr.cpp
@@ -12,12 +12,16 @@ Author: Leonardo de Moura
 #include "library/string.h"
 #include "library/vm/vm.h"
 #include "library/vm/vm_expr.h"
+#include "library/vm/vm_level.h"
 #include "library/vm/vm_name.h"
+#include "library/vm/vm_int.h"
 #include "library/vm/vm_string.h"
 #include "library/vm/vm_option.h"
 #include "library/vm/vm_pos_info.h"
+#include "library/vm/vm_list.h"
 #include "frontends/lean/prenum.h"
 #include "frontends/lean/structure_cmd.h"
+#include "frontends/lean/prenum.h"
 #include "frontends/lean/util.h"
 
 namespace lean {
@@ -69,6 +73,67 @@ vm_obj pexpr_mk_field_macro(vm_obj const & e, vm_obj const & fname) {
     return to_obj(mk_field_notation(to_expr(e), to_name(fname)));
 }
 
+unsigned pexpr_cases_on(vm_obj const & o, buffer<vm_obj> & data) {
+    expr const & e = to_expr(o);
+    // std::cout << "into pexpr cases on: " << e << std::endl;
+    switch (e.kind()) {
+    case expr_kind::Var:
+        data.push_back(mk_vm_nat(var_idx(e)));
+        break;
+    case expr_kind::Sort:
+        data.push_back(to_obj(sort_level(e)));
+        break;
+    case expr_kind::Constant:
+        data.push_back(to_obj(const_name(e)));
+        data.push_back(to_obj(const_levels(e)));
+        break;
+    case expr_kind::Meta:
+        data.push_back(to_obj(mlocal_name(e)));
+        data.push_back(to_obj(mlocal_type(e)));
+        break;
+    case expr_kind::Local:
+        data.push_back(to_obj(mlocal_name(e)));
+        data.push_back(to_obj(local_pp_name(e)));
+        data.push_back(to_obj(local_info(e)));
+        data.push_back(to_obj(mlocal_type(e)));
+        break;
+    case expr_kind::App:
+        data.push_back(to_obj(app_fn(e)));
+        data.push_back(to_obj(app_arg(e)));
+        break;
+    case expr_kind::Lambda:
+    case expr_kind::Pi:
+        data.push_back(to_obj(binding_name(e)));
+        data.push_back(to_obj(binding_info(e)));
+        data.push_back(to_obj(binding_domain(e)));
+        data.push_back(to_obj(binding_body(e)));
+        break;
+    case expr_kind::Let:
+        data.push_back(to_obj(let_name(e)));
+        data.push_back(to_obj(let_type(e)));
+        data.push_back(to_obj(let_value(e)));
+        data.push_back(to_obj(let_body(e)));
+        break;
+    case expr_kind::Macro:
+        auto macro_name = macro_def(e).get_name();
+        // We place all the special macro constructors at the
+        // end of the inductive declaration so they should
+        // be the ctor index for macro +1, +2, etc.
+        if (macro_name == "prenum") {
+            data.push_back(mk_vm_nat(prenum_value(e)));
+            return static_cast<unsigned>(e.kind()) + 1;
+        } else if (equations == "equations") {
+            // data.push_back(to_obj(macro_def(e)));
+            // data.push_back(mk_vm_nat(macro_num_args(e)));
+            // data.push_back(mk_vm_closure(g_expr_macro_arg_fun_idx, 1, &o));
+            std::cout << macro_def(e).get_name() << std::endl;
+            throw "foooo";
+        }
+        break;
+    }
+    return static_cast<unsigned>(e.kind());
+}
+
 void initialize_vm_pexpr() {
     DECLARE_VM_BUILTIN(name({"pexpr", "subst"}),          expr_subst);
     DECLARE_VM_BUILTIN(name({"pexpr", "of_expr"}),        pexpr_of_expr);
@@ -84,6 +149,8 @@ void initialize_vm_pexpr() {
     DECLARE_VM_BUILTIN(name("pexpr", "mk_string_macro"),  pexpr_mk_string_macro);
     DECLARE_VM_BUILTIN(name("pexpr", "mk_explicit"),      pexpr_mk_explicit);
     DECLARE_VM_BUILTIN(name("pexpr", "mk_field_macro"),   pexpr_mk_field_macro);
+
+    DECLARE_VM_CASES_BUILTIN(name({"pexpr", "cases_on"}),   pexpr_cases_on);
 }
 
 void finalize_vm_pexpr() {

--- a/src/library/vm/vm_pos_info_provider.cpp
+++ b/src/library/vm/vm_pos_info_provider.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Jared Roesch
+*/
+#include "library/vm/vm_pos_info.h"
+#include "kernel/pos_info_provider.h"
+#include "library/vm/vm_nat.h"
+#include "library/vm/vm_expr.h"
+#include "library/vm/vm_option.h"
+
+namespace lean {
+
+struct vm_pos_info_provider : public vm_external {
+    pos_info_provider const & m_val;
+
+    vm_pos_info_provider(pos_info_provider const & v) : m_val(v) {}
+    virtual ~vm_pos_info_provider() {}
+
+    virtual void dealloc() override {
+        this->~vm_pos_info_provider();
+        get_vm_allocator().deallocate(sizeof(vm_pos_info_provider), this);
+    }
+
+    virtual vm_external * ts_clone(vm_clone_fn const &) override {
+        return new vm_pos_info_provider(m_val);
+    }
+    virtual vm_external * clone(vm_clone_fn const &) override {
+        lean_unreachable();
+    }
+};
+
+pos_info_provider const & to_pos_info_provider(vm_obj const & o) {
+    lean_vm_check(dynamic_cast<vm_pos_info_provider *>(to_external(o)));
+    return static_cast<vm_pos_info_provider*>(to_external(o))->m_val;
+}
+
+vm_obj to_obj(pos_info_provider const & p) {
+    return mk_vm_external(new (get_vm_allocator().allocate(sizeof(vm_pos_info_provider))) vm_pos_info_provider(p));
+}
+
+vm_obj vm_expr_pos(vm_obj const & provider_obj, vm_obj const & expr_obj) {
+    pos_info_provider const & provider = to_pos_info_provider(provider_obj);
+    auto opt_pos_info = provider.get_pos_info(to_expr(expr_obj));
+    if (opt_pos_info) {
+        return mk_vm_some(to_obj(*opt_pos_info));
+    } else {
+        return mk_vm_none();
+    }
+}
+
+void initialize_vm_pos_info_provider() {
+    DECLARE_VM_BUILTIN(name({"pos_info_provider", "expr_pos"}), vm_expr_pos);
+}
+
+void finalize_vm_pos_info_provider() {}
+}
+

--- a/src/library/vm/vm_pos_info_provider.cpp
+++ b/src/library/vm/vm_pos_info_provider.cpp
@@ -44,8 +44,10 @@ vm_obj vm_expr_pos(vm_obj const & provider_obj, vm_obj const & expr_obj) {
     pos_info_provider const & provider = to_pos_info_provider(provider_obj);
     auto opt_pos_info = provider.get_pos_info(to_expr(expr_obj));
     if (opt_pos_info) {
+        std::cout << opt_pos_info->first << opt_pos_info->second << std::endl;
         return mk_vm_some(to_obj(*opt_pos_info));
     } else {
+        std::cout << "none" << std::endl;
         return mk_vm_none();
     }
 }

--- a/src/library/vm/vm_pos_info_provider.cpp
+++ b/src/library/vm/vm_pos_info_provider.cpp
@@ -6,54 +6,21 @@ Author: Jared Roesch
 */
 #include "library/vm/vm_pos_info.h"
 #include "kernel/pos_info_provider.h"
+#include "kernel/scope_pos_info_provider.h"
 #include "library/vm/vm_nat.h"
 #include "library/vm/vm_expr.h"
 #include "library/vm/vm_option.h"
+#include "library/tactic/tactic_state.h"
 
 namespace lean {
 
-struct vm_pos_info_provider : public vm_external {
-    pos_info_provider const & m_val;
-
-    vm_pos_info_provider(pos_info_provider const & v) : m_val(v) {}
-    virtual ~vm_pos_info_provider() {}
-
-    virtual void dealloc() override {
-        this->~vm_pos_info_provider();
-        get_vm_allocator().deallocate(sizeof(vm_pos_info_provider), this);
-    }
-
-    virtual vm_external * ts_clone(vm_clone_fn const &) override {
-        return new vm_pos_info_provider(m_val);
-    }
-    virtual vm_external * clone(vm_clone_fn const &) override {
-        lean_unreachable();
-    }
-};
-
-pos_info_provider const & to_pos_info_provider(vm_obj const & o) {
-    lean_vm_check(dynamic_cast<vm_pos_info_provider *>(to_external(o)));
-    return static_cast<vm_pos_info_provider*>(to_external(o))->m_val;
-}
-
-vm_obj to_obj(pos_info_provider const & p) {
-    return mk_vm_external(new (get_vm_allocator().allocate(sizeof(vm_pos_info_provider))) vm_pos_info_provider(p));
-}
-
-vm_obj vm_expr_pos(vm_obj const & provider_obj, vm_obj const & expr_obj) {
-    pos_info_provider const & provider = to_pos_info_provider(provider_obj);
-    auto opt_pos_info = provider.get_pos_info(to_expr(expr_obj));
-    if (opt_pos_info) {
-        std::cout << opt_pos_info->first << opt_pos_info->second << std::endl;
-        return mk_vm_some(to_obj(*opt_pos_info));
-    } else {
-        std::cout << "none" << std::endl;
-        return mk_vm_none();
-    }
+vm_obj vm_expr_pos(vm_obj const & expr_obj, vm_obj const & st) {
+    auto pos = get_pos_info_provider()->get_pos_info_or_some(to_expr(expr_obj));
+    return tactic::mk_success(to_obj(pos), tactic::to_state(st));
 }
 
 void initialize_vm_pos_info_provider() {
-    DECLARE_VM_BUILTIN(name({"pos_info_provider", "expr_pos"}), vm_expr_pos);
+    DECLARE_VM_BUILTIN(name({"tactic", "expr_pos"}), vm_expr_pos);
 }
 
 void finalize_vm_pos_info_provider() {}

--- a/src/library/vm/vm_pos_info_provider.h
+++ b/src/library/vm/vm_pos_info_provider.h
@@ -8,10 +8,6 @@ Author: Jared Roesch
 #include "library/vm/vm.h"
 
 namespace lean {
-pos_info to_pos_info_provider(vm_obj const & o);
-vm_obj to_obj(pos_info_provider const & p);
-
 void initialize_vm_pos_info_provider();
-
 void finalize_vm_pos_info_provider();
 }

--- a/src/library/vm/vm_pos_info_provider.h
+++ b/src/library/vm/vm_pos_info_provider.h
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Jared Roesch
+*/
+#pragma once
+#include "library/vm/vm.h"
+
+namespace lean {
+pos_info to_pos_info_provider(vm_obj const & o);
+vm_obj to_obj(pos_info_provider const & p);
+
+void initialize_vm_pos_info_provider();
+
+void finalize_vm_pos_info_provider();
+}


### PR DESCRIPTION
This a prototype for enabling user scriptable linting/warnings, there are a couple issues to work out.

What is the right way to query position information, given the decl hasn't been added to the environment yet, it seems we should use `save_info_thunk` for attaching warnings.

I'm also not sure what the success/failure semantics should be, it seems that in a `-Werror` mode we would want any generated diagnostics to cause an error in Lean.

Below is an example of using the attribute:

```lean
set_option linter true

def name_str_is_accepted_style (s : string) : bool :=
  if (64 < s.head.to_nat) && (s.head.to_nat < 91)
  then bool.tt
  else bool.ff

def name_is_accepted_style : name → bool
| (name.mk_numeral i n) := name_is_accepted_style n
| (name.mk_string str n) :=
name_str_is_accepted_style str.reverse &&
name_is_accepted_style n
| (name.anonymous) := bool.tt

open tactic

private meta def warn_declaration_name : declaration → tactic unit :=
fun d,
  let name := d.to_name in
  if name_is_accepted_style name
  then constructor
  else trace $ "warning: `" ++ to_string name ++ "` violates style guidelines"

    -- we need to pass in position or commit it to env first?
    -- do env ← get_env,
    --       pos ← env.decl_pos name,
    --       tactic.save_info_thunk pos (fun u, to_fmt "hello world"),
    --       constructor,
    --       trace "done"

@[linter] meta def warn_names : linter :=
⟨ warn_declaration_name ⟩

def Foo : nat := 1

def b : nat := 2

def baz : nat := 3
```

![linting](https://cloud.githubusercontent.com/assets/696509/25321620/e3b531a6-2864-11e7-875d-8975248c4ced.gif)
