### PR TITLE
adapt leanpkg to change in to_string method for char

### DIFF
--- a/leanpkg/leanpkg/toml.lean
+++ b/leanpkg/leanpkg/toml.lean
@@ -28,7 +28,7 @@ private def escapec : char → string
 | '\t' := "\\t"
 | '\n' := "\\n"
 | '\\' := "\\\\"
-| c    := to_string c
+| c    := c.to_string
 
 private def escape (s : string) : string :=
 s.fold "" (λ s c, s ++ escapec c)


### PR DESCRIPTION
The recent changes to string have broken `leanpkg`: if you do `leanpkg init foo` the `leanpkg.toml` file looks like this:
```
[package]
name = "'f''o''o'"
version = "'0''.''1'"
```
The problem is that there is now a difference between `to_string 'a'` and `'a'.to_string`:
``` lean
#eval to_string 'a'  -- "'a'"
#eval 'a'.to_string  -- "a"
```
We can discuss whether or not this is problematic, but in the meanwhile the easy fix is to make `leanpkg` use the correct one.
