### PR TITLE
Server: declaration search command

### DIFF
--- a/src/frontends/lean/completion.h
+++ b/src/frontends/lean/completion.h
@@ -24,6 +24,9 @@ std::vector<json> get_interactive_tactic_completions(std::string const & pattern
 std::vector<json> get_attribute_completions(std::string const & pattern, environment const & env, options const & opts);
 std::vector<json> get_namespace_completions(std::string const & pattern, environment const & env, options const & opts);
 
+void search_decls(std::string const & pattern, std::vector<pair<std::string, environment>> const & envs,
+                  options const & opts, std::vector<json> & completions);
+
 void initialize_completion();
 void finalize_completion();
 }

--- a/src/library/module_mgr.h
+++ b/src/library/module_mgr.h
@@ -58,6 +58,8 @@ struct module_info {
     environment const & get_produced_env() const {
         return get(get(m_result).m_loaded_module->m_env);
     }
+
+    environment get_latest_env() const;
 };
 
 class module_vfs {
@@ -106,6 +108,8 @@ public:
     void invalidate(module_id const & id);
 
     std::shared_ptr<module_info const> get_module(module_id const &);
+
+    std::vector<std::shared_ptr<module_info const>> get_all_modules();
 
     void cancel_all();
 

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -97,6 +97,7 @@ class server : public module_vfs {
     cmd_res handle_sync(cmd_req const & req);
     task<cmd_res> handle_complete(cmd_req const & req);
     task<cmd_res> handle_info(cmd_req const & req);
+    cmd_res handle_search(cmd_req const & req);
     cmd_res handle_roi(cmd_req const & req);
 
     json autocomplete(std::shared_ptr<module_info const> const & mod_info, bool skip_completions, pos_info const & pos);

--- a/src/shell/server.h
+++ b/src/shell/server.h
@@ -86,15 +86,17 @@ class server : public module_vfs {
     template <class Msg>
     void send_msg(Msg const &);
 
+    template <class Msg>
+    void send_async_msg(task<Msg> const &);
+
     struct cmd_res;
     struct cmd_req;
     void handle_request(cmd_req const & req);
+    void handle_async_response(cmd_req const & req, task<cmd_res> const & res);
 
     cmd_res handle_sync(cmd_req const & req);
-    class auto_complete_task;
-    void handle_complete(cmd_req const & req);
-    class info_task;
-    void handle_info(cmd_req const & req);
+    task<cmd_res> handle_complete(cmd_req const & req);
+    task<cmd_res> handle_info(cmd_req const & req);
     cmd_res handle_roi(cmd_req const & req);
 
     json autocomplete(std::shared_ptr<module_info const> const & mod_info, bool skip_completions, pos_info const & pos);


### PR DESCRIPTION
![vscode_search](https://cloud.githubusercontent.com/assets/313929/26284050/dd4265a8-3e32-11e7-884f-e2808e4fc92c.png)

This PR adds a new request to the server interface:
```json
{"seq_num": 1, "command": "search", "query": "addcomm"}
```
The search command looks for declarations in all files that are open in the server.  It returns an array of results, in the same format as the auto-completion commands (it is also implemented using the auto-completion code).

There is already support for it in the git version of the vscode extension ("ctrl+p #" or "ctrl+t").