### PR TITLE
Unify expr and pexpr

### DIFF
--- a/library/init/meta/pexpr.lean
+++ b/library/init/meta/pexpr.lean
@@ -8,26 +8,15 @@ import init.meta.expr
 universe u
 
 /- Quoted expressions. They can be converted into expressions by using a tactic. -/
-meta constant pexpr : Type
+@[reducible] meta def pexpr := expr ff
 protected meta constant pexpr.of_expr  : expr → pexpr
-protected meta constant pexpr.subst    : pexpr → pexpr → pexpr
 
-/- Low level primitives for accessing internal representation. -/
-protected meta constant pexpr.to_raw_expr : pexpr → expr
-protected meta constant pexpr.of_raw_expr : expr → pexpr
 meta constant pexpr.mk_placeholder : pexpr
-
-meta constant pexpr.pos : pexpr → option pos
-
 meta constant pexpr.mk_field_macro : pexpr → name → pexpr
 meta constant pexpr.mk_explicit : pexpr → pexpr
 
-meta constant pexpr.to_string : pexpr → string
-meta instance : has_to_string pexpr :=
-⟨pexpr.to_string⟩
-
-meta constant pexpr.reflect (p : pexpr) : reflected p
-attribute [instance] pexpr.reflect
+/- Choice macros are used to implement overloading. -/
+meta constant pexpr.is_choice_macro : pexpr → bool
 
 meta class has_to_pexpr (α : Type u) :=
 (to_pexpr : α → pexpr)

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -429,7 +429,7 @@ try $ do
 meta constant decl_name : tactic name
 
 /- (save_type_info e ref) save (typeof e) at position associated with ref -/
-meta constant save_type_info : expr → expr → tactic unit
+meta constant save_type_info {elab : bool} : expr → expr elab → tactic unit
 meta constant save_info_thunk : pos → (unit → format) → tactic unit
 /-- Return list of currently open namespaces -/
 meta constant open_namespaces : tactic (list name)
@@ -501,7 +501,7 @@ meta def intro_lst : list name → tactic (list expr)
 
 /-- Returns n fully qualified if it refers to a constant, or else fails. -/
 meta def resolve_constant (n : name) : tactic name :=
-do (expr.const n _) ← pexpr.to_raw_expr <$> resolve_name n,
+do (expr.const n _) ← resolve_name n,
    pure n
 
 meta def to_expr_strict (q : pexpr) : tactic expr :=
@@ -776,7 +776,7 @@ do env  ← get_env,
 meta def applyc (c : name) : tactic unit :=
 mk_const c >>= apply
 
-meta def save_const_type_info (n : name) (ref : expr) : tactic unit :=
+meta def save_const_type_info (n : name) {elab : bool} (ref : expr elab) : tactic unit :=
 try (do c ← mk_const n, save_type_info c ref)
 
 /- Create a fresh universe ?u, a metavariable (?T : Type.{?u}),
