### PR TITLE
`assume` and `suppose` tactics

### DIFF
--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -247,11 +247,11 @@ meta def local_uniq_name : expr → name
 | (local_const n m bi t) := n
 | e                      := name.anonymous
 
-meta def local_pp_name : expr → name
+meta def local_pp_name : expr elab → name
 | (local_const x n bi t) := n
 | e                      := name.anonymous
 
-meta def local_type : expr → expr
+meta def local_type : expr elab → expr elab
 | (local_const _ _ _ t) := t
 | e := e
 

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -450,6 +450,26 @@ tactic.any_goals
 meta def focus (tac : itactic) : tactic unit :=
 tactic.focus [tac]
 
+meta def assume_tac (p : parse parse_binders) : tactic unit :=
+list.mfor' p $ λ b,
+  do t ← target,
+     when (not $ t.is_pi ∨ t.is_let) whnf_target,
+     when (not $ t.is_pi ∨ t.is_let) $
+       fail "assume tactic failed, Pi/let expression expected",
+     ty ← i_to_expr b.local_type,
+     unify ty t.binding_domain,
+     intro_core b.local_pp_name
+
+meta def suppose_tac (h : parse ident?) (q : parse (tk ":" *> texpr)?) : tactic unit :=
+let h := h.get_or_else `this in
+match q with
+| some e := do
+  uniq_name ← mk_fresh_name,
+  let l := expr.local_const uniq_name h binder_info.default e,
+  assume_tac [l]
+| none := intro h
+end
+
 /--
 This tactic applies to any goal.
 - `have h : T := p` adds the hypothesis `h : T` to the current goal if `p` a term of type `T`.

--- a/library/init/meta/interactive_base.lean
+++ b/library/init/meta/interactive_base.lean
@@ -142,6 +142,9 @@ meta def param_desc : expr → tactic format
   else paren <$> pp e
 
 
+private meta constant parse_binders_core (rbp : ℕ) : parser (list pexpr)
+meta def parse_binders (rbp := std.prec.max) := with_desc "<binders>" (parse_binders_core rbp)
+
 meta constant decl_attributes : Type
 
 meta constant decl_attributes.apply : decl_attributes → name → parser unit

--- a/src/frontends/lean/builtin_exprs.cpp
+++ b/src/frontends/lean/builtin_exprs.cpp
@@ -1030,6 +1030,7 @@ parse_table init_nud_table() {
     parse_table r;
     r = r.add({transition("by", mk_ext_action_core(parse_by))}, x0);
     r = r.add({transition("have", mk_ext_action(parse_have))}, x0);
+    r = r.add({transition("assume", mk_ext_action(parse_lambda))}, x0);
     r = r.add({transition("suppose", mk_ext_action(parse_suppose))}, x0);
     r = r.add({transition("show", mk_ext_action(parse_show))}, x0);
     r = r.add({transition("suffices", mk_ext_action(parse_suffices))}, x0);

--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -116,14 +116,13 @@ name get_interactive_tactic_full_name(name const & tac_class, name const & tac) 
 }
 
 static bool is_curr_exact_shortcut(parser & p) {
-    return
-            p.curr_is_token(get_assume_tk()) ||
-            p.curr_is_token(get_calc_tk()) ||
-            p.curr_is_token(get_suppose_tk());
+    return p.curr_is_token(get_calc_tk());
 }
 
 static bool is_keyword_tactic(parser & p) {
     return
+            p.curr_is_token(get_assume_tk()) ||
+            p.curr_is_token(get_suppose_tk()) ||
             p.curr_is_token(get_let_tk()) ||
             p.curr_is_token(get_have_tk()) ||
             p.curr_is_token(get_show_tk());

--- a/src/frontends/lean/token_table.cpp
+++ b/src/frontends/lean/token_table.cpp
@@ -79,7 +79,7 @@ void for_each(token_table const & s, std::function<void(char const *, token_info
 void init_token_table(token_table & t) {
     pair<char const *, unsigned> builtin[] =
         {{"fun", 0}, {"Pi", 0}, {"let", 0}, {"in", 0}, {"at", 0},
-         {"have", 0}, {"suppose", 0}, {"show", 0}, {"suffices", 0},
+         {"have", 0}, {"assume", 0}, {"suppose", 0}, {"show", 0}, {"suffices", 0},
          {"do", 0}, {"if", 0}, {"then", 0}, {"else", 0}, {"by", 0},
          {"hiding", 0}, {"replacing", 0}, {"renaming", 0},
          {"from", 0}, {"(", g_max_prec}, {"`(", g_max_prec}, {"``(", g_max_prec},
@@ -114,7 +114,7 @@ void init_token_table(token_table & t) {
          "#compile", "#unify", nullptr};
 
     pair<char const *, char const *> aliases[] =
-        {{"λ", "fun"}, {"assume", "fun"}, {"take", "fun"}, {"forall", "Pi"},
+        {{"λ", "fun"}, {"take", "fun"}, {"forall", "Pi"},
          {"∀", "Pi"}, {"Π", "Pi"}, {"(|", "⟨"}, {"|)", "⟩"}, {nullptr, nullptr}};
 
     pair<char const *, char const *> cmd_aliases[] =

--- a/src/library/vm/vm_parser.cpp
+++ b/src/library/vm/vm_parser.cpp
@@ -289,6 +289,15 @@ static vm_obj interactive_inductive_decl_parse(vm_obj const & vm_meta, vm_obj co
     CATCH;
 }
 
+static vm_obj interactive_parse_binders(vm_obj const & vm_rbp, vm_obj const & vm_s) {
+    auto s = lean_parser::to_state(vm_s);
+    TRY;
+        buffer<expr> binders;
+        s.m_p->parse_binders(binders, to_unsigned(vm_rbp));
+        return lean_parser::mk_success(to_obj(binders), s);
+    CATCH;
+}
+
 void initialize_vm_parser() {
     DECLARE_VM_BUILTIN(name({"lean", "parser_state", "env"}),         vm_parser_state_env);
     DECLARE_VM_BUILTIN(name({"lean", "parser_state", "options"}),     vm_parser_state_options);
@@ -304,6 +313,7 @@ void initialize_vm_parser() {
 
     DECLARE_VM_BUILTIN(name({"interactive", "decl_attributes", "apply"}), interactive_decl_attributes_apply);
     DECLARE_VM_BUILTIN(name({"interactive", "inductive_decl", "parse"}),  interactive_inductive_decl_parse);
+    DECLARE_VM_BUILTIN(name({"interactive", "parse_binders"}),            interactive_parse_binders);
 }
 
 void finalize_vm_parser() {

--- a/tests/lean/keyword_tactics.lean
+++ b/tests/lean/keyword_tactics.lean
@@ -1,0 +1,32 @@
+example : ℕ → ℕ → ℕ :=
+begin
+  assume n m,
+  apply n
+end
+
+example : ℕ → ℕ → ℕ :=
+begin
+  assume (n m : ℕ),
+  apply n
+end
+
+example : ℕ → ℕ → ℕ :=
+begin
+  assume n m : bool,
+  apply n
+end
+
+example : ℕ → ℕ → ℕ :=
+begin
+  have: _ → ℕ,
+  { assume m : ℕ, apply m },
+  { assume n, apply this },
+end
+
+
+example : ℕ → ℕ → ℕ :=
+begin
+  suppose: ℕ,
+  suppose m,
+  apply this
+end

--- a/tests/lean/keyword_tactics.lean.expected.out
+++ b/tests/lean/keyword_tactics.lean.expected.out
@@ -1,0 +1,6 @@
+keyword_tactics.lean:15:2: error: unify tactic failed, failed to unify
+  bool : Type
+and
+  ℕ : Type
+state:
+⊢ ℕ → ℕ → ℕ


### PR DESCRIPTION
`assume` works the same as in term mode, except without anonymous constructor notation (would depend on #1483). `suppose` uses the same syntax as `have`/`let` without the value part, `suppose [id] [: type]`.