### PR TITLE
fix(frontent/lean/elaborator): check if field is found in structure update

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2598,18 +2598,18 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
                     }
                     if (j == fnames.size()) {
                         if (src && !is_subobject_field(m_env, nested_S_name, S_fname)) {
-                            name base_S_name = *find_field(m_env, src_S_name, S_fname);
+                            optional<name> opt_base_S_name = find_field(m_env, src_S_name, S_fname);
+                            if (!opt_base_S_name) {
+                                throw elaborator_exception(ref,
+                                                           sstream() << "invalid structure update { src with ... }, field '"
+                                                                     << S_fname << "'"
+                                                                     << " was not provided, nor was it found in the source of type '"
+                                                                     << src_S_name << "'.");
+                            }
+                            name base_S_name = *opt_base_S_name;
                             expr base_src = *mk_base_projections(m_env, src_S_name, base_S_name, *src);
                             expr f = mk_proj_app(m_env, base_S_name, S_fname, base_src);
-                            try {
-                                c_arg = visit(f, none_expr());
-                            } catch (exception & ex) {
-                                throw nested_exception(some_expr(e),
-                                                       sstream() << "invalid structure update { src with ... }, field '"
-                                                                 << S_fname << "'"
-                                                                 << " was not provided, nor was it found in the source",
-                                                       ex);
-                            }
+                            c_arg = visit(f, none_expr());
                             expr c_arg_type = infer_type(c_arg);
                             if (!is_def_eq(c_arg_type, d)) {
                                 auto pp_data = pp_until_different(c_arg_type, d);

--- a/tests/lean/structure_instance_bug2.lean
+++ b/tests/lean/structure_instance_bug2.lean
@@ -5,3 +5,9 @@ def my_pre_config1 : smt_pre_config :=
 
 def my_pre_config2 : smt_pre_config :=
 { default_smt_pre_config with zeta := tt }
+
+structure st :=
+(i : ℕ)
+
+example (s : st) : unit × st :=
+{s with i := 0}

--- a/tests/lean/structure_instance_bug2.lean.expected.out
+++ b/tests/lean/structure_instance_bug2.lean.expected.out
@@ -1,1 +1,2 @@
 structure_instance_bug2.lean:4:0: error: invalid structure instance, 'default_smt_pre_config' is not the name of a structure type
+structure_instance_bug2.lean:13:0: error: invalid structure update { src with ... }, field 'fst' was not provided, nor was it found in the source of type 'st'.


### PR DESCRIPTION
Fixes #1549

@Kha is this the right fix? A couple of lines later, at https://github.com/johoelzl/lean/blob/fef58aa304b9de6208eab960eac38d6e4bf42b3a/src/frontends/lean/elaborator.cpp#L2615 is the same exception again. What are the reasons that `visit(f, ...)` could fail?