### PR TITLE
fix(init/meta/interactive): elab terms of change-with using same type

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -164,8 +164,10 @@ meta def change (q : parse texpr) : parse (tk "with" *> texpr)? → parse locati
 | none _ := fail "change-at does not support multiple locations"
 | (some w) l :=
   do hs ← l.get_locals,
-     eq ← i_to_expr_strict q,
-     ew ← i_to_expr_strict w,
+     u ← mk_meta_univ, 
+     ty ← mk_meta_var (sort u), 
+     eq ← i_to_expr ``(%%q : %%ty),
+     ew ← i_to_expr ``(%%w : %%ty),
      let repl := λe : expr, e.replace (λ a n, if a = eq then some ew else none),
      hs.mmap' (λh, do e ← infer_type h, change_core (repl e) (some h)),
      if l.include_goal then do g ← target, change_core (repl g) none else skip


### PR DESCRIPTION
This elaborates the two sides of `change with` with the same type, so that `2` below is interpreted as `2 : ℤ` instead of `2 : ℕ`, and metavariables are tolerated (so `change term with _` works now but does nothing since `_` will unify with `term`).

    example : (1 + 1 : ℤ) = 2 :=
    begin
      change (1 + 1 : ℤ) with 2, -- goal : 2 = 2
      refl
    end