### PR TITLE
Add user-defined commands and use them to define `coinductive` in Lean

### DIFF
--- a/library/init/meta/environment.lean
+++ b/library/init/meta/environment.lean
@@ -36,6 +36,8 @@ match env.get d with
 | exceptional.success _      := tt
 | exceptional.exception ._ _ := ff
 end
+/-- Register the given name as a namespace, making it available to the `open` command -/
+meta constant add_namespace   : environment → name → environment
 /-- Return tt iff the given name is a namespace -/
 meta constant is_namespace    : environment → name → bool
 /-- Add a new inductive datatype to the environment

--- a/library/init/meta/interactive_base.lean
+++ b/library/init/meta/interactive_base.lean
@@ -140,6 +140,41 @@ meta def param_desc : expr → tactic format
 | e := if is_constant e ∧ (const_name e).components.ilast = `itactic
   then return $ to_fmt "{ tactic }"
   else paren <$> pp e
+
+
+meta constant decl_attributes : Type
+
+meta constant decl_attributes.apply : decl_attributes → name → parser unit
+
+meta structure decl_modifiers :=
+(is_private       : bool)
+(is_protected     : bool)
+(is_meta          : bool)
+(is_mutual        : bool)
+(is_noncomputable : bool)
+
+meta structure decl_meta_info :=
+(attrs      : decl_attributes)
+(modifiers  : decl_modifiers)
+(doc_string : option string)
+
+
+meta structure single_inductive_decl :=
+(attrs  : decl_attributes)
+(sig    : expr)
+(intros : list expr)
+
+meta def single_inductive_decl.name (d : single_inductive_decl) : name :=
+d.sig.app_fn.const_name
+
+meta structure inductive_decl :=
+(u_names     : list name)
+(params      : list expr)
+(decls       : list single_inductive_decl)
+
+/-- Parses and elaborates a single or multiple mutual inductive declarations (without the `inductive` keyword), depending on `is_mutual` -/
+meta constant inductive_decl.parse : decl_meta_info → parser inductive_decl
+
 end interactive
 
 section macros

--- a/library/init/meta/lean/parser.lean
+++ b/library/init/meta/lean/parser.lean
@@ -23,6 +23,8 @@ open interaction_monad.result
 namespace parser
 variable {α : Type}
 
+meta constant set_env : environment → parser unit
+
 /-- Make sure the next token is an identifier, consume it, and
     produce the quoted name `t, where t is the identifier. -/
 meta constant ident : parser name

--- a/library/init/meta/lean/parser.lean
+++ b/library/init/meta/lean/parser.lean
@@ -78,11 +78,14 @@ local postfix `*`:100 := many
 meta def sep_by : parser unit → parser α → parser (list α)
 | s p := (list.cons <$> p <*> (s *> p)*) <|> return []
 
-meta instance tactic_to_parser : has_coe (tactic α) (parser α) :=
-⟨λ t s, match t (tactic_state.mk_empty s.env s.options) with
- | success x _     := success x s
+meta def tactic_to_parser : tactic α → parser α :=
+λ t s, match t (tactic_state.mk_empty s.env s.options) with
+ | success x ts    := (set_env ts.env >> pure x) s
  | exception f p _ := exception f p s
- end⟩
+ end
+
+meta instance : has_coe (tactic α) (parser α) :=
+⟨tactic_to_parser⟩
 
 end parser
 end lean

--- a/src/frontends/lean/CMakeLists.txt
+++ b/src/frontends/lean/CMakeLists.txt
@@ -8,4 +8,5 @@ init_module.cpp type_util.cpp decl_attributes.cpp
 prenum.cpp print_cmd.cpp elaborator.cpp
 match_expr.cpp local_context_adapter.cpp decl_util.cpp definition_cmds.cpp
 brackets.cpp tactic_notation.cpp info_manager.cpp json.cpp module_parser.cpp
-equations_validator.cpp parser_state.cpp interactive.cpp completion.cpp user_notation.cpp)
+equations_validator.cpp parser_state.cpp interactive.cpp completion.cpp
+user_notation.cpp user_command.cpp)

--- a/src/frontends/lean/decl_attributes.h
+++ b/src/frontends/lean/decl_attributes.h
@@ -36,6 +36,7 @@ public:
     list<entry> const & get_entries() const { return m_entries; }
     bool is_parsing_only() const { return m_parsing_only; }
     optional<unsigned > get_priority() const { return m_prio; }
+    void set_persistent(bool persistent) { m_persistent = persistent; }
     bool ok_for_inductive_type() const;
     bool has_class() const;
     operator bool() const { return static_cast<bool>(m_entries); }

