### PR TITLE
fix(init/meta/interactive): generalize2 rollback if typecheck fails

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -391,7 +391,11 @@ meta def generalize2 (p : parse qexpr) (x : parse ident) (h : parse ident) : tac
 do tgt ← target,
    e ← to_expr p,
    let e' := tgt.replace $ λa n, if a = e then some (var n.succ) else none,
-   to_expr ``(Π x, %%e = x → %%e') >>= assert h,
+   tgt' ← (do
+     tgt' ← to_expr ``(Π x, %%e = x → %%e'),
+     type_check tgt',
+     return tgt') <|> to_expr ``(Π x, %%e = x → %%tgt),
+   assert h tgt',
    swap,
    t ← get_local h,
    exact ``(%%t %%p rfl),


### PR DESCRIPTION
Before, `generalize2` would silently produce an ill-typed term if the rewrite fails (which is only noticed when the tactic block finishes). Now it will leave the target unsubstituted if the rewrite fails (since even in this case the equality introduction can be useful).