### PR TITLE
fix(init/meta/mk_dec_eq_instance): bug for dependent structures

### DIFF
--- a/tests/lean/run/mk_dec_eq1.lean
+++ b/tests/lean/run/mk_dec_eq1.lean
@@ -4,8 +4,7 @@ namespace test
 
 inductive enum1 : Type | ea | eb | ec | ed
 
-attribute [instance]
-definition enum1_dec_eq : decidable_eq enum1 :=
+instance enum1_dec_eq : decidable_eq enum1 :=
 by mk_dec_eq_instance
 
 inductive Expr
@@ -14,23 +13,22 @@ inductive Expr
 | Elet : Expr → Expr
 | bla  : list nat → Expr
 
-attribute [instance]
-definition Expr_has_dec_eq : decidable_eq Expr :=
+instance Expr_has_dec_eq : decidable_eq Expr :=
 by mk_dec_eq_instance
 universe variables u v
-definition prod_decidable {A : Type u} {B : Type v} [decidable_eq A] [decidable_eq B] : decidable_eq (A × B) :=
+def prod_decidable {A : Type u} {B : Type v} [decidable_eq A] [decidable_eq B] : decidable_eq (A × B) :=
 by mk_dec_eq_instance
 
-definition sum_decidable {A : Type u} {B : Type v} [decidable_eq A] [decidable_eq B] : decidable_eq (sum A B) :=
+def sum_decidable {A : Type u} {B : Type v} [decidable_eq A] [decidable_eq B] : decidable_eq (sum A B) :=
 by mk_dec_eq_instance
 
-definition nat_decidable : decidable_eq nat :=
+def nat_decidable : decidable_eq nat :=
 by mk_dec_eq_instance
 
-definition list_decidable {A : Type u} [decidable_eq A] : decidable_eq (list A) :=
+def list_decidable {A : Type u} [decidable_eq A] : decidable_eq (list A) :=
 by mk_dec_eq_instance
 
-definition option_decidable {A : Type v} [decidable_eq A] : decidable_eq (option A) :=
+def option_decidable {A : Type v} [decidable_eq A] : decidable_eq (option A) :=
 by mk_dec_eq_instance
 
 end test

--- a/tests/lean/run/mk_dec_eq_instance_indices.lean
+++ b/tests/lean/run/mk_dec_eq_instance_indices.lean
@@ -31,3 +31,16 @@ inductive Foo : Pi (n : nat), C n -> Type
 noncomputable instance (n : nat) (c : C n) : decidable_eq (Foo n c) := by mk_dec_eq_instance
 
 end X3
+
+namespace X4
+
+inductive Foo
+| mk (n : nat) (val : fin n)
+
+def fin_decidable (n) : decidable_eq (fin n) :=
+by mk_dec_eq_instance
+
+def dep_decidable : decidable_eq Foo :=
+by mk_dec_eq_instance
+
+end X4


### PR DESCRIPTION
I noticed this bug when trying to show that `buffer` has decidable equality.