### PR TITLE
Refactor delegation of command meta infos

### DIFF
--- a/src/frontends/lean/decl_attributes.h
+++ b/src/frontends/lean/decl_attributes.h
@@ -36,6 +36,7 @@ public:
     list<entry> const & get_entries() const { return m_entries; }
     bool is_parsing_only() const { return m_parsing_only; }
     optional<unsigned > get_priority() const { return m_prio; }
+    void set_persistent(bool persistent) { m_persistent = persistent; }
     bool ok_for_inductive_type() const;
     bool has_class() const;
     operator bool() const { return static_cast<bool>(m_entries); }

--- a/src/frontends/lean/decl_util.h
+++ b/src/frontends/lean/decl_util.h
@@ -13,7 +13,7 @@ namespace lean {
 class parser;
 class elaborator;
 
-enum def_cmd_kind { Theorem, Definition, Example };
+enum def_cmd_kind { Theorem, Definition, Example, Instance };
 
 struct decl_modifiers {
     bool m_is_private{false};
@@ -21,8 +21,10 @@ struct decl_modifiers {
     bool m_is_meta{false};
     bool m_is_mutual{false};
     bool m_is_noncomputable{false};
-    bool m_is_instance{false};
-    bool m_is_class{false};
+
+    operator bool() const {
+        return m_is_private || m_is_protected || m_is_meta || m_is_mutual || m_is_noncomputable;
+    }
 };
 
 /** \brief In Lean, declarations may contain nested definitions.

--- a/src/frontends/lean/definition_cmds.h
+++ b/src/frontends/lean/definition_cmds.h
@@ -10,7 +10,7 @@ Author: Leonardo de Moura
 #include "frontends/lean/decl_util.h"
 namespace lean {
 
-environment definition_cmd_core(parser & p, def_cmd_kind k, decl_modifiers const & modifies, decl_attributes attributes);
+environment definition_cmd_core(parser & p, def_cmd_kind k, cmd_meta const & meta);
 
 environment ensure_decl_namespaces(environment const & env, name const & full_n);
 }

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -89,8 +89,7 @@ static level subtract_from_max(level const & l, unsigned offset) {
 class inductive_cmd_fn {
     parser &                        m_p;
     environment                     m_env;
-    decl_attributes                 m_attrs;
-    bool                            m_is_trusted;
+    cmd_meta                        m_meta_info;
     buffer<decl_attributes>         m_mut_attrs;
     type_context                    m_ctx;
     buffer<name>                    m_lp_names;
@@ -102,7 +101,6 @@ class inductive_cmd_fn {
     unsigned                        m_u_param_offset;
 
     bool                            m_infer_result_universe{false};
-    optional<std::string>           m_doc_string;
 
     [[ noreturn ]] void throw_error(char const * error_msg) const { throw parser_error(error_msg, m_pos); }
     [[ noreturn ]] void throw_error(sstream const & strm) const { throw parser_error(strm, m_pos); }
@@ -568,9 +566,6 @@ class inductive_cmd_fn {
         parser::local_scope scope(m_p);
         m_pos = m_p.pos();
 
-        m_attrs.parse(m_p);
-        check_attrs(m_attrs);
-
         declaration_name_scope nscope;
         expr ind = parse_single_header(m_p, nscope, m_lp_names, params);
         m_explicit_levels = !m_lp_names.empty();
@@ -601,9 +596,6 @@ class inductive_cmd_fn {
 
     void parse_mutual_inductive(buffer<expr> & params, buffer<expr> & inds, buffer<buffer<expr> > & intro_rules) {
         parser::local_scope scope(m_p);
-
-        m_attrs.parse(m_p);
-        check_attrs(m_attrs);
 
         buffer<expr> pre_inds;
         parse_mutual_header(m_p, m_lp_names, pre_inds, params);
@@ -641,25 +633,33 @@ class inductive_cmd_fn {
         if (!attrs.ok_for_inductive_type())
             throw_error("only attribute [class] accepted for inductive types");
     }
+
+    void check_modifiers() const {
+        if (m_meta_info.m_modifiers.m_is_noncomputable)
+            throw_error("invalid 'noncomputable' modifier for inductive type");
+        if (m_meta_info.m_modifiers.m_is_private)
+            throw_error("invalid 'private' modifier for inductive type");
+        if (m_meta_info.m_modifiers.m_is_protected)
+            throw_error("invalid 'protected' modifier for inductive type");
+    }
 public:
-    inductive_cmd_fn(parser & p, decl_attributes const & attrs, bool is_trusted):
-        m_p(p), m_env(p.env()), m_attrs(attrs),
-        m_is_trusted(is_trusted), m_ctx(p.env()) {
+    inductive_cmd_fn(parser & p, cmd_meta const & meta):
+        m_p(p), m_env(p.env()), m_meta_info(meta), m_ctx(p.env()) {
         m_u_meta = m_ctx.mk_univ_metavar_decl();
-        check_attrs(m_attrs);
-        m_doc_string = p.get_doc_string();
+        check_attrs(m_meta_info.m_attrs);
+        check_modifiers();
     }
 
     void post_process(buffer<expr> const & new_params, buffer<expr> const & new_inds, buffer<buffer<expr> > const & new_intro_rules) {
         add_aliases(new_params, new_inds, new_intro_rules);
         add_namespaces(new_inds);
         for (expr const & ind : new_inds) {
-            m_env = m_attrs.apply(m_env, m_p.ios(), mlocal_name(ind));
+            m_env = m_meta_info.m_attrs.apply(m_env, m_p.ios(), mlocal_name(ind));
             /* TODO(Leo): add support for doc-strings in mutual inductive definitions.
                We are currently using the same doc string for all elements.
             */
-            if (m_doc_string)
-                m_env = add_doc_string(m_env, mlocal_name(ind), *m_doc_string);
+            if (m_meta_info.m_doc_string)
+                m_env = add_doc_string(m_env, mlocal_name(ind), *m_meta_info.m_doc_string);
         }
         if (!m_mut_attrs.empty()) {
             lean_assert(new_inds.size() == m_mut_attrs.size());
@@ -668,7 +668,17 @@ public:
         }
     }
 
