### PR TITLE
User-defined notation parsers

### DIFF
--- a/library/data/hash_map.lean
+++ b/library/data/hash_map.lean
@@ -716,7 +716,7 @@ section string
 variables [has_to_string α] [∀ a, has_to_string (β a)]
 open prod
 private def key_data_to_string (a : α) (b : β a) (first : bool) : string :=
-(if first then "" else ", ") ++ to_string a ++ " ← " ++ to_string b
+(if first then "" else ", ") ++ sformat!"{a} ← {b}"
 
 private def to_string (m : hash_map α β) : string :=
 "⟨" ++ (fst (fold m ("", tt) (λ p a b, (fst p ++ key_data_to_string a b (snd p), ff)))) ++ "⟩"

--- a/library/init/meta/converter.lean
+++ b/library/init/meta/converter.lean
@@ -38,7 +38,7 @@ match o₁, o₂ with
   env ← get_env,
   match env.trans_for r with
   | some trans := do pr ← mk_app trans [p₁, p₂], return $ some pr
-  | none       := fail $ "converter failed, relation '" ++ r.to_string ++ "' is not transitive"
+  | none       := fail format!"converter failed, relation '{r}' is not transitive"
   end
 end
 
@@ -120,7 +120,7 @@ private meta def mk_refl_proof (r : name) (e : expr) : tactic expr :=
 do env ← get_env,
    match (environment.refl_for env r) with
    | (some refl) := do pr ← mk_app refl [e], return pr
-   | none        := fail $ "converter failed, relation '" ++ r.to_string ++ "' is not reflexive"
+   | none        := fail format!"converter failed, relation '{r}' is not reflexive"
    end
 
 meta def to_tactic (c : conv unit) : name → expr → tactic (expr × expr) :=

--- a/library/init/meta/has_reflect.lean
+++ b/library/init/meta/has_reflect.lean
@@ -17,6 +17,7 @@ local attribute [semireducible] reflected
 
 meta instance nat.reflect : has_reflect ℕ
 | n := if n = 0 then `(nat.zero)
+       else if n = 1 then `(1 : nat)
        else if n % 2 = 0 then `(bit0 %%(nat.reflect (n / 2)) : ℕ)
        else `(bit1 %%(nat.reflect (n / 2)) : ℕ)
 

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -6,133 +6,13 @@ Authors: Leonardo de Moura
 prelude
 import init.meta.tactic init.meta.rewrite_tactic init.meta.simp_tactic
 import init.meta.smt.congruence_closure init.category.combinators
-import init.meta.lean.parser init.meta.has_reflect
+import init.meta.interactive_base
 
 open lean
 open lean.parser
 
 local postfix `?`:9001 := optional
 local postfix *:9001 := many
-
-namespace interactive
-/-- (parse p) as the parameter type of an interactive tactic will instruct the Lean parser
-    to run `p` when parsing the parameter and to pass the parsed value as an argument
-    to the tactic. -/
-@[reducible] meta def parse {α : Type} [has_reflect α] (p : parser α) : Type := α
-
-inductive loc : Type
-| wildcard : loc
-| ns       : list name → loc
-
-meta instance : has_reflect loc
-| loc.wildcard := `(_)
-| (loc.ns xs)  := `(_)
-
-namespace types
-variables {α β : Type}
-
--- optimized pretty printer
-meta def brackets (l r : string) (p : parser α) := tk l *> p <* tk r
-
-meta def list_of (p : parser α) := brackets "[" "]" $ sep_by (skip_info (tk ",")) p
-
-/-- A 'tactic expression', which uses right-binding power 2 so that it is terminated by
-    '<|>' (rbp 2), ';' (rbp 1), and ',' (rbp 0). It should be used for any (potentially)
-    trailing expression parameters. -/
-meta def texpr := qexpr 2
-/-- Parse an identifier or a '_' -/
-meta def ident_ : parser name := ident <|> tk "_" *> return `_
-meta def using_ident := (tk "using" *> ident)?
-meta def with_ident_list := (tk "with" *> ident_*) <|> return []
-meta def without_ident_list := (tk "without" *> ident*) <|> return []
-meta def location := (tk "at" *> (tk "*" *> return loc.wildcard <|> (loc.ns <$> ident*))) <|> return (loc.ns [])
-meta def qexpr_list := list_of (qexpr 0)
-meta def opt_qexpr_list := qexpr_list <|> return []
-meta def qexpr_list_or_texpr := qexpr_list <|> list.ret <$> texpr
-meta def only_flag : parser bool := (tk "only" *> return tt) <|> return ff
-end types
-
-precedence only:0
-
-/-- Use `desc` as the interactive description of `p`. -/
-meta def with_desc {α : Type} (desc : format) (p : parser α) : parser α := p
-
-open expr format tactic types
-private meta def maybe_paren : list format → format
-| []  := ""
-| [f] := f
-| fs  := paren (join fs)
-
-private meta def unfold (e : expr) : tactic expr :=
-do (expr.const f_name f_lvls) ← return e.get_app_fn | failed,
-   env   ← get_env,
-   decl  ← env.get f_name,
-   new_f ← decl.instantiate_value_univ_params f_lvls,
-   head_beta (expr.mk_app new_f e.get_app_args)
-
-private meta def concat (f₁ f₂ : list format) :=
-if f₁.empty then f₂ else if f₂.empty then f₁ else f₁ ++ [" "] ++ f₂
-
-private meta def parser_desc_aux : expr → tactic (list format)
-| `(ident)  := return ["id"]
-| `(ident_) := return ["id"]
-| `(qexpr) := return ["expr"]
-| `(tk %%c) := list.ret <$> to_fmt <$> eval_expr string c
-| `(cur_pos) := return []
-| `(pure ._) := return []
-| `(._ <$> %%p) := parser_desc_aux p
-| `(skip_info %%p) := parser_desc_aux p
-| `(set_goal_info_pos %%p) := parser_desc_aux p
-| `(with_desc %%desc %%p) := list.ret <$> eval_expr format desc
-| `(%%p₁ <*> %%p₂) := do
-  f₁ ← parser_desc_aux p₁,
-  f₂ ← parser_desc_aux p₂,
-  return $ concat f₁ f₂
-| `(%%p₁ <* %%p₂) := do
-  f₁ ← parser_desc_aux p₁,
-  f₂ ← parser_desc_aux p₂,
-  return $ concat f₁ f₂
-| `(%%p₁ *> %%p₂) := do
-  f₁ ← parser_desc_aux p₁,
-  f₂ ← parser_desc_aux p₂,
-  return $ concat f₁ f₂
-| `(many %%p) := do
-  f ← parser_desc_aux p,
-  return [maybe_paren f ++ "*"]
-| `(optional %%p) := do
-  f ← parser_desc_aux p,
-  return [maybe_paren f ++ "?"]
-| `(sep_by %%sep %%p) := do
-  f₁ ← parser_desc_aux sep,
-  f₂ ← parser_desc_aux p,
-  return [maybe_paren f₂ ++ join f₁, " ..."]
-| `(%%p₁ <|> %%p₂) := do
-  f₁ ← parser_desc_aux p₁,
-  f₂ ← parser_desc_aux p₂,
-  return $ if f₁.empty then [maybe_paren f₂ ++ "?"] else
-    if f₂.empty then [maybe_paren f₁ ++ "?"] else
-    [paren $ join $ f₁ ++ [to_fmt " | "] ++ f₂]
-| `(brackets %%l %%r %%p) := do
-  f ← parser_desc_aux p,
-  l ← eval_expr string l,
-  r ← eval_expr string r,
-  -- much better than the naive [l, " ", f, " ", r]
-  return [to_fmt l ++ join f ++ to_fmt r]
-| e          := do
-  e' ← (do e' ← unfold e,
-        guard $ e' ≠ e,
-        return e') <|>
-       (do f ← pp e,
-        fail $ to_fmt "don't know how to pretty print " ++ f),
-  parser_desc_aux e'
-
-meta def param_desc : expr → tactic format
-| `(parse %%p) := join <$> parser_desc_aux p
-| `(opt_param %%t ._) := (++ "?") <$> pp t
-| e := if is_constant e ∧ (const_name e).components.ilast = `itactic
-  then return $ to_fmt "{ tactic }"
-  else paren <$> pp e
-end interactive
 
 namespace tactic
 /- allows metavars and report errors -/

