### PR TITLE
generalize_proofs tactic

### DIFF
--- a/library/init/meta/generalize_proofs.lean
+++ b/library/init/meta/generalize_proofs.lean
@@ -13,8 +13,7 @@ private meta def collect_proofs_in :
   expr → list name × list expr → tactic (list name × list expr) | e (ns, hs) :=
 let go : tactic (list name × list expr) :=
 (do t ← infer_type e,
-    s ← infer_type t,
-    guard (s = expr.sort level.zero),
+    is_prop t >>= guardb,
     first (hs.map $ λ h, do
       t' ← infer_type h,
       is_def_eq t t',
@@ -47,10 +46,7 @@ end
 
 meta def generalize_proofs (ns : list name) : tactic unit :=
 do intros_dep,
-   hs ← local_context >>= mfilter (λh,
-   (do ty ← infer_type h,
-      expr.sort zero ← infer_type ty,
-      return tt) <|> return ff),
+   hs ← local_context >>= mfilter is_proof,
    t ← target,
    collect_proofs_in t (ns, hs) >> skip
 

--- a/library/init/meta/generalize_proofs.lean
+++ b/library/init/meta/generalize_proofs.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2017 Mario Carneiro. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Mario Carneiro
+-/
+
+prelude
+import init.meta.tactic
+
+namespace tactic
+
+private meta def collect_proofs_in :
+  expr → list name × list expr → tactic (list name × list expr) | e (ns, hs) :=
+let go : tactic (list name × list expr) :=
+(do t ← infer_type e,
+    s ← infer_type t,
+    guard (s = expr.sort level.zero),
+    first (hs.map $ λ h, do
+      t' ← infer_type h,
+      is_def_eq t t',
+      g ← target,
+      change $ g.replace (λ a n, if a = e then some h else none),
+      return (ns, hs)) <|>
+    (let (n, ns) := (match ns with
+       | [] := (`_x, [])
+       | (n :: ns) := (n, ns)
+       end : name × list name) in
+     do generalize e n,
+        h ← intro n,
+        return (ns, h::hs))) <|> return (ns, hs) in
+match e with
+| (expr.const _ _)   := go
+| (expr.local_const _ _ _ t) := collect_proofs_in t (ns, hs)
+| (expr.mvar _ t)    := collect_proofs_in t (ns, hs)
+| (expr.app f x)     :=
+  go >>= collect_proofs_in f >>= collect_proofs_in x
+| (expr.lam n b d e) :=
+  go >>= collect_proofs_in d >>= collect_proofs_in e
+| (expr.pi n b d e) :=
+  collect_proofs_in d (ns, hs) >>= collect_proofs_in e
+| (expr.elet n t d e) :=
+  go >>= collect_proofs_in t >>= collect_proofs_in d >>= collect_proofs_in e
+| (expr.macro m l) :=
+  do x ← go, mfoldl (λ x e, collect_proofs_in e x) x l
+| _                  := return (ns, hs)
+end
+
+meta def generalize_proofs (ns : list name) : tactic unit :=
+do intros_dep,
+   hs ← local_context >>= mfilter (λh,
+   (do ty ← infer_type h,
+      expr.sort zero ← infer_type ty,
+      return tt) <|> return ff),
+   t ← target,
+   collect_proofs_in t (ns, hs) >> skip
+
+end tactic

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -6,7 +6,7 @@ Authors: Leonardo de Moura
 prelude
 import init.meta.tactic init.meta.rewrite_tactic init.meta.simp_tactic
 import init.meta.smt.congruence_closure init.category.combinators
-import init.meta.interactive_base
+import init.meta.interactive_base init.meta.generalize_proofs
 
 open lean
 open lean.parser
@@ -411,6 +411,9 @@ do x ← mk_fresh_name,
    generalize2 p x h,
    t ← get_local x,
    induction (to_pexpr t) rec_name hs ([] : list name)
+
+meta def generalize_proofs : parse ident_* → tactic unit :=
+tactic.generalize_proofs
 
 meta def trivial : tactic unit :=
 tactic.triv <|> tactic.reflexivity <|> tactic.contradiction <|> fail "trivial tactic failed"

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -250,7 +250,7 @@ do t ← target,
    assert `htarget new_target, swap,
    ht        ← get_local `htarget,
    eq_type   ← mk_app `eq [t, new_target],
-   locked_pr ← return $ expr.app (expr.app (expr.const ``id_locked [level.zero]) eq_type) pr,
+   let locked_pr := expr.app (expr.app (expr.const ``id_locked [level.zero]) eq_type) pr,
    mk_eq_mpr locked_pr ht >>= exact
 
 meta def simplify_goal (S : simp_lemmas) (cfg : simp_config := {}) : tactic unit :=


### PR DESCRIPTION
I thought I PR'd this a while ago, but I can't find it in the history... This tactic will generalize or merge to existing local constants any proofs within the goal. Not much configuration is available, just setting the names of generated hypotheses. I'm thinking about using a special notation where the name would go like `.` or something to indicate that the proof at this position should not be generalized, but even as is this is a very useful tactic for cleaning up the goal and also fixing some dependent rewrite issues.