-    environment shared_inductive_cmd(buffer<expr> const & params, buffer<expr> const & inds, buffer<buffer<expr> > const & intro_rules) {
+    environment inductive_cmd() {
+        buffer<expr> params;
+        buffer<expr> inds;
+        buffer<buffer<expr> > intro_rules;
+        if (m_meta_info.m_modifiers.m_is_mutual) {
+            parse_mutual_inductive(params, inds, intro_rules);
+        } else {
+            intro_rules.emplace_back();
+            inds.push_back(parse_inductive(params, intro_rules.back()));
+        }
+
         buffer<expr> new_params;
         buffer<expr> new_inds;
         buffer<buffer<expr> > new_intro_rules;
@@ -677,31 +687,21 @@ public:
         }
         elaborate_inductive_decls(params, inds, intro_rules, new_params, new_inds, new_intro_rules);
         m_env = add_inductive_declaration(m_p.env(), m_p.get_options(), m_implicit_infer_map, m_lp_names, new_params,
-                                          new_inds, new_intro_rules, m_is_trusted);
+                                          new_inds, new_intro_rules, !m_meta_info.m_modifiers.m_is_meta);
         post_process(new_params, new_inds, new_intro_rules);
         return m_env;
     }
 
-    environment inductive_cmd() {
+    environment coinductive_cmd() {
         buffer<expr> params;
         buffer<expr> inds;
         buffer<buffer<expr> > intro_rules;
-        intro_rules.emplace_back();
-        inds.push_back(parse_inductive(params, intro_rules.back()));
-        return shared_inductive_cmd(params, inds, intro_rules);
-    }
-
-    environment mutual_inductive_cmd() {
-        buffer<expr> params;
-        buffer<expr> inds;
-        buffer<buffer<expr> > intro_rules;
-        parse_mutual_inductive(params, inds, intro_rules);
-        return shared_inductive_cmd(params, inds, intro_rules);
-    }
-
-    environment shared_coinductive_cmd(buffer<expr> const & params,
-                                       buffer<expr> const & inds,
-                                       buffer<buffer<expr> > const & intro_rules) {
+        if (m_meta_info.m_modifiers.m_is_mutual) {
+            parse_mutual_inductive(params, inds, intro_rules);
+        } else {
+            intro_rules.emplace_back();
+            inds.push_back(parse_inductive(params, intro_rules.back()));
+        }
         buffer<expr> new_params;
         buffer<expr> new_inds;
         buffer<buffer<expr> > new_intro_rules;
@@ -734,59 +734,20 @@ public:
 
         throw generic_exception(first_ind, "coinduction command failed");
     }
-
-    environment coinductive_cmd() {
-        buffer<expr> params;
-        buffer<expr> inds;
-        buffer<buffer<expr> > intro_rules;
-        intro_rules.emplace_back();
-        inds.push_back(parse_inductive(params, intro_rules.back()));
-        return shared_coinductive_cmd(params, inds, intro_rules);
-    }
-
-    environment mutual_coinductive_cmd() {
-        buffer<expr> params;
-        buffer<expr> inds;
-        buffer<buffer<expr> > intro_rules;
-        parse_mutual_inductive(params, inds, intro_rules);
-        return shared_coinductive_cmd(params, inds, intro_rules);
-    }
 };
 
