### PR TITLE
fix(tests/lean/interactive/mk_input): strip \r from input files (win)

### DIFF
--- a/tests/lean/interactive/mk_input.sh
+++ b/tests/lean/interactive/mk_input.sh
@@ -2,6 +2,7 @@
 # generate server input from "--^" markers
 INPUT="$(cat)"
 ESC_INPUT="${INPUT//$'\n'/\\n}"
+ESC_INPUT="${ESC_INPUT//$'\r'/}"
 ESC_INPUT="${ESC_INPUT//\"/\\\"}"
 echo "{\"seq_num\": 0, \"command\": \"sync\", \"file_name\": \"f\", \"content\": \"$ESC_INPUT\"}"
 awk '{


### PR DESCRIPTION
This causes tests like the following to fail on windows:

    example :=
    true

out:

    {"message":"parse error - unexpected '\"'","response":"error"}

expected:

    {"message":"file invalidated","response":"ok","seq_num":0}
