### PR TITLE
system.io: environment variables

### DIFF
--- a/leanpkg/leanpkg/main.lean
+++ b/leanpkg/leanpkg/main.lean
@@ -46,7 +46,7 @@ path_file_cnts ← mk_path_file <$> construct_path assg,
 write_file "leanpkg.path" path_file_cnts
 
 def make : io unit :=
-exec_cmd "env" ["-u", "LEAN_PATH", "lean", "--make"]
+exec_cmd "lean" ["--make"] none [("LEAN_PATH", none)]
 
 def build := configure >> make
 

--- a/leanpkg/leanpkg/main.lean
+++ b/leanpkg/leanpkg/main.lean
@@ -20,8 +20,9 @@ def write_manifest (d : manifest) (fn := leanpkg_toml_fn) : io unit :=
 write_file fn (to_string d)
 
 -- TODO(gabriel): implement a cross-platform api
-def get_dot_lean_dir : io string :=
-io.cmd "bash" ["-c", "echo -n ~/.lean"]
+def get_dot_lean_dir : io string := do
+some home ← io.env.get "HOME" | io.fail "environment variable HOME is not set",
+return $ home ++ "/.lean"
 
 -- TODO(gabriel): file existence testing
 def exists_file (f : string) : io bool := do

--- a/leanpkg/leanpkg/proc.lean
+++ b/leanpkg/leanpkg/proc.lean
@@ -9,14 +9,14 @@ variable [io.interface]
 
 namespace leanpkg
 
-def exec_cmd (cmd : string) (args : list string) (cwd : option string := none) : io unit := do
+def exec_cmd (cmd : string) (args : list string) (cwd : option string := none) (env : list (string × option string) := []) : io unit := do
 let cmdstr := join " " (cmd::args),
 io.put_str_ln $ "> " ++
   match cwd with
   | some cwd := cmdstr ++ "    # in directory " ++ cwd
   | none := cmdstr
   end,
-ch ← spawn { cmd := cmd, args := args, cwd := cwd },
+ch ← spawn { cmd := cmd, args := args, cwd := cwd, env := env },
 exitv ← wait ch,
 when (exitv ≠ 0) $ io.fail $
   "external command exited with status " ++ exitv.to_string

--- a/leanpkg/leanpkg/proc.lean
+++ b/leanpkg/leanpkg/proc.lean
@@ -9,14 +9,14 @@ variable [io.interface]
 
 namespace leanpkg
 
-def exec_cmd (cmd : string) (args : list string) (cwd : option string := none) (env : list (string × option string) := []) : io unit := do
-let cmdstr := join " " (cmd::args),
+def exec_cmd (args : io.process.spawn_args) : io unit := do
+let cmdstr := join " " (args.cmd :: args.args),
 io.put_str_ln $ "> " ++
-  match cwd with
+  match args.cwd with
   | some cwd := cmdstr ++ "    # in directory " ++ cwd
   | none := cmdstr
   end,
-ch ← spawn { cmd := cmd, args := args, cwd := cwd, env := env },
+ch ← spawn args,
 exitv ← wait ch,
 when (exitv ≠ 0) $ io.fail $
   "external command exited with status " ++ exitv.to_string

--- a/leanpkg/leanpkg/resolve.lean
+++ b/leanpkg/leanpkg/resolve.lean
@@ -46,18 +46,18 @@ match dep.src with
 | (source.git url rev) := do
   let depdir := "_target/deps/" ++ dep.name,
   already_there ← dir_exists depdir,