--- a/library/init/meta/interactive_base.lean
+++ b/library/init/meta/interactive_base.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2016 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Leonardo de Moura
+-/
+prelude
+import init.data.option.instances
+import init.meta.lean.parser init.meta.tactic init.meta.has_reflect
+
+open lean
+open lean.parser
+
+local postfix `?`:9001 := optional
+local postfix *:9001 := many
+
+namespace interactive
+/-- (parse p) as the parameter type of an interactive tactic will instruct the Lean parser
+    to run `p` when parsing the parameter and to pass the parsed value as an argument
+    to the tactic. -/
+@[reducible] meta def parse {α : Type} [has_reflect α] (p : parser α) : Type := α
+
+inductive loc : Type
+| wildcard : loc
+| ns       : list name → loc
+
+meta instance : has_reflect loc
+| loc.wildcard := `(_)
+| (loc.ns xs)  := `(_)
+
+namespace types
+variables {α β : Type}
+
+-- optimized pretty printer
+meta def brackets (l r : string) (p : parser α) := tk l *> p <* tk r
+
+meta def list_of (p : parser α) := brackets "[" "]" $ sep_by (skip_info (tk ",")) p
+
+/-- A 'tactic expression', which uses right-binding power 2 so that it is terminated by
+    '<|>' (rbp 2), ';' (rbp 1), and ',' (rbp 0). It should be used for any (potentially)
+    trailing expression parameters. -/
+meta def texpr := qexpr 2
+/-- Parse an identifier or a '_' -/
+meta def ident_ : parser name := ident <|> tk "_" *> return `_
+meta def using_ident := (tk "using" *> ident)?
+meta def with_ident_list := (tk "with" *> ident_*) <|> return []
+meta def without_ident_list := (tk "without" *> ident*) <|> return []
+meta def location := (tk "at" *> (tk "*" *> return loc.wildcard <|> (loc.ns <$> ident*))) <|> return (loc.ns [])
+meta def qexpr_list := list_of (qexpr 0)
+meta def opt_qexpr_list := qexpr_list <|> return []
+meta def qexpr_list_or_texpr := qexpr_list <|> list.ret <$> texpr
+meta def only_flag : parser bool := (tk "only" *> return tt) <|> return ff
+end types
+
+precedence only:0
+
+/-- Use `desc` as the interactive description of `p`. -/
+meta def with_desc {α : Type} (desc : format) (p : parser α) : parser α := p
+
+open expr format tactic types
+private meta def maybe_paren : list format → format
+| []  := ""
+| [f] := f
+| fs  := paren (join fs)
+
+private meta def unfold (e : expr) : tactic expr :=
+do (expr.const f_name f_lvls) ← return e.get_app_fn | failed,
+   env   ← get_env,
+   decl  ← env.get f_name,
+   new_f ← decl.instantiate_value_univ_params f_lvls,
+   head_beta (expr.mk_app new_f e.get_app_args)
+
+private meta def concat (f₁ f₂ : list format) :=
+if f₁.empty then f₂ else if f₂.empty then f₁ else f₁ ++ [" "] ++ f₂
+
+private meta def parser_desc_aux : expr → tactic (list format)
+| `(ident)  := return ["id"]
+| `(ident_) := return ["id"]
+| `(qexpr) := return ["expr"]
+| `(tk %%c) := list.ret <$> to_fmt <$> eval_expr string c
+| `(cur_pos) := return []
+| `(pure ._) := return []
+| `(._ <$> %%p) := parser_desc_aux p
+| `(skip_info %%p) := parser_desc_aux p
+| `(set_goal_info_pos %%p) := parser_desc_aux p
+| `(with_desc %%desc %%p) := list.ret <$> eval_expr format desc
+| `(%%p₁ <*> %%p₂) := do
+  f₁ ← parser_desc_aux p₁,
+  f₂ ← parser_desc_aux p₂,
+  return $ concat f₁ f₂
+| `(%%p₁ <* %%p₂) := do
+  f₁ ← parser_desc_aux p₁,
+  f₂ ← parser_desc_aux p₂,
+  return $ concat f₁ f₂
+| `(%%p₁ *> %%p₂) := do
+  f₁ ← parser_desc_aux p₁,
+  f₂ ← parser_desc_aux p₂,
+  return $ concat f₁ f₂
+| `(many %%p) := do
+  f ← parser_desc_aux p,
+  return [maybe_paren f ++ "*"]
+| `(optional %%p) := do
+  f ← parser_desc_aux p,
+  return [maybe_paren f ++ "?"]
+| `(sep_by %%sep %%p) := do
+  f₁ ← parser_desc_aux sep,
+  f₂ ← parser_desc_aux p,
+  return [maybe_paren f₂ ++ join f₁, " ..."]
+| `(%%p₁ <|> %%p₂) := do
+  f₁ ← parser_desc_aux p₁,
+  f₂ ← parser_desc_aux p₂,
+  return $ if f₁.empty then [maybe_paren f₂ ++ "?"] else
+    if f₂.empty then [maybe_paren f₁ ++ "?"] else
+    [paren $ join $ f₁ ++ [to_fmt " | "] ++ f₂]
+| `(brackets %%l %%r %%p) := do
+  f ← parser_desc_aux p,
+  l ← eval_expr string l,
+  r ← eval_expr string r,
+  -- much better than the naive [l, " ", f, " ", r]
+  return [to_fmt l ++ join f ++ to_fmt r]
+| e          := do
+  e' ← (do e' ← unfold e,
+        guard $ e' ≠ e,
+        return e') <|>
+       (do f ← pp e,
+        fail $ to_fmt "don't know how to pretty print " ++ f),
+  parser_desc_aux e'
+
+meta def param_desc : expr → tactic format
+| `(parse %%p) := join <$> parser_desc_aux p
+| `(opt_param %%t ._) := (++ "?") <$> pp t
+| e := if is_constant e ∧ (const_name e).components.ilast = `itactic
+  then return $ to_fmt "{ tactic }"
+  else paren <$> pp e
+end interactive

--- a/library/init/meta/lean/parser.lean
+++ b/library/init/meta/lean/parser.lean
@@ -25,6 +25,8 @@ namespace parser
 meta constant ident : parser name
 /-- Check that the next token is `tk` and consume it. `tk` must be a registered token. -/
 meta constant tk (tk : string) : parser unit
+/-- Parse an unelaborated expression using the given right-binding power. -/
+protected meta constant pexpr (rbp := std.prec.max) : parser pexpr
 /-- Parse an unelaborated expression using the given right-binding power. The expression
     may contain antiquotations (`%%e`). -/
 meta constant qexpr (rbp := std.prec.max) : parser pexpr

--- a/library/init/meta/lean/parser.lean
+++ b/library/init/meta/lean/parser.lean
@@ -42,6 +42,9 @@ meta constant set_goal_info_pos (p : parser α) : parser α
 /-- Return the current parser position without consuming any input. -/
 meta def cur_pos : parser pos := λ s, success (parser_state.cur_pos s) s
 
+/-- Temporarily replace input of the parser state, run `p`, and return remaining input. -/
+meta constant with_input (p : parser α) (input : string) : parser (α × string)
+
 meta def parser_orelse (p₁ p₂ : parser α) : parser α :=
 λ s,
 let pos₁ := parser_state.cur_pos s in

--- a/library/init/meta/match_tactic.lean
+++ b/library/init/meta/match_tactic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.tactic init.function
+import init.meta.interactive_base init.function
 
 namespace tactic
 meta structure pattern :=
@@ -110,6 +110,6 @@ meta instance : has_to_tactic_format pattern :=
   uo ← pp p.uoutput,
   u ← pp p.nuvars,
   m ← pp p.nmvars,
-  return $ to_fmt "pattern.mk (" ++ t ++ ") " ++ uo ++ " " ++ mo ++ " " ++ u ++ " " ++ m ++ "" ⟩
+  return format!"pattern.mk ({t}) {uo} {mo} {u} {m}" ⟩
 
 end tactic

--- a/library/init/meta/mk_inhabited_instance.lean
+++ b/library/init/meta/mk_inhabited_instance.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura
 Helper tactic for showing that a type has decidable equality.
 -/
 prelude
+import init.meta.interactive_base
 import init.meta.contradiction_tactic init.meta.constructor_tactic
 import init.meta.injection_tactic init.meta.relation_tactics
 
@@ -41,10 +42,10 @@ do
   I      ← get_inhabited_type_name,
   env    ← get_env,
   let n  := length (constructors_of env I),
-  when (n = 0) (fail $ "mk_inhabited_instance failed, type '" ++ to_string I ++ "' does not have constructors"),
+  when (n = 0) (fail format!"mk_inhabited_instance failed, type '{I}' does not have constructors"),
   constructor,
   (try_constructors n n)
   <|>
-  (fail $ "mk_inhabited_instance failed, failed to build instance using all constructors of '" ++ to_string I ++ "'")
+  (fail format!"mk_inhabited_instance failed, failed to build instance using all constructors of '{I}'")
 
 end tactic

--- a/library/init/meta/pexpr.lean
+++ b/library/init/meta/pexpr.lean
@@ -18,10 +18,10 @@ meta constant pexpr.mk_explicit : pexpr → pexpr
 /- Choice macros are used to implement overloading. -/
 meta constant pexpr.is_choice_macro : pexpr → bool
 
-meta class has_to_pexpr (α : Type u) :=
+meta class has_to_pexpr (α : Sort u) :=
 (to_pexpr : α → pexpr)
 
-meta def to_pexpr {α : Type u} [has_to_pexpr α] : α → pexpr :=
+meta def to_pexpr {α : Sort u} [has_to_pexpr α] : α → pexpr :=
 has_to_pexpr.to_pexpr
 
 meta instance : has_to_pexpr pexpr :=
@@ -29,3 +29,6 @@ meta instance : has_to_pexpr pexpr :=
 
 meta instance : has_to_pexpr expr :=
 ⟨pexpr.of_expr⟩