@@ -1008,7 +1008,7 @@ end list
 -/
 run_cmd do
  let l  := level.param `l,
- let Ty := expr.sort l,
+ let Ty : pexpr := expr.sort l,
  type ← to_expr ``(Π (α : %%Ty), α → α),
  val  ← to_expr ``(λ (α : %%Ty) (a : α), a),
  add_decl (declaration.defn `id_locked [`l] type val reducibility_hints.opaque tt)

--- a/library/init/meta/transfer.lean
+++ b/library/init/meta/transfer.lean
@@ -174,11 +174,11 @@ meta def transfer (ds : list name) : tactic unit := do
   (guard (¬ tgt.has_meta_var) <|>
     fail "Target contains (universe) meta variables. This is not supported by transfer."),
 
-  (new_tgt, pr, ms) ← compute_transfer rds [] (const `iff [] tgt),
+  (new_tgt, pr, ms) ← compute_transfer rds [] ((const `iff [] : expr) tgt),
   new_pr ← mk_meta_var new_tgt,
 
   /- Setup final tactic state -/
-  exact (const `iff.mpr [] tgt new_tgt pr new_pr),
+  exact ((const `iff.mpr [] : expr) tgt new_tgt pr new_pr),
   ms ← monad.for ms (λm, (get_assignment m >> return []) <|> return [m]),
   gs ← get_goals,
   set_goals (list.join ms ++ new_pr :: gs)

--- a/library/system/io.lean
+++ b/library/system/io.lean
@@ -74,7 +74,8 @@ class io.interface :=
 (process  : io.process handle m)
 (env      : io.environment m)
 
-variable [io.interface]
+variable [ioi : io.interface]
+include ioi
 
 def io_core (e : Type) (α : Type) :=
 io.interface.m e α
@@ -214,7 +215,7 @@ end proc
 
 end io
 
-meta constant format.print_using [io.interface] : format → options → io unit
+meta constant format.print_using : format → options → io unit
 
 meta definition format.print (fmt : format) : io unit :=
 format.print_using fmt options.mk
@@ -237,5 +238,6 @@ do child ← io.proc.spawn { args with stdout := io.process.stdio.piped },
   when (exitv ≠ 0) $ io.fail $ "process exited with status " ++ exitv.to_string,
   return buf.to_string
 
+omit ioi
 /-- Lift a monadic `io` action into the `tactic` monad. -/
 meta constant tactic.run_io {α : Type} : (Π ioi : io.interface, @io ioi α) → tactic α

--- a/src/frontends/lean/decl_cmds.cpp
+++ b/src/frontends/lean/decl_cmds.cpp
@@ -114,7 +114,14 @@ static environment declare_var(parser & p, environment env,
         lean_assert(k == variable_kind::Constant || k == variable_kind::Axiom);
         name const & ns = get_namespace(env);
         name full_n  = ns + n;
-        expr new_type = unfold_untrusted_macros(env, type);
+
+        buffer<name> new_ls;
+        to_buffer(ls, new_ls);
+        buffer<expr> new_params;
+        collect_implicit_locals(p, new_ls, new_params, type);
+        expr new_type = Pi(new_params, type);
+        new_type = unfold_untrusted_macros(env, new_type);
+
         if (k == variable_kind::Axiom) {
             env = module::add(env, check(env, mk_axiom(full_n, ls, new_type)));
         } else {

--- a/src/frontends/lean/decl_util.cpp
+++ b/src/frontends/lean/decl_util.cpp
@@ -42,8 +42,8 @@ bool parse_univ_params(parser & p, buffer<name> & lp_names) {
     }
 }
 
-expr parse_single_header(parser & p, declaration_name_scope & scope, buffer<name> & lp_names, buffer<expr> & params,
-                         bool is_example, bool is_instance, bool allow_default) {
+expr parse_single_header(parser & p, declaration_name_scope & scope, buffer <name> & lp_names, buffer <expr> & params,
+                         bool is_example, bool is_instance) {
     auto c_pos  = p.pos();
     name c_name;
     if (is_example) {
@@ -57,7 +57,7 @@ expr parse_single_header(parser & p, declaration_name_scope & scope, buffer<name
             scope.set_name(c_name);
         }
     }
-    p.parse_optional_binders(params, allow_default);
+    p.parse_optional_binders(params, /* allow_default */ true);
     for (expr const & param : params)
         p.add_local(param);
     expr type;
@@ -89,8 +89,7 @@ expr parse_single_header(parser & p, declaration_name_scope & scope, buffer<name
     return p.save_pos(mk_local(c_name, type), c_pos);
 }
 
-void parse_mutual_header(parser & p, buffer<name> & lp_names, buffer<expr> & cs, buffer<expr> & params,
-                         bool allow_default) {
+void parse_mutual_header(parser & p, buffer <name> & lp_names, buffer <expr> & cs, buffer <expr> & params) {
     parse_univ_params(p, lp_names);
     while (true) {
         auto c_pos  = p.pos();
@@ -103,7 +102,7 @@ void parse_mutual_header(parser & p, buffer<name> & lp_names, buffer<expr> & cs,
     if (cs.size() < 2) {
         throw parser_error("invalid mutual declaration, must provide more than one identifier (separated by commas)", p.pos());
     }
-    p.parse_optional_binders(params, allow_default);
+    p.parse_optional_binders(params, /* allow_default */ true);
     for (expr const & param : params)
         p.add_local(param);
     for (expr const & c : cs)

--- a/src/frontends/lean/decl_util.h
+++ b/src/frontends/lean/decl_util.h
@@ -78,9 +78,8 @@ bool parse_univ_params(parser & p, buffer<name> & lp_names);
     Both lp_names and params are added to the parser scope.
 
     \remark Caller is responsible for using: parser::local_scope scope2(p, env); */
-expr parse_single_header(parser & p, declaration_name_scope & s, buffer<name> & lp_names, buffer<expr> & params,
-                         bool is_example = false, bool is_instance = false,
-                         bool allow_default = false);
+expr parse_single_header(parser & p, declaration_name_scope & s, buffer <name> & lp_names, buffer <expr> & params,
+                         bool is_example = false, bool is_instance = false);
 /** \brief Parse the header of a mutually recursive declaration. It has the form
 
         {u_1 ... u_k} id_1, ... id_n (params)
@@ -94,8 +93,7 @@ expr parse_single_header(parser & p, declaration_name_scope & s, buffer<name> & 
     \remark Caller is responsible for adding expressions encoding the c_names to the parser
     scope.
     \remark Caller is responsible for using: parser::local_scope scope2(p, env); */
-void parse_mutual_header(parser & p, buffer<name> & lp_names, buffer<expr> & cs, buffer<expr> & params,
-                         bool allow_default = false);
+void parse_mutual_header(parser & p, buffer <name> & lp_names, buffer <expr> & cs, buffer <expr> & params);
 /** \brief Parse the header for one of the declarations in a mutually recursive declaration.
     It has the form
 

--- a/src/frontends/lean/definition_cmds.cpp
+++ b/src/frontends/lean/definition_cmds.cpp
@@ -169,9 +169,8 @@ static expr_pair parse_definition(parser & p, buffer<name> & lp_names, buffer<ex
                                   bool is_example, bool is_instance, bool is_meta) {
     parser::local_scope scope1(p);
     auto header_pos = p.pos();
-    bool allow_default = true;
     declaration_name_scope scope2;
-    expr fn = parse_single_header(p, scope2, lp_names, params, is_example, is_instance, allow_default);
+    expr fn = parse_single_header(p, scope2, lp_names, params, is_example, is_instance);
     expr val;
     if (p.curr_is_token(get_assign_tk())) {
         p.next();

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2834,7 +2834,7 @@ expr elaborator::visit_expr_quote(expr const & e, optional<expr> const & expecte
             throw elaborator_exception(e, "invalid quotation, contains local constant");
         q = mk_expr_quote(new_s);
         q = mk_as_is(q);
-        expr subst_fn = mk_constant(get_expr_subst_name());
+        expr subst_fn = mk_app(mk_explicit(mk_constant(get_expr_subst_name())), mk_bool_tt());
         for (expr const & subst : substs) {
             q = mk_app(subst_fn, q, subst);
         }
@@ -3862,7 +3862,7 @@ expr resolve_names(environment const & env, local_context const & lctx, expr con
     return resolve_names_fn(env, lctx)(e);
 }
 
-static vm_obj tactic_save_type_info(vm_obj const & _e, vm_obj const & ref, vm_obj const & _s) {
+static vm_obj tactic_save_type_info(vm_obj const &, vm_obj const & _e, vm_obj const & ref, vm_obj const & _s) {
     expr const & e = to_expr(_e);
     tactic_state const & s = tactic::to_state(_s);
     if (!get_global_info_manager() || !get_pos_info_provider()) return tactic::mk_success(s);

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -1709,7 +1709,7 @@ expr elaborate_quote(expr e, environment const & env, options const & opts) {
 
     e = instantiate_rev(body, aqs.size(), aqs.data());
     e = quote(e);
-    return e;
+    return mk_typed_expr(mk_app(mk_constant(get_expr_name()), mk_bool_tt()), e);
 }
 
 expr parser::patexpr_to_pattern(expr const & pat_or_expr, bool skip_main_fn, buffer<expr> & new_locals) {

--- a/src/frontends/lean/pp.h
+++ b/src/frontends/lean/pp.h
@@ -87,6 +87,7 @@ private:
     level purify(level const & l);
     expr purify(expr const & e);
     bool is_implicit(expr const & f);
+    bool is_default_arg_app(expr const & e);
     optional<expr> is_proof(expr const & f);
     bool is_prop(expr const & e);
     bool has_implicit_args(expr const & f);

--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -143,7 +143,7 @@ static expr parse_interactive_param(parser & p, expr const & ty, expr const & qu
     vm_state S(env, p.get_options());
     auto vm_res = S.invoke(n, vm_parsed);
     expr r = to_expr(vm_res);
-    if (is_app_of(r, get_pexpr_subst_name())) {
+    if (is_app_of(r, get_expr_subst_name())) {
         return r; // HACK
     } else {
         return mk_as_is(r);

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -294,8 +294,6 @@ name const * g_pprod_mk = nullptr;
 name const * g_pprod_fst = nullptr;
 name const * g_pprod_snd = nullptr;
 name const * g_propext = nullptr;
-name const * g_pexpr = nullptr;
-name const * g_pexpr_subst = nullptr;
 name const * g_to_pexpr = nullptr;
 name const * g_quot_mk = nullptr;
 name const * g_quot_lift = nullptr;
@@ -665,8 +663,6 @@ void initialize_constants() {
     g_pprod_fst = new name{"pprod", "fst"};
     g_pprod_snd = new name{"pprod", "snd"};
     g_propext = new name{"propext"};
-    g_pexpr = new name{"pexpr"};
-    g_pexpr_subst = new name{"pexpr", "subst"};
     g_to_pexpr = new name{"to_pexpr"};
     g_quot_mk = new name{"quot", "mk"};
     g_quot_lift = new name{"quot", "lift"};
@@ -1037,8 +1033,6 @@ void finalize_constants() {
     delete g_pprod_fst;
     delete g_pprod_snd;
     delete g_propext;
-    delete g_pexpr;
-    delete g_pexpr_subst;
     delete g_to_pexpr;
     delete g_quot_mk;
     delete g_quot_lift;
@@ -1408,8 +1402,6 @@ name const & get_pprod_mk_name() { return *g_pprod_mk; }
 name const & get_pprod_fst_name() { return *g_pprod_fst; }
 name const & get_pprod_snd_name() { return *g_pprod_snd; }
 name const & get_propext_name() { return *g_propext; }
-name const & get_pexpr_name() { return *g_pexpr; }
-name const & get_pexpr_subst_name() { return *g_pexpr_subst; }
 name const & get_to_pexpr_name() { return *g_to_pexpr; }
 name const & get_quot_mk_name() { return *g_quot_mk; }
 name const & get_quot_lift_name() { return *g_quot_lift; }

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -296,8 +296,6 @@ name const & get_pprod_mk_name();
 name const & get_pprod_fst_name();
 name const & get_pprod_snd_name();
 name const & get_propext_name();
-name const & get_pexpr_name();
-name const & get_pexpr_subst_name();
 name const & get_to_pexpr_name();
 name const & get_quot_mk_name();
 name const & get_quot_lift_name();

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -289,8 +289,6 @@ pprod.mk
 pprod.fst
 pprod.snd
 propext
-pexpr
-pexpr.subst
 to_pexpr
 quot.mk
 quot.lift

--- a/src/library/init_module.cpp
+++ b/src/library/init_module.cpp
@@ -87,7 +87,6 @@ void initialize_library_module() {
     initialize_string();
     initialize_num();
     initialize_annotation();
-    initialize_quote();
     initialize_explicit();
     initialize_protected();
     initialize_private();
@@ -97,6 +96,7 @@ void initialize_library_module() {
     initialize_sorry();
     initialize_class();
     initialize_library_util();
+    initialize_quote();
     initialize_pp_options();
     initialize_projection();
     initialize_relation_manager();
@@ -140,6 +140,7 @@ void finalize_library_module() {
     finalize_relation_manager();
     finalize_projection();
     finalize_pp_options();
+    finalize_quote();
     finalize_library_util();
     finalize_class();
     finalize_sorry();
@@ -149,7 +150,6 @@ void finalize_library_module() {
     finalize_private();
     finalize_protected();
     finalize_explicit();
-    finalize_quote();
     finalize_annotation();
     finalize_num();
     finalize_string();

--- a/src/library/quote.cpp
+++ b/src/library/quote.cpp
@@ -141,8 +141,8 @@ expr mk_pexpr_quote_and_substs(expr const & e, bool is_strict) {
             return none_expr();
         });
     expr r        = mk_pexpr_quote(Fun(locals, s));
-    expr subst    = mk_constant(get_pexpr_subst_name());
-    expr to_pexpr = mk_constant(get_to_pexpr_name(), {mk_level_zero()});
+    expr subst    = mk_constant(get_expr_subst_name());
+    expr to_pexpr = mk_constant(get_to_pexpr_name());
     for (expr const & aq : aqs) {
         r = mk_app(subst, r, mk_app(to_pexpr, aq));
     }
@@ -154,8 +154,8 @@ void initialize_quote() {
     g_pexpr_quote_macro   = new name("pexpr_quote_macro");
     g_expr_quote_opcode   = new std::string("Quote");
     g_pexpr_quote_opcode  = new std::string("PQuote");
-    g_expr           = new expr(Const(get_expr_name()));
-    g_pexpr          = new expr(Const(get_pexpr_name()));
+    g_expr           = new expr(mk_app(Const(get_expr_name()), mk_bool_tt()));
+    g_pexpr          = new expr(mk_app(Const(get_expr_name()), mk_bool_ff()));
 
     g_antiquote  = new name("antiquote");
     register_annotation(*g_antiquote);

--- a/src/library/util.cpp
+++ b/src/library/util.cpp
@@ -1050,7 +1050,7 @@ void finalize_bool() {
 
 expr mk_bool() { return *g_bool; }
 expr mk_bool_tt() { return *g_bool_tt; }
-expr mk_bool_ff() { return *g_bool_tt; }
+expr mk_bool_ff() { return *g_bool_ff; }
 expr to_bool_expr(bool b) { return b ? mk_bool_tt() : mk_bool_ff(); }
 
 name get_dep_recursor(environment const & env, name const & n) {

--- a/src/library/vm/vm_expr.h
+++ b/src/library/vm/vm_expr.h
@@ -17,7 +17,6 @@ bool is_expr(vm_obj const & o);
 expr const & to_expr(vm_obj const & o);
 vm_obj to_obj(expr const & e);
 vm_obj to_obj(optional<expr> const & e);
-vm_obj expr_subst(vm_obj const & _e1, vm_obj const & _e2);
 void initialize_vm_expr();
 void finalize_vm_expr();
 void initialize_vm_expr_builtin_idxs();

--- a/src/library/vm/vm_pexpr.cpp
+++ b/src/library/vm/vm_pexpr.cpp
@@ -5,19 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: Leonardo de Moura
 */
 #include "kernel/instantiate.h"
-#include "kernel/scope_pos_info_provider.h"
 #include "library/placeholder.h"
 #include "library/explicit.h"
-#include "library/quote.h"
-#include "library/string.h"
+#include "library/choice.h"
 #include "library/vm/vm.h"
 #include "library/vm/vm_expr.h"
 #include "library/vm/vm_name.h"
-#include "library/vm/vm_string.h"
-#include "library/vm/vm_option.h"
-#include "library/vm/vm_pos_info.h"
-#include "frontends/lean/prenum.h"
-#include "frontends/lean/structure_cmd.h"
 #include "frontends/lean/util.h"
 
 namespace lean {
@@ -25,28 +18,8 @@ vm_obj pexpr_of_expr(vm_obj const & e) {
     return to_obj(mk_as_is(to_expr(e)));
 }
 
-vm_obj expr_to_string(vm_obj const &);
-
-vm_obj pexpr_to_string(vm_obj const & e) {
-    return expr_to_string(e);
-}
-
-vm_obj pexpr_to_raw_expr(vm_obj const & e) {
-    return e;
-}
-
-vm_obj pexpr_of_raw_expr(vm_obj const & e) {
-    return e;
-}
-
 vm_obj pexpr_mk_placeholder() {
     return to_obj(mk_expr_placeholder());
-}
-
-vm_obj pexpr_pos(vm_obj const & e) {
-    if (auto p = get_pos_info(to_expr(e)))
-        return mk_vm_some(to_obj(*p));
-    return mk_vm_none();
 }
 
 vm_obj pexpr_mk_explicit(vm_obj const & e) {
@@ -57,18 +30,18 @@ vm_obj pexpr_mk_field_macro(vm_obj const & e, vm_obj const & fname) {
     return to_obj(mk_field_notation(to_expr(e), to_name(fname)));
 }
 
-void initialize_vm_pexpr() {
-    DECLARE_VM_BUILTIN(name({"pexpr", "subst"}),          expr_subst);
-    DECLARE_VM_BUILTIN(name({"pexpr", "of_expr"}),        pexpr_of_expr);
-    DECLARE_VM_BUILTIN(name({"pexpr", "to_string"}),      pexpr_to_string);
-    DECLARE_VM_BUILTIN(name({"pexpr", "of_raw_expr"}),    pexpr_of_raw_expr);
-    DECLARE_VM_BUILTIN(name({"pexpr", "to_raw_expr"}),    pexpr_to_raw_expr);
-    DECLARE_VM_BUILTIN(name({"pexpr", "mk_placeholder"}), pexpr_mk_placeholder);
+vm_obj pexpr_is_choice_macro(vm_obj const & e) {
+    return mk_vm_bool(is_choice(to_expr(e)));
+}
 
-    DECLARE_VM_BUILTIN(name("pexpr", "pos"),              pexpr_pos);
+void initialize_vm_pexpr() {
+    DECLARE_VM_BUILTIN(name({"pexpr", "of_expr"}),        pexpr_of_expr);
+    DECLARE_VM_BUILTIN(name({"pexpr", "mk_placeholder"}), pexpr_mk_placeholder);
 
     DECLARE_VM_BUILTIN(name("pexpr", "mk_explicit"),      pexpr_mk_explicit);
     DECLARE_VM_BUILTIN(name("pexpr", "mk_field_macro"),   pexpr_mk_field_macro);
+
+    DECLARE_VM_BUILTIN(name("expr", "is_choice_macro"),   pexpr_is_choice_macro);
 }
 
 void finalize_vm_pexpr() {

--- a/tests/lean/coe5.lean.expected.out
+++ b/tests/lean/coe5.lean.expected.out
@@ -2,4 +2,4 @@
 ⇑(⇑f a) b : expr
 ⇑(⇑(⇑f a) b) a : expr
 f a b a : expr
-@coe_fn.{1 1} expr expr_to_app (@coe_fn.{1 1} expr expr_to_app f a) b : expr
+@coe_fn.{1 1} (expr bool.tt) expr_to_app (@coe_fn.{1 1} (expr bool.tt) expr_to_app f a) b : expr bool.tt

--- a/tests/lean/macro_args.lean
+++ b/tests/lean/macro_args.lean
@@ -1,1 +1,1 @@
-#eval ``({pos . line := has_zero.zero, col := 1}).to_raw_expr.to_raw_fmt
+#eval ``({pos . line := has_zero.zero, col := 1}).to_raw_fmt

--- a/tests/lean/pp_opt_param.lean
+++ b/tests/lean/pp_opt_param.lean
@@ -1,0 +1,6 @@
+#check expr
+#check expr ff
+def f (x := 3) (y : nat) := y
+#check f 3 4
+set_option pp.implicit true
+#check expr

--- a/tests/lean/pp_opt_param.lean.expected.out
+++ b/tests/lean/pp_opt_param.lean.expected.out
@@ -1,0 +1,4 @@
+expr : Type
+expr ff : Type
+f 3 4 : ℕ
+expr tt : Type

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -294,8 +294,6 @@ run_cmd script_check_id `pprod.mk
 run_cmd script_check_id `pprod.fst
 run_cmd script_check_id `pprod.snd
 run_cmd script_check_id `propext
-run_cmd script_check_id `pexpr
-run_cmd script_check_id `pexpr.subst
 run_cmd script_check_id `to_pexpr
 run_cmd script_check_id `quot.mk
 run_cmd script_check_id `quot.lift

--- a/tests/lean/run/meta_expr1.lean
+++ b/tests/lean/run/meta_expr1.lean
@@ -30,7 +30,7 @@ meta definition v1 := expr.app (expr.app (expr.const `f []) (expr.mk_var 0)) (ex
 
 #eval expr.instantiate_vars v1 [expr.const `a [], expr.const `b []]
 
-meta definition fv1 :=
+meta definition fv1 : expr :=
 expr.app
   (expr.app (expr.const `f [])
             (expr.local_const `a `a binder_info.default (expr.sort level.zero)))


### PR DESCRIPTION
...but not in the C++ way :) . Still gets rid of all `to/of_raw_expr` (one could always use `unchecked_cast` if they really need them).

Also contains the commits of #1578 because I was too lazy to rebase and fix.

There are still a few broken tests - should we try and print `expr tt` as `expr`?