-  let checkout_action := exec_cmd "git" ["checkout", "--detach", rev] (some depdir),
+  let checkout_action := exec_cmd {cmd := "git", args := ["checkout", "--detach", rev], cwd := depdir},
   (do guard already_there,
       io.put_str_ln $ dep.name ++ ": trying to update " ++ depdir ++ " to revision " ++ rev,
       checkout_action) <|>
   (do guard already_there,
-      exec_cmd "git" ["fetch"] (some depdir),
+      exec_cmd {cmd := "git", args := ["fetch"], cwd := depdir},
       checkout_action) <|>
   (do io.put_str_ln $ dep.name ++ ": cloning " ++ url ++ " to " ++ depdir,
-      exec_cmd "rm" ["-rf", depdir],
-      exec_cmd "mkdir" ["-p", depdir],
-      exec_cmd "git" ["clone", url, depdir],
-      exec_cmd "git" ["checkout", "--detach", rev] (some depdir)),
+      exec_cmd {cmd := "rm", args := ["-rf", depdir]},
+      exec_cmd {cmd := "mkdir", args := ["-p", depdir]},
+      exec_cmd {cmd := "git", args := ["clone", url, depdir]},
+      exec_cmd {cmd := "git", args := ["checkout", "--detach", rev], cwd := depdir}),
   state_t.modify $ λ assg, assg.insert dep.name depdir
 end
 

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -52,6 +52,8 @@ structure io.process.spawn_args :=
 (stderr := stdio.inherit)
 /- Working directory for the process. -/
 (cwd : option string := none)
+/- Environment variables for the process. -/
+(env : list (string × option string) := [])
 
 structure io.process (handle : Type) (m : Type → Type → Type) :=
 (child : Type) (stdin : child → handle) (stdout : child → handle) (stderr : child → handle)
@@ -228,10 +230,11 @@ format.print (to_fmt a)
     The process will run to completion with its output captured by a pipe, and
     read into `string` which is then returned.
 -/
-def io.cmd [io.interface] (cmd : string) (args : list string) (cwd : option string := none) : io string :=
+def io.cmd [io.interface] (cmd : string) (args : list string) (cwd : option string := none) (env : list (string × option string) := []) : io string :=
 do child ← io.proc.spawn {
     cmd := cmd,
     cwd := cwd,
+    env := env,
     args := args,
     stdout := io.process.stdio.piped
   },

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -30,6 +30,10 @@ structure io.file_system (handle : Type) (m : Type → Type → Type) :=
 (stdout         : m io.error handle)
 (stderr         : m io.error handle)
 
+structure io.environment (m : Type → Type → Type) :=
+(get_env : string → m io.error (option string))
+-- we don't provide set_env as it is (thread-)unsafe (at least with glibc)
+
 inductive io.process.stdio
 | piped
 | inherit
@@ -66,6 +70,7 @@ class io.interface :=
 (term     : io.terminal m)
 (fs       : io.file_system handle m)
 (process  : io.process handle m)
+(env      : io.environment m)
 
 variable [io.interface]
 
@@ -132,6 +137,13 @@ interface.fs.stderr
 
 def stdout : io handle :=
 interface.fs.stdout
+
+namespace env
+
+def get (env_var : string) : io (option string) :=
+interface.env.get_env env_var
+
+end env
 
 namespace fs
 def is_eof : handle → io bool :=

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -100,6 +100,14 @@ iterate () $ λ _, a >> return (some ())
 def catch {e₁ e₂ α} (a : io_core e₁ α) (b : e₁ → io_core e₂ α) : io_core e₂ α :=
 interface.catch e₁ e₂ α a b
 
+def finally {α e} (a : io_core e α) (cleanup : io_core e unit) : io_core e α := do
+res ← catch (sum.inr <$> a) (return ∘ sum.inl),
+cleanup,
+match res with
+| sum.inr res := return res
+| sum.inl error := io.interface.fail _ _ error
+end
+
 instance : alternative io :=
 { interface.monad _ with
   orelse := λ _ a b, catch a (λ _, b),

--- a/src/library/process.h
+++ b/src/library/process.h
@@ -8,6 +8,7 @@ Author: Jared Roesch
 
 #include <iostream>
 #include <string>
+#include <unordered_map>
 #include "library/handle.h"
 #include "util/buffer.h"
 #include "library/pipe.h"
@@ -35,6 +36,7 @@ class process {
     optional<stdio> m_stdin;
     optional<stdio> m_stderr;
     optional<std::string> m_cwd;
+    std::unordered_map<std::string, optional<std::string>> m_env;
 public:
     process(process const & proc) = default;
     process(std::string exe_name);
@@ -43,6 +45,7 @@ public:
     process & set_stdout(stdio cfg);
     process & set_stderr(stdio cfg);
     process & set_cwd(std::string const & cwd);
+    process & set_env(std::string const & var, optional<std::string> const & val);
     std::shared_ptr<child> spawn();
     void run();
 };

--- a/src/library/vm/vm_io.cpp
+++ b/src/library/vm/vm_io.cpp
@@ -425,6 +425,19 @@ static vm_obj io_iterate(vm_obj const &, vm_obj const &, vm_obj const & a, vm_ob
     }
 }
 
