### PR TITLE
Transient message boxes in Emacs

### DIFF
--- a/src/emacs/README.md
+++ b/src/emacs/README.md
@@ -20,9 +20,9 @@ Trying It Out
 If things are working correctly, you should see the word ``Lean`` in the
 Emacs mode line when you open a file with extension `.lean`. If you type
 ```lean
-check id
+#check id
 ```
-the word ``check`` will be underlined, and hovering over it will show
+the word ``#check`` will be underlined, and hovering over it will show
 you the type of ``id``. The mode line will show ``FlyC:0/1``, indicating
 that there are no errors and one piece of information displayed.
 
@@ -37,6 +37,7 @@ Key Bindings and Commands
 | <kbd>C-c C-x</kbd> | execute lean in stand-alone mode (`lean-std-exe`)                               |
 | <kbd>C-c C-g</kbd> | toggle showing current tactic proof goal (`lean-toggle-show-goal`)              |
 | <kbd>C-c C-n</kbd> | toggle showing next error in dedicated buffer (`lean-toggle-next-error`)        |
+| <kbd>C-c C-b</kbd> | toggle showing output in inline boxes (`lean-message-boxes-toggle`)             |
 | <kbd>C-c C-r</kbd> | restart the lean server (`lean-server-restart`)                                 |
 | <kbd>C-c ! n</kbd> | flycheck: go to next error                                                      |
 | <kbd>C-c ! p</kbd> | flycheck: go to previous error                                                  |
@@ -44,6 +45,17 @@ Key Bindings and Commands
 
 In the default configuration, the Flycheck annotation `FlyC:n/n` indicates the
 number of errors / responses from Lean; clicking on `FlyC` opens the Flycheck menu.
+
+
+Message Boxes
+================
+To view the output of commands such as `check` and `print` in boxes in the buffer, enable the feature using <kbd>C-c C-b</kbd>.
+If you then type
+```lean
+#check id
+```
+a box appears after the line showing the type of `id`. Customize `lean-message-boxes-enabled-captions` to choose categories of boxes.
+In particular, add `"trace output"` to the list to see proof states and other traces in the buffer.
 
 Requirements
 ============

--- a/src/emacs/lean-message-boxes.el
+++ b/src/emacs/lean-message-boxes.el
@@ -1,0 +1,108 @@
+;;  -*- lexical-binding: t -*-
+;;
+;; Copyright (c) 2016 David Christiansen.
+;; Released under Apache 2.0 license as described in the file LICENSE.
+;;
+;; Author: David Christiansen
+;;
+;;; Code:
+
+(require 's)
+
+(defface lean-message-boxes-caption-face
+  '((t :inherit bold))
+  "Face for Lean message box captions."
+  :group 'lean)
+
+(defcustom lean-message-boxes-enabled-captions '("check result" "print result")
+  "Which captions should result in boxes?"
+  :group 'lean
+  :type '(repeat (choice (const "check result")
+                         (const "print result")
+                         (const "trace output"))))
+
+(defvar lean-message-boxes-enabledp nil
+  "Whether or not to display message boxes.")
+(make-variable-buffer-local 'lean-message-boxes-enabledp)
+
+(defun lean-message-boxes-toggle ()
+  "Toggle the display of message boxes."
+  (interactive)
+  (setq lean-message-boxes-enabledp (not lean-message-boxes-enabledp)))
+
+(defun lean-message-boxes-enable ()
+  "Enable the display of message boxes."
+  (interactive)
+  (setq lean-message-boxes-enabledp t))
+
+(defun lean-message-boxes-disable ()
+  "Disable the display of message boxes."
+  (interactive)
+  (setq lean-message-boxes-disabledp t))
+
+(defvar lean-message-boxes--overlays '()
+  "The overlays in the current buffer from Lean messages.")
+(make-variable-buffer-local 'lean-message-boxes--overlays)
+
+(defun lean-message-boxes--kill-overlays ()
+  "Delete all Lean message overlays in the current buffer."
+  (dolist (o lean-message-boxes--overlays)
+    (delete-overlay o))
+  (setq lean-message-boxes--overlays '()))
+
+(defun lean-message-boxes--pad-to (str width)
+  "Pad the string STR to a particular WIDTH."
+  (concat str (make-string (max 0 (- width (length str))) ?\ )))
+
+(defun lean-message-boxes-display (msgs)
+  "Show the messages MSGS in the Lean buffer as boxes when `lean-message-boxes-enabledp' is non-nil."
+  (lean-message-boxes--kill-overlays)
+  (when lean-message-boxes-enabledp
+    (dolist (msg msgs)
+      (let ((line (plist-get msg :pos_line))
+            (col (plist-get msg :pos_col))
+            (caption (plist-get msg :caption))
+            (text (plist-get msg :text)))
+        (when (member caption lean-message-boxes-enabled-captions)
+          (let ((overlay (lean-message-boxes--make-overlay line col caption text)))
+            (push overlay lean-message-boxes--overlays)))))))
+
+(defun lean-message-boxes--as-string (caption str)
+  "Construct a propertized string representing CAPTION and STR."
+  (let* ((caption-copy (concat caption))
+         (lines (s-lines str))
+         (w (apply #'max (mapcar #'length (cons caption lines))))
+         (top (concat "╭" (make-string (+ w 2) ?─) "╮"))
+         (horiz (concat "├" (make-string (+ w 2) ?─) "┤"))
+         (bot (concat "╰" (make-string (+ w 2) ?─) "╯")))
+    (put-text-property 0 (length caption-copy)
+                       'face 'lean-message-boxes-caption-face
+                       caption-copy)
+    (apply #'concat
+           top "\n"
+           "│ " (lean-message-boxes--pad-to caption-copy w)  " │\n"
+           horiz "\n"
+           (append
+            (mapcar
+             (lambda (l)
+               (concat "│ "
+                       (lean-message-boxes--pad-to l w)
+                       " │\n"))
+             lines)
+            (list bot)))))
+
+(defun lean-message-boxes--make-overlay (line col caption text)
+  "Construct a message box overlay at LINE and COL with CAPTION and TEXT."
+  (let* ((where (save-excursion (goto-char (point-min))
+                                (forward-line (1- line))
+                                (line-end-position)))
+         (overlay (make-overlay where (+ 1 where))))
+    (overlay-put overlay 'display
+                 (concat "\n" (lean-message-boxes--as-string caption text) "\n"))
+                                        ;(overlay-put overlay 'face font-lock-builtin-face)
+    (overlay-put overlay 'mouse-face font-lock-warning-face)
+    (overlay-put overlay 'lean-is-output-overlay t)
+    overlay))
+
+(add-hook 'lean-server-show-message-hook 'lean-message-boxes-display)
+(provide 'lean-message-boxes)

--- a/src/emacs/lean-message-boxes.el
+++ b/src/emacs/lean-message-boxes.el
@@ -8,6 +8,7 @@
 ;;; Code:
 
 (require 's)
+(require 'lean-server)
 
 (defface lean-message-boxes-caption-face
   '((t :inherit bold))
@@ -25,20 +26,35 @@
   "Whether or not to display message boxes.")
 (make-variable-buffer-local 'lean-message-boxes-enabledp)
 
+(defun lean-message-boxes--ask-for-messages ()
+  "Get the current messages out of the Lean server session."
+  (let ((buf (current-buffer)))
+    (if lean-server-session
+        (remove-if-not (lambda (msg)
+                         (equal (buffer-file-name buf)
+                                (plist-get msg :file_name)))
+                       (lean-server-session-messages lean-server-session))
+      '())))
+
+(defun lean-message-boxes--set-enabledp (enabledp)
+  "Enable the boxes if ENABLEDP is non-nil."
+  (setq lean-message-boxes-enabledp enabledp)
+  (lean-message-boxes-display (lean-message-boxes--ask-for-messages)))
+
 (defun lean-message-boxes-toggle ()
   "Toggle the display of message boxes."
   (interactive)
-  (setq lean-message-boxes-enabledp (not lean-message-boxes-enabledp)))
+  (lean-message-boxes--set-enabledp (not lean-message-boxes-enabledp)))
 
 (defun lean-message-boxes-enable ()
   "Enable the display of message boxes."
   (interactive)
-  (setq lean-message-boxes-enabledp t))
+  (setq lean-message-boxes--set-enabledp t))
 
 (defun lean-message-boxes-disable ()
   "Disable the display of message boxes."
   (interactive)
-  (setq lean-message-boxes-disabledp t))
+  (setq lean-message-boxes--set-enabledp t))
 
 (defvar lean-message-boxes--overlays '()
   "The overlays in the current buffer from Lean messages.")

--- a/src/emacs/lean-mode.el
+++ b/src/emacs/lean-mode.el
@@ -30,6 +30,7 @@
 (require 'lean-flycheck)
 (require 'lean-info)
 (require 'lean-type)
+(require 'lean-message-boxes)
 
 (defun lean-compile-string (exe-name args file-name)
   "Concatenate exe-name, args, and file-name"
@@ -83,7 +84,7 @@
   (local-set-key lean-keybinding-auto-complete             'company-complete)
   (local-set-key lean-keybinding-lean-toggle-show-goal     'lean-toggle-show-goal)
   (local-set-key lean-keybinding-lean-toggle-next-error    'lean-toggle-next-error)
-  )
+  (local-set-key lean-keybinding-lean-message-boxes-toggle 'lean-message-boxes-toggle))
 
 (define-abbrev-table 'lean-abbrev-table
   '())
@@ -104,6 +105,7 @@
     ["Show type info"       lean-show-type                    (and lean-eldoc-use eldoc-mode)]
     ["Toggle goal display"  lean-toggle-show-goal             t]
     ["Toggle next error display" lean-toggle-next-error       t]
+    ["Toggle message boxes" lean-message-boxes-toggle         t]
     ["Highlight pending tasks"  lean-server-toggle-show-pending-tasks
      :active t :style toggle :selected lean-server-show-pending-tasks]
     ["Find definition at point" lean-find-definition          t]

--- a/src/emacs/lean-server.el
+++ b/src/emacs/lean-server.el
@@ -11,7 +11,7 @@
 (require 'lean-pkg)
 (require 'dash)
 
-(defcustom lean-server-show-message-hook '()
+(defcustom lean-server-show-message-hook '(lean-message-boxes-display)
   "Hook run on messages from Lean, allowing custom display.
 
 Each hook is a function that receives a list of message objects
@@ -22,7 +22,8 @@ least the following keys:
  - :caption is a category of message, a string
  - :text is the text to display, a string."
   :group 'lean
-  :type 'hook)
+  :type 'hook
+  :options '(lean-message-boxes-display))
 
 (defstruct lean-server-session
   path-file        ; the leanpkg.path file of this lean server

--- a/src/emacs/lean-settings.el
+++ b/src/emacs/lean-settings.el
@@ -126,4 +126,7 @@ false (nil)."
 (defcustom lean-keybinding-lean-toggle-next-error (kbd "C-c C-n")
   "Lean Keybinding for lean-toggle-next-error"
   :group 'lean-keybinding  :type 'key-sequence)
+(defcustom lean-keybinding-lean-message-boxes-toggle (kbd "C-c C-b")
+  "Lean Keybinding for lean-message-boxes-toggle"
+  :group 'lean-keybinding :type 'key-sequence)
 (provide 'lean-settings)


### PR DESCRIPTION
# Transient message boxes in Emacs

Adds a message display hook to the Emacs mode, and uses it to display boxes containing the results of various commands in the buffer, in addition to the Flycheck interface. The categories of output to display are customizable, and `C-c C-b` toggles the display of boxes in `lean-mode`.

![screenshot from 2017-06-13 17-49-08](https://user-images.githubusercontent.com/115330/27110822-c66b3040-5060-11e7-9830-585c5a3dbdfc.png)