--- a/src/frontends/lean/decl_util.h
+++ b/src/frontends/lean/decl_util.h
@@ -13,7 +13,7 @@ namespace lean {
 class parser;
 class elaborator;
 
-enum def_cmd_kind { Theorem, Definition, Example };
+enum def_cmd_kind { Theorem, Definition, Example, Instance };
 
 struct decl_modifiers {
     bool m_is_private{false};
@@ -21,8 +21,10 @@ struct decl_modifiers {
     bool m_is_meta{false};
     bool m_is_mutual{false};
     bool m_is_noncomputable{false};
-    bool m_is_instance{false};
-    bool m_is_class{false};
+
+    operator bool() const {
+        return m_is_private || m_is_protected || m_is_meta || m_is_mutual || m_is_noncomputable;
+    }
 };
 
 /** \brief In Lean, declarations may contain nested definitions.

--- a/src/frontends/lean/definition_cmds.h
+++ b/src/frontends/lean/definition_cmds.h
@@ -10,7 +10,7 @@ Author: Leonardo de Moura
 #include "frontends/lean/decl_util.h"
 namespace lean {
 
-environment definition_cmd_core(parser & p, def_cmd_kind k, decl_modifiers const & modifies, decl_attributes attributes);
+environment definition_cmd_core(parser & p, def_cmd_kind k, cmd_meta const & meta);
 
 environment ensure_decl_namespaces(environment const & env, name const & full_n);
 }

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -89,8 +89,7 @@ static level subtract_from_max(level const & l, unsigned offset) {
 class inductive_cmd_fn {
     parser &                        m_p;
     environment                     m_env;
-    decl_attributes                 m_attrs;
-    bool                            m_is_trusted;
+    cmd_meta                        m_meta_info;
     buffer<decl_attributes>         m_mut_attrs;
     type_context                    m_ctx;
     buffer<name>                    m_lp_names;
@@ -102,7 +101,6 @@ class inductive_cmd_fn {
     unsigned                        m_u_param_offset;
 
     bool                            m_infer_result_universe{false};
-    optional<std::string>           m_doc_string;
 
     [[ noreturn ]] void throw_error(char const * error_msg) const { throw parser_error(error_msg, m_pos); }
     [[ noreturn ]] void throw_error(sstream const & strm) const { throw parser_error(strm, m_pos); }
@@ -568,9 +566,6 @@ class inductive_cmd_fn {
         parser::local_scope scope(m_p);
         m_pos = m_p.pos();
 
-        m_attrs.parse(m_p);
-        check_attrs(m_attrs);
-
         declaration_name_scope nscope;
         expr ind = parse_single_header(m_p, nscope, m_lp_names, params);
         m_explicit_levels = !m_lp_names.empty();
@@ -601,9 +596,6 @@ class inductive_cmd_fn {
 
     void parse_mutual_inductive(buffer<expr> & params, buffer<expr> & inds, buffer<buffer<expr> > & intro_rules) {
         parser::local_scope scope(m_p);
-
-        m_attrs.parse(m_p);
-        check_attrs(m_attrs);
 
         buffer<expr> pre_inds;
         parse_mutual_header(m_p, m_lp_names, pre_inds, params);
@@ -641,25 +633,33 @@ class inductive_cmd_fn {
         if (!attrs.ok_for_inductive_type())
             throw_error("only attribute [class] accepted for inductive types");
     }
+
+    void check_modifiers() const {
+        if (m_meta_info.m_modifiers.m_is_noncomputable)
+            throw_error("invalid 'noncomputable' modifier for inductive type");
+        if (m_meta_info.m_modifiers.m_is_private)
+            throw_error("invalid 'private' modifier for inductive type");
+        if (m_meta_info.m_modifiers.m_is_protected)
+            throw_error("invalid 'protected' modifier for inductive type");
+    }
 public:
-    inductive_cmd_fn(parser & p, decl_attributes const & attrs, bool is_trusted):
-        m_p(p), m_env(p.env()), m_attrs(attrs),
-        m_is_trusted(is_trusted), m_ctx(p.env()) {
+    inductive_cmd_fn(parser & p, cmd_meta const & meta):
+        m_p(p), m_env(p.env()), m_meta_info(meta), m_ctx(p.env()) {
         m_u_meta = m_ctx.mk_univ_metavar_decl();
-        check_attrs(m_attrs);
-        m_doc_string = p.get_doc_string();
+        check_attrs(m_meta_info.m_attrs);
+        check_modifiers();
     }
 
     void post_process(buffer<expr> const & new_params, buffer<expr> const & new_inds, buffer<buffer<expr> > const & new_intro_rules) {
         add_aliases(new_params, new_inds, new_intro_rules);
         add_namespaces(new_inds);
         for (expr const & ind : new_inds) {
-            m_env = m_attrs.apply(m_env, m_p.ios(), mlocal_name(ind));
+            m_env = m_meta_info.m_attrs.apply(m_env, m_p.ios(), mlocal_name(ind));
             /* TODO(Leo): add support for doc-strings in mutual inductive definitions.
                We are currently using the same doc string for all elements.
             */
-            if (m_doc_string)
-                m_env = add_doc_string(m_env, mlocal_name(ind), *m_doc_string);
+            if (m_meta_info.m_doc_string)
+                m_env = add_doc_string(m_env, mlocal_name(ind), *m_meta_info.m_doc_string);
         }
         if (!m_mut_attrs.empty()) {
             lean_assert(new_inds.size() == m_mut_attrs.size());
@@ -668,7 +668,17 @@ public:
         }
     }
 
-    environment shared_inductive_cmd(buffer<expr> const & params, buffer<expr> const & inds, buffer<buffer<expr> > const & intro_rules) {
+    environment inductive_cmd() {
+        buffer<expr> params;
+        buffer<expr> inds;
+        buffer<buffer<expr> > intro_rules;
+        if (m_meta_info.m_modifiers.m_is_mutual) {
+            parse_mutual_inductive(params, inds, intro_rules);
+        } else {
+            intro_rules.emplace_back();
+            inds.push_back(parse_inductive(params, intro_rules.back()));
+        }
+
         buffer<expr> new_params;
         buffer<expr> new_inds;
         buffer<buffer<expr> > new_intro_rules;
@@ -677,31 +687,21 @@ public:
         }
         elaborate_inductive_decls(params, inds, intro_rules, new_params, new_inds, new_intro_rules);
         m_env = add_inductive_declaration(m_p.env(), m_p.get_options(), m_implicit_infer_map, m_lp_names, new_params,
-                                          new_inds, new_intro_rules, m_is_trusted);
+                                          new_inds, new_intro_rules, !m_meta_info.m_modifiers.m_is_meta);
         post_process(new_params, new_inds, new_intro_rules);
         return m_env;
     }
 
-    environment inductive_cmd() {
+    environment coinductive_cmd() {
         buffer<expr> params;
         buffer<expr> inds;
         buffer<buffer<expr> > intro_rules;
-        intro_rules.emplace_back();
-        inds.push_back(parse_inductive(params, intro_rules.back()));
-        return shared_inductive_cmd(params, inds, intro_rules);
-    }
-
-    environment mutual_inductive_cmd() {
-        buffer<expr> params;
-        buffer<expr> inds;
-        buffer<buffer<expr> > intro_rules;
-        parse_mutual_inductive(params, inds, intro_rules);
-        return shared_inductive_cmd(params, inds, intro_rules);
-    }
-
-    environment shared_coinductive_cmd(buffer<expr> const & params,
-                                       buffer<expr> const & inds,
-                                       buffer<buffer<expr> > const & intro_rules) {
+        if (m_meta_info.m_modifiers.m_is_mutual) {
+            parse_mutual_inductive(params, inds, intro_rules);
+        } else {
+            intro_rules.emplace_back();
+            inds.push_back(parse_inductive(params, intro_rules.back()));
+        }
         buffer<expr> new_params;
         buffer<expr> new_inds;
         buffer<buffer<expr> > new_intro_rules;
@@ -734,59 +734,20 @@ public:
 
         throw generic_exception(first_ind, "coinduction command failed");
     }
-
-    environment coinductive_cmd() {
-        buffer<expr> params;
-        buffer<expr> inds;
-        buffer<buffer<expr> > intro_rules;
-        intro_rules.emplace_back();
-        inds.push_back(parse_inductive(params, intro_rules.back()));
-        return shared_coinductive_cmd(params, inds, intro_rules);
-    }
-
-    environment mutual_coinductive_cmd() {
-        buffer<expr> params;
-        buffer<expr> inds;
-        buffer<buffer<expr> > intro_rules;
-        parse_mutual_inductive(params, inds, intro_rules);
-        return shared_coinductive_cmd(params, inds, intro_rules);
-    }
 };
 
