### PR TITLE
refactor(init/meta/tactic): replace assertv -> note, definev -> pose

### DIFF
--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -1094,7 +1094,7 @@ begin
     rw [sub_mul_mod _ _ _ b_pos h₁],
     rw [sub_mul_div _ _ _ b_pos h₁],
     -- Cancel subtraction inside mod b^w
-    assertv b_w_pos : b^w > 0 := pos_pow_of_pos _ b_pos,
+    note b_w_pos : b^w > 0 := pos_pow_of_pos _ b_pos,
     assert p_b_ge :  b^w ≤ p / b,
     {
       rw [le_div_iff_mul_le _ _ b_pos],

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -495,25 +495,29 @@ do e ← i_to_expr_strict q,
    tactic.define h e
 
 /--
-This tactic applies to any goal. `assertv h : T := p` adds a new hypothesis of name `h` and type `T` to the current goal if `p` a term of type `T`.
+This tactic applies to any goal. `note h : T := p` adds a new hypothesis of name `h` and type `T` to the current goal if `p` a term of type `T`.
 -/
-meta def assertv (h : parse ident) (q₁ : parse $ tk ":" *> texpr) (q₂ : parse $ tk ":=" *> texpr) : tactic unit :=
-do t ← i_to_expr_strict q₁,
-   v ← i_to_expr_strict ``(%%q₂ : %%t),
-   tactic.assertv h t v
+meta def note (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ tk ":=" *> texpr) : tactic unit :=
+match q₁ with
+| some e := do
+  t ← i_to_expr_strict e,
+  v ← i_to_expr_strict ``(%%q₂ : %%t),
+  tactic.assertv (h.get_or_else `this) t v
+| none := do
+  p ← i_to_expr_strict q₂,
+  tactic.note (h.get_or_else `this) none p
+end
 
-meta def definev (h : parse ident) (q₁ : parse $ tk ":" *> texpr) (q₂ : parse $ tk ":=" *> texpr) : tactic unit :=
-do t ← i_to_expr_strict q₁,
-   v ← i_to_expr_strict ``(%%q₂ : %%t),
-   tactic.definev h t v
-
-meta def note (h : parse ident) (q : parse $ tk ":=" *> texpr) : tactic unit :=
-do p ← i_to_expr_strict q,
-   tactic.note h p
-
-meta def pose (h : parse ident) (q : parse $ tk ":=" *> texpr) : tactic unit :=
-do p ← i_to_expr_strict q,
-   tactic.pose h p
+meta def pose (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ tk ":=" *> texpr) : tactic unit :=
+match q₁ with
+| some e := do
+  t ← i_to_expr_strict e,
+  v ← i_to_expr_strict ``(%%q₂ : %%t),
+  tactic.definev (h.get_or_else `this) t v
+| none := do
+  p ← i_to_expr_strict q₂,
+  tactic.pose (h.get_or_else `this) none p
+end
 
 /--
 This tactic displays the current state in the tracing buffer.

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -85,28 +85,32 @@ meta def define (h : parse ident) (q : parse $ tk ":" *> texpr) : smt_tactic uni
 do e ← tactic.to_expr_strict q,
    smt_tactic.define h e
 
-meta def assertv (h : parse ident) (q₁ : parse $ tk ":" *> texpr) (q₂ : parse $ tk ":=" *> texpr) : smt_tactic unit :=
-do t ← tactic.to_expr_strict q₁,
-   v ← tactic.to_expr_strict ``(%%q₂ : %%t),
-   smt_tactic.assertv h t v
+meta def note (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ tk ":=" *> texpr) : smt_tactic unit :=
+match q₁ with
+| some e := do
+  t ← tactic.to_expr_strict e,
+  v ← tactic.to_expr_strict ``(%%q₂ : %%t),
+  smt_tactic.assertv (h.get_or_else `this) t v
+| none := do
+  p ← tactic.to_expr_strict q₂,
+  smt_tactic.note (h.get_or_else `this) none p
+end
 
-meta def definev (h : parse ident) (q₁ : parse $ tk ":" *> texpr) (q₂ : parse $ tk ":=" *> texpr) : smt_tactic unit :=
-do t ← tactic.to_expr_strict q₁,
-   v ← tactic.to_expr_strict ``(%%q₂ : %%t),
-   smt_tactic.definev h t v
-
-meta def note (h : parse ident) (q : parse $ tk ":=" *> texpr) : smt_tactic unit :=
-do p ← tactic.to_expr_strict q,
-   smt_tactic.note h p
-
-meta def pose (h : parse ident) (q : parse $ tk ":=" *> texpr) : smt_tactic unit :=
-do p ← tactic.to_expr_strict q,
-   smt_tactic.pose h p
+meta def pose (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ tk ":=" *> texpr) : smt_tactic unit :=
+match q₁ with
+| some e := do
+  t ← tactic.to_expr_strict e,
+  v ← tactic.to_expr_strict ``(%%q₂ : %%t),
+  smt_tactic.definev (h.get_or_else `this) t v
+| none := do
+  p ← tactic.to_expr_strict q₂,
+  smt_tactic.pose (h.get_or_else `this) none p
+end
 
 meta def add_fact (q : parse texpr) : smt_tactic unit :=
 do h ← tactic.get_unused_name `h none,
    p ← tactic.to_expr_strict q,
-   smt_tactic.note h p
+   smt_tactic.note h none p
 
 meta def trace_state : smt_tactic unit :=
 smt_tactic.trace_state

--- a/library/init/meta/smt/smt_tactic.lean
+++ b/library/init/meta/smt/smt_tactic.lean
@@ -309,14 +309,14 @@ meta def definev (h : name) (t : expr) (v : expr) : smt_tactic unit :=
 tactic.definev_core h t v >> intros >> return ()
 
 /-- Add (h : t := pr) to the current goal -/
-meta def pose (h : name) (pr : expr) : smt_tactic unit :=
-do t ← tactic.infer_type pr,
-   definev h t pr
+meta def pose (h : name) (t : option expr := none) (pr : expr) : smt_tactic unit :=
+let dv := λt, definev h t pr in
+option.cases_on t (infer_type pr >>= dv) dv
 
-/- Add (h : t) to the current goal, given a proof (pr : t) -/
-meta def note (n : name) (pr : expr) : smt_tactic unit :=
-do t ← tactic.infer_type pr,
-   assertv n t pr
+/-- Add (h : t) to the current goal, given a proof (pr : t) -/
+meta def note (h : name) (t : option expr := none) (pr : expr) : smt_tactic unit :=
+let dv := λt, assertv h t pr in
+option.cases_on t (infer_type pr >>= dv) dv
 
 meta def destruct (e : expr) : smt_tactic unit :=
 smt_tactic.seq (tactic.destruct e) smt_tactic.intros

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -617,14 +617,14 @@ meta def definev (h : name) (t : expr) (v : expr) : tactic unit :=
 definev_core h t v >> intro h >> return ()
 
 /- Add (h : t := pr) to the current goal -/
-meta def pose (h : name) (pr : expr) : tactic unit :=
-do t ← infer_type pr,
-   definev h t pr
+meta def pose (h : name) (t : option expr := none) (pr : expr) : tactic unit :=
+let dv := λt, definev h t pr in
+option.cases_on t (infer_type pr >>= dv) dv
 
 /- Add (h : t) to the current goal, given a proof (pr : t) -/
-meta def note (n : name) (pr : expr) : tactic unit :=
-do t ← infer_type pr,
-   assertv n t pr
+meta def note (h : name) (t : option expr := none) (pr : expr) : tactic unit :=
+let dv := λt, assertv h t pr in
+option.cases_on t (infer_type pr >>= dv) dv
 
 /- Return the number of goals that need to be solved -/
 meta def num_goals     : tactic nat :=

--- a/tests/lean/1207.lean
+++ b/tests/lean/1207.lean
@@ -1,12 +1,12 @@
 example : true :=
 begin
-  assertv H : true := (by trivial),
+  note H : true := (by trivial),
   exact H
 end
 
 example : true :=
 begin
-  assertv H : true := (by tactic.triv),
+  note H : true := (by tactic.triv),
   exact H
 end
 
@@ -18,13 +18,13 @@ end
 
 example : false :=
 begin
-  assertv H : true := (by foo), -- ERROR
+  note H : true := (by foo), -- ERROR
   exact sorry
 end
 
 constant P : Prop
 example (p : P) : true :=
 begin
-  assertv H : P := by do { p ← tactic.get_local `p, tactic.exact p },
+  note H : P := by do { p ← tactic.get_local `p, tactic.exact p },
   trivial
 end

--- a/tests/lean/1467.lean
+++ b/tests/lean/1467.lean
@@ -3,8 +3,8 @@ axiom H_f_g : ∀ n, f (g n) = n
 
 example (m : ℕ) : h m = h m :=
 begin
-definev n : ℕ := g m,
-assertv H : f n = m := begin dsimp, rw H_f_g end,
+pose n : ℕ := g m,
+note H : f n = m := begin dsimp, rw H_f_g end,
 subst H, -- Error here
 end
 
@@ -14,14 +14,14 @@ example (m : ℕ) : h m = h m :=
 begin
 define n : ℕ, -- add metavar
 exact g m,
-assertv H : f n = m := begin dsimp, rw H_f_g end,
+note H : f n = m := begin dsimp, rw H_f_g end,
 subst H, -- Error here
 end
 
 example (m : ℕ) : h m = h m :=
 begin
-definev n : ℕ := g m,
-assertv H : f n = m := begin dsimp, rw H_f_g end,
+pose n : ℕ := g m,
+note H : f n = m := begin dsimp, rw H_f_g end,
 subst m, -- Error here
 end
 
@@ -31,13 +31,13 @@ example (m : ℕ) : h m = h m :=
 begin
 define n : ℕ, -- add metavar
 exact g m,
-assertv H : f n = m := begin dsimp, rw H_f_g end,
+note H : f n = m := begin dsimp, rw H_f_g end,
 subst m, -- Error here
 end
 
 example (m p: ℕ) : h m = h m :=
 begin
-definev a : ℕ := g p,
-definev n : ℕ := g a,
+pose a : ℕ := g p,
+pose n : ℕ := g a,
 clear p -- Error here
 end

--- a/tests/lean/run/assert_tac3.lean
+++ b/tests/lean/run/assert_tac3.lean
@@ -34,7 +34,7 @@ end
 
 definition tst5 (a : nat) : a = a :=
 begin
-  definev x : nat := a,
+  pose x : nat := a,
   trace_state,
   exact eq.refl x
 end

--- a/tests/lean/run/super_examples.lean
+++ b/tests/lean/run/super_examples.lean
@@ -24,7 +24,7 @@ example (m n : ℕ) : 0 + m = 0 + n → m = n :=
 by super with nat.zero_add
 
 example : ∀x y : ℕ, x + y = y + x :=
-begin intros, induction x, assertv h : nat.zero = 0 := rfl,
+begin intros, induction x, note h : nat.zero = 0 := rfl,
       super with nat.add_zero nat.zero_add,
       super with nat.add_succ nat.succ_add end
 


### PR DESCRIPTION
This commit replaces the `assertv` tactic in interactive mode with `note`, and similarly for `definev`. Additionally, the name in `note` and `pose`  is now optional, with `this` being used as the name if not specified. That is, the following are all valid in a `begin...end`:

    note h : t := pr -- was assertv h : t := pr
    note : t := pr -- was assertv this : t := pr
    note h := pr
    note := pr -- was note this := pr
    pose h : t := pr -- was definev h : t := pr
    pose : t := pr -- was definev this : t := pr
    pose h := pr
    pose := pr -- was pose this := pr

Also, `tactic.assertv` still exists with the same type, but `tactic.note` now accepts an optional type argument which will make it act like `tactic.assertv` if used.
