### PR TITLE
feat(leanpkg): support (deterministic) timeout value in leanpkg.toml

### DIFF
--- a/library/data/buffer/parser.lean
+++ b/library/data/buffer/parser.lean
@@ -120,9 +120,12 @@ def char_buf (s : char_buffer) : parser unit :=
 decorate_error s.to_string $ monad.for' s.to_list ch
 
 /-- Matches one out of a list of characters. -/
-def one_of (cs : list char) : parser unit :=
+def one_of (cs : list char) : parser char :=
 decorate_errors (do c ← cs, return [c]) $
-sat (∈ cs) >> eps
+sat (∈ cs)
+
+def one_of' (cs : list char) : parser unit :=
+one_of cs >> eps
 
 /-- Matches a string.  Does not consume input in case of failure. -/
 def str (s : string) : parser unit :=


### PR DESCRIPTION
Add an option the the `leanpkg.toml` file to set a value of the timeout. When compiling the current value is `0` (i.e. infinity). For compiling `library_dev` it makes more sense to have a smaller value.

