### PR TITLE
feat(library/type_context): unfold lemmas in major premise of acc.rec

### DIFF
--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -116,7 +116,6 @@ namespace nat
   def ldiff : ℕ → ℕ → ℕ := bitwise (λ a b, a && bnot b)
   def lxor  : ℕ → ℕ → ℕ := bitwise bxor
 
-  set_option type_context.unfold_lemmas true
   lemma binary_rec_eq {C : nat → Sort u} {f : ∀ b n, C n → C (bit b n)} {z}
     (h : f ff 0 z = z) (b n) :
     binary_rec f z (bit b n) = f b n (binary_rec f z n) :=

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -6,6 +6,7 @@ namespace lean{
 name const * g_abs = nullptr;
 name const * g_absurd = nullptr;
 name const * g_acc_cases_on = nullptr;
+name const * g_acc_rec = nullptr;
 name const * g_add_comm_group = nullptr;
 name const * g_add_comm_semigroup = nullptr;
 name const * g_add_group = nullptr;
@@ -379,6 +380,7 @@ void initialize_constants() {
     g_abs = new name{"abs"};
     g_absurd = new name{"absurd"};
     g_acc_cases_on = new name{"acc", "cases_on"};
+    g_acc_rec = new name{"acc", "rec"};
     g_add_comm_group = new name{"add_comm_group"};
     g_add_comm_semigroup = new name{"add_comm_semigroup"};
     g_add_group = new name{"add_group"};
@@ -753,6 +755,7 @@ void finalize_constants() {
     delete g_abs;
     delete g_absurd;
     delete g_acc_cases_on;
+    delete g_acc_rec;
     delete g_add_comm_group;
     delete g_add_comm_semigroup;
     delete g_add_group;
@@ -1126,6 +1129,7 @@ void finalize_constants() {
 name const & get_abs_name() { return *g_abs; }
 name const & get_absurd_name() { return *g_absurd; }
 name const & get_acc_cases_on_name() { return *g_acc_cases_on; }
+name const & get_acc_rec_name() { return *g_acc_rec; }
 name const & get_add_comm_group_name() { return *g_add_comm_group; }
 name const & get_add_comm_semigroup_name() { return *g_add_comm_semigroup; }
 name const & get_add_group_name() { return *g_add_group; }

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -8,6 +8,7 @@ void finalize_constants();
 name const & get_abs_name();
 name const & get_absurd_name();
 name const & get_acc_cases_on_name();
+name const & get_acc_rec_name();
 name const & get_add_comm_group_name();
 name const & get_add_comm_semigroup_name();
 name const & get_add_group_name();

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -1,6 +1,7 @@
 abs
 absurd
 acc.cases_on
+acc.rec
 add_comm_group
 add_comm_semigroup
 add_group

--- a/src/library/type_context.h
+++ b/src/library/type_context.h
@@ -403,6 +403,7 @@ public:
         This method is useful when we want to normalize the expression until we get a particular symbol as the head symbol. */
     expr whnf_head_pred(expr const & e, std::function<bool(expr const &)> const & pred); // NOLINT
     optional<expr> reduce_aux_recursor(expr const & e);
+    optional<expr> reduce_large_elim_recursor(expr const & e);
     optional<expr> reduce_projection(expr const & e);
     optional<expr> norm_ext(expr const & e) { return env().norm_ext()(e, *this); }
 

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -6,6 +6,7 @@ do env ← get_env, (env^.get n >> return ()) <|> (guard $ env^.is_namespace n) 
 run_cmd script_check_id `abs
 run_cmd script_check_id `absurd
 run_cmd script_check_id `acc.cases_on
+run_cmd script_check_id `acc.rec
 run_cmd script_check_id `add_comm_group
 run_cmd script_check_id `add_comm_semigroup
 run_cmd script_check_id `add_group

--- a/tests/lean/run/unfold_lemmas.lean
+++ b/tests/lean/run/unfold_lemmas.lean
@@ -1,10 +1,10 @@
 open nat well_founded
 
-def gcd.F : Π (y : ℕ), (Π (y' : ℕ), y' < y → nat → nat) → nat → nat
-| 0        f x := x
-| (succ y) f x := f (x % succ y) (mod_lt _ $ succ_pos _) (succ y)
+def gcd : ℕ → ℕ → ℕ | y := λ x,
+if h : y = 0 then
+    x
+else
+    have x % y < y, by { apply mod_lt, cases y, contradiction, apply succ_pos },
+    gcd (x % y) y
 
-def gcd (x y : nat) := fix lt_wf gcd.F y x
-
-set_option type_context.unfold_lemmas true
-@[simp] lemma gcd_zero_right (x : nat) : gcd x 0 = x := rfl
+@[simp] lemma gcd_zero_right (x : nat) : gcd 0 x = x := rfl


### PR DESCRIPTION
See [discussion at the bitwise operations issue](https://github.com/leanprover/lean/pull/1665#discussion_r122654173).

Basically the issue is once again that even though terms such as `4 % 2` definitionally reduce to `0` in the kernel, we can't make use of that fact anywhere else, since the type_context doesn't reduce lemmas.

The `type_context.unfold_lemmas` option that I added a while back is also problematic, since it is local: consider a definition where the type depends on the definitional equality `4 % 2 = 0`.  Then whenever you want to use this definition, you have to enable the unfold lemmas option at the use site.

This PR introduces a seemingly cheap workaround for this issue.  In the type_context, we iota-reduce `acc.rec` applications with transparency_mode::All.  This makes some well-founded definitions reduce definitionally (and should solve the @digama0's issue).  I originally wanted to treat `eq.rec` and `heq.rec` in the same way, but this breaks the equation compiler.

@leodemoura Another way to solve this issue is to unfold definitions in the type_context using the equational (rfl-)lemmas.  You mentioned a while back that this approach has some issues.  Could you elaborate on that, or point to me to previous discussions?