+
+meta instance (α : Sort u) (a : α) : has_to_pexpr (reflected a) :=
+⟨pexpr.of_expr ∘ reflected.to_expr⟩

--- a/library/init/meta/smt/congruence_closure.lean
+++ b/library/init/meta/smt/congruence_closure.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.tactic init.meta.set_get_option_tactics
+import init.meta.interactive_base init.meta.tactic init.meta.set_get_option_tactics
 
 structure cc_config :=
 /- If tt, congruence closure will treat implicit instance arguments as constants. -/
@@ -103,8 +103,7 @@ do intros, s ← cc_state.mk_using_hs_core cfg, t ← target, s ← s.internaliz
        dbg ← get_bool_option `trace.cc.failure ff,
        if dbg then do {
          ccf ← pp s,
-         msg ← return $ to_fmt "cc tactic failed, equivalence classes: " ++ format.line ++ ccf,
-         fail msg
+         fail format!"cc tactic failed, equivalence classes: \n{ccf}"
        } else do {
          fail "cc tactic failed"
        }

--- a/library/init/meta/smt/ematch.lean
+++ b/library/init/meta/smt/ematch.lean
@@ -6,6 +6,7 @@ Authors: Leonardo de Moura
 prelude
 import init.meta.smt.congruence_closure
 import init.meta.attribute init.meta.simp_tactic
+import init.meta.interactive_base
 open tactic
 
 /- Heuristic instantiation lemma -/
@@ -44,7 +45,7 @@ let tac := s.fold (return format.nil)
       hpp ← h.pp,
       r   ← tac,
       if r.is_nil then return hpp
-      else return (r ++ to_fmt "," ++ format.line ++ hpp))
+      else return format!"{r},\n{hpp}")
 in do
   r ← tac,
   return $ format.cbrace (format.group r)
@@ -94,7 +95,7 @@ meta def mk_hinst_lemma_attrs_core (as_simp : bool) : list name → command
   (do type ← infer_type (expr.const n []),
       let expected := `(caching_user_attribute hinst_lemmas),
       (is_def_eq type expected
-       <|> fail ("failed to create hinst_lemma attribute '" ++ n.to_string ++ "', declaration already exists and has different type.")),
+       <|> fail format!"failed to create hinst_lemma attribute '{n}', declaration already exists and has different type."),
       mk_hinst_lemma_attrs_core ns)
 
 meta def merge_hinst_lemma_attrs (m : transparency) (as_simp : bool) : list name → hinst_lemmas → tactic hinst_lemmas

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -135,7 +135,7 @@ smt_tactic.by_contradiction
 open tactic (resolve_name transparency to_expr)
 
 private meta def report_invalid_em_lemma {α : Type} (n : name) : smt_tactic α :=
-fail ("invalid ematch lemma '" ++ to_string n ++ "'")
+fail format!"invalid ematch lemma '{n}'"
 
 private meta def add_lemma_name (md : transparency) (lhs_lemma : bool) (n : name) (ref : pexpr) : smt_tactic unit :=
 do
@@ -169,7 +169,7 @@ private meta def add_eqn_lemmas_for_core (md : transparency) : list name → smt
   p ← resolve_name c,
   match p with
   | expr.const n _           := add_ematch_eqn_lemmas_for_core md n >> add_eqn_lemmas_for_core cs
-  | _                        := fail $ "'" ++ to_string c ++ "' is not a constant"
+  | _                        := fail format!"'{c}' is not a constant"
   end
 
 meta def add_eqn_lemmas_for (ids : parse ident*) : smt_tactic unit :=

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.meta.smt.smt_tactic init.meta.interactive
+import init.meta.smt.smt_tactic init.meta.interactive_base
 import init.meta.smt.rsimp
 
 namespace smt_tactic

--- a/library/init/meta/smt/rsimp.lean
+++ b/library/init/meta/smt/rsimp.lean
@@ -31,7 +31,7 @@ private meta def to_hinst_lemmas (m : transparency) (ex : name_set) : list name 
 meta def mk_hinst_lemma_attr_from_simp_attr (attr_decl_name attr_name : name) (simp_attr_name : name) (ex_attr_name : name) : command :=
 do let t := `(caching_user_attribute hinst_lemmas),
    let v := `({name     := attr_name,
-                 descr    := "hinst_lemma attribute derived from '" ++ to_string simp_attr_name ++ "'",
+                 descr    := sformat!"hinst_lemma attribute derived from '{simp_attr_name}'",
                  mk_cache := λ ns,
                  let aux := simp_attr_name in
                  let ex_attr := ex_attr_name in

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -14,6 +14,8 @@ meta constant tactic_state : Type
 universes u v
 
 namespace tactic_state
+/-- Create a tactic state with an empty local context and a dummy goal. -/
+meta constant mk_empty    : environment → options → tactic_state
 meta constant env         : tactic_state → environment
 meta constant to_format   : tactic_state → format
 /- Format expression with respect to the main goal in the tactic state.

--- a/library/init/meta/transfer.lean
+++ b/library/init/meta/transfer.lean
@@ -48,7 +48,7 @@ meta instance has_to_tactic_format_rel_data : has_to_tactic_format rel_data :=
   R ← pp r.relation,
   α ← pp r.in_type,
   β ← pp r.out_type,
-  return $ to_fmt "(" ++ R ++ ": rel (" ++ α ++ ") (" ++ β ++ "))" ⟩
+  return format!"({R}: rel ({α}) ({β}))" ⟩
 
 private meta structure rule_data :=
 (pr      : expr)
@@ -68,7 +68,7 @@ meta instance has_to_tactic_format_rule_data : has_to_tactic_format rule_data :=
   ma ← pp r.args,
   pat ← pp r.pat.target,
   out ← pp r.out,
-  return $ to_fmt "{ ⟨" ++ pat ++ "⟩ pr: " ++ pr ++ " → " ++ out ++ ", " ++ up ++ " " ++ mp ++ " " ++ ua ++ " " ++ ma ++ " }" ⟩
+  return format!"{{ ⟨{pat}⟩ pr: {pr} → {out}, {up} {mp} {ua} {ma} }" ⟩
 
 private meta def get_lift_fun : expr → tactic (list rel_data × expr)
 | e :=
@@ -150,9 +150,9 @@ meta def compute_transfer : list rule_data → list expr → expr → tactic (ex
     -- Argument has function type
     (args, r) ← get_lift_fun (i d.relation),
     ((a_vars, b_vars), (R_vars, bnds)) ← monad.for (enum args) (λ⟨n, arg⟩, do
-      a ← mk_local_def (("a" ++ to_string n) : string) arg.in_type,
-      b ← mk_local_def (("b" ++ to_string n) : string) arg.out_type,
-      R ← mk_local_def (("R" ++ to_string n) : string) (arg.relation a b),
+      a ← mk_local_def sformat!"a{n}" arg.in_type,
+      b ← mk_local_def sformat!"b{n}" arg.out_type,
+      R ← mk_local_def sformat!"R{n}" (arg.relation a b),
       return ((a, b), (R, [a, b, R]))) >>= (return ∘ prod.map unzip unzip ∘ unzip),
     rds'      ← monad.for R_vars (analyse_rule []),
 

--- a/library/tools/debugger/util.lean
+++ b/library/tools/debugger/util.lean
@@ -47,16 +47,16 @@ do {
   d      ← vm.get_decl fn,
   some p ← return (vm_decl.pos d) | failure,
   file   ← get_file fn,
-  return (file ++ ":" ++ p.line.to_string ++ ":" ++ p.column.to_string)
+  return sformat!"{file}:{p.line}:{p.column}"
 }
 <|>
 return "<position not available>"
 
 meta def show_fn (header : string) (fn : name) (frame : nat) : vm unit :=
 do pos ← pos_info fn,
-   vm.put_str ("[" ++ frame.to_string ++ "] " ++ header),
+   vm.put_str sformat!"[{frame}] {header}",
    if header = "" then return () else vm.put_str " ",
-   vm.put_str (fn.to_string ++ " at " ++ pos ++ "\n")
+   vm.put_str sformat!"{fn} at {pos}\n"
 
 meta def show_curr_fn (header : string) : vm unit :=
 do fn ← vm.curr_fn,
@@ -105,7 +105,7 @@ meta def show_vars_core : nat → nat → nat → vm unit
   else do
     (n, type) ← vm.stack_obj_info i,
     type_str  ← type_to_string type i,
-    vm.put_str $ "#" ++ c.to_string ++ " " ++ n.to_string ++ " : " ++ type_str ++ "\n",
+    vm.put_str sformat!"#{c} {n} : {type_str}\n",
     show_vars_core (c+1) (i+1) e
 
 meta def show_vars (frame : nat) : vm unit :=

--- a/src/frontends/lean/CMakeLists.txt
+++ b/src/frontends/lean/CMakeLists.txt
@@ -8,4 +8,4 @@ init_module.cpp type_util.cpp decl_attributes.cpp
 prenum.cpp print_cmd.cpp elaborator.cpp
 match_expr.cpp local_context_adapter.cpp decl_util.cpp definition_cmds.cpp
 brackets.cpp tactic_notation.cpp info_manager.cpp json.cpp module_parser.cpp
-equations_validator.cpp parser_state.cpp interactive.cpp completion.cpp)
+equations_validator.cpp parser_state.cpp interactive.cpp completion.cpp user_notation.cpp)

--- a/src/frontends/lean/builtin_exprs.cpp
+++ b/src/frontends/lean/builtin_exprs.cpp
@@ -684,7 +684,7 @@ static expr parse_quoted_expr(parser_state & p, unsigned, expr const *, pos_info
         }
         p.check_token_next(get_rparen_tk(), "invalid quoted expression, `)` expected");
     }
