### PR TITLE
Minor changes to hash_map.lean

### DIFF
--- a/library/data/hash_map.lean
+++ b/library/data/hash_map.lean
@@ -476,7 +476,7 @@ theorem find_iff (m : hash_map α β) (a : α) (b : β a) :
   m.find a = some b ↔ sigma.mk a b ∈ m.entries :=
 m.is_valid.find_aux_iff _ _ _
 
-theorem contains_iff (m : hash_map α β) (a : α) (b : β a) :
+theorem contains_iff (m : hash_map α β) (a : α) :
   m.contains a ↔ a ∈ m.keys :=
 m.is_valid.contains_aux_iff _ _
 


### PR DESCRIPTION
The first commit removes an unused argument to a lemma that prevents the simplifier from using it, and the second adds a basic lemma that no element is contained in the empty hash map.
