### PR TITLE
feat(init/meta/name): make name non-meta

### DIFF
--- a/library/init/data/list/basic.lean
+++ b/library/init/data/list/basic.lean
@@ -318,4 +318,14 @@ infix ` <+: `:50 := is_prefix
 infix ` <:+ `:50 := is_suffix
 infix ` <:+: `:50 := is_infix
 
+instance {α : Type u} [decidable_eq α] : decidable_eq (list α)
+| []     []      := is_true rfl
+| (a::l) []      := is_false (λh, list.no_confusion h)
+| []     (b::l') := is_false (λh, list.no_confusion h)
+| (a::l) (b::l') := if ab : a = b then
+  @dite _ (decidable_eq l l') _
+    (λll, is_true $ congr (congr_arg cons ab) ll)
+    (λll, is_false $ λh, list.no_confusion h (λ_, ll))
+  else is_false $ λh, list.no_confusion h (λn _, ab n)
+
 end list

--- a/library/init/data/list/instances.lean
+++ b/library/init/data/list/instances.lean
@@ -5,7 +5,6 @@ Author: Leonardo de Moura
 -/
 prelude
 import init.data.list.lemmas
-import init.meta.mk_dec_eq_instance
 open list
 
 universes u v
@@ -49,12 +48,6 @@ instance : alternative list :=
 { list.monad with
   failure := @list.nil,
   orelse  := @list.append }
-
-instance {α : Type u} [decidable_eq α] : decidable_eq (list α) :=
-by tactic.mk_dec_eq_instance
-
-instance : decidable_eq string :=
-list.decidable_eq
 
 namespace list
 

--- a/library/init/data/ordering.lean
+++ b/library/init/data/ordering.lean
@@ -6,6 +6,8 @@ Authors: Leonardo de Moura
 prelude
 import init.data.to_string init.data.prod init.data.sum.basic
 
+universes u v
+
 inductive ordering
 | lt | eq | gt
 
@@ -14,6 +16,11 @@ namespace ordering
   | lt := gt
   | eq := eq
   | gt := lt
+
+  def or_else : ordering → thunk ordering → ordering
+  | lt _ := lt
+  | eq f := f ()
+  | gt _ := gt
 
   theorem swap_swap : ∀ (o : ordering), o.swap.swap = o
   | lt := rfl
@@ -26,7 +33,7 @@ open ordering
 instance : has_to_string ordering :=
 has_to_string.mk (λ s, match s with | ordering.lt := "lt" | ordering.eq := "eq" | ordering.gt := "gt" end)
 
-class has_ordering (α : Type) :=
+class has_ordering (α : Type u) :=
 (cmp : α → α → ordering)
 
 def nat.cmp (a b : nat) : ordering :=
@@ -37,27 +44,45 @@ else               ordering.gt
 instance : has_ordering nat :=
 ⟨nat.cmp⟩
 
+instance (n) : has_ordering (fin n) :=
+⟨λ a b, nat.cmp a.1 b.1⟩
+
+instance : has_ordering char :=
+fin.has_ordering _
+
+instance : has_ordering unsigned :=
+fin.has_ordering _
+
+def list.cmp {α : Type u} [has_ordering α] : list α → list α → ordering
+| []     []      := ordering.eq
+| []     (b::l') := ordering.lt
+| (a::l) []      := ordering.gt
+| (a::l) (b::l') := (has_ordering.cmp a b).or_else (list.cmp l l')
+
+instance {α : Type u} [has_ordering α] : has_ordering (list α) :=
+⟨list.cmp⟩
+
+def string.cmp : string → string → ordering := list.cmp
+
+instance : has_ordering string :=
+⟨string.cmp⟩
+
 section
 open prod
 
-variables {α β : Type} [has_ordering α] [has_ordering β]
+variables {α : Type u} {β : Type v} [has_ordering α] [has_ordering β]
 
 def prod.cmp : α × β → α × β → ordering
-| (a₁, b₁) (a₂, b₂) :=
-   match (has_ordering.cmp a₁ a₂) with
-   | ordering.lt := lt
-   | ordering.eq := has_ordering.cmp b₁ b₂
-   | ordering.gt := gt
-   end
+| (a₁, b₁) (a₂, b₂) := (has_ordering.cmp a₁ a₂).or_else (has_ordering.cmp b₁ b₂)
 
-instance {α β : Type} [has_ordering α] [has_ordering β] : has_ordering (α × β) :=
+instance {α : Type u} {β : Type v} [has_ordering α] [has_ordering β] : has_ordering (α × β) :=
 ⟨prod.cmp⟩
 end
 
 section
 open sum
 
-variables {α β : Type} [has_ordering α] [has_ordering β]
+variables {α : Type u} {β : Type v} [has_ordering α] [has_ordering β]
 
 def sum.cmp : α ⊕ β → α ⊕ β → ordering
 | (inl a₁) (inl a₂) := has_ordering.cmp a₁ a₂
@@ -65,14 +90,14 @@ def sum.cmp : α ⊕ β → α ⊕ β → ordering
 | (inl a₁) (inr b₂) := lt
 | (inr b₁) (inl a₂) := gt
 
-instance {α β : Type} [has_ordering α] [has_ordering β] : has_ordering (α ⊕ β) :=
+instance {α : Type u} {β : Type v} [has_ordering α] [has_ordering β] : has_ordering (α ⊕ β) :=
 ⟨sum.cmp⟩
 end
 
 section
 open option
 
-variables {α : Type} [has_ordering α]
+variables {α : Type u} [has_ordering α]
 
 def option.cmp : option α → option α → ordering
 | (some a₁) (some a₂) := has_ordering.cmp a₁ a₂
@@ -80,6 +105,6 @@ def option.cmp : option α → option α → ordering
 | none      (some a₂) := lt
 | none      none      := eq
 
-instance {α : Type} [has_ordering α] : has_ordering (option α) :=
+instance {α : Type u} [has_ordering α] : has_ordering (option α) :=
 ⟨option.cmp⟩
 end

--- a/library/init/data/string/basic.lean
+++ b/library/init/data/string/basic.lean
@@ -25,6 +25,10 @@ list.append b a
 
 instance : has_append string :=
 ⟨string.concat⟩
+
+instance : decidable_eq string :=
+list.decidable_eq
+
 end string
 
 open list

--- a/library/init/data/unsigned/basic.lean
+++ b/library/init/data/unsigned/basic.lean
@@ -7,7 +7,7 @@ prelude
 import init.data.fin.basic
 
 open nat
-def unsigned_sz : nat := succ 4294967295
+def unsigned_sz : nat := succ 0xFFFFFFFF
 
 def unsigned := fin unsigned_sz
 


### PR DESCRIPTION
Everything in name.lean was implemented except name.cmp, which depends on hashing the pointer to the name, which is not type-safe.