### PR TITLE
Format `reflected a`

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -157,6 +157,9 @@ attribute [irreducible] reflected reflected.subst reflected.to_expr
 
 meta def reflect {α : Sort u} (a : α) [h : reflected a] : reflected a := h
 
+meta instance {α} (a : α) : has_to_format (reflected a) :=
+⟨λ h, to_fmt h.to_expr⟩
+
 namespace expr
 open decidable
 

--- a/library/init/meta/has_reflect.lean
+++ b/library/init/meta/has_reflect.lean
@@ -49,9 +49,8 @@ meta instance prod.reflect {α β : Type} [has_reflect α] [reflected α] [has_r
 meta instance pos.reflect : has_reflect pos
 | ⟨l, c⟩ := `(_)
 
-meta def reflect_to_format {α} {a : α} (h : reflected a) : format :=
+meta def reflected.to_format {α} {a : α} (h : reflected a) : format :=
 to_fmt (reflect a).to_expr
 
-meta instance reflected.has_to_format {α} (a : α) : has_to_format (reflected a) :=
-⟨reflect_to_format⟩
-
+meta instance {α} (a : α) : has_to_format (reflected a) :=
+⟨reflected.to_format⟩

--- a/library/init/meta/has_reflect.lean
+++ b/library/init/meta/has_reflect.lean
@@ -16,8 +16,8 @@ section
 local attribute [semireducible] reflected
 
 meta instance nat.reflect : has_reflect ℕ
-| n := if n = 0 then `(nat.zero)
-       else if n = 1 then `(1 : nat)
+| n := if n = 0 then `(0 : ℕ)
+       else if n = 1 then `(1 : ℕ)
        else if n % 2 = 0 then `(bit0 %%(nat.reflect (n / 2)) : ℕ)
        else `(bit1 %%(nat.reflect (n / 2)) : ℕ)
 
@@ -48,3 +48,10 @@ meta instance prod.reflect {α β : Type} [has_reflect α] [reflected α] [has_r
 
 meta instance pos.reflect : has_reflect pos
 | ⟨l, c⟩ := `(_)
+
+meta def reflect_to_format {α} {a : α} (h : reflected a) : format :=
+to_fmt (reflect a).to_expr
+
+meta instance reflected.has_to_format {α} (a : α) : has_to_format (reflected a) :=
+⟨reflect_to_format⟩
+

--- a/library/init/meta/has_reflect.lean
+++ b/library/init/meta/has_reflect.lean
@@ -48,9 +48,3 @@ meta instance prod.reflect {α β : Type} [has_reflect α] [reflected α] [has_r
 
 meta instance pos.reflect : has_reflect pos
 | ⟨l, c⟩ := `(_)
-
-meta def reflected.to_format {α} {a : α} (h : reflected a) : format :=
-to_fmt (reflect a).to_expr
-
-meta instance {α} (a : α) : has_to_format (reflected a) :=
-⟨reflected.to_format⟩

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -189,6 +189,12 @@ meta def option_to_tactic_format {α : Type u} [has_to_tactic_format α] : optio
 meta instance {α : Type u} [has_to_tactic_format α] : has_to_tactic_format (option α) :=
 ⟨option_to_tactic_format⟩
 
+meta def reflect_to_tactic_format {α} {a : α} (h : reflected a) : tactic format :=
+pp (reflect a).to_expr
+
+meta instance reflected.has_to_tactic_format {α} (a : α) : has_to_tactic_format (reflected a) :=
+⟨reflect_to_tactic_format⟩
+
 @[priority 10] meta instance has_to_format_to_has_to_tactic_format (α : Type) [has_to_format α] : has_to_tactic_format α :=
 ⟨(λ x, return x) ∘ to_fmt⟩
 

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -189,11 +189,11 @@ meta def option_to_tactic_format {α : Type u} [has_to_tactic_format α] : optio
 meta instance {α : Type u} [has_to_tactic_format α] : has_to_tactic_format (option α) :=
 ⟨option_to_tactic_format⟩
 
-meta def reflect_to_tactic_format {α} {a : α} (h : reflected a) : tactic format :=
+meta def reflected.to_tactic_format {α} {a : α} (h : reflected a) : tactic format :=
 pp (reflect a).to_expr
 
-meta instance reflected.has_to_tactic_format {α} (a : α) : has_to_tactic_format (reflected a) :=
-⟨reflect_to_tactic_format⟩
+meta instance {α} (a : α) : has_to_tactic_format (reflected a) :=
+⟨reflected.to_tactic_format⟩
 
 @[priority 10] meta instance has_to_format_to_has_to_tactic_format (α : Type) [has_to_format α] : has_to_tactic_format α :=
 ⟨(λ x, return x) ∘ to_fmt⟩

--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -189,11 +189,8 @@ meta def option_to_tactic_format {α : Type u} [has_to_tactic_format α] : optio
 meta instance {α : Type u} [has_to_tactic_format α] : has_to_tactic_format (option α) :=
 ⟨option_to_tactic_format⟩
 
-meta def reflected.to_tactic_format {α} {a : α} (h : reflected a) : tactic format :=
-pp (reflect a).to_expr
-
 meta instance {α} (a : α) : has_to_tactic_format (reflected a) :=
-⟨reflected.to_tactic_format⟩
+⟨λ h, pp h.to_expr⟩
 
 @[priority 10] meta instance has_to_format_to_has_to_tactic_format (α : Type) [has_to_format α] : has_to_tactic_format α :=
 ⟨(λ x, return x) ∘ to_fmt⟩


### PR DESCRIPTION
This allows you to write e.g. `tactic.trace (0 : ℕ)`. (Pretend that there's a backtick before `(0`. Is there a way to type that here?)

I've also adjusted `nat.reflect 0` to produce the numeral `0` instead of `nat.zero`.