### PR TITLE
fix(frontends/lean/elaborator): @applications don't make thunks

### DIFF
--- a/library/data/lazy_list.lean
+++ b/library/data/lazy_list.lean
@@ -29,7 +29,7 @@ def tail : lazy_list α → lazy_list α
 
 def append : lazy_list α → thunk (lazy_list α) → lazy_list α
 | nil        l  := l ()
-| (cons h t) l  := cons h (append (t ()) (l ()))
+| (cons h t) l  := cons h (@append (t ()) l)
 
 def map (f : α → β) : lazy_list α → lazy_list β
 | nil        := nil

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -1516,7 +1516,7 @@ expr elaborator::visit_base_app_simple(expr const & _fn, arg_mask amask, buffer<
             } else if (i < args.size()) {
                 expr expected_type = d;
                 optional<expr> thunk_of;
-                if (!m_in_pattern) thunk_of = is_thunk(d);
+                if (!m_in_pattern && amask == arg_mask::Default) thunk_of = is_thunk(d);
                 if (thunk_of) expected_type = *thunk_of;
                 // explicit argument
                 expr ref_arg = get_ref_for_child(args[i], ref);

--- a/tests/lean/interactive/my_tac_class.lean
+++ b/tests/lean/interactive/my_tac_class.lean
@@ -16,7 +16,7 @@ meta def step {α : Type} (t : mytac α) : mytac unit :=
 t >> return ()
 
 meta def istep {α : Type} (line0 col0 line col : nat) (t : mytac α) : mytac unit :=
-λ v s, result.cases_on (@scope_trace _ line col (t v s))
+λ v s, result.cases_on (@scope_trace _ line col (λ_, t v s))
   (λ ⟨a, v⟩ new_s, result.success ((), v) new_s)
   (λ opt_msg_thunk e new_s, match opt_msg_thunk with
     | some msg_thunk :=

--- a/tests/lean/interactive/rb_map_ts.lean
+++ b/tests/lean/interactive/rb_map_ts.lean
@@ -16,7 +16,7 @@ meta def step {α : Type} (t : mytac α) : mytac unit :=
 t >> return ()
 
 meta def istep {α : Type} (line0 col0 line col : nat) (t : mytac α) : mytac unit :=
-λ v s, result.cases_on (@scope_trace _ line col (t v s))
+λ v s, result.cases_on (@scope_trace _ line col (λ_, t v s))
   (λ ⟨a, v⟩ new_s, result.success ((), v) new_s)
   (λ opt_msg_thunk e new_s,
     match opt_msg_thunk with

--- a/tests/lean/run/my_tac_class.lean
+++ b/tests/lean/run/my_tac_class.lean
@@ -16,7 +16,7 @@ meta def step {α : Type} (t : mytac α) : mytac unit :=
 t >> return ()
 
 meta def istep {α : Type} (line0 col0 line col : nat) (t : mytac α) : mytac unit :=
-λ v s, result.cases_on (@scope_trace _ line col (t v s))
+λ v s, result.cases_on (@scope_trace _ line col (λ_, t v s))
   (λ ⟨a, v⟩ new_s, result.success ((), v) new_s)
   (λ opt_msg_thunk e new_s,
     match opt_msg_thunk with


### PR DESCRIPTION
If `f : thunk A -> B` and `g : thunk A`, then `f g` will automatically apply thunk parsing to create the ill-typed term `f (λ_, g)`. With this PR, you can now write `@f g` in order to disable thunk parsing.