### PR TITLE
Preserve type ascriptions during elaboration

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -825,7 +825,7 @@ expr elaborator::visit_typed_expr(expr const & e) {
     expr new_val      = visit(val, some_expr(new_type));
     expr new_val_type = infer_type(new_val);
     if (auto r = ensure_has_type(new_val, new_val_type, new_type, ref))
-        return *r;
+        return mk_typed_expr(new_type, *r);
 
     auto pp_data = pp_until_different(new_val_type, new_type);
     auto pp_fn   = std::get<0>(pp_data);
@@ -3526,6 +3526,14 @@ struct sanitize_param_names_fn : public replace_visitor {
 
     virtual expr visit_sort(expr const & e) override {
         return update_sort(e, sanitize(sort_level(e)));
+    }
+
+    virtual expr visit_macro(expr const & e) override {
+        if (is_typed_expr(e)) {
+            return visit(get_typed_expr_expr(e));
+        } else {
+            return replace_visitor::visit_macro(e);
+        }
     }
 
     void collect_params(expr const & e) {

--- a/src/library/arith_instance.cpp
+++ b/src/library/arith_instance.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include "library/constants.h"
 #include "library/arith_instance.h"
 #include "library/num.h"
+#include "library/typed_expr.h"
 
 namespace lean {
 // TODO(Leo): pre compute arith_instance_info for nat, int and real
@@ -129,7 +130,9 @@ bool arith_instance::is_nat() {
 optional<mpq> arith_instance::eval(expr const & e) {
     buffer<expr> args;
     expr f = get_app_args(e, args);
-    if (!is_constant(f)) {
+    if (is_typed_expr(f)) {
+        return eval(mk_app(get_typed_expr_expr(f), args));
+    } else if (!is_constant(f)) {
         throw exception("cannot find num of nonconstant");
     } else if (const_name(f) == get_has_add_add_name() && args.size() == 4) {
         if (auto r1 = eval(args[2]))

--- a/src/library/comp_val.cpp
+++ b/src/library/comp_val.cpp
@@ -11,12 +11,15 @@ Author: Leonardo de Moura
 #include "library/comp_val.h"
 #include "library/expr_pair.h"
 #include "library/trace.h"
+#include "library/typed_expr.h"
 
 /* Remark: we can improve performance by using Lean macros for delaying the
    proof construction. */
 
 namespace lean {
 optional<expr> mk_nat_val_ne_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_nat_val_ne_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_nat_val_ne_proof(a, get_typed_expr_expr(b));
     if (a == b) return none_expr();
     if (auto a1 = is_bit0(a)) {
         if (auto b1 = is_bit0(b)) {
@@ -67,6 +70,8 @@ optional<expr> mk_nat_val_ne_proof(expr const & a, expr const & b) {
 optional<expr> mk_nat_val_le_proof(expr const & a, expr const & b);
 
 optional<expr> mk_nat_val_lt_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_nat_val_lt_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_nat_val_lt_proof(a, get_typed_expr_expr(b));
     if (a == b) return none_expr();
     if (auto a1 = is_bit0(a)) {
         if (auto b1 = is_bit0(b)) {
@@ -106,6 +111,8 @@ optional<expr> mk_nat_val_lt_proof(expr const & a, expr const & b) {
 }
 
 optional<expr> mk_nat_val_le_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_nat_val_le_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_nat_val_le_proof(a, get_typed_expr_expr(b));
     if (a == b)
         return some_expr(mk_app(mk_constant(get_nat_le_refl_name()), a));
     if (auto pr = mk_nat_val_lt_proof(a, b))
@@ -114,6 +121,8 @@ optional<expr> mk_nat_val_le_proof(expr const & a, expr const & b) {
 }
 
 optional<expr> mk_fin_val_ne_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_fin_val_ne_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_fin_val_ne_proof(a, get_typed_expr_expr(b));
     if (!is_app_of(a, get_fin_mk_name(), 3) ||
         !is_app_of(b, get_fin_mk_name(), 3))
         return none_expr();
@@ -128,6 +137,8 @@ optional<expr> mk_fin_val_ne_proof(expr const & a, expr const & b) {
 static expr * g_char_sz = nullptr;
 
 optional<expr> mk_char_val_ne_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_char_val_ne_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_char_val_ne_proof(a, get_typed_expr_expr(b));
     if (is_app_of(a, get_char_of_nat_name(), 1) &&
         is_app_of(a, get_char_of_nat_name(), 1)) {
         expr const & v_a = app_arg(a);
@@ -185,6 +196,7 @@ optional<expr> mk_string_val_ne_proof(expr a, expr b) {
 }
 
 optional<expr> mk_int_val_nonneg_proof(expr const & a) {
+    if (is_typed_expr(a)) return mk_int_val_nonneg_proof(get_typed_expr_expr(a));
     if (auto a1 = is_bit0(a)) {
         if (auto pr = mk_int_val_nonneg_proof(*a1))
             return some_expr(mk_app(mk_constant(get_int_bit0_nonneg_name()), *a1, *pr));
@@ -200,6 +212,7 @@ optional<expr> mk_int_val_nonneg_proof(expr const & a) {
 }
 
 optional<expr> mk_int_val_pos_proof(expr const & a) {
+    if (is_typed_expr(a)) return mk_int_val_pos_proof(get_typed_expr_expr(a));
     if (auto a1 = is_bit0(a)) {
         if (auto pr = mk_int_val_pos_proof(*a1))
             return some_expr(mk_app(mk_constant(get_int_bit0_pos_name()), *a1, *pr));
@@ -215,6 +228,7 @@ optional<expr> mk_int_val_pos_proof(expr const & a) {
 /* Given a nonnegative int numeral a, return a pair (n, H)
    where n is a nat numeral, and (H : nat_abs a = n) */
 optional<expr_pair> mk_nat_abs_eq(expr const & a) {
+    if (is_typed_expr(a)) return mk_nat_abs_eq(get_typed_expr_expr(a));
     if (is_zero(a)) {
         return optional<expr_pair>(mk_pair(mk_nat_zero(), mk_constant(get_int_nat_abs_zero_name())));
     } else if (is_one(a)) {
@@ -236,6 +250,8 @@ optional<expr_pair> mk_nat_abs_eq(expr const & a) {
 
 /* Given nonneg int numerals a and b, create a proof for a != b IF they are not equal. */
 optional<expr> mk_int_nonneg_val_ne_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_int_nonneg_val_ne_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_int_nonneg_val_ne_proof(a, get_typed_expr_expr(b));
     auto p1 = mk_nat_abs_eq(a);
     if (!p1) return none_expr();
     auto p2 = mk_nat_abs_eq(b);
@@ -252,6 +268,8 @@ optional<expr> mk_int_nonneg_val_ne_proof(expr const & a, expr const & b) {
 }
 
 optional<expr> mk_int_val_ne_proof(expr const & a, expr const & b) {
+    if (is_typed_expr(a)) return mk_int_val_ne_proof(get_typed_expr_expr(a), b);
+    if (is_typed_expr(b)) return mk_int_val_ne_proof(a, get_typed_expr_expr(b));
     if (auto a1 = is_neg(a)) {
         if (auto b1 = is_neg(b)) {
             auto H = mk_int_nonneg_val_ne_proof(*a1, *b1);

--- a/src/library/head_map.cpp
+++ b/src/library/head_map.cpp
@@ -6,23 +6,27 @@ Author: Leonardo de Moura
 */
 #include "library/head_map.h"
 #include "library/explicit.h"
+#include "library/typed_expr.h"
 
 namespace lean {
-head_index::head_index(expr const & e) {
-    expr f = get_app_fn(e);
+head_index::head_index(expr e) {
     while (true) {
-        if (is_as_atomic(f))
-            f = get_app_fn(get_as_atomic_arg(f));
-        else if (is_explicit(f))
-            f = get_explicit_arg(f);
+        m_num_args += get_app_num_args(e);
+        e = get_app_fn(e);
+        if (is_as_atomic(e))
+            e = get_as_atomic_arg(e);
+        else if (is_explicit(e))
+            e = get_explicit_arg(e);
+        else if (is_typed_expr(e))
+            e = get_typed_expr_expr(e);
         else
             break;
     }
-    m_kind = f.kind();
-    if (is_constant(f))
-        m_name = const_name(f);
-    else if (is_local(f))
-        m_name = mlocal_name(f);
+    m_kind = e.kind();
+    if (is_constant(e))
+        m_name = const_name(e);
+    else if (is_local(e))
+        m_name = mlocal_name(e);
 }
 
 int head_index::cmp::operator()(head_index const & i1, head_index const & i2) const {

--- a/src/library/head_map.h
+++ b/src/library/head_map.h
@@ -14,11 +14,13 @@ namespace lean {
 struct head_index {
     expr_kind m_kind;
     name      m_name;
+    unsigned  m_num_args = 0;
     explicit head_index(expr_kind k = expr_kind::Var):m_kind(k) {}
     explicit head_index(name const & c):m_kind(expr_kind::Constant), m_name(c) {}
-    head_index(expr const & e);
+    head_index(expr e);
     expr_kind kind() const { return m_kind; }
     name const & get_name() const { return m_name; }
+    unsigned get_num_args() const { return m_num_args; }
 
     struct cmp {
         int operator()(head_index const & i1, head_index const & i2) const;

--- a/src/library/norm_num.cpp
+++ b/src/library/norm_num.cpp
@@ -8,6 +8,7 @@ Author: Robert Y. Lewis
 #include "library/util.h"
 #include "library/constants.h"
 #include "library/comp_val.h"
+#include "library/typed_expr.h"
 
 namespace lean {
 bool norm_num_context::is_numeral(expr const & e) const {
@@ -425,6 +426,7 @@ expr_pair norm_num_context::mk_norm_nat_sub(expr const & s_lhs, expr const & s_r
 }
 
 pair<expr, expr> norm_num_context::mk_norm(expr const & e) {
+    if (is_typed_expr(e)) return mk_norm(get_typed_expr_expr(e));
     buffer<expr> args;
     expr f = get_app_args(e, args);
     if (!is_constant(f) || args.size() == 0) {

--- a/src/library/string.cpp
+++ b/src/library/string.cpp
@@ -13,6 +13,7 @@ Author: Leonardo de Moura
 #include "library/constants.h"
 #include "library/num.h"
 #include "library/trace.h"
+#include "library/typed_expr.h"
 
 namespace lean {
 static name * g_string_macro         = nullptr;
@@ -142,6 +143,7 @@ void initialize_string() {
 }
 
 optional<expr> expand_string_macro(expr const & e) {
+    if (is_typed_expr(e)) return expand_string_macro(get_typed_expr_expr(e));
     if (!is_string_macro(e)) return none_expr();
     return some_expr(from_string_core(to_string_macro(e).get_value()));
 }

--- a/src/library/tactic/kabstract.cpp
+++ b/src/library/tactic/kabstract.cpp
@@ -158,14 +158,13 @@ expr kabstract(type_context & ctx, expr const & e, expr const & t, occurrences c
     head_index idx1(t);
     key_equivalence_ext const & ext = get_extension(ctx.env());
     unsigned i = 1;
-    unsigned t_nargs = get_app_num_args(t);
     return replace(e, [&](expr const & s, unsigned offset) {
             if (closed(s)) {
                 head_index idx2(s);
                 if (idx1.kind() == idx2.kind() &&
                     ext.is_eqv(idx1.get_name(), idx2.get_name()) &&
                     /* fail if same function application and different number of arguments */
-                    (idx1.get_name() != idx2.get_name() || t_nargs == get_app_num_args(s)) &&
+                    (idx1.get_name() != idx2.get_name() || idx1.get_num_args() == idx2.get_num_args()) &&
                     ctx.is_def_eq(t, s)) {
                     if (occs.contains(i)) {
                         lean_trace("kabstract", scope_trace_env _(ctx.env(), ctx);
@@ -185,7 +184,6 @@ bool kdepends_on(type_context & ctx, expr const & e, expr const & t) {
     bool found = false;
     head_index idx1(t);
     key_equivalence_ext const & ext = get_extension(ctx.env());
-    unsigned t_nargs = get_app_num_args(t);
     for_each(e, [&](expr const & s, unsigned) {
             if (found) return false;
             if (closed(s)) {
@@ -193,7 +191,7 @@ bool kdepends_on(type_context & ctx, expr const & e, expr const & t) {
                 if (idx1.kind() == idx2.kind() &&
                     ext.is_eqv(idx1.get_name(), idx2.get_name()) &&
                     /* fail if same function application and different number of arguments */
-                    (idx1.get_name() != idx2.get_name() || t_nargs == get_app_num_args(s)) &&
+                    (idx1.get_name() != idx2.get_name() || idx1.get_num_args() == idx2.get_num_args()) &&
                     ctx.is_def_eq(t, s)) {
                     found = true; return false;
                 }

--- a/tests/lean/run/default_param.lean
+++ b/tests/lean/run/default_param.lean
@@ -56,7 +56,7 @@ open tactic
 set_option pp.all true
 
 meta def check_expr (p : pexpr) (t : expr) : tactic unit :=
-do e ← to_expr p, guard (t = e)
+do e ← to_expr p, is_def_eq t e
 
 run_cmd do
   e ← to_expr `(boo 2),

--- a/tests/lean/run/default_param2.lean
+++ b/tests/lean/run/default_param2.lean
@@ -56,7 +56,7 @@ open tactic
 set_option pp.all true
 
 meta def check_expr (p : pexpr) (t : expr) : tactic unit :=
-do e ← to_expr p, guard (t = e)
+do e ← to_expr p, is_def_eq t e
 
 run_cmd do
   e ← to_expr `(boo 2),

--- a/tests/lean/run/type_ascription.lean
+++ b/tests/lean/run/type_ascription.lean
@@ -1,0 +1,17 @@
+def my_list := list ℕ
+variable (l : my_list)
+example := ∀ x ∈ (l : list ℕ), x > 3
+             -- ^ should use has_mem instance for lists here
+
+def frob := (l : list ℕ)
+-- inferred type of frob should be my_list → list ℕ
+open tactic run_cmd do
+t ← infer_type ```(frob l),
+guard $ t = ```(list ℕ)
+
+class foo (α : Type) := (u : unit)
+def my_unit := unit
+instance : foo my_unit := ⟨_, ()⟩
+def gadget {α} (x : α) [foo α] : Type := unit
+example : gadget (() : my_unit) := ()
+               -- ^^ type class inference should be invoked for `foo my_unit` here


### PR DESCRIPTION
It is a bit surprising that type ascription does not affect the inferred type of an expression at the moment.  This usually shows up in the context of type class inference (are there other places where we care about the inferred type?):
```lean
def looks_like_git_url (dep : string) : bool :=
':' ∈ (dep : list char)
-- does not work since we infer the type `string` for `dep` here
```
I would have expected this to work.  Mario was also independently surprised about this behavior.

This PR preserves the type ascription during elaboration.  That is, they are present in the elaborated expressions, but they are removed during finalization.

The main downside is that we now need to unwrap type ascriptions in many places.  A particularly egregious example is in `comp_val.cpp`: here we need to unwrap all arguments in every function, since we might want to prove `(10:nat) < 20`...

Alternatives:
 * Use the `show list char, from dep` workaround.