### PR TITLE
fix(library/vm/vm_environment) use is_structure rather than try to catch an assertion

### DIFF
--- a/src/library/tactic/smt/ematch.cpp
+++ b/src/library/tactic/smt/ematch.cpp
@@ -697,6 +697,10 @@ class ematch_fn {
                 new_states.emplace_back(new_state, std::max(m_gen, gen));
             }
         }
+        if (new_states.empty()) {
+            lean_trace(name({"debug", "smt", "ematch"}), tout() << "(no new states)\n";);
+            return false;
+        }
         push_states(new_states);
         return true;
     }

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -218,9 +218,9 @@ vm_obj environment_is_namespace(vm_obj const & env, vm_obj const & n) {
 }
 
 vm_obj environment_structure_fields(vm_obj const & env, vm_obj const & n) {
-    try {
+    if(is_structure(to_env(env), to_name(n))) {
         return mk_vm_some(to_obj(get_structure_fields(to_env(env), to_name(n))));
-    } catch (exception &) {
+    } else {
         return mk_vm_none();
     }
 }


### PR DESCRIPTION
`get_structure_fields` throws an assertion if its argument is not a structure, so there's no point trying to catch an exception. Instead we should just use `is_structure`.

(Sorry, my git-fu is weak, and there are more commits here than necessary.)