-    return p.save_pos(mk_expr_quote(e), pos);
+    return p.save_pos(mk_unelaborated_expr_quote(e), pos);
 }
 
 static expr parse_antiquote_expr(parser_state & p, unsigned, expr const *, pos_info const & pos) {

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2913,7 +2913,7 @@ expr elaborator::visit_expr_quote(expr const & e, optional<expr> const & expecte
             throw elaborator_exception(e, "invalid quotation, contains universe metavariable");
         if (has_local(new_s))
             throw elaborator_exception(e, "invalid quotation, contains local constant");
-        q = mk_expr_quote(new_s);
+        q = mk_elaborated_expr_quote(new_s);
         q = mk_as_is(q);
         expr subst_fn = mk_app(mk_explicit(mk_constant(get_expr_subst_name())), mk_bool_tt());
         for (expr const & subst : substs) {

--- a/src/frontends/lean/init_module.cpp
+++ b/src/frontends/lean/init_module.cpp
@@ -28,6 +28,7 @@ Author: Leonardo de Moura
 #include "frontends/lean/brackets.h"
 #include "frontends/lean/interactive.h"
 #include "frontends/lean/completion.h"
+#include "frontends/lean/user_notation.h"
 
 namespace lean {
 void initialize_frontend_lean_module() {
@@ -55,8 +56,10 @@ void initialize_frontend_lean_module() {
     initialize_brackets();
     initialize_interactive();
     initialize_completion();
+    initialize_user_notation();
 }
 void finalize_frontend_lean_module() {
+    finalize_user_notation();
     finalize_completion();
     finalize_interactive();
     finalize_brackets();

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -189,6 +189,14 @@ public:
         flet<optional<pos_info>> l(m_break_at_pos, {});
         return f();
     }
+    template <class T>
+    pair<T, pos_info> with_input(std::istream & input, std::function<T()> const & f) {
+        flet<token_kind> l(m_curr, token_kind::Eof);
+        flet<scanner> l1(m_scanner, scanner(input, m_scanner.get_stream_name().c_str()));
+        m_curr = m_scanner.scan(m_env);
+        T t = f();
+        return {t, pos()};
+    }
     bool get_complete() { return m_complete; }
     void set_complete(bool complete) { m_complete = complete; }
     /** \brief Throw \c break_at_pos_exception with given context if \c m_break_at_pos is inside current token. */

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -319,6 +319,10 @@ name * notation_config::g_class_name = nullptr;
 template class scoped_ext<notation_config>;
 typedef scoped_ext<notation_config> notation_ext;
 
+environment add_notation(environment const & env, notation_entry const & e, persistence persistent) {
+    return notation_ext::add_entry(env, get_dummy_ios(), e, persistent);
+}
+
 environment add_notation(environment const & env, notation_entry const & e, bool persistent) {
     return notation_ext::add_entry(env, get_dummy_ios(), e, persistent);
 }

--- a/src/frontends/lean/parser_config.h
+++ b/src/frontends/lean/parser_config.h
@@ -87,7 +87,7 @@ list<expr> get_mpz_notation(environment const & env, mpz const & n);
 /** \brief Return the notation declaration that start with a given head symbol.
 
     \remark Notation declarations that contain C++ and Lua actions are not indexed.
-    Thus, they are to included in the result.
+    Thus, they are not included in the result.
 */
 list<notation_entry> get_notation_entries(environment const & env, head_index const & idx);
 

--- a/src/frontends/lean/parser_config.h
+++ b/src/frontends/lean/parser_config.h
@@ -8,6 +8,7 @@ Author: Leonardo de Moura
 #include <string>
 #include <vector>
 #include "kernel/environment.h"
+#include "library/scoped_ext.h"
 #include "frontends/lean/token_table.h"
 #include "frontends/lean/parse_table.h"
 #include "frontends/lean/cmd_table.h"
@@ -67,6 +68,7 @@ inline bool operator!=(notation_entry const & e1, notation_entry const & e2) {
 notation_entry replace(notation_entry const & e, std::function<expr(expr const &)> const & f);
 
 environment add_token(environment const & env, token_entry const & e, bool persistent = true);
+environment add_notation(environment const & env, notation_entry const & e, persistence persistent);
 environment add_notation(environment const & env, notation_entry const & e, bool persistent = true);
 environment add_token(environment const & env, char const * val, unsigned prec);
 token_table const & get_token_table(environment const & env);

--- a/src/frontends/lean/scanner.cpp
+++ b/src/frontends/lean/scanner.cpp
@@ -70,7 +70,7 @@ bool is_sub_script_alnum_unicode(unsigned u) {
 
 void scanner::fetch_line() {
     m_curr_line.clear();
-    if (std::getline(m_stream, m_curr_line)) {
+    if (std::getline(*m_stream, m_curr_line)) {
         m_curr_line.push_back('\n');
         m_sline++;
         m_spos  = 0;
@@ -681,7 +681,7 @@ auto scanner::scan(environment const & env) -> token_kind {
 }
 
 scanner::scanner(std::istream & strm, char const * strm_name):
-    m_tokens(nullptr), m_stream(strm) {
+    m_tokens(nullptr), m_stream(&strm) {
     m_stream_name = strm_name ? strm_name : "[unknown]";
     m_sline = 0;
     m_spos  = 0;

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -29,7 +29,7 @@ enum class token_kind {Keyword, CommandKeyword, Identifier, Numeral, Decimal,
 class scanner {
 protected:
     token_table const * m_tokens;
-    std::istream &      m_stream;
+    std::istream *      m_stream;
     std::string         m_stream_name;
     std::string         m_curr_line;
     bool                m_last_line;

--- a/src/frontends/lean/user_notation.cpp
+++ b/src/frontends/lean/user_notation.cpp
@@ -21,7 +21,7 @@ static environment add_user_notation(environment const & env, name const & d, un
     name tk;
     if (is_app_of(binding_domain(type), get_interactive_parse_name(), 3)) {
         auto const & parser = app_arg(binding_domain(type));
-        if (is_app_of(parser, get_lean_parser_qexpr_name(), 1)) {
+        if (is_app_of(parser, get_lean_parser_pexpr_name(), 1)) {
             is_nud = false;
             type = binding_body(type);
         }

--- a/src/frontends/lean/user_notation.cpp
+++ b/src/frontends/lean/user_notation.cpp
@@ -46,24 +46,21 @@ static environment add_user_notation(environment const & env, name const & d, un
     return add_notation(env, notation_entry(is_nud, {notation::transition(tk, notation::mk_ext_action(
             [=](parser & p, unsigned num, expr const * args, pos_info const &) -> expr {
                 lean_assert(num == (is_nud ? 0 : 1));
-                expr tactic = mk_constant(d);
+                expr parser = mk_constant(d);
                 if (!is_nud)
-                    tactic = mk_app(tactic, mk_pexpr_quote(args[0]));
+                    parser = mk_app(parser, mk_pexpr_quote(args[0]));
                 // `parse (tk c)` arg
-                tactic = mk_app(tactic, mk_constant(get_unit_star_name()));
+                parser = mk_app(parser, mk_constant(get_unit_star_name()));
                 for (expr t = type; is_pi(t); t = binding_body(t)) {
                     expr arg_type = binding_domain(t);
                     if (is_app_of(arg_type, get_interactive_parse_name())) {
-                        tactic = mk_app(tactic, parse_interactive_param(p, arg_type));
+                        parser = mk_app(parser, parse_interactive_param(p, arg_type));
                     } else {
-                        tactic = mk_app(tactic, p.parse_expr(get_max_prec()));
+                        parser = mk_app(parser, p.parse_expr(get_max_prec()));
                     }
                 }
-                tactic = p.elaborate("_user_notation", {}, tactic).first;
-                tactic_state s = mk_tactic_state_for(p.env(), p.get_options(), "_user_notation", local_context(), dummy);
-                type_context ctx(p.env());
-                auto result = tactic::evaluator(ctx, p.get_options())(tactic, s);
-                return to_expr(tactic::get_result_value(result));
+                parser = p.elaborate("_user_notation", {}, parser).first;
+                return to_expr(run_parser(p, parser));
             }))}, Var(0), /* overload */ persistent, prio, notation_entry_group::Main, /* parse_only */ true));
 }
 

--- a/src/frontends/lean/user_notation.cpp
+++ b/src/frontends/lean/user_notation.cpp
@@ -59,7 +59,11 @@ static environment add_user_notation(environment const & env, name const & d, un
                     if (is_app_of(arg_type, get_interactive_parse_name())) {
                         parser = mk_app(parser, parse_interactive_param(p, arg_type));
                     } else {
-                        parser = mk_app(parser, p.parse_expr(get_max_prec()));
+                        expr e = p.parse_expr(get_max_prec());
+                        if (!closed(e) || has_local(e)) {
+                            throw elaborator_exception(e, "invalid argument to user-defined notation, must be closed term");
+                        }
+                        parser = mk_app(parser, e);
                     }
                 }
                 parser = p.elaborate("_user_notation", {}, parser).first;

--- a/src/frontends/lean/user_notation.cpp
+++ b/src/frontends/lean/user_notation.cpp
@@ -1,0 +1,79 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Sebastian Ullrich
+*/
+#include "kernel/abstract.h"
+#include "library/constants.h"
+#include "library/attribute_manager.h"
+#include "library/tactic/elaborator_exception.h"
+#include "library/string.h"
+#include "library/vm/vm_expr.h"
+#include "library/vm/vm_parser.h"
+#include "library/quote.h"
+#include "frontends/lean/elaborator.h"
+
+namespace lean {
+static environment add_user_notation(environment const & env, name const & d, unsigned prio, bool persistent) {
+    auto type = env.get(d).get_type();
+    bool is_nud = true;
+    name tk;
+    if (is_app_of(binding_domain(type), get_interactive_parse_name(), 3)) {
+        auto const & parser = app_arg(binding_domain(type));
+        if (is_app_of(parser, get_lean_parser_qexpr_name(), 1)) {
+            is_nud = false;
+            type = binding_body(type);
+        }
+    }
+    if (is_app_of(binding_domain(type), get_interactive_parse_name(), 3)) {
+        auto const & parser = app_arg(binding_domain(type));
+        if (is_app_of(parser, get_lean_parser_tk_name(), 1)) {
+            if (auto lit = to_string(app_arg(parser))) {
+                tk = *lit;
+                type = binding_body(type);
+            } else {
+                throw elaborator_exception(app_arg(parser),
+                                           "invalid user-defined notation, token must be a name literal");
+            }
+        }
+    }
+    if (!tk) {
+        throw exception("invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` "
+                                "parameter, optionally preceded by `interactive.parse lean.parser.qexpr` parameter");
+    }
+    expr dummy = mk_true();
+    return add_notation(env, notation_entry(is_nud, {notation::transition(tk, notation::mk_ext_action(
+            [=](parser & p, unsigned num, expr const * args, pos_info const &) -> expr {
+                lean_assert(num == (is_nud ? 0 : 1));
+                expr tactic = mk_constant(d);
+                if (!is_nud)
+                    tactic = mk_app(tactic, mk_pexpr_quote(args[0]));
+                // `parse (tk c)` arg
+                tactic = mk_app(tactic, mk_constant(get_unit_star_name()));
+                for (expr t = type; is_pi(t); t = binding_body(t)) {
+                    expr arg_type = binding_domain(t);
+                    if (is_app_of(arg_type, get_interactive_parse_name())) {
+                        tactic = mk_app(tactic, parse_interactive_param(p, arg_type));
+                    } else {
+                        tactic = mk_app(tactic, p.parse_expr(get_max_prec()));
+                    }
+                }
+                tactic = p.elaborate("_user_notation", {}, tactic).first;
+                tactic_state s = mk_tactic_state_for(p.env(), p.get_options(), "_user_notation", local_context(), dummy);
+                type_context ctx(p.env());
+                auto result = tactic::evaluator(ctx, p.get_options())(tactic, s);
+                return to_expr(tactic::get_result_value(result));
+            }))}, Var(0), /* overload */ persistent, prio, notation_entry_group::Main, /* parse_only */ true));
+}
+
+void initialize_user_notation() {
+    register_system_attribute(basic_attribute(
+            "user_notation", "user-defined notation",
+            [](environment const & env, io_state const &, name const & d, unsigned prio, bool persistent) {
+                return add_user_notation(env, d, prio, persistent);
+            }));
+}
+void finalize_user_notation() {
+}
+}

--- a/src/frontends/lean/user_notation.h
+++ b/src/frontends/lean/user_notation.h
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Sebastian Ullrich
+*/
+#pragma once
+
+namespace lean {
+void initialize_user_notation();
+void finalize_user_notation();
+}

--- a/src/library/compiler/comp_irrelevant.cpp
+++ b/src/library/compiler/comp_irrelevant.cpp
@@ -62,7 +62,7 @@ protected:
     }
 
     virtual expr visit_macro(expr const & e) override {
-        if (is_marked_as_comp_irrelevant(e) || is_expr_quote(e))
+        if (is_marked_as_comp_irrelevant(e))
             return e;
         else if (auto v = mark_if_irrel_core(e))
             return *v;

--- a/src/library/compiler/compiler_step_visitor.cpp
+++ b/src/library/compiler/compiler_step_visitor.cpp
@@ -53,8 +53,6 @@ expr compiler_step_visitor::visit_let(expr const & e) {
 expr compiler_step_visitor::visit_macro(expr const & e) {
     if (is_marked_as_comp_irrelevant(e))
         return e;
-    else if (is_expr_quote(e))
-        return e;
     else
         return replace_visitor::visit_macro(e);
 }

--- a/src/library/compiler/erase_irrelevant.cpp
+++ b/src/library/compiler/erase_irrelevant.cpp
@@ -69,8 +69,6 @@ class erase_irrelevant_fn : public compiler_step_visitor {
             return mk_constant(get_rec_fn_name(e));
         } else if (is_nat_value(e)) {
             return e;
-        } else if (is_expr_quote(e)) {
-            return e;
         } else if (auto r = macro_def(e).expand(e, m_ctx)) {
             return visit(*r);
         } else {

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -174,7 +174,7 @@ name const * g_is_associative_assoc = nullptr;
 name const * g_is_commutative = nullptr;
 name const * g_is_commutative_comm = nullptr;
 name const * g_ite = nullptr;
-name const * g_lean_parser_qexpr = nullptr;
+name const * g_lean_parser_pexpr = nullptr;
 name const * g_lean_parser_tk = nullptr;
 name const * g_left_distrib = nullptr;
 name const * g_left_comm = nullptr;
@@ -544,7 +544,7 @@ void initialize_constants() {
     g_is_commutative = new name{"is_commutative"};
     g_is_commutative_comm = new name{"is_commutative", "comm"};
     g_ite = new name{"ite"};
-    g_lean_parser_qexpr = new name{"lean", "parser", "qexpr"};
+    g_lean_parser_pexpr = new name{"lean", "parser", "pexpr"};
     g_lean_parser_tk = new name{"lean", "parser", "tk"};
     g_left_distrib = new name{"left_distrib"};
     g_left_comm = new name{"left_comm"};
@@ -915,7 +915,7 @@ void finalize_constants() {
     delete g_is_commutative;
     delete g_is_commutative_comm;
     delete g_ite;
-    delete g_lean_parser_qexpr;
+    delete g_lean_parser_pexpr;
     delete g_lean_parser_tk;
     delete g_left_distrib;
     delete g_left_comm;
@@ -1285,7 +1285,7 @@ name const & get_is_associative_assoc_name() { return *g_is_associative_assoc; }
 name const & get_is_commutative_name() { return *g_is_commutative; }
 name const & get_is_commutative_comm_name() { return *g_is_commutative_comm; }
 name const & get_ite_name() { return *g_ite; }
-name const & get_lean_parser_qexpr_name() { return *g_lean_parser_qexpr; }
+name const & get_lean_parser_pexpr_name() { return *g_lean_parser_pexpr; }
 name const & get_lean_parser_tk_name() { return *g_lean_parser_tk; }
 name const & get_left_distrib_name() { return *g_left_distrib; }
 name const & get_left_comm_name() { return *g_left_comm; }

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -174,6 +174,8 @@ name const * g_is_associative_assoc = nullptr;
 name const * g_is_commutative = nullptr;
 name const * g_is_commutative_comm = nullptr;
 name const * g_ite = nullptr;
+name const * g_lean_parser_qexpr = nullptr;
+name const * g_lean_parser_tk = nullptr;
 name const * g_left_distrib = nullptr;
 name const * g_left_comm = nullptr;
 name const * g_le_refl = nullptr;
@@ -542,6 +544,8 @@ void initialize_constants() {
     g_is_commutative = new name{"is_commutative"};
     g_is_commutative_comm = new name{"is_commutative", "comm"};
     g_ite = new name{"ite"};
+    g_lean_parser_qexpr = new name{"lean", "parser", "qexpr"};
+    g_lean_parser_tk = new name{"lean", "parser", "tk"};
     g_left_distrib = new name{"left_distrib"};
     g_left_comm = new name{"left_comm"};
     g_le_refl = new name{"le_refl"};
@@ -911,6 +915,8 @@ void finalize_constants() {
     delete g_is_commutative;
     delete g_is_commutative_comm;
     delete g_ite;
+    delete g_lean_parser_qexpr;
+    delete g_lean_parser_tk;
     delete g_left_distrib;
     delete g_left_comm;
     delete g_le_refl;
@@ -1279,6 +1285,8 @@ name const & get_is_associative_assoc_name() { return *g_is_associative_assoc; }
 name const & get_is_commutative_name() { return *g_is_commutative; }
 name const & get_is_commutative_comm_name() { return *g_is_commutative_comm; }
 name const & get_ite_name() { return *g_ite; }
+name const & get_lean_parser_qexpr_name() { return *g_lean_parser_qexpr; }
+name const & get_lean_parser_tk_name() { return *g_lean_parser_tk; }
 name const & get_left_distrib_name() { return *g_left_distrib; }
 name const & get_left_comm_name() { return *g_left_comm; }
 name const & get_le_refl_name() { return *g_le_refl; }

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -174,6 +174,7 @@ name const * g_is_associative_assoc = nullptr;
 name const * g_is_commutative = nullptr;
 name const * g_is_commutative_comm = nullptr;
 name const * g_ite = nullptr;
+name const * g_lean_parser = nullptr;
 name const * g_lean_parser_pexpr = nullptr;
 name const * g_lean_parser_tk = nullptr;
 name const * g_left_distrib = nullptr;
@@ -544,6 +545,7 @@ void initialize_constants() {
     g_is_commutative = new name{"is_commutative"};
     g_is_commutative_comm = new name{"is_commutative", "comm"};
     g_ite = new name{"ite"};
+    g_lean_parser = new name{"lean", "parser"};
     g_lean_parser_pexpr = new name{"lean", "parser", "pexpr"};
     g_lean_parser_tk = new name{"lean", "parser", "tk"};
     g_left_distrib = new name{"left_distrib"};
@@ -915,6 +917,7 @@ void finalize_constants() {
     delete g_is_commutative;
     delete g_is_commutative_comm;
     delete g_ite;
+    delete g_lean_parser;
     delete g_lean_parser_pexpr;
     delete g_lean_parser_tk;
     delete g_left_distrib;
@@ -1285,6 +1288,7 @@ name const & get_is_associative_assoc_name() { return *g_is_associative_assoc; }
 name const & get_is_commutative_name() { return *g_is_commutative; }
 name const & get_is_commutative_comm_name() { return *g_is_commutative_comm; }
 name const & get_ite_name() { return *g_ite; }
+name const & get_lean_parser_name() { return *g_lean_parser; }
 name const & get_lean_parser_pexpr_name() { return *g_lean_parser_pexpr; }
 name const & get_lean_parser_tk_name() { return *g_lean_parser_tk; }
 name const & get_left_distrib_name() { return *g_left_distrib; }

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -176,6 +176,7 @@ name const & get_is_associative_assoc_name();
 name const & get_is_commutative_name();
 name const & get_is_commutative_comm_name();
 name const & get_ite_name();
+name const & get_lean_parser_name();
 name const & get_lean_parser_pexpr_name();
 name const & get_lean_parser_tk_name();
 name const & get_left_distrib_name();

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -176,6 +176,8 @@ name const & get_is_associative_assoc_name();
 name const & get_is_commutative_name();
 name const & get_is_commutative_comm_name();
 name const & get_ite_name();
+name const & get_lean_parser_qexpr_name();
+name const & get_lean_parser_tk_name();
 name const & get_left_distrib_name();
 name const & get_left_comm_name();
 name const & get_le_refl_name();

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -176,7 +176,7 @@ name const & get_is_associative_assoc_name();
 name const & get_is_commutative_name();
 name const & get_is_commutative_comm_name();
 name const & get_ite_name();
-name const & get_lean_parser_qexpr_name();
+name const & get_lean_parser_pexpr_name();
 name const & get_lean_parser_tk_name();
 name const & get_left_distrib_name();
 name const & get_left_comm_name();

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -169,6 +169,7 @@ is_associative.assoc
 is_commutative
 is_commutative.comm
 ite
+lean.parser
 lean.parser.pexpr
 lean.parser.tk
 left_distrib

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -169,7 +169,7 @@ is_associative.assoc
 is_commutative
 is_commutative.comm
 ite
-lean.parser.qexpr
+lean.parser.pexpr
 lean.parser.tk
 left_distrib
 left_comm

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -169,6 +169,8 @@ is_associative.assoc
 is_commutative
 is_commutative.comm
 ite
+lean.parser.qexpr
+lean.parser.tk
 left_distrib
 left_comm
 le_refl

--- a/src/library/quote.h
+++ b/src/library/quote.h
@@ -12,7 +12,8 @@ bool is_expr_quote(expr const &e);
 bool is_pexpr_quote(expr const &e);
 expr const & get_expr_quote_value(expr const & e);
 expr const & get_pexpr_quote_value(expr const & e);
-expr mk_expr_quote(expr const & e);
+expr mk_unelaborated_expr_quote(expr const & e);
+expr mk_elaborated_expr_quote(expr const & e);
 expr mk_pexpr_quote(expr const & e);
 
 expr mk_antiquote(expr const & e);

--- a/src/library/tactic/algebraic_normalizer.cpp
+++ b/src/library/tactic/algebraic_normalizer.cpp
@@ -63,7 +63,7 @@ void initialize_algebraic_normalizer() {
     register_trace_class("algebra");
 
     g_algebra = new name("algebra");
-    register_class_symbol_tracking_attribute(*g_algebra, "mark class whose instances are relevant for txhe algebraic normalizer");
+    register_class_symbol_tracking_attribute(*g_algebra, "mark class whose instances are relevant for the algebraic normalizer");
 
     DECLARE_VM_BUILTIN(name({"tactic", "trace_algebra_info"}), tactic_trace_algebra_info);
 }

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -226,6 +226,10 @@ vm_obj to_obj(transparency_mode m) {
 }
 
 
+vm_obj tactic_state_mk_empty(vm_obj const & vm_env, vm_obj const & vm_opts) {
+    return to_obj(mk_tactic_state_for(to_env(vm_env), to_options(vm_opts), "_mk_empty", local_context(), mk_true()));
+}
+
 vm_obj tactic_state_env(vm_obj const & s) {
     return to_obj(tactic::to_state(s).env());
 }
@@ -842,6 +846,7 @@ vm_obj tactic_sleep(vm_obj const & msecs, vm_obj const & s0) {
 }
 
 void initialize_tactic_state() {
+    DECLARE_VM_BUILTIN(name({"tactic_state", "mk_empty"}),       tactic_state_mk_empty);
     DECLARE_VM_BUILTIN(name({"tactic_state", "env"}),            tactic_state_env);
     DECLARE_VM_BUILTIN(name({"tactic_state", "format_expr"}),    tactic_state_format_expr);
     DECLARE_VM_BUILTIN(name({"tactic_state", "to_format"}),      tactic_state_to_format);

--- a/src/library/type_context.cpp
+++ b/src/library/type_context.cpp
@@ -3570,7 +3570,7 @@ struct instance_synthesizer {
             collect_locals(r, r_locals);
             r = m_ctx.mk_lambda(r_locals.get_collected(), r);
             expr r_ty = m_ctx.infer(r);
-            expr q = mk_expr_quote(r);
+            expr q = mk_elaborated_expr_quote(r);
             buffer<expr> new_inst_mvars;
             for (expr const & local : r_locals.get_collected()) {
                 expr ty = m_ctx.infer(local);

--- a/src/library/vm/vm_expr.cpp
+++ b/src/library/vm/vm_expr.cpp
@@ -450,7 +450,7 @@ vm_obj expr_is_annotation(vm_obj const &, vm_obj const & _e) {
 
 vm_obj reflect_expr(vm_obj const & elab, vm_obj const & e) {
     if (to_bool(elab))
-        return to_obj(mk_expr_quote(to_expr(e)));
+        return to_obj(mk_elaborated_expr_quote(to_expr(e)));
     else
         return to_obj(mk_pexpr_quote_and_substs(to_expr(e), /* is_strict */ false));
 }

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -95,6 +95,18 @@ vm_obj vm_parser_tk(vm_obj const & vm_tk, vm_obj const & o) {
     CATCH;
 }
 
+vm_obj vm_parser_pexpr(vm_obj const & vm_rbp, vm_obj const & o) {
+    auto const & s = lean_parser::to_state(o);
+    TRY;
+        auto rbp = to_unsigned(vm_rbp);
+        if (auto e = s.m_p->maybe_parse_expr(rbp)) {
+            return lean_parser::mk_success(to_obj(*e), s);
+        } else {
+            throw parser_error(sstream() << "expression expected", s.m_p->pos());
+        }
+    CATCH;
+}
+
 vm_obj vm_parser_qexpr(vm_obj const & vm_rbp, vm_obj const & o) {
     auto const & s = lean_parser::to_state(o);
     TRY;
@@ -130,7 +142,8 @@ void initialize_vm_parser() {
     DECLARE_VM_BUILTIN(name({"lean", "parser_state", "cur_pos"}),     vm_parser_state_cur_pos);
     DECLARE_VM_BUILTIN(name({"lean", "parser", "ident"}),             vm_parser_ident);
     DECLARE_VM_BUILTIN(get_lean_parser_tk_name(),                     vm_parser_tk);
-    DECLARE_VM_BUILTIN(get_lean_parser_qexpr_name(),                  vm_parser_qexpr);
+    DECLARE_VM_BUILTIN(get_lean_parser_pexpr_name(),                  vm_parser_pexpr);
+    DECLARE_VM_BUILTIN(name({"lean", "parser", "qexpr"}),             vm_parser_qexpr);
     DECLARE_VM_BUILTIN(name({"lean", "parser", "skip_info"}),         vm_parser_skip_info);
     DECLARE_VM_BUILTIN(name({"lean", "parser", "set_goal_info_pos"}), vm_parser_set_goal_info_pos);
 }

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -70,6 +70,16 @@ expr parse_interactive_param(parser & p, expr const & param_ty) {
     }
 }
 
+vm_obj vm_parser_state_env(vm_obj const & o) {
+    auto const & s = lean_parser::to_state(o);
+    return to_obj(s.m_p->env());
+}
+
+vm_obj vm_parser_state_options(vm_obj const & o) {
+    auto const & s = lean_parser::to_state(o);
+    return to_obj(s.m_p->get_options());
+}
+
 vm_obj vm_parser_state_cur_pos(vm_obj const & o) {
     auto const & s = lean_parser::to_state(o);
     return to_obj(s.m_p->pos());
@@ -139,6 +149,8 @@ vm_obj vm_parser_set_goal_info_pos(vm_obj const &, vm_obj const & vm_p, vm_obj c
 }
 
 void initialize_vm_parser() {
+    DECLARE_VM_BUILTIN(name({"lean", "parser_state", "env"}),         vm_parser_state_env);
+    DECLARE_VM_BUILTIN(name({"lean", "parser_state", "options"}),     vm_parser_state_options);
     DECLARE_VM_BUILTIN(name({"lean", "parser_state", "cur_pos"}),     vm_parser_state_cur_pos);
     DECLARE_VM_BUILTIN(name({"lean", "parser", "ident"}),             vm_parser_ident);
     DECLARE_VM_BUILTIN(get_lean_parser_tk_name(),                     vm_parser_tk);

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -4,25 +4,27 @@ Released under Apache 2.0 license as described in the file LICENSE.
 
 Author: Sebastian Ullrich
 */
+#include "library/vm/vm_parser.h"
 #include <string>
 #include <iostream>
 #include <vector>
-#include "library/type_context.h"
+#include "library/constants.h"
+#include "library/explicit.h"
 #include "library/num.h"
 #include "library/quote.h"
 #include "library/trace.h"
-#include "library/tactic/tactic_evaluator.h"
-#include "library/explicit.h"
+#include "library/vm/interaction_state_imp.h"
 #include "library/tactic/elaborate.h"
-#include "library/vm/vm.h"
 #include "library/vm/vm_string.h"
+#include "library/vm/vm_options.h"
+#include "library/vm/vm_environment.h"
 #include "library/vm/vm_expr.h"
 #include "library/vm/vm_nat.h"
-#include "library/vm/vm_parser.h"
+#include "library/vm/vm_name.h"
 #include "library/vm/vm_pos_info.h"
-#include "library/vm/interaction_state_imp.h"
 #include "frontends/lean/info_manager.h"
 #include "frontends/lean/elaborator.h"
+#include "frontends/lean/parser.h"
 #include "util/utf8.h"
 
 namespace lean {
@@ -57,7 +59,7 @@ expr parse_interactive_param(parser & p, expr const & param_ty) {
         vm_obj vm_parsed = run_parser(p, param_args[2]);
         type_context ctx(p.env());
         name n("_reflect");
-        tactic_evaluator eval(ctx, p.get_options(), param_args[0]);
+        lean_parser::evaluator eval(ctx, p.get_options());
         auto env = eval.compile(n, param_args[1]);
         vm_state S(env, p.get_options());
         auto vm_res = S.invoke(n, vm_parsed);

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -157,9 +157,12 @@ vm_obj vm_parser_with_input(vm_obj const &, vm_obj const & vm_p, vm_obj const & 
     std::string input = to_string(vm_input);
     std::istringstream strm(input);
     vm_obj vm_state; pos_info pos;
-    std::tie(vm_state, pos) = s.m_p->with_input<vm_obj>(strm, [&]() {
-        return invoke(vm_p, o);
-    });
+    auto _ = s.m_p->no_error_recovery_scope();
+    TRY;
+        std::tie(vm_state, pos) = s.m_p->with_input<vm_obj>(strm, [&]() {
+            return invoke(vm_p, o);
+        });
+    CATCH;
 
     if (lean_parser::is_result_exception(vm_state)) {
         return vm_state;

--- a/src/library/vm/vm_parser.h
+++ b/src/library/vm/vm_parser.h
@@ -10,6 +10,8 @@ Author: Sebastian Ullrich
 
 namespace lean {
 vm_obj run_parser(parser & p, expr const & spec);
+expr parse_interactive_param(parser & p, expr const & param_ty);
+
 void initialize_vm_parser();
 void finalize_vm_parser();
 }

--- a/tests/lean/expr_quote.lean.expected.out
+++ b/tests/lean/expr_quote.lean.expected.out
@@ -1,4 +1,4 @@
-expr_quote.lean:1:27: error: invalid quotation, contains universe metavariable
+expr_quote.lean:1:30: error: invalid quotation, contains universe metavariable
 expr_quote.lean:1:9: error: don't know how to synthesize placeholder
 context:
 α a : expr

--- a/tests/lean/reflect.lean
+++ b/tests/lean/reflect.lean
@@ -1,0 +1,1 @@
+#eval (reflect 0).to_expr

--- a/tests/lean/reflect.lean.expected.out
+++ b/tests/lean/reflect.lean.expected.out
@@ -1,0 +1,1 @@
+has_zero.zero.{0} nat nat.has_zero

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -174,7 +174,7 @@ run_cmd script_check_id `is_associative.assoc
 run_cmd script_check_id `is_commutative
 run_cmd script_check_id `is_commutative.comm
 run_cmd script_check_id `ite
-run_cmd script_check_id `lean.parser.qexpr
+run_cmd script_check_id `lean.parser.pexpr
 run_cmd script_check_id `lean.parser.tk
 run_cmd script_check_id `left_distrib
 run_cmd script_check_id `left_comm

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -174,6 +174,8 @@ run_cmd script_check_id `is_associative.assoc
 run_cmd script_check_id `is_commutative
 run_cmd script_check_id `is_commutative.comm
 run_cmd script_check_id `ite
+run_cmd script_check_id `lean.parser.qexpr
+run_cmd script_check_id `lean.parser.tk
 run_cmd script_check_id `left_distrib
 run_cmd script_check_id `left_comm
 run_cmd script_check_id `le_refl

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -174,6 +174,7 @@ run_cmd script_check_id `is_associative.assoc
 run_cmd script_check_id `is_commutative
 run_cmd script_check_id `is_commutative.comm
 run_cmd script_check_id `ite
+run_cmd script_check_id `lean.parser
 run_cmd script_check_id `lean.parser.pexpr
 run_cmd script_check_id `lean.parser.tk
 run_cmd script_check_id `left_distrib

--- a/tests/lean/user_notation.lean
+++ b/tests/lean/user_notation.lean
@@ -17,3 +17,9 @@ do n₁ ← ↑(to_expr e₁ >>= eval_expr nat),
    pure $ (n₂+1-n₁).repeat (λ i e, ``(%%e + %%(reflect $ n₁ + i))) ``(0)
 
 #check 1 +⋯+ 10
+
+@[user_notation]
+meta def no_tk (e₁ : parse lean.parser.pexpr) := e₁
+
+@[user_notation]
+meta def no_parser (e₁ : parse $ tk "(") := e₁

--- a/tests/lean/user_notation.lean
+++ b/tests/lean/user_notation.lean
@@ -10,24 +10,6 @@ meta def unquote_macro (_ : parse $ tk "unquote!") (e : parse lean.parser.pexpr)
 
 #eval unquote! ``(1 + 1)
 
-private meta def parse_format : string → string → parser pexpr
-| acc []            := pure $ pexpr.of_expr (reflect acc)
-| acc ('{'::'{'::s) := parse_format (acc ++ "{") s
-| acc ('{'::s) :=
-do (e, s) ← with_input (lean.parser.pexpr 0) s.reverse,
-   '}'::s ← pure s.reverse | fail "'}' expected",
-   f ← parse_format [] s,
-   pure ``(to_fmt %%(reflect acc) ++ to_fmt %%(e) ++ %%f)
-| acc (c::s) := parse_format (acc ++ [c]) s
-
-reserve prefix `format! `:100
-@[user_notation]
-meta def format_macro (_ : parse $ tk "format!") (s : string) : parser pexpr :=
-parse_format "" s.reverse
-
-#eval let a := "bla" in format! "({to_fmt a ++ format! \"{a}\"} {42})"
--- #eval format! "{} {}" "a" "bla" -- TODO: delayed abstractions issue
-
 reserve infix ` +⋯+ `:65
 @[user_notation]
 meta def upto_notation (e₁ : parse lean.parser.pexpr) (_ : parse $ tk "+⋯+") (n₂ : ℕ) : parser pexpr :=

--- a/tests/lean/user_notation.lean
+++ b/tests/lean/user_notation.lean
@@ -1,11 +1,12 @@
+open lean (parser)
 open lean.parser
 open interactive
 open tactic
 
 reserve prefix `unquote! `:100
 @[user_notation]
-to_expr e >>= eval_expr pexpr
 meta def unquote_macro (_ : parse $ tk "unquote!") (e : parse lean.parser.pexpr) : parser pexpr :=
+↑(to_expr e >>= eval_expr pexpr)
 
 #eval unquote! ``(1 + 1)
 
@@ -19,17 +20,17 @@ private meta def parse_format : string → string → ℕ × pexpr
 
 reserve prefix `format! `:100
 @[user_notation]
-meta def format_macro (_ : parse $ tk "format!") (s : string) : tactic pexpr :=
 let (n, f) := parse_format "" s.reverse in
 pure $ n.repeat (λ _ e, expr.lam `_ binder_info.default pexpr.mk_placeholder e) f
+meta def format_macro (_ : parse $ tk "format!") (s : string) : parser pexpr :=
 
 #eval format! "a{}c" "b"
 -- #eval format! "{} {}" "a" "bla" -- TODO: delayed abstractions issue
 
 reserve infix ` +⋯+ `:65
 @[user_notation]
-do n₁ ← to_expr e₁ >>= eval_expr nat,
 meta def upto_notation (e₁ : parse lean.parser.pexpr) (_ : parse $ tk "+⋯+") (n₂ : ℕ) : parser pexpr :=
+do n₁ ← ↑(to_expr e₁ >>= eval_expr nat),
    pure $ (n₂+1-n₁).repeat (λ i e, ``(%%e + %%(reflect $ n₁ + i))) ``(0)
 
 #check 1 +⋯+ 10

--- a/tests/lean/user_notation.lean
+++ b/tests/lean/user_notation.lean
@@ -4,11 +4,10 @@ open tactic
 
 reserve prefix `unquote! `:100
 @[user_notation]
-meta def unquote_macro (_ : parse $ tk "unquote!") (e : parse qexpr) : tactic pexpr :=
 to_expr e >>= eval_expr pexpr
+meta def unquote_macro (_ : parse $ tk "unquote!") (e : parse lean.parser.pexpr) : parser pexpr :=
 
-meta def e := ``(1 + 1)
-#eval unquote! e
+#eval unquote! ``(1 + 1)
 
 private meta def parse_format : string → string → ℕ × pexpr
 | acc [] := (0, pexpr.of_expr (reflect acc))
@@ -29,8 +28,8 @@ pure $ n.repeat (λ _ e, expr.lam `_ binder_info.default pexpr.mk_placeholder e)
 
 reserve infix ` +⋯+ `:65
 @[user_notation]
-meta def upto_notation (e₁ : parse qexpr) (_ : parse $ tk "+⋯+") (n₂ : ℕ) : tactic pexpr :=
 do n₁ ← to_expr e₁ >>= eval_expr nat,
+meta def upto_notation (e₁ : parse lean.parser.pexpr) (_ : parse $ tk "+⋯+") (n₂ : ℕ) : parser pexpr :=
    pure $ (n₂+1-n₁).repeat (λ i e, ``(%%e + %%(reflect $ n₁ + i))) ``(0)
 
 #check 1 +⋯+ 10

--- a/tests/lean/user_notation.lean
+++ b/tests/lean/user_notation.lean
@@ -1,0 +1,36 @@
+open lean.parser
+open interactive
+open tactic
+
+reserve prefix `unquote! `:100
+@[user_notation]
+meta def unquote_macro (_ : parse $ tk "unquote!") (e : parse qexpr) : tactic pexpr :=
+to_expr e >>= eval_expr pexpr
+
+meta def e := ``(1 + 1)
+#eval unquote! e
+
+private meta def parse_format : string → string → ℕ × pexpr
+| acc [] := (0, pexpr.of_expr (reflect acc))
+| acc ('{'::'{'::s) := parse_format (acc ++ "{") s
+| acc ('{'::'}'::s) :=
+  let (n, f) := parse_format [] s in
+  (n + 1, ``(to_fmt %%(reflect acc) ++ to_fmt %%(expr.var n : pexpr) ++ %%f))
+| acc (c::s) := parse_format (acc ++ [c]) s
+
+reserve prefix `format! `:100
+@[user_notation]
+meta def format_macro (_ : parse $ tk "format!") (s : string) : tactic pexpr :=
+let (n, f) := parse_format "" s.reverse in
+pure $ n.repeat (λ _ e, expr.lam `_ binder_info.default pexpr.mk_placeholder e) f
+
+#eval format! "a{}c" "b"
+-- #eval format! "{} {}" "a" "bla" -- TODO: delayed abstractions issue
+
+reserve infix ` +⋯+ `:65
+@[user_notation]
+meta def upto_notation (e₁ : parse qexpr) (_ : parse $ tk "+⋯+") (n₂ : ℕ) : tactic pexpr :=
+do n₁ ← to_expr e₁ >>= eval_expr nat,
+   pure $ (n₂+1-n₁).repeat (λ i e, ``(%%e + %%(reflect $ n₁ + i))) ``(0)
+
+#check 1 +⋯+ 10

--- a/tests/lean/user_notation.lean.expected.out
+++ b/tests/lean/user_notation.lean.expected.out
@@ -1,12 +1,12 @@
 2
-abc
-0 + (bit1 [nat_value_macro] + [nat_value_macro]) + (bit1 [nat_value_macro] + bit1 [nat_value_macro]) +
-                (bit1 [nat_value_macro] + bit0 (bit1 [nat_value_macro])) +
-              (bit1 [nat_value_macro] + bit1 (bit1 [nat_value_macro])) +
-            (bit1 [nat_value_macro] + bit0 (bit0 (bit1 [nat_value_macro]))) +
-          (bit1 [nat_value_macro] + bit1 (bit0 (bit1 [nat_value_macro]))) +
-        (bit1 [nat_value_macro] + bit0 (bit1 (bit1 [nat_value_macro]))) +
-      (bit1 [nat_value_macro] + bit1 (bit1 (bit1 [nat_value_macro]))) +
-    (bit1 [nat_value_macro] + bit0 (bit0 (bit0 (bit1 [nat_value_macro])))) +
-  (bit1 [nat_value_macro] + bit1 (bit0 (bit0 (bit1 [nat_value_macro])))) :
-  ℕ
+0 + (1 + 0) + (1 + 1) + (1 + 2) + (1 + 3) + (1 + 4) + (1 + 5) + (1 + 6) + (1 + 7) + (1 + 8) + (1 + 9) : ℕ
+user_notation.lean:21:0: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.[pq]expr` parameter
+user_notation.lean:22:9: error: don't know how to synthesize placeholder
+context:
+e₁ : parse lean.parser.pexpr
+⊢ Sort ?
+user_notation.lean:24:0: error: invalid user-defined notation, must return type `lean.parser p`
+user_notation.lean:25:9: error: don't know how to synthesize placeholder
+context:
+e₁ : parse (tk "(")
+⊢ Sort ?

--- a/tests/lean/user_notation.lean.expected.out
+++ b/tests/lean/user_notation.lean.expected.out
@@ -1,6 +1,6 @@
 2
 0 + (1 + 0) + (1 + 1) + (1 + 2) + (1 + 3) + (1 + 4) + (1 + 5) + (1 + 6) + (1 + 7) + (1 + 8) + (1 + 9) : ℕ
-user_notation.lean:21:0: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.[pq]expr` parameter
+user_notation.lean:21:0: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.pexpr` parameter
 user_notation.lean:22:9: error: don't know how to synthesize placeholder
 context:
 e₁ : parse lean.parser.pexpr

--- a/tests/lean/user_notation.lean.expected.out
+++ b/tests/lean/user_notation.lean.expected.out
@@ -1,0 +1,12 @@
+2
+abc
+0 + (bit1 [nat_value_macro] + [nat_value_macro]) + (bit1 [nat_value_macro] + bit1 [nat_value_macro]) +
+                (bit1 [nat_value_macro] + bit0 (bit1 [nat_value_macro])) +
+              (bit1 [nat_value_macro] + bit1 (bit1 [nat_value_macro])) +
+            (bit1 [nat_value_macro] + bit0 (bit0 (bit1 [nat_value_macro]))) +
+          (bit1 [nat_value_macro] + bit1 (bit0 (bit1 [nat_value_macro]))) +
+        (bit1 [nat_value_macro] + bit0 (bit1 (bit1 [nat_value_macro]))) +
+      (bit1 [nat_value_macro] + bit1 (bit1 (bit1 [nat_value_macro]))) +
+    (bit1 [nat_value_macro] + bit0 (bit0 (bit0 (bit1 [nat_value_macro])))) +
+  (bit1 [nat_value_macro] + bit1 (bit0 (bit0 (bit1 [nat_value_macro])))) :
+  ℕ


### PR DESCRIPTION
Allow user-defined notation that uses `lean.parser` for parsing its parameters and computes a pre-term in the tactic monad. The notation is activated by a single `tk` parser, which may optionally be preceded by a `qexpr` parser for postfix/infix notations.

[Examples](https://github.com/leanprover/lean/commit/674cec026989f87c7ff5f4fbd7297c0603f1d52c#diff-4b4ca2d079ab4a76b323a473ec3f6eaf): the mandatory `unquote!` macro, a `format!` macro, and a non-creative infix notation example. More suggestions welcome.