### PR TITLE
Use opaque, general type class instead of special app elaboration for `eval_expr`

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -46,6 +46,13 @@ meta inductive expr
 | elet        : name → expr → expr → expr → expr
 | macro       : macro_def → ∀ n, (fin n → expr) → expr
 
+/-- (reflected a) is a special opaque container for an `expr` representing `a`.
+    It can only be obtained via type class inference, which will use the representation
+    of `a` in the calling context. -/
+meta constant {u} reflected {α : Type u} : α → Type u
+attribute [class] reflected
+meta constant {u} reflect {α : Type u} (a : α) [reflected a] : expr
+
 meta instance : inhabited expr :=
 ⟨expr.sort level.zero⟩
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -213,11 +213,8 @@ inductive transparency
 
 export transparency (reducible semireducible)
 
-/- (eval_expr α α_as_expr e) evaluates 'e' IF 'e' has type 'α'.
-   'α' must be a closed term.
-   'α_as_expr' is synthesized by the code generator.
-   'e' must be a closed expression at runtime. -/
-meta constant eval_expr (α : Type u) {α_expr : pexpr} : expr → tactic α
+/- (eval_expr α e) evaluates 'e' IF 'e' has type 'α'. -/
+meta constant eval_expr (α : Type u) [reflected α] : expr → tactic α
 
 /- Return the partial term/proof constructed so far. Note that the resultant expression
    may contain variables that are not declarate in the current main goal. -/

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -1978,7 +1978,6 @@ expr elaborator::visit_scope_trace(expr const & e, optional<expr> const & expect
 expr elaborator::visit_app(expr const & e, optional<expr> const & expected_type) {
     if (is_app_of(e, get_scope_trace_name(), 1))
         return visit_scope_trace(e, expected_type);
-    expr const & ref = e;
     buffer<expr> args;
     expr const & fn = get_app_args(e, args);
     if (is_infix_function(fn)) {
@@ -1987,20 +1986,6 @@ expr elaborator::visit_app(expr const & e, optional<expr> const & expected_type)
         return visit(head_beta_reduce(copy_tag(e, mk_app(infix_fn, args))), expected_type);
     } else if (is_equations(fn)) {
         return visit_convoy(e, expected_type);
-    } else if (is_constant(fn, get_tactic_eval_expr_name())) {
-        buffer<expr> new_args;
-        expr ref_arg = get_ref_for_child(args[0], ref);
-        expr A = ensure_type(visit(args[0], none_expr()), ref_arg);
-        if (has_local(A))
-            throw elaborator_exception(e, "invalid eval_expr, type must be a closed expression");
-        new_args.push_back(mk_as_is(A));
-        /* Remark: the code generator will replace the following argument */
-        new_args.push_back(copy_tag(e, mk_pexpr_quote(mk_Prop())));
-        if (args.size() > 1) {
-            lean_assert(args.size() == 2);
-            new_args.push_back(args[1]);
-        }
-        return visit(copy_tag(e, mk_app(mk_explicit(fn), new_args)), expected_type);
     } else {
         return visit_app_core(fn, args, expected_type, e);
     }

--- a/src/library/quote.h
+++ b/src/library/quote.h
@@ -13,6 +13,7 @@ bool is_quote(expr const & e);
 bool is_expr_quote(expr const &e);
 expr const & get_quote_expr(expr const & e);
 expr mk_quote_core(expr const & e, bool is_expr);
+expr mk_reflected(expr const & e, expr const & ty, level const & l);
 
 expr mk_antiquote(expr const & e);
 bool is_antiquote(expr const & e);

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -31,6 +31,7 @@ Author: Leonardo de Moura
 #include "library/delayed_abstraction.h"
 #include "library/fun_info.h"
 #include "library/num.h"
+#include "library/quote.h"
 
 #ifndef LEAN_DEFAULT_CLASS_INSTANCE_MAX_DEPTH
 #define LEAN_DEFAULT_CLASS_INSTANCE_MAX_DEPTH 32
@@ -3419,9 +3420,40 @@ struct instance_synthesizer {
         return false;
     }
 
+    bool process_special(stack_entry const & e) {
+        expr const & mvar_type = mlocal_type(e.m_mvar);
+        if (is_app_of(mvar_type, "reflected", 2)) {
+            expr const & r = app_arg(mvar_type);
+            if (!closed(r) || has_local(r)) {
+                lean_trace_plain("class_instances",
+                                 scope_trace_env scope(m_ctx.env(), m_ctx);
+                                 tout() << "not using special support for `reflected` synthesis because '" << r
+                                        << "' is not closed and locals-free";);
+
+                return false;
+            }
+            expr r_ty = app_arg(app_fn(mvar_type));
+            level l = *dec_level(get_level(m_ctx, r_ty));
+            lean_trace_plain("class_instances",
+                             scope_trace_env scope(m_ctx.env(), m_ctx);
+                             trace(e.m_depth, e.m_mvar, mvar_type, r););
+            if (!m_ctx.is_def_eq(e.m_mvar, mk_reflected(r, r_ty, l))) {
+                lean_trace_plain("class_instances", tout() << "failed is_def_eq\n";);
+                return false;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool process_next_mvar() {
         lean_assert(!is_done());
         stack_entry e = head(m_state.m_stack);
+        if (process_special(e)) {
+            m_state.m_stack = tail(m_state.m_stack);
+            return true;
+        }
         if (!mk_choice_point(e.m_mvar))
             return false;
         m_state.m_stack = tail(m_state.m_stack);

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -463,6 +463,10 @@ vm_obj expr_is_annotation(vm_obj const & _e) {
     }
 }
 
+vm_obj reflect(vm_obj const &, vm_obj const &, vm_obj const & r) {
+    return r;
+}
+
 void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "var"}),              expr_var);
     DECLARE_VM_BUILTIN(name({"expr", "sort"}),             expr_sort);
@@ -501,6 +505,8 @@ void initialize_vm_expr() {
     DECLARE_VM_BUILTIN(name({"expr", "occurs"}),           expr_occurs);
     DECLARE_VM_BUILTIN(name({"expr", "collect_univ_params"}), expr_collect_univ_params);
     DECLARE_VM_CASES_BUILTIN(name({"expr", "cases_on"}),   expr_cases_on);
+
+    DECLARE_VM_BUILTIN("reflect",                          reflect);
 
     DECLARE_VM_BUILTIN(name("mk_nat_val_ne_proof"),        vm_mk_nat_val_ne_proof);
     DECLARE_VM_BUILTIN(name("mk_nat_val_lt_proof"),        vm_mk_nat_val_lt_proof);

--- a/tests/lean/eval_expr_error.lean.expected.out
+++ b/tests/lean/eval_expr_error.lean.expected.out
@@ -1,10 +1,8 @@
-eval_expr_error.lean:5:8: error: invalid eval_expr, type must be a closed expression
-eval_expr_error.lean:5:4: error: don't know how to synthesize placeholder
-context:
+eval_expr_error.lean:5:8: error: failed to synthesize type class instance for
 A : Type,
 tst1 : tactic unit,
 a : expr
-⊢ Type
+⊢ reflected A
 eval_expr_error.lean:8:0: error: invalid eval_expr, type mismatch
 state:
 ⊢ true


### PR DESCRIPTION
This is just the beginning! :)
The obvious first extension is to also allow locals and vars to be reflected if there are `reflected` instances for them in the local context. This finally allows us to use `eval_expr` in generic contexts.

Going further, it would make sense to lift the same restriction for ```(e), in which case we can also change its return type to `reflected e`. We can install `reflect` as the "forgetful" coercion `reflected e -> expr` so as not to break the old behavior. Then we should be able to replace many usages of `quote` with `reflected` - or even all of them, if we find a clever new encoding for `interactive.parse`.