-environment inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta) {
+environment inductive_cmd(parser & p, cmd_meta const & meta) {
     p.next();
     auto pos = p.pos();
     module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, !is_meta).inductive_cmd();
+    return inductive_cmd_fn(p, meta).inductive_cmd();
 }
 
-environment mutual_inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta) {
+environment coinductive_cmd(parser & p, cmd_meta const & meta) {
     p.next();
     auto pos = p.pos();
     module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, !is_meta).mutual_inductive_cmd();
-}
-
-environment coinductive_cmd_ex(parser & p, decl_attributes const & attrs) {
-    p.next();
-    auto pos = p.pos();
-    module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, true).coinductive_cmd();
-}
-
-environment mutual_coinductive_cmd_ex(parser & p, decl_attributes const & attrs) {
-    p.next();
-    auto pos = p.pos();
-    module::scope_pos_info scope_pos(pos);
-    return inductive_cmd_fn(p, attrs, true).mutual_coinductive_cmd();
-}
-
-environment inductive_cmd(parser & p) {
-    return inductive_cmd_ex(p, {}, false);
-}
-
-environment coinductive_cmd(parser & p) {
-    return coinductive_cmd_ex(p, {});
+    return inductive_cmd_fn(p, meta).coinductive_cmd();
 }
 
 void register_inductive_cmds(cmd_table & r) {

--- a/src/frontends/lean/inductive_cmds.cpp
+++ b/src/frontends/lean/inductive_cmds.cpp
@@ -569,6 +569,7 @@ class inductive_cmd_fn {
         declaration_name_scope nscope;
         expr ind = parse_single_header(m_p, nscope, m_lp_names, params);
         m_explicit_levels = !m_lp_names.empty();
+        m_mut_attrs.push_back({});
 
         ind = mk_local(get_namespace(m_p.env()) + mlocal_name(ind), mlocal_name(ind), mlocal_type(ind), local_info(ind));
 
@@ -661,11 +662,9 @@ public:
             if (m_meta_info.m_doc_string)
                 m_env = add_doc_string(m_env, mlocal_name(ind), *m_meta_info.m_doc_string);
         }
-        if (!m_mut_attrs.empty()) {
-            lean_assert(new_inds.size() == m_mut_attrs.size());
-            for (unsigned i = 0; i < new_inds.size(); ++i)
-                m_env = m_mut_attrs[i].apply(m_env, m_p.ios(), mlocal_name(new_inds[i]));
-        }
+        lean_assert(new_inds.size() == m_mut_attrs.size());
+        for (unsigned i = 0; i < new_inds.size(); ++i)
+            m_env = m_mut_attrs[i].apply(m_env, m_p.ios(), mlocal_name(new_inds[i]));
     }
 
     environment inductive_cmd() {

--- a/src/frontends/lean/inductive_cmds.h
+++ b/src/frontends/lean/inductive_cmds.h
@@ -8,6 +8,19 @@ Author: Daniel Selsam
 #include "frontends/lean/cmd_table.h"
 #include "frontends/lean/decl_attributes.h"
 namespace lean {
+struct single_inductive_decl {
+    decl_attributes m_attrs;
+    expr            m_expr;
+    buffer<expr>    m_intros;
+};
+
+struct inductive_decl {
+    buffer<name>                  m_lp_names;
+    buffer<expr>                  m_params;
+    buffer<single_inductive_decl> m_decls;
+};
+
+inductive_decl parse_inductive_decl(parser & p, cmd_meta const & meta);
 environment inductive_cmd(parser & p, cmd_meta const & meta);
 environment coinductive_cmd(parser & p, cmd_meta const & meta);
 

--- a/src/frontends/lean/inductive_cmds.h
+++ b/src/frontends/lean/inductive_cmds.h
@@ -8,10 +8,8 @@ Author: Daniel Selsam
 #include "frontends/lean/cmd_table.h"
 #include "frontends/lean/decl_attributes.h"
 namespace lean {
-environment inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta);
-environment mutual_inductive_cmd_ex(parser & p, decl_attributes const & attrs, bool is_meta);
-environment coinductive_cmd_ex(parser & p, decl_attributes const & attrs);
-environment mutual_coinductive_cmd_ex(parser & p, decl_attributes const & attrs);
+environment inductive_cmd(parser & p, cmd_meta const & meta);
+environment coinductive_cmd(parser & p, cmd_meta const & meta);
 
 void register_inductive_cmds(cmd_table & r);
 void initialize_inductive_cmds();

--- a/src/frontends/lean/inductive_cmds.h
+++ b/src/frontends/lean/inductive_cmds.h
@@ -22,7 +22,6 @@ struct inductive_decl {
 
 inductive_decl parse_inductive_decl(parser & p, cmd_meta const & meta);
 environment inductive_cmd(parser & p, cmd_meta const & meta);
-environment coinductive_cmd(parser & p, cmd_meta const & meta);
 
 void register_inductive_cmds(cmd_table & r);
 void initialize_inductive_cmds();

--- a/src/frontends/lean/init_module.cpp
+++ b/src/frontends/lean/init_module.cpp
@@ -29,6 +29,7 @@ Author: Leonardo de Moura
 #include "frontends/lean/interactive.h"
 #include "frontends/lean/completion.h"
 #include "frontends/lean/user_notation.h"
+#include "frontends/lean/user_command.h"
 
 namespace lean {
 void initialize_frontend_lean_module() {
@@ -57,8 +58,10 @@ void initialize_frontend_lean_module() {
     initialize_interactive();
     initialize_completion();
     initialize_user_notation();
+    initialize_user_command();
 }
 void finalize_frontend_lean_module() {
+    finalize_user_command();
     finalize_user_notation();
     finalize_completion();
     finalize_interactive();

--- a/src/frontends/lean/notation_cmd.cpp
+++ b/src/frontends/lean/notation_cmd.cpp
@@ -318,7 +318,7 @@ static unsigned get_precedence(environment const & env, buffer<token_entry> cons
     std::string token_str = token.to_string();
     for (auto const & e : new_tokens) {
         if (e.m_token == token_str)
-            return e.m_prec;
+            return *e.m_prec;
     }
     auto prec = get_expr_precedence(get_token_table(env), token_str.c_str());
     if (prec)

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2270,22 +2270,15 @@ public:
     virtual optional<expr> is_stuck(expr const & e) override { return ctx().is_stuck(e); }
 };
 
-static name_set * g_documentable_cmds = nullptr;
-
-static bool support_docummentation(name const & n) {
-    return g_documentable_cmds->contains(n);
-}
-
-void parser::parse_command() {
-    lean_assert(curr() == token_kind::CommandKeyword);
+void parser::parse_command(cmd_meta const & meta) {
+    if (curr() != token_kind::CommandKeyword) {
+        auto p = pos();
+        maybe_throw_error({"expected command", p});
+        return;
+    }
     m_last_cmd_pos = pos();
     name cmd_name = get_token_info().value();
     m_cmd_token = get_token_info().token();
-    if (m_doc_string && !support_docummentation(cmd_name)) {
-        next();
-        reset_doc_string();
-        maybe_throw_error({sstream() << "command '" << cmd_name << "' does not support doc string", m_last_cmd_pos});
-    }
     if (auto it = cmds().find(cmd_name)) {
         lazy_type_context tc(m_env, get_options());
         scope_global_ios scope1(m_ios);
@@ -2295,42 +2288,28 @@ void parser::parse_command() {
             in_notation_ctx ctx(*this);
             if (it->get_skip_token())
                 next();
-            m_env = it->get_fn()(*this);
+            m_env = it->get_fn()(*this, meta);
         } else {
             if (it->get_skip_token())
                 next();
-            m_env = it->get_fn()(*this);
+            m_env = it->get_fn()(*this, meta);
         }
     } else {
-        reset_doc_string();
         auto p = pos();
         next();
         maybe_throw_error({sstream() << "unknown command '" << cmd_name << "'", p});
     }
-    reset_doc_string();
 }
 
-void parser::parse_doc_block() {
-    m_doc_string = m_scanner.get_str_val();
+std::string parser::parse_doc_block() {
+    auto val = m_scanner.get_str_val();
     next();
+    return val;
 }
 
 void parser::parse_mod_doc_block() {
     m_env = add_module_doc_string(m_env, m_scanner.get_str_val());
     next();
-}
-
-void parser::check_no_doc_string() {
-    if (m_doc_string) {
-        auto p = pos();
-        next();
-        reset_doc_string();
-        maybe_throw_error({"invalid occurrence of doc string immediately before current position", p});
-    }
-}
-
-void parser::reset_doc_string() {
-    m_doc_string = optional<std::string>();
 }
 
 #if defined(__GNUC__) && !defined(__CLANG__)
@@ -2494,29 +2473,22 @@ bool parser::parse_command_like() {
 
     switch (curr()) {
         case token_kind::CommandKeyword:
-            if (curr_is_token(get_end_tk())) {
-                check_no_doc_string();
-            }
-            parse_command();
+            parse_command({});
             updt_options();
             break;
         case token_kind::DocBlock:
-            check_no_doc_string();
-            parse_doc_block();
+            parse_command({{}, {}, some(parse_doc_block())});
             break;
         case token_kind::ModDocBlock:
-            check_no_doc_string();
             parse_mod_doc_block();
             break;
         case token_kind::Eof:
-            check_no_doc_string();
             if (has_open_scopes(m_env)) {
                 maybe_throw_error({"invalid end of module, expecting 'end'", pos()});
             }
             return true;
             break;
         case token_kind::Keyword:
-            check_no_doc_string();
             if (curr_is_token(get_period_tk())) {
                 next();
                 break;
@@ -2625,26 +2597,10 @@ void initialize_parser() {
     register_bool_option(*g_parser_show_errors, LEAN_DEFAULT_PARSER_SHOW_ERRORS,
                          "(lean parser) display error messages in the regular output channel");
     g_tmp_prefix = new name(name::mk_internal_unique_name());
-    g_documentable_cmds = new name_set();
-
-    g_documentable_cmds->insert("definition");
-    g_documentable_cmds->insert("theorem");
-    g_documentable_cmds->insert("constant");
-    g_documentable_cmds->insert("axiom");
-    g_documentable_cmds->insert("meta");
-    g_documentable_cmds->insert("mutual");
-    g_documentable_cmds->insert("@[");
-    g_documentable_cmds->insert("protected");
-    g_documentable_cmds->insert("class");
-    g_documentable_cmds->insert("instance");
-    g_documentable_cmds->insert("inductive");
-    g_documentable_cmds->insert("coinductive");
-    g_documentable_cmds->insert("structure");
 }
 
 void finalize_parser() {
     delete g_tmp_prefix;
     delete g_parser_show_errors;
-    delete g_documentable_cmds;
 }
 }

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -212,6 +212,7 @@ public:
     cmd_table const & cmds() const { return get_cmd_table(env()); }
 
     environment const & env() const { return m_env; }
+    void set_env(environment const & env) { m_env = env; }
     io_state const & ios() const { return m_ios; }
 
     message_builder mk_message(pos_info const & p, message_severity severity) const;

--- a/src/frontends/lean/parser.h
+++ b/src/frontends/lean/parser.h
@@ -26,6 +26,7 @@ Author: Leonardo de Moura
 #include "frontends/lean/local_level_decls.h"
 #include "frontends/lean/parser_config.h"
 #include "frontends/lean/local_context_adapter.h"
+#include "frontends/lean/decl_util.h"
 
 namespace lean {
 struct interrupt_parser {};
@@ -83,9 +84,6 @@ class parser : public abstract_parser {
     // noncomputable definitions not tagged as noncomputable.
     bool                   m_ignore_noncomputable;
 
-    // Docgen
-    optional<std::string>  m_doc_string;
-
     void sync_command();
 
     tag get_tag(expr e);
@@ -96,13 +94,10 @@ class parser : public abstract_parser {
     level parse_level_nud();
     level parse_level_led(level left);
 
-    void parse_doc_block();
+    std::string parse_doc_block();
     void parse_mod_doc_block();
-    void check_no_doc_string();
-    void reset_doc_string();
 
     void process_imports();
-    void parse_command();
     bool parse_command_like();
     void process_postponed(buffer<expr> const & args, bool is_left, buffer<notation::action_kind> const & kinds,
                            buffer<list<expr>> const & nargs, buffer<expr> const & ps, buffer<pair<unsigned, pos_info>> const & scoped_info,
@@ -240,8 +235,6 @@ public:
     pos_info pos_of(expr const & e) const { return pos_of(e, pos()); }
     pos_info cmd_pos() const { return m_last_cmd_pos; }
     name const & get_cmd_token() const { return m_cmd_token; }
-
-    optional<std::string> get_doc_string() const { return m_doc_string; }
 
     parser_pos_provider get_parser_pos_provider(pos_info const & some_pos) const {
         return parser_pos_provider(m_pos_table, m_file_name, some_pos, m_next_tag_idx);
@@ -412,6 +405,7 @@ public:
     expr parse_scoped_expr(buffer<expr> const & ps, unsigned rbp = 0) { return parse_scoped_expr(ps.size(), ps.data(), rbp); }
     expr parse_expr_with_env(local_environment const & lenv, unsigned rbp = 0);
 
+    void parse_command(cmd_meta const & meta);
     void parse_imports(unsigned & fingerprint, std::vector<module_name> &);
 
     struct local_scope {

--- a/src/frontends/lean/parser_config.cpp
+++ b/src/frontends/lean/parser_config.cpp
@@ -83,7 +83,11 @@ struct token_config {
     static name * g_class_name;
 
     static void add_entry(environment const &, io_state const &, state & s, entry const & e) {
-        s.m_table = add_token(s.m_table, e.m_token.c_str(), e.m_prec);
+        if (e.m_prec) {
+            s.m_table = add_token(s.m_table, e.m_token.c_str(), *e.m_prec);
+        } else {
+            s.m_table = add_command_token(s.m_table, e.m_token.c_str());
+        }
     }
     static name const & get_class_name() {
         return *g_class_name;
@@ -93,9 +97,9 @@ struct token_config {
         s << e.m_token.c_str() << e.m_prec;
     }
     static entry read_entry(deserializer & d) {
-        std::string tk = d.read_string();
-        unsigned prec  = d.read_unsigned();
-        return entry(tk, prec);
+        entry e;
+        d >> e.m_token >> e.m_prec;
+        return e;
     }
     static optional<unsigned> get_fingerprint(entry const &) {
         return optional<unsigned>();
@@ -388,6 +392,13 @@ static cmd_ext const & get_extension(environment const & env) {
 }
 cmd_table const & get_cmd_table(environment const & env) {
     return get_extension(env).m_cmds;
+}
+
+environment add_command(environment const & env, name const & n, cmd_info const & info) {
+    auto env2 = token_ext::register_entry(env, get_dummy_ios(), token_entry(n.to_string()));
+    cmd_ext ext = get_extension(env2);
+    ext.m_cmds.insert(n, info);
+    return env2.update(g_ext->m_ext_id, std::make_shared<cmd_ext>(ext));
 }
 
 void initialize_parser_config() {

--- a/src/frontends/lean/parser_config.h
+++ b/src/frontends/lean/parser_config.h
@@ -17,8 +17,9 @@ Author: Leonardo de Moura
 namespace lean {
 struct token_entry {
     std::string m_token;
-    unsigned    m_prec;
+    optional<unsigned> m_prec; // if none: command token
     token_entry(std::string const & tk, unsigned prec): m_token(tk), m_prec(prec) {}
+    token_entry(std::string const & tk): m_token(tk) {}
     token_entry() : m_prec(0) {}
 };
 inline token_entry mk_token_entry(std::string const & tk, unsigned prec) { return token_entry(tk, prec); }
@@ -77,6 +78,7 @@ parse_table const & get_led_table(environment const & env);
 parse_table const & get_reserved_nud_table(environment const & env);
 parse_table const & get_reserved_led_table(environment const & env);
 cmd_table const & get_cmd_table(environment const & env);
+environment add_command(environment const & env, name const & n, cmd_info const & info);
 
 /** \brief Add \c n as notation for \c e */
 environment add_mpz_notation(environment const & env, mpz const & n, expr const & e, bool overload = true, bool parse_only = false);

--- a/src/frontends/lean/structure_cmd.h
+++ b/src/frontends/lean/structure_cmd.h
@@ -9,8 +9,8 @@ Author: Leonardo de Moura
 #include "frontends/lean/decl_util.h"
 #include "frontends/lean/cmd_table.h"
 namespace lean {
-environment structure_cmd_ex(parser & p, decl_attributes const & attrs, decl_modifiers const & modifiers);
-environment class_cmd_ex(parser & p, decl_attributes attrs, decl_modifiers const & modifiers);
+environment structure_cmd(parser & p, cmd_meta const & meta);
+environment class_cmd(parser & p, cmd_meta const & meta);
 buffer<name> get_structure_fields(environment const & env, name const & S);
 void register_structure_cmd(cmd_table & r);
 /** \brief Return true iff \c S is a structure created with the structure command */

--- a/src/frontends/lean/user_command.cpp
+++ b/src/frontends/lean/user_command.cpp
@@ -1,0 +1,123 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Sebastian Ullrich
+*/
+#include <string>
+#include "kernel/abstract.h"
+#include "library/constants.h"
+#include "library/attribute_manager.h"
+#include "library/scoped_ext.h"
+#include "library/tactic/elaborator_exception.h"
+#include "library/string.h"
+#include "library/vm/vm_expr.h"
+#include "library/vm/vm_parser.h"
+#include "library/quote.h"
+#include "library/placeholder.h"
+#include "frontends/lean/elaborator.h"
+
+namespace lean {
+static environment add_user_command(environment const & env, name const & d) {
+    auto type = env.get(d).get_type();
+    bool takes_meta_infos = false;
+    if (is_binding(type) && is_constant(binding_domain(type), {"interactive", "decl_meta_info"})) {
+        takes_meta_infos = true;
+        type = binding_body(type);
+    }
+    std::string tk;
+    if (is_binding(type) && is_app_of(binding_domain(type), get_interactive_parse_name(), 3)) {
+        auto const & parser = app_arg(binding_domain(type));
+        if (is_app_of(parser, get_lean_parser_tk_name(), 1)) {
+            if (auto lit = to_string(app_arg(parser))) {
+                tk = *lit;
+                type = binding_body(type);
+            } else {
+                throw elaborator_exception(app_arg(parser),
+                                           "invalid user-defined command, token must be a name literal");
+            }
+        }
+    } else {
+        throw exception("invalid user-defined command, must take `interactive.parse (lean.parser.tk c)` parameter, "
+                        "optionally preceded by `interactive.decl_meta_info` parameter");
+    }
+
+    if (!(is_app_of(type, get_lean_parser_name(), 1) && is_constant(app_arg(type), get_unit_name()))) {
+        throw exception("invalid user-defined command, must return type `lean.parser unit`");
+    }
+
+    expr dummy = mk_true();
+
+    auto run = [=](parser & p, cmd_meta const & meta) {
+        expr parser = mk_constant(d);
+        // we don't want to reflect `meta` into an expr, so abstract the parameter and pass it as a vm_obj arg
+        if (takes_meta_infos) {
+            parser = mk_app(parser, mk_var(0));
+        }
+        // `parse (tk c)` arg
+        parser = mk_app(parser, mk_constant(get_unit_star_name()));
+        for (expr t = type; is_pi(t); t = binding_body(t)) {
+            expr arg_type = binding_domain(t);
+            if (is_app_of(arg_type, get_interactive_parse_name())) {
+                parser = mk_app(parser, parse_interactive_param(p, arg_type));
+            } else {
+                expr e = p.parse_expr(get_max_prec());
+                if (!closed(e) || has_local(e)) {
+                    throw elaborator_exception(e, "invalid argument to user-defined command, must be closed term");
+                }
+                parser = mk_app(parser, e);
+            }
+        }
+        buffer<vm_obj> args;
+        if (takes_meta_infos) {
+            parser = mk_lambda("a", mk_expr_placeholder(), parser);
+            args.push_back(to_obj(meta));
+        }
+        parser = p.elaborate("_user_command", {}, parser).first;
+        run_parser(p, parser, args);
+        return p.env();
+    };
+
+    if (takes_meta_infos) {
+        return add_command(env, tk, cmd_info(tk, "description", run));
+    } else {
+        return add_command(env, tk, cmd_info(tk, "description", [=](parser & p) { return run(p, {}); }));
+    }
+}
+
+struct user_command_modification : public modification {
+    LEAN_MODIFICATION("USR_CMD")
+
+    name m_name;
+
+    user_command_modification() {}
+    user_command_modification(name const & name) : m_name(name) {}
+
+    void perform(environment & env) const override {
+        env = add_user_command(env, m_name);
+    }
+
+    void serialize(serializer & s) const override {
+        s << m_name;
+    }
+
+    static std::shared_ptr<modification const> deserialize(deserializer & d) {
+        return std::make_shared<user_command_modification>(read_name(d));
+    }
+};
+void initialize_user_command() {
+    user_command_modification::init();
+    register_system_attribute(basic_attribute(
+            "user_command", "user-defined command",
+            [](environment const & env, io_state const &, name const & d, unsigned, bool persistent) {
+                if (persistent) {
+                    return module::add_and_perform(env, std::make_shared<user_command_modification>(d));
+                } else {
+                    throw exception("[user_command] cannot be used locally");
+                }
+            }));
+}
+void finalize_user_command() {
+    user_command_modification::finalize();
+}
+}

--- a/src/frontends/lean/user_command.h
+++ b/src/frontends/lean/user_command.h
@@ -1,0 +1,12 @@
+/*
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Sebastian Ullrich
+*/
+#pragma once
+
+namespace lean {
+void initialize_user_command();
+void finalize_user_command();
+}

--- a/src/library/module.cpp
+++ b/src/library/module.cpp
@@ -599,6 +599,7 @@ modification_list parse_olean_modifications(std::vector<char> const & olean_code
     unsigned obj_counter = 0;
     while (true) {
         std::string k;
+        unsigned offset = in.tellg();
         d >> k;
         if (k == g_olean_end_file) {
             break;
@@ -606,7 +607,8 @@ modification_list parse_olean_modifications(std::vector<char> const & olean_code
 
         auto it = readers.find(k);
         if (it == readers.end())
-            throw exception(sstream() << "file '" << file_name << "' has been corrupted, unknown object: " << k);
+            throw exception(sstream() << "file '" << file_name << "' has been corrupted at offset " << offset
+                                      << ", unknown object: " << k);
         ms.emplace_back(it->second(d));
 
         obj_counter++;

--- a/src/library/vm/vm_environment.cpp
+++ b/src/library/vm/vm_environment.cpp
@@ -216,6 +216,10 @@ vm_obj environment_decl_pos(vm_obj const & env, vm_obj const & n) {
     }
 }
 
+vm_obj environment_add_namespace(vm_obj const & env, vm_obj const & n) {
+    return to_obj(add_namespace(to_env(env), to_name(n)));
+}
+
 vm_obj environment_is_namespace(vm_obj const & env, vm_obj const & n) {
     return mk_vm_bool(is_namespace(to_env(env), to_name(n)));
 }
@@ -273,6 +277,7 @@ void initialize_vm_environment() {
     DECLARE_VM_BUILTIN(name({"environment", "inductive_num_params"}),  environment_inductive_num_params);
     DECLARE_VM_BUILTIN(name({"environment", "inductive_num_indices"}), environment_inductive_num_indices);
     DECLARE_VM_BUILTIN(name({"environment", "inductive_dep_elim"}),    environment_inductive_dep_elim);
+    DECLARE_VM_BUILTIN(name({"environment", "add_namespace"}),         environment_add_namespace);
     DECLARE_VM_BUILTIN(name({"environment", "is_namespace"}),          environment_is_namespace);
     DECLARE_VM_BUILTIN(name({"environment", "is_ginductive"}),         environment_is_ginductive);
     DECLARE_VM_BUILTIN(name({"environment", "is_projection"}),         environment_is_projection);

--- a/src/library/vm/vm_option.h
+++ b/src/library/vm/vm_option.h
@@ -10,6 +10,12 @@ Author: Leonardo de Moura
 namespace lean {
 inline vm_obj mk_vm_none() { return mk_vm_simple(0); }
 inline vm_obj mk_vm_some(vm_obj const & a) { return mk_vm_constructor(1, 1, &a); }
+
+template<typename T>
+vm_obj to_obj(optional<T> const & o) {
+    return o ? mk_vm_some(to_obj(*o)) : mk_vm_none();
+}
+
 inline bool is_none(vm_obj const & o) { return is_simple(o); }
 inline vm_obj get_some_value(vm_obj const & o) { lean_assert(!is_none(o)); return cfield(o, 0); }
 }

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -42,9 +42,10 @@ typedef interaction_monad<lean_parser_state> lean_parser;
 #define CATCH } catch (break_at_pos_exception const & ex) { throw; }\
                 catch (exception const & ex) { return lean_parser::mk_exception(ex, s); }
 
-vm_obj run_parser(parser & p, expr const & spec) {
+vm_obj run_parser(parser & p, expr const & spec, buffer<vm_obj> const & args) {
     type_context ctx(p.env(), p.get_options());
-    return lean_parser::get_result_value(lean_parser::evaluator(ctx, p.get_options())(spec, lean_parser_state {&p}));
+    auto r = lean_parser::evaluator(ctx, p.get_options())(spec, args, lean_parser_state {&p});
+    return lean_parser::get_result_value(r);
 }
 
 expr parse_interactive_param(parser & p, expr const & param_ty) {

--- a/src/library/vm/vm_parser.h
+++ b/src/library/vm/vm_parser.h
@@ -9,7 +9,7 @@ Author: Sebastian Ullrich
 #include "frontends/lean/parser.h"
 
 namespace lean {
-vm_obj run_parser(parser & p, expr const & spec);
+vm_obj run_parser(parser & p, expr const & spec, buffer<vm_obj> const & args = {});
 expr parse_interactive_param(parser & p, expr const & param_ty);
 
 vm_obj to_obj(cmd_meta const & meta);

--- a/src/library/vm/vm_parser.h
+++ b/src/library/vm/vm_parser.h
@@ -12,6 +12,8 @@ namespace lean {
 vm_obj run_parser(parser & p, expr const & spec);
 expr parse_interactive_param(parser & p, expr const & param_ty);
 
+vm_obj to_obj(cmd_meta const & meta);
+
 void initialize_vm_parser();
 void finalize_vm_parser();
 }

--- a/tests/lean/bad_unification_hint.lean.expected.out
+++ b/tests/lean/bad_unification_hint.lean.expected.out
@@ -1,4 +1,4 @@
-bad_unification_hint.lean:7:0: error: invalid unification hint, failed to unify pattern after unifying constraints
-bad_unification_hint.lean:7:0: warning: declaration 'append_cons_hint' uses sorry
-bad_unification_hint.lean:12:0: error: invalid unification hint, failed to unify constraint #1
-bad_unification_hint.lean:12:0: warning: declaration 'cons_append_hint'' uses sorry
+bad_unification_hint.lean:7:9: error: invalid unification hint, failed to unify pattern after unifying constraints
+bad_unification_hint.lean:7:9: warning: declaration 'append_cons_hint' uses sorry
+bad_unification_hint.lean:12:9: error: invalid unification hint, failed to unify constraint #1
+bad_unification_hint.lean:12:9: warning: declaration 'cons_append_hint'' uses sorry

--- a/tests/lean/cls_err.lean
+++ b/tests/lean/cls_err.lean
@@ -1,6 +1,6 @@
 --
 universe variables u
-inductive [class] H (A : Type u)
+class inductive H (A : Type u)
 | mk : A → H
 
 definition foo {A : Type u} [h : H A] : A :=

--- a/tests/lean/cmd_meta_errors.lean
+++ b/tests/lean/cmd_meta_errors.lean
@@ -1,0 +1,20 @@
+/-- docs -/
+run_cmd
+
+@[class]
+run_cmd
+
+private run_cmd
+
+meta axiom
+
+private protected def f := 42
+private private def f := 42
+
+private inductive
+protected inductive
+noncomputable inductive
+
+private instance
+protected instance
+mutual instance

--- a/tests/lean/cmd_meta_errors.lean.expected.out
+++ b/tests/lean/cmd_meta_errors.lean.expected.out
@@ -1,0 +1,12 @@
+cmd_meta_errors.lean:2:0: error: command does not accept doc string
+cmd_meta_errors.lean:5:0: error: command does not accept attributes
+cmd_meta_errors.lean:7:8: error: command does not accept modifiers
+cmd_meta_errors.lean:9:5: error: invalid 'meta' modifier for axiom
+cmd_meta_errors.lean:11:8: error: unexpected definition modifier
+cmd_meta_errors.lean:12:8: error: unexpected definition modifier
+cmd_meta_errors.lean:14:0: error: invalid 'private' modifier for inductive type
+cmd_meta_errors.lean:15:0: error: invalid 'protected' modifier for inductive type
+cmd_meta_errors.lean:16:0: error: invalid 'noncomputable' modifier for inductive type
+cmd_meta_errors.lean:18:8: error: invalid 'private' modifier for instance command
+cmd_meta_errors.lean:19:10: error: invalid 'protected' modifier for instance command
+cmd_meta_errors.lean:20:7: error: invalid 'mutual' modifier for instance command

--- a/tests/lean/elab_error_msgs.lean.expected.out
+++ b/tests/lean/elab_error_msgs.lean.expected.out
@@ -8,7 +8,7 @@ but is expected to have type
   ?m_1 → ?m_2 → ?m_4
 Additional information:
 elab_error_msgs.lean:2:0: context: 'eliminator' elaboration was not used for 'and.rec' because it is not fully applied, #2 explicit arguments expected
-elab_error_msgs.lean:4:0: warning: declaration 'bogus_elim' uses sorry
+elab_error_msgs.lean:5:0: warning: declaration 'bogus_elim' uses sorry
 elab_error_msgs.lean:9:0: error: type mismatch at application
   bogus_elim trivial
 term

--- a/tests/lean/hole_issue2.lean.expected.out
+++ b/tests/lean/hole_issue2.lean.expected.out
@@ -1,4 +1,4 @@
-hole_issue2.lean:12:0: warning: declaration 'count' uses sorry
+hole_issue2.lean:12:14: warning: declaration 'count' uses sorry
 hole_issue2.lean:22:74: error: don't know how to synthesize placeholder
 context:
 A : Type,

--- a/tests/lean/inst.lean
+++ b/tests/lean/inst.lean
@@ -1,6 +1,6 @@
 set_option pp.notation false
 
-inductive [class] C (A : Type*)
+class inductive C (A : Type*)
 | mk : A → C
 
 definition val {A : Type*} (c : C A) : A :=

--- a/tests/lean/run/class11.lean
+++ b/tests/lean/run/class11.lean
@@ -1,4 +1,4 @@
-inductive [class] C {A : Type} : A → Prop
+class inductive C {A : Type} : A → Prop
 
 constant f {A : Type} (a : A) [H : C a] : Prop
 

--- a/tests/lean/run/imp3.lean
+++ b/tests/lean/run/imp3.lean
@@ -1,4 +1,4 @@
-structure [class] is_equiv {A B : Type} (f : A → B) :=
+class is_equiv {A B : Type} (f : A → B) :=
   (inv : B → A)
 
 #check @is_equiv.inv

--- a/tests/lean/run/parent_struct_inst.lean
+++ b/tests/lean/run/parent_struct_inst.lean
@@ -1,6 +1,6 @@
 open nat
 
-structure [class] A := (n : ℕ)
+class A := (n : ℕ)
 
 definition f [A] := A.n
 

--- a/tests/lean/run/priority_test2.lean
+++ b/tests/lean/run/priority_test2.lean
@@ -1,6 +1,6 @@
 open nat
 
-structure [class] foo :=
+class foo :=
 (a : nat) (b : nat)
 
 attribute [instance, priority std.priority.default-2]

--- a/tests/lean/run/record10.lean
+++ b/tests/lean/run/record10.lean
@@ -4,12 +4,12 @@ set_option old_structure_cmd true
 
 #print "======================="
 
-structure [class] has_two_muls (A : Type) extends has_mul A renaming mul→mul1,
-                                          private has_mul A renaming mul→mul2
+class has_two_muls (A : Type) extends has_mul A renaming mul→mul1,
+                              private has_mul A renaming mul→mul2
 
 #print prefix has_two_muls
 
 #print "======================="
 
-structure [class] another_two_muls (A : Type) extends has_mul A renaming mul→mul1,
-                                                      has_mul A renaming mul→mul2
+class another_two_muls (A : Type) extends has_mul A renaming mul→mul1,
+                                          has_mul A renaming mul→mul2

--- a/tests/lean/run/section5.lean
+++ b/tests/lean/run/section5.lean
@@ -5,7 +5,7 @@ section foo
 
   #check foo
 
-  structure [class] point :=
+  class point :=
   (x : A) (y : A)
 end foo
 

--- a/tests/lean/run/struc_names.lean
+++ b/tests/lean/run/struc_names.lean
@@ -1,9 +1,9 @@
 namespace foo
 
-  structure [class] structA :=
+  class structA :=
   mk :: (a : nat)
 
-  structure [class] structB extends structA :=
+  class structB extends structA :=
   mk :: (b : nat)
 
   #check @structA.a

--- a/tests/lean/run/univ_bug1.lean
+++ b/tests/lean/run/univ_bug1.lean
@@ -10,7 +10,7 @@ namespace nsimp
 -- set_option pp.implicit true
 
 -- first define a class of homogeneous equality
-inductive [class] simplifies_to {T : Type} (t1 t2 : T) : Prop
+class inductive simplifies_to {T : Type} (t1 t2 : T) : Prop
 | mk : t1 = t2 → simplifies_to
 
 theorem get_eq {T : Type} {t1 t2 : T} (C : simplifies_to t1 t2) : t1 = t2 :=

--- a/tests/lean/run/univ_bug2.lean
+++ b/tests/lean/run/univ_bug2.lean
@@ -6,7 +6,7 @@
 open nat
 
 -- first define a class of homogeneous equality
-inductive [class] simplifies_to {T : Type} (t1 t2 : T) : Prop
+class inductive simplifies_to {T : Type} (t1 t2 : T) : Prop
 | mk : t1 = t2 → simplifies_to
 
 namespace simplifies_to

--- a/tests/lean/struct_class.lean
+++ b/tests/lean/struct_class.lean
@@ -1,7 +1,7 @@
 prelude
 import init.core
 
-structure [class] point (A : Type*) (B : Type*) :=
+class point (A : Type*) (B : Type*) :=
 mk :: (x : A) (y : B)
 
 #print classes

--- a/tests/lean/user_attribute.lean.expected.out
+++ b/tests/lean/user_attribute.lean.expected.out
@@ -7,11 +7,11 @@ eq.refl
 @[foo, foo.baz, refl]
 constructor eq.refl : ∀ {α : Sort u} (a : α), a = a
 [eq.refl]
-user_attribute.lean:22:0: error: an attribute named [reducible] has already been registered
-user_attribute.lean:22:0: warning: declaration 'duplicate' uses sorry
-user_attribute.lean:27:0: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:23:0: error: an attribute named [reducible] has already been registered
+user_attribute.lean:23:0: warning: declaration 'duplicate' uses sorry
+user_attribute.lean:28:0: error: invalid [user_attribute], must be applied to definition of type user_attribute
 user_attribute.lean:28:11: error: don't know how to synthesize placeholder
 context:
 ⊢ Sort ?
-user_attribute.lean:33:2: error: invalid [user_attribute], must be applied to definition of type user_attribute
-user_attribute.lean:33:2: warning: declaration 'baz_attr' uses sorry
+user_attribute.lean:34:2: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:34:2: warning: declaration 'baz_attr' uses sorry

--- a/tests/lean/user_command.lean
+++ b/tests/lean/user_command.lean
@@ -1,0 +1,36 @@
+open lean
+open lean.parser
+open interactive
+open tactic
+
+-- missing tk
+@[user_command]
+meta def foo_cmd : parser unit := pure ()
+
+-- wrong return type
+@[user_command]
+meta def foo_cmd (_ : parse $ tk "foo") : unit := ()
+
+foo
+
+@[user_command]
+meta def foo_cmd (_ : parse $ tk "foo") : parser unit :=
+trace "foo"
+
+run_cmd skip
+
+foo
+private foo
+
+@[user_command]
+meta def foo_cmd2 (_ : parse $ tk "foo") : parser unit :=
+trace "bar"
+
+foo
+
+@[user_command]
+meta def foo_cmd3 (dmi : decl_meta_info) (_ : parse $ tk "foo") : parser unit :=
+trace format!"{dmi.modifiers.is_private}"
+
+foo
+private foo

--- a/tests/lean/user_command.lean.expected.out
+++ b/tests/lean/user_command.lean.expected.out
@@ -1,0 +1,11 @@
+user_command.lean:8:5: error: invalid user-defined command, must take `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.decl_meta_info` parameter
+user_command.lean:8:5: warning: declaration 'foo_cmd' uses sorry
+user_command.lean:14:0: error: unknown identifier 'foo'
+user_command.lean:12:5: error: invalid user-defined command, must return type `lean.parser unit`
+user_command.lean:12:50: error: function expected at
+  ()
+foo
+user_command.lean:23:8: error: command does not accept modifiers
+bar
+ff
+tt

--- a/tests/lean/user_notation.lean.expected.out
+++ b/tests/lean/user_notation.lean.expected.out
@@ -1,11 +1,11 @@
 2
 0 + (1 + 0) + (1 + 1) + (1 + 2) + (1 + 3) + (1 + 4) + (1 + 5) + (1 + 6) + (1 + 7) + (1 + 8) + (1 + 9) : ℕ
-user_notation.lean:21:0: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.pexpr` parameter
+user_notation.lean:22:5: error: invalid user-defined notation, must start with `interactive.parse (lean.parser.tk c)` parameter, optionally preceded by `interactive.parse lean.parser.pexpr` parameter
 user_notation.lean:22:9: error: don't know how to synthesize placeholder
 context:
 e₁ : parse lean.parser.pexpr
 ⊢ Sort ?
-user_notation.lean:24:0: error: invalid user-defined notation, must return type `lean.parser p`
+user_notation.lean:25:5: error: invalid user-defined notation, must return type `lean.parser p`
 user_notation.lean:25:9: error: don't know how to synthesize placeholder
 context:
 e₁ : parse (tk "(")


### PR DESCRIPTION
The move itself is of dubious value, but the newly exposed primitives should help with defining other inductive-like commands and of course user-defined commands in general.