### PR TITLE
feat(leanpkg): add initial support for test command

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -790,6 +790,9 @@ tactic.apply_auto_param
 meta def fail_if_success (tac : itactic) : tactic unit :=
 tactic.fail_if_success tac
 
+meta def success_if_fail (tac : itactic) : tactic unit :=
+tactic.success_if_fail tac
+
 meta def guard_expr_eq (t : expr) (p : parse $ tk ":=" *> texpr) : tactic unit :=
 do e ← to_expr p, guard (alpha_eqv t e)
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -86,6 +86,13 @@ meta def fail_if_success {α : Type u} (t : tactic α) : tactic unit :=
  (λ a s, mk_exception "fail_if_success combinator failed, given tactic succeeded" none s)
  (λ e ref s', success () s)
 
+meta def success_if_fail {α : Type u} (t : tactic α) : tactic unit :=
+λ s, match t s with
+| (interaction_monad.result.exception _ _ s') := success () s
+| (interaction_monad.result.success a s) :=
+   mk_exception "success_if_fail combinator failed, given tactic succeeded" none s
+end
+
 open nat
 /- (repeat_at_most n t): repeat the given tactic at most n times or until t fails -/
 meta def repeat_at_most : nat → tactic unit → tactic unit


### PR DESCRIPTION
Making a few tweaks to `leanpkg` added a simple test command which reuses the LEAN_PATH and invokes `--make` in the test directory. You can see an example on the `smt2_interface` repository. 