+static vm_obj mk_io_env() {
+    return mk_vm_constructor(0, {
+        // get_env
+        mk_native_closure([] (vm_obj const & k, vm_obj const &) {
+            if (auto v = getenv(to_string(k).c_str())) {
+                return mk_io_result(mk_vm_some(to_obj(std::string(v))));
+            } else {
+                return mk_io_result(mk_vm_none());
+            }
+        }),
+    });
+}
+
 /*
 class io.interface :=
 (m        : Type → Type → Type)
@@ -438,10 +451,10 @@ class io.interface :=
 (term     : io.terminal m)
 (fs       : io.file_system handle m)
 (process  : io.process io.error handle m)
+(env      : io.environment _)
 */
 vm_obj mk_io_interface(std::vector<std::string> const & cmdline_args) {
-    constexpr size_t num_fields = 7;
-    vm_obj fields[num_fields] = {
+    return mk_vm_constructor(0, {
         mk_native_closure(io_monad),
         mk_native_closure(io_catch),
         mk_native_closure(io_fail),
@@ -449,8 +462,8 @@ vm_obj mk_io_interface(std::vector<std::string> const & cmdline_args) {
         mk_terminal(cmdline_args),
         mk_fs(),
         mk_process(),
-    };
-    return mk_vm_constructor(0, num_fields, fields);
+        mk_io_env(),
+    });
 }
 
 vm_obj mk_io_interface() {

--- a/tests/lean/run/io_process_echo.lean
+++ b/tests/lean/run/io_process_echo.lean
@@ -3,7 +3,7 @@ import system.io
 variable [io.interface]
 
 def main : io unit := do
-  out ← io.cmd "echo" ["Hello World!"],
+  out ← io.cmd {cmd := "echo", args := ["Hello World!"]},
   io.put_str out,
   return ()
 

--- a/tests/lean/run/io_process_env.lean
+++ b/tests/lean/run/io_process_env.lean
@@ -2,5 +2,5 @@ import system.io
 variable [io.interface]
 
 #eval do
-res ← io.cmd "printenv" ["foo"] none [("foo", "bar")],
+res ← io.cmd {cmd := "printenv", args := ["foo"], env := [("foo", "bar")]},
 when (res ≠ "bar\n") $ io.fail $ "unexpected value for foo: " ++ res

--- a/tests/lean/run/io_process_env.lean
+++ b/tests/lean/run/io_process_env.lean
@@ -1,0 +1,6 @@
+import system.io
+variable [io.interface]
+
+#eval do
+res ← io.cmd "printenv" ["foo"] none [("foo", "bar")],
+when (res ≠ "bar\n") $ io.fail $ "unexpected value for foo: " ++ res


### PR DESCRIPTION
This PR adds support to read environment variables, and set environment variables for child processes.

Notably, it does *not* add a function to *set* environment variables.  In the presence of multiple threads, there is no way to do this safely on any platform; on Linux (glibc) it is explicitly verboten and [leads to segfaults](https://rachelbythebay.com/w/2017/01/30/env/).

Since spawning a child process now takes a lot of (optional) parameters, I also changed the `io.cmd` function to accept a structure.  (I made the same change in leanpkg's internal `exec_cmd` function.)