-environment inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta) {
+environment inductive_cmd(parser & p, cmd_meta const & meta) {
     p.next();
     auto pos = p.pos();
     module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, !is_meta).inductive_cmd();
+    return inductive_cmd_fn(p, meta).inductive_cmd();
 }
 
-environment mutual_inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta) {
+environment coinductive_cmd(parser & p, cmd_meta const & meta) {
     p.next();
     auto pos = p.pos();
     module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, !is_meta).mutual_inductive_cmd();
-}
-
-environment coinductive_cmd_ex(parser & p, decl_attributes const & attrs) {
-    p.next();
-    auto pos = p.pos();
-    module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, true).coinductive_cmd();
-}
-
-environment mutual_coinductive_cmd_ex(parser & p, decl_attributes const & attrs) {
-    p.next();
-    auto pos = p.pos();
-    module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, true).mutual_coinductive_cmd();
-}
-
-environment inductive_cmd(parser & p) {
-    return inductive_cmd_ex(p, {}, false);
-}
-
-environment coinductive_cmd(parser & p) {
-    return coinductive_cmd_ex(p, {});
+    return inductive_cmd_fn(p, meta).coinductive_cmd();
 }
 
 void register_inductive_cmds(cmd_table & r) {

--- a/src/frontends/lean/inductive_cmds.h
+++ b/src/frontends/lean/inductive_cmds.h
@@ -8,10 +8,8 @@ Author: Daniel Selsam
 #include "frontends/lean/cmd_table.h"
 #include "frontends/lean/decl_attributes.h"
 namespace lean {
-environment inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta);
-environment mutual_inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta);
-environment coinductive_cmd_ex(parser & p, decl_attributes const & attrs);
-environment mutual_coinductive_cmd_ex(parser & p, decl_attributes const & attrs);
+environment inductive_cmd(parser & p, cmd_meta const & meta);
+environment coinductive_cmd(parser & p, cmd_meta const & meta);
 
 void register_inductive_cmds(cmd_table & r);
 void initialize_inductive_cmds();

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2270,22 +2270,15 @@ public:
     virtual optional<expr> is_stuck(expr const & e) override { return ctx().is_stuck(e); }
 };
 
-static name_set * g_documentable_cmds = nullptr;
-
-static bool support_docummentation(name const & n) {
-    return g_documentable_cmds->contains(n);
-}
-
-void parser::parse_command() {
-    lean_assert(curr() == token_kind::CommandKeyword);
+void parser::parse_command(cmd_meta const & meta) {
+    if (curr() != token_kind::CommandKeyword) {
+        auto p = pos();
+        maybe_throw_error({"expected command", p});
+        return;
+    }
     m_last_cmd_pos = pos();
     name cmd_name = get_token_info().value();
     m_cmd_token = get_token_info().token();
-    if (m_doc_string && !support_docummentation(cmd_name)) {
-        next();
-        reset_doc_string();
-        maybe_throw_error({sstream() << "command '" << cmd_name << "' does not support doc string", m_last_cmd_pos});
-    }
     if (auto it = cmds().find(cmd_name)) {
         lazy_type_context tc(m_env, get_options());
         scope_global_ios scope1(m_ios);
@@ -2295,42 +2288,28 @@ void parser::parse_command() {
             in_notation_ctx ctx(*this);
             if (it->get_skip_token())
                 next();
-            m_env = it->get_fn()(*this);
+            m_env = it->get_fn()(*this, meta);
         } else {
             if (it->get_skip_token())
                 next();
-            m_env = it->get_fn()(*this);
+            m_env = it->get_fn()(*this, meta);
         }
     } else {
-        reset_doc_string();
         auto p = pos();
         next();
         maybe_throw_error({sstream() << "unknown command '" << cmd_name << "'", p});
     }
-    reset_doc_string();
 }
 
-void parser::parse_doc_block() {
-    m_doc_string = m_scanner.get_str_val();
+std::string parser::parse_doc_block() {
+    auto val = m_scanner.get_str_val();
     next();
+    return val;
 }
 
 void parser::parse_mod_doc_block() {
     m_env = add_module_doc_string(m_env, m_scanner.get_str_val());
     next();
-}
-
-void parser::check_no_doc_string() {
-    if (m_doc_string) {
-        auto p = pos();
-        next();
-        reset_doc_string();
-        maybe_throw_error({"invalid occurrence of doc string immediately before current position", p});
-    }
-}
-
-void parser::reset_doc_string() {
-    m_doc_string = optional<std::string>();
 }
 
 #if defined(__GNUC__) && !defined(__CLANG__)
@@ -2494,29 +2473,22 @@ bool parser::parse_command_like() {
 
     switch (curr()) {
         case token_kind::CommandKeyword:
-            if (curr_is_token(get_end_tk())) {
-                check_no_doc_string();
-            }
-            parse_command();
+            parse_command({});
             updt_options();
             break;
         case token_kind::DocBlock:
-            check_no_doc_string();
-            parse_doc_block();
+            parse_command({{}, {}, some(parse_doc_block())});
             break;
         case token_kind::ModDocBlock:
-            check_no_doc_string();
             parse_mod_doc_block();
             break;
         case token_kind::Eof:
-            check_no_doc_string();
             if (has_open_scopes(m_env)) {
                 maybe_throw_error({"invalid end of module, expecting 'end'", pos()});
             }
             return true;
             break;
         case token_kind::Keyword:
-            check_no_doc_string();
             if (curr_is_token(get_period_tk())) {
                 next();
                 break;
@@ -2625,26 +2597,10 @@ void initialize_parser() {
     register_bool_option(*g_parser_show_errors, LEAN_DEFAULT_PARSER_SHOW_ERRORS,
                          "(lean parser) display error messages in the regular output channel");
     g_tmp_prefix = new name(name::mk_internal_unique_name());
-    g_documentable_cmds = new name_set();
-
-    g_documentable_cmds->insert("definition");
-    g_documentable_cmds->insert("theorem");
-    g_documentable_cmds->insert("constant");
-    g_documentable_cmds->insert("axiom");
-    g_documentable_cmds->insert("meta");
-    g_documentable_cmds->insert("mutual");
-    g_documentable_cmds->insert("@[");
-    g_documentable_cmds->insert("protected");
-    g_documentable_cmds->insert("class");
-    g_documentable_cmds->insert("instance");
-    g_documentable_cmds->insert("inductive");
-    g_documentable_cmds->insert("coinductive");
-    g_documentable_cmds->insert("structure");
 }
 
 void finalize_parser() {
     delete g_tmp_prefix;
     delete g_parser_show_errors;
-    delete g_documentable_cmds;
 }
 }

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -26,6 +26,7 @@ Author: Leonardo de Moura
 #include "frontends/lean/local_level_decls.h"
 #include "frontends/lean/parser_config.h"
 #include "frontends/lean/local_context_adapter.h"
+#include "frontends/lean/decl_util.h"
 
 namespace lean {
 struct interrupt_parser {};
@@ -83,9 +84,6 @@ class parser : public abstract_parser {
     // noncomputable definitions not tagged as noncomputable.
     bool                   m_ignore_noncomputable;
 
-    // Docgen
-    optional<std::string>  m_doc_string;
-
     void sync_command();
 
     tag get_tag(expr e);
@@ -96,13 +94,10 @@ class parser : public abstract_parser {
     level parse_level_nud();
     level parse_level_led(level left);
 
-    void parse_doc_block();
+    std::string parse_doc_block();
     void parse_mod_doc_block();
-    void check_no_doc_string();
-    void reset_doc_string();
 
     void process_imports();
-    void parse_command();
     bool parse_command_like();
     void process_postponed(buffer<expr> const & args, bool is_left, buffer<notation::action_kind> const & kinds,
                            buffer<list<expr>> const & nargs, buffer<expr> const & ps, buffer<pair<unsigned, pos_info>> const & scoped_info,
@@ -240,8 +235,6 @@ public:
     pos_info pos_of(expr const & e) const { return pos_of(e, pos()); }
     pos_info cmd_pos() const { return m_last_cmd_pos; }
     name const & get_cmd_token() const { return m_cmd_token; }
-
-    optional<std::string> get_doc_string() const { return m_doc_string; }
 
     parser_pos_provider get_parser_pos_provider(pos_info const & some_pos) const {
         return parser_pos_provider(m_pos_table, m_file_name, some_pos, m_next_tag_idx);
@@ -412,6 +405,7 @@ public:
     expr parse_scoped_expr(buffer<expr> const & ps, unsigned rbp = 0) { return parse_scoped_expr(ps.size(), ps.data(), rbp); }
     expr parse_expr_with_env(local_environment const & lenv, unsigned rbp = 0);
 
+    void parse_command(cmd_meta const & meta);
     void parse_imports(unsigned & fingerprint, std::vector<module_name> &);
 
     struct local_scope {

--- a/src/frontends/lean/structure_cmd.h
+++ b/src/frontends/lean/structure_cmd.h
@@ -9,8 +9,8 @@ Author: Leonardo de Moura
 #include "frontends/lean/decl_util.h"
 #include "frontends/lean/cmd_table.h"
 namespace lean {
-environment structure_cmd_ex(parser & p, decl_attributes const & attrs, decl_modifiers const & modifiers);
-environment class_cmd_ex(parser & p, decl_attributes attrs, decl_modifiers const & modifiers);
+environment structure_cmd(parser & p, cmd_meta const & meta);
+environment class_cmd(parser & p, cmd_meta const & meta);
 buffer<name> get_structure_fields(environment const & env, name const & S);
 void register_structure_cmd(cmd_table & r);
 /** \brief Return true iff \c S is a structure created with the structure command */

--- a/tests/lean/bad_unification_hint.lean.expected.out
+++ b/tests/lean/bad_unification_hint.lean.expected.out
@@ -1,4 +1,4 @@
-bad_unification_hint.lean:7:0: error: invalid unification hint, failed to unify pattern after unifying constraints
-bad_unification_hint.lean:7:0: warning: declaration 'append_cons_hint' uses sorry
-bad_unification_hint.lean:12:0: error: invalid unification hint, failed to unify constraint #1
-bad_unification_hint.lean:12:0: warning: declaration 'cons_append_hint'' uses sorry
+bad_unification_hint.lean:7:9: error: invalid unification hint, failed to unify pattern after unifying constraints
+bad_unification_hint.lean:7:9: warning: declaration 'append_cons_hint' uses sorry
+bad_unification_hint.lean:12:9: error: invalid unification hint, failed to unify constraint #1
+bad_unification_hint.lean:12:9: warning: declaration 'cons_append_hint'' uses sorry

--- a/tests/lean/cls_err.lean
+++ b/tests/lean/cls_err.lean
@@ -1,6 +1,6 @@
 --
 universe variables u
-inductive [class] H (A : Type u)
+class inductive H (A : Type u)
 | mk : A → H
 
 definition foo {A : Type u} [h : H A] : A :=

--- a/tests/lean/cmd_meta_errors.lean
+++ b/tests/lean/cmd_meta_errors.lean
@@ -1,0 +1,20 @@
+/-- docs -/
+run_cmd
+
+@[class]
+run_cmd
+
+private run_cmd
+
+meta axiom
+
+private protected def f := 42
+private private def f := 42
+
+private inductive
+protected inductive
+noncomputable inductive
+
+private instance
+protected instance
+mutual instance

--- a/tests/lean/cmd_meta_errors.lean.expected.out
+++ b/tests/lean/cmd_meta_errors.lean.expected.out
@@ -1,0 +1,12 @@
+cmd_meta_errors.lean:2:0: error: command does not accept doc string
+cmd_meta_errors.lean:5:0: error: command does not accept attributes
+cmd_meta_errors.lean:7:8: error: command does not accept modifiers
+cmd_meta_errors.lean:9:5: error: invalid 'meta' modifier for axiom
+cmd_meta_errors.lean:11:8: error: unexpected definition modifier
+cmd_meta_errors.lean:12:8: error: unexpected definition modifier
+cmd_meta_errors.lean:14:0: error: invalid 'private' modifier for inductive type
+cmd_meta_errors.lean:15:0: error: invalid 'protected' modifier for inductive type
+cmd_meta_errors.lean:16:0: error: invalid 'noncomputable' modifier for inductive type
+cmd_meta_errors.lean:18:8: error: invalid 'private' modifier for instance command
+cmd_meta_errors.lean:19:10: error: invalid 'protected' modifier for instance command
+cmd_meta_errors.lean:20:7: error: invalid 'mutual' modifier for instance command

--- a/tests/lean/elab_error_msgs.lean.expected.out
+++ b/tests/lean/elab_error_msgs.lean.expected.out
@@ -8,7 +8,7 @@ but is expected to have type
   ?m_1 → ?m_2 → ?m_4
 Additional information:
 elab_error_msgs.lean:2:0: context: 'eliminator' elaboration was not used for 'and.rec' because it is not fully applied, #2 explicit arguments expected
-elab_error_msgs.lean:4:0: warning: declaration 'bogus_elim' uses sorry
+elab_error_msgs.lean:5:0: warning: declaration 'bogus_elim' uses sorry
 elab_error_msgs.lean:9:0: error: type mismatch at application
   bogus_elim trivial
 term

--- a/tests/lean/hole_issue2.lean.expected.out
+++ b/tests/lean/hole_issue2.lean.expected.out
@@ -1,4 +1,4 @@
-hole_issue2.lean:12:0: warning: declaration 'count' uses sorry
+hole_issue2.lean:12:14: warning: declaration 'count' uses sorry
 hole_issue2.lean:22:74: error: don't know how to synthesize placeholder
 context:
 A : Type,

--- a/tests/lean/inst.lean
+++ b/tests/lean/inst.lean
@@ -1,6 +1,6 @@
 set_option pp.notation false
 
-inductive [class] C (A : Type*)
+class inductive C (A : Type*)
 | mk : A → C
 
 definition val {A : Type*} (c : C A) : A :=

--- a/tests/lean/run/class11.lean
+++ b/tests/lean/run/class11.lean
@@ -1,4 +1,4 @@
-inductive [class] C {A : Type} : A → Prop
+class inductive C {A : Type} : A → Prop
 
 constant f {A : Type} (a : A) [H : C a] : Prop
 

--- a/tests/lean/run/imp3.lean
+++ b/tests/lean/run/imp3.lean
@@ -1,4 +1,4 @@
-structure [class] is_equiv {A B : Type} (f : A → B) :=
+class is_equiv {A B : Type} (f : A → B) :=
   (inv : B → A)
 
 #check @is_equiv.inv

--- a/tests/lean/run/parent_struct_inst.lean
+++ b/tests/lean/run/parent_struct_inst.lean
@@ -1,6 +1,6 @@
 open nat
 
-structure [class] A := (n : ℕ)
+class A := (n : ℕ)
 
 definition f [A] := A.n
 

--- a/tests/lean/run/priority_test2.lean
+++ b/tests/lean/run/priority_test2.lean
@@ -1,6 +1,6 @@
 open nat
 
-structure [class] foo :=
+class foo :=
 (a : nat) (b : nat)
 
 attribute [instance, priority std.priority.default-2]

--- a/tests/lean/run/record10.lean
+++ b/tests/lean/run/record10.lean
@@ -4,12 +4,12 @@ set_option old_structure_cmd true
 
 #print "======================="
 
-structure [class] has_two_muls (A : Type) extends has_mul A renaming mul→mul1,
-                                          private has_mul A renaming mul→mul2
+class has_two_muls (A : Type) extends has_mul A renaming mul→mul1,
+                              private has_mul A renaming mul→mul2
 
 #print prefix has_two_muls
 
 #print "======================="
 
-structure [class] another_two_muls (A : Type) extends has_mul A renaming mul→mul1,
-                                                      has_mul A renaming mul→mul2
+class another_two_muls (A : Type) extends has_mul A renaming mul→mul1,
+                                          has_mul A renaming mul→mul2

--- a/tests/lean/run/section5.lean
+++ b/tests/lean/run/section5.lean
@@ -5,7 +5,7 @@ section foo
 
   #check foo
 
-  structure [class] point :=
+  class point :=
   (x : A) (y : A)
 end foo
 

--- a/tests/lean/run/struc_names.lean
+++ b/tests/lean/run/struc_names.lean
@@ -1,9 +1,9 @@
 namespace foo
 
-  structure [class] structA :=
+  class structA :=
   mk :: (a : nat)
 
-  structure [class] structB extends structA :=
+  class structB extends structA :=
   mk :: (b : nat)
 
   #check @structA.a

--- a/tests/lean/run/univ_bug1.lean
+++ b/tests/lean/run/univ_bug1.lean
@@ -10,7 +10,7 @@ namespace nsimp
 -- set_option pp.implicit true
 
 -- first define a class of homogeneous equality
-inductive [class] simplifies_to {T : Type} (t1 t2 : T) : Prop
+class inductive simplifies_to {T : Type} (t1 t2 : T) : Prop
 | mk : t1 = t2 → simplifies_to
 
 theorem get_eq {T : Type} {t1 t2 : T} (C : simplifies_to t1 t2) : t1 = t2 :=

--- a/tests/lean/run/univ_bug2.lean
+++ b/tests/lean/run/univ_bug2.lean
@@ -6,7 +6,7 @@
 open nat
 
 -- first define a class of homogeneous equality
-inductive [class] simplifies_to {T : Type} (t1 t2 : T) : Prop
+class inductive simplifies_to {T : Type} (t1 t2 : T) : Prop
 | mk : t1 = t2 → simplifies_to
 
 namespace simplifies_to

--- a/tests/lean/struct_class.lean
+++ b/tests/lean/struct_class.lean
@@ -1,7 +1,7 @@
 prelude
 import init.core
 
-structure [class] point (A : Type*) (B : Type*) :=
+class point (A : Type*) (B : Type*) :=
 mk :: (x : A) (y : B)
 
 #print classes

--- a/tests/lean/user_attribute.lean.expected.out
+++ b/tests/lean/user_attribute.lean.expected.out
@@ -7,11 +7,11 @@ eq.refl
 @[foo, foo.baz, refl]
 constructor eq.refl : ∀ {α : Sort u} (a : α), a = a
 [eq.refl]
-user_attribute.lean:22:0: error: an attribute named [reducible] has already been registered
-user_attribute.lean:22:0: warning: declaration 'duplicate' uses sorry
-user_attribute.lean:27:0: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:23:0: error: an attribute named [reducible] has already been registered
+user_attribute.lean:23:0: warning: declaration 'duplicate' uses sorry
+user_attribute.lean:28:0: error: invalid [user_attribute], must be applied to definition of type user_attribute
 user_attribute.lean:28:11: error: don't know how to synthesize placeholder
 context:
 ⊢ Sort ?
-user_attribute.lean:33:2: error: invalid [user_attribute], must be applied to definition of type user_attribute
-user_attribute.lean:33:2: warning: declaration 'baz_attr' uses sorry
+user_attribute.lean:34:2: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:34:2: warning: declaration 'baz_attr' uses sorry

--- a/tests/lean/user_notation.lean.expected.out
+++ b/tests/lean/user_notation.lean.expected.out
@@ -1,11 +1,11 @@
 2
 0 + (1 + 0) + (1 + 1) + (1 + 2) + (1 + 3) + (1 + 4) + (1 + 5) + (1 + 6) + (1 + 7) + (1 + 8) + (1 + 9) : ℕ
-user_notation.lean:21:0: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.pexpr` parameter
+user_notation.lean:22:5: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.pexpr` parameter
 user_notation.lean:22:9: error: don't know how to synthesize placeholder
 context:
 e₁ : parse lean.parser.pexpr
 ⊢ Sort ?
-user_notation.lean:24:0: error: invalid user-defined notation, must return type `lean.parser p`
+user_notation.lean:25:5: error: invalid user-defined notation, must return type `lean.parser p`
 user_notation.lean:25:9: error: don't know how to synthesize placeholder
 context:
 e₁ : parse (tk "(")


### PR DESCRIPTION
Preparatory work for user-defined commands. Doc strings, attributes, and modifiers are now passed to any command (which may decide to reject them) instead of being hard-coded in the parser.

Incidental grammar changes:
* The old `structure [class]` syntax is finally gone
* There may be some new combinations which previously had been illegal, e.g. `private axiom`, `meta structure`s with attributes, etc.
* Definition errors without location information are now shown at the command keyword instead of at its attributes/modifiers, which should help with the Next Error view.