### PR TITLE
Escaped identifiers

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -15,6 +15,9 @@ master branch (aka work in progress branch)
   Simplified hypotheses are automatically inserted into the simplification set
   as additional simplification rules.
 
+* Add `«id»` notation that can be used to declare and refer to identifiers containing prohibited characters.
+  For example, `a.«b.c»` is a two-part identifier with parts `a` and `b.c`.
+
 *Changes*
 
 * We now have two type classes for converting to string: `has_to_string` and `has_repr`.

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -516,7 +516,7 @@ tactic.any_goals
 meta def focus (tac : itactic) : tactic unit :=
 tactic.focus [tac]
 
-meta def assume_tac (p : parse parse_binders) : tactic unit :=
+meta def «assume» (p : parse parse_binders) : tactic unit :=
 list.mfor' p $ λ b,
   do t ← target,
      when (not $ t.is_pi ∨ t.is_let) whnf_target,
@@ -526,13 +526,13 @@ list.mfor' p $ λ b,
      unify ty t.binding_domain,
      intro_core b.local_pp_name
 
-meta def suppose_tac (h : parse ident?) (q : parse (tk ":" *> texpr)?) : tactic unit :=
+meta def «suppose» (h : parse ident?) (q : parse (tk ":" *> texpr)?) : tactic unit :=
 let h := h.get_or_else `this in
 match q with
 | some e := do
   uniq_name ← mk_fresh_name,
   let l := expr.local_const uniq_name h binder_info.default e,
-  assume_tac [l]
+  «assume» [l]
 | none := intro h
 end
 
@@ -545,7 +545,7 @@ The new subgoal becomes the main goal. If `T` is omitted, it will be replaced by
 
 If `h` is omitted, it defaults to `this`.
 -/
-meta def have_tac (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : tactic unit :=
+meta def «have» (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : tactic unit :=
 let h := h.get_or_else `this in
 match q₁, q₂ with
 | some e, some p := do
@@ -571,7 +571,7 @@ The new subgoal becomes the main goal. If `T` is omitted, it will be replaced by
 
 If `h` is omitted, it defaults to `this`.
 -/
-meta def let_tac (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : tactic unit :=
+meta def «let» (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : tactic unit :=
 let h := h.get_or_else `this in
 match q₁, q₂ with
 | some e, some p := do
@@ -959,16 +959,16 @@ do e ← to_expr p, tactic.type_check e, infer_type e >>= trace
 meta def done : tactic unit :=
 tactic.done
 
-private meta def show_tac_aux (p : pexpr) : list expr → list expr → tactic unit
+private meta def show_aux (p : pexpr) : list expr → list expr → tactic unit
 | []      r := fail "show tactic failed"
 | (g::gs) r := do
   do {set_goals [g], g_ty ← target, ty ← i_to_expr p, unify g_ty ty, set_goals (g :: r.reverse ++ gs), tactic.change ty}
   <|>
-  show_tac_aux gs (g::r)
+  show_aux gs (g::r)
 
-meta def show_tac (q : parse texpr) : tactic unit :=
+meta def «show» (q : parse texpr) : tactic unit :=
 do gs ← get_goals,
-   show_tac_aux q gs []
+   show_aux q gs []
 
 end interactive
 end tactic

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -77,7 +77,7 @@ tactic.interactive.change q none (loc.ns [])
 meta def exact (q : parse texpr) : smt_tactic unit :=
 tactic.interactive.exact q
 
-meta def assume_tac (p : parse parse_binders) : smt_tactic unit :=
+meta def «assume» (p : parse parse_binders) : smt_tactic unit :=
 list.mfor' p $ λ b,
   do t ← tactic.target,
      when (not $ t.is_pi ∨ t.is_let) tactic.whnf_target,
@@ -87,17 +87,17 @@ list.mfor' p $ λ b,
      tactic.unify ty t.binding_domain,
      smt_tactic.intro_lst [b.local_pp_name]
 
-meta def suppose_tac (h : parse ident?) (q : parse (tk ":" *> texpr)?) : smt_tactic unit :=
+meta def «suppose» (h : parse ident?) (q : parse (tk ":" *> texpr)?) : smt_tactic unit :=
 let h := h.get_or_else `this in
 match q with
 | some e := do
   uniq_name ← tactic.mk_fresh_name,
   let l := expr.local_const uniq_name h binder_info.default e,
-  assume_tac [l]
+  «assume» [l]
 | none := smt_tactic.intro_lst [h]
 end
 
-meta def have_tac (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : smt_tactic unit :=
+meta def «have» (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : smt_tactic unit :=
 let h := h.get_or_else `this in
 match q₁, q₂ with
 | some e, some p := do
@@ -114,7 +114,7 @@ match q₁, q₂ with
   smt_tactic.assert h e
 end >> return ()
 
-meta def let_tac (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : smt_tactic unit :=
+meta def «let» (h : parse ident?) (q₁ : parse (tk ":" *> texpr)?) (q₂ : parse $ (tk ":=" *> texpr)?) : smt_tactic unit :=
 let h := h.get_or_else `this in
 match q₁, q₂ with
 | some e, some p := do

--- a/src/emacs/lean-syntax.el
+++ b/src/emacs/lean-syntax.el
@@ -57,6 +57,8 @@
     (modify-syntax-entry ?/ ". 14nb" st)
     (modify-syntax-entry ?- ". 123" st)
     (modify-syntax-entry ?\n ">" st)
+    (modify-syntax-entry ?« "<" st)
+    (modify-syntax-entry ?» ">" st)
 
     ;; Word constituent
     (--map (modify-syntax-entry it "w" st)
@@ -166,6 +168,11 @@
      (,(rx symbol-start "_" symbol-end) . 'font-lock-preprocessor-face)
      ;; warnings
      (,lean-warnings-regexp . 'font-lock-warning-face)
+     ;; escaped identifiers
+     (,(rx (and (group "«") (group (one-or-more (not (any "»")))) (group "»")))
+      (1 font-lock-comment-face t)
+      (2 nil t)
+      (3 font-lock-comment-face t))
      )))
 
 ;; Syntax Highlighting for Lean Info Mode

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -3853,7 +3853,7 @@ static expr resolve_local_name(environment const & env, local_context const & lc
         } catch (exception &) {}
     }
     if (!r)
-        throw elaborator_exception(src, format("unknown identifier '") + format(id) + format("'"));
+        throw elaborator_exception(src, format("unknown identifier '") + format(id.escape()) + format("'"));
     return *r;
 }
 

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -1988,7 +1988,7 @@ expr parser::id_to_expr(name const & id, pos_info const & p, bool resolve_only, 
         } catch (exception &) {}
     }
     if (!r) {
-        return parser_error_or_expr({sstream() << "unknown identifier '" << id << "'", p});
+        return parser_error_or_expr({sstream() << "unknown identifier '" << id.escape() << "'", p});
     }
     return *r;
 }
@@ -2043,7 +2043,7 @@ list<name> parser::to_constants(name const & id, char const * msg, pos_info cons
     }
 
     if (rs.empty()) {
-        throw parser_error(sstream() << "unknown identifier '" << id << "'", p);
+        throw parser_error(sstream() << "unknown identifier '" << id.escape() << "'", p);
     }
 
     return to_list(rs);

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -669,6 +669,10 @@ optional<name> pretty_fn::is_aliased(name const & n) const {
     }
 }
 
+static format escape(name const & n) {
+    return format(n.escape());
+}
+
 auto pretty_fn::pp_const(expr const & e, optional<unsigned> const & num_ref_univ_params) -> result {
     if (is_neutral_expr(e) && m_unicode)
         return format("◾");
@@ -720,11 +724,11 @@ auto pretty_fn::pp_const(expr const & e, optional<unsigned> const & num_ref_univ
         to_buffer(const_levels(e), ls);
         if (num_ref_univ_params) {
             if (ls.size() <= *num_ref_univ_params)
-                return result(format(n));
+                return result(escape(n));
             else
                 first_idx = *num_ref_univ_params;
         }
-        format r = compose(format(n), format(".{"));
+        format r = compose(escape(n), format(".{"));
         bool first = true;
         for (unsigned i = first_idx; i < ls.size(); i++) {
             level const & l = ls[i];
@@ -740,7 +744,7 @@ auto pretty_fn::pp_const(expr const & e, optional<unsigned> const & num_ref_univ
         r += format("}");
         return result(group(r));
     } else {
-        return result(format(n));
+        return result(escape(n));
     }
 }
 
@@ -765,7 +769,7 @@ auto pretty_fn::pp_local(expr const & e) -> result {
     if (m_locals_full_names)
         return result(format("<") + format(n + mlocal_name(e)) + format(">"));
     else
-        return format(n);
+        return format(escape(n));
 }
 
 bool pretty_fn::has_implicit_args(expr const & f) {
@@ -893,7 +897,7 @@ format pretty_fn::pp_binder(expr const & local) {
     auto bi = local_info(local);
     if (bi != binder_info())
         r += format(open_binder_string(bi, m_unicode));
-    r += format(local_pp_name(local));
+    r += escape(local_pp_name(local));
     if (m_binder_types) {
         r += space();
         r += compose(colon(), nest(m_indent, compose(line(), pp_child(mlocal_type(local), 0).fmt())));
@@ -908,7 +912,7 @@ format pretty_fn::pp_binder_block(buffer<name> const & names, expr const & type,
     if (m_binder_types || bi != binder_info())
         r += format(open_binder_string(bi, m_unicode));
     for (name const & n : names) {
-        r += format(n);
+        r += escape(n);
     }
     if (m_binder_types) {
         r += space();
@@ -1009,7 +1013,7 @@ auto pretty_fn::pp_have(expr const & e) -> result {
     format proof_fmt = pp_child(proof, 0).fmt();
     format body_fmt  = pp_child(body, 0).fmt();
     format head_fmt  = *g_have_fmt;
-    format r = head_fmt + space() + format(n) + space();
+    format r = head_fmt + space() + escape(n) + space();
     r += colon() + nest(m_indent, line() + type_fmt + comma() + space() + *g_from_fmt);
     r = group(r);
     r += nest(m_indent, line() + proof_fmt + comma());

--- a/src/frontends/lean/scanner.h
+++ b/src/frontends/lean/scanner.h
@@ -10,6 +10,7 @@ Author: Leonardo de Moura
 #include "kernel/pos_info_provider.h"
 #include "util/name.h"
 #include "util/flet.h"
+#include "util/utf8.h"
 #include "util/numerics/mpq.h"
 #include "kernel/environment.h"
 #include "library/io_state.h"
@@ -19,8 +20,6 @@ namespace lean {
 enum class token_kind {Keyword, CommandKeyword, Identifier, Numeral, Decimal,
         String, Char, QuotedSymbol,
         DocBlock, ModDocBlock, FieldNum, FieldName, Eof};
-
-using uchar = unsigned char;
 
 /**
     \brief Scanner. The behavior of the scanner is controlled using a token set.
@@ -119,11 +118,6 @@ public:
     };
 };
 std::ostream & operator<<(std::ostream & out, token_kind k);
-bool is_id_rest(uchar const * begin, uchar const * end);
-inline bool is_id_rest(char const * begin, char const * end) {
-    return is_id_rest(reinterpret_cast<uchar const *>(begin),
-                      reinterpret_cast<uchar const *>(end));
-}
 
 class token {
     token_kind  m_kind;

--- a/src/frontends/lean/tactic_notation.cpp
+++ b/src/frontends/lean/tactic_notation.cpp
@@ -119,15 +119,6 @@ static bool is_curr_exact_shortcut(parser & p) {
     return p.curr_is_token(get_calc_tk());
 }
 
-static bool is_keyword_tactic(parser & p) {
-    return
-            p.curr_is_token(get_assume_tk()) ||
-            p.curr_is_token(get_suppose_tk()) ||
-            p.curr_is_token(get_let_tk()) ||
-            p.curr_is_token(get_have_tk()) ||
-            p.curr_is_token(get_show_tk());
-}
-
 static optional<name> is_interactive_tactic(parser & p, name const & tac_class) {
     name id;
     switch (p.curr()) {
@@ -135,11 +126,8 @@ static optional<name> is_interactive_tactic(parser & p, name const & tac_class) 
             id = p.get_name_val();
             break;
         case token_kind::Keyword:
-            if (is_keyword_tactic(p)) {
-                id = p.get_token_info().value().append_after("_tac");
-                break;
-            }
-            /* fall through */
+            id = p.get_token_info().value();
+            break;
         default:
             return {};
     }

--- a/src/tests/frontends/lean/scanner.cpp
+++ b/src/tests/frontends/lean/scanner.cpp
@@ -191,6 +191,25 @@ static void tst4(unsigned N) {
     std::cout << i << "\n";
 }
 
+static void tst_id_escape() {
+    check_name("«a»", name("a"));
+    check_name("«a».b", name({"a", "b"}));
+    check_name("a.«b»", name({"a", "b"}));
+    check_name("a.«b».c", name({"a", "b", "c"}));
+
+    check_name("«a.b».c", name({"a.b", "c"}));
+    check_name("«a b».c", name({"a b", "c"}));
+    check_name("«a🍏b».c", name({"a🍏b", "c"}));
+
+    check_name("a«b»", "ab");
+    check_name("«a»b", "ab");
+
+    scan_error("«");
+    scan_error("«a");
+    scan_error("«a\nb»");
+    scan_error("a.«");
+}
+
 int main() {
     save_stack_info();
     initialize();
@@ -198,6 +217,7 @@ int main() {
     tst2();
     tst3();
     tst4(100000);
+    tst_id_escape();
     finalize();
     return has_violations() ? 1 : 0;
 }

--- a/src/util/name.cpp
+++ b/src/util/name.cpp
@@ -35,7 +35,8 @@ bool is_letter_like_unicode(unsigned u) {
 bool is_sub_script_alnum_unicode(unsigned u) {
     return
             (0x207f <= u && u <= 0x2089) || // n superscript and numberic subscripts
-            (0x2090 <= u && u <= 0x209c);   // letter-like subscripts
+            (0x2090 <= u && u <= 0x209c) || // letter-like subscripts
+            (0x1d62 <= u && u <= 0x1d6a);   // letter-like subscripts
 }
 
 bool is_id_first(char const * begin, char const * end) {

--- a/src/util/name.h
+++ b/src/util/name.h
@@ -18,6 +18,21 @@ Author: Leonardo de Moura
 
 namespace lean {
 constexpr char const * lean_name_separator = ".";
+constexpr char16_t id_begin_escape = u'«';
+constexpr char16_t id_end_escape = u'»';
+
+bool is_id_first(char const * begin, char const * end);
+inline bool is_id_first(unsigned char const * begin, unsigned char const * end) {
+    return is_id_first(reinterpret_cast<char const *>(begin),
+                      reinterpret_cast<char const *>(end));
+}
+
+bool is_id_rest(char const * begin, char const * end);
+inline bool is_id_rest(unsigned char const * begin, unsigned char const * end) {
+    return is_id_rest(reinterpret_cast<char const *>(begin),
+                      reinterpret_cast<char const *>(end));
+}
+
 enum class name_kind { ANONYMOUS, STRING, NUMERAL };
 /**
    \brief Hierarchical names.
@@ -36,8 +51,8 @@ public:
         };
         void dealloc();
         imp(bool s, imp * p):m_rc(1), m_is_string(s), m_hash(0), m_prefix(p) { if (p) p->inc_ref(); }
-        static void display_core(std::ostream & out, imp * p, char const * sep);
-        static void display(std::ostream & out, imp * p, char const * sep = lean_name_separator);
+        static void display_core(std::ostream & out, imp * p, bool escape, char const * sep);
+        static void display(std::ostream & out, imp * p, bool escape, char const * sep = lean_name_separator);
         friend void copy_limbs(imp * p, buffer<name::imp *> & limbs);
     };
 private:
@@ -125,6 +140,7 @@ public:
     name get_root() const;
     /** \brief Convert this hierarchical name into a string. */
     std::string to_string(char const * sep = lean_name_separator) const;
+    std::string escape(char const * sep = lean_name_separator) const;
     /** \brief Size of the this name (in characters). */
     size_t size() const;
     /** \brief Size of the this name in unicode. */

--- a/src/util/utf8.h
+++ b/src/util/utf8.h
@@ -9,10 +9,17 @@ Author: Leonardo de Moura
 #include "util/optional.h"
 
 namespace lean {
+using uchar = unsigned char;
+
 bool is_utf8_next(unsigned char c);
 unsigned get_utf8_size(unsigned char c);
 size_t utf8_strlen(char const * str);
 optional<size_t> utf8_char_pos(char const * str, size_t char_idx);
 char const * get_utf8_last_char(char const * str);
 std::string utf8_trim(std::string const & s);
+unsigned utf8_to_unicode(uchar const * begin, uchar const * end);
+inline unsigned utf8_to_unicode(char const * begin, char const * end) {
+    return utf8_to_unicode(reinterpret_cast<uchar const *>(begin),
+                           reinterpret_cast<uchar const *>(end));
+}
 }

--- a/tests/lean/escape_id.lean
+++ b/tests/lean/escape_id.lean
@@ -1,0 +1,17 @@
+def «def» := 1
+#check «def»
+
+def «[ ]» := 1
+#check «[ ]»
+#check «[»
+
+def a.«b.c» := 1
+#check a.«b.c»
+#check a.b.c
+#check «a.b.c»
+
+#check [1].«length»
+
+#check ««»
+#check «
+»

--- a/tests/lean/escape_id.lean.expected.out
+++ b/tests/lean/escape_id.lean.expected.out
@@ -1,0 +1,12 @@
+def : ℕ
+«[ ]» : ℕ
+escape_id.lean:6:7: error: unknown identifier '«[»'
+a.«b.c» : ℕ
+escape_id.lean:10:7: error: unknown identifier 'a.b.c'
+escape_id.lean:11:7: error: unknown identifier '«a.b.c»'
+list.length [1] : ℕ
+escape_id.lean:15:8: error: illegal character in escaped identifier
+escape_id.lean:16:0: error: invalid expression, unexpected token
+escape_id.lean:16:8: error: illegal character in escaped identifier
+escape_id.lean:17:0: error: unexpected token
+escape_id.lean:17:1: error: invalid expression, unexpected token


### PR DESCRIPTION
Add `«id»` notation that can be used to declare and refer to identifiers containing prohibited characters. For example, `a.«b.c»` is a two-part identifier with parts `a` and `b.c`.