### PR TITLE
Error recovery in the equations compiler

### DIFF
--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -245,18 +245,6 @@ expr elaborator::recoverable_error(optional<expr> const & expected_type, expr co
     return mk_sorry(expected_type, ref);
 }
 
-template <class Fn>
-expr elaborator::recover_expr_from_exception(optional<expr> const & expected_type, expr const & ref, Fn && fn) {
-    try {
-        return fn();
-    } catch (std::exception & ex) {
-        if (!try_report(ex, some_expr(ref))) {
-            throw;
-        } else {
-            return mk_sorry(expected_type, ref);
-        }
-    }
-}
 
 level elaborator::mk_univ_metavar() {
     return m_ctx.mk_univ_metavar_decl();
@@ -2372,7 +2360,7 @@ expr elaborator::visit_equations(expr const & e) {
     new_e = instantiate_mvars(new_e);
     ensure_no_unassigned_metavars(new_e);
     metavar_context mctx = m_ctx.mctx();
-    expr r = compile_equations(m_env, m_opts, mctx, m_ctx.lctx(), new_e);
+    expr r = compile_equations(m_env, m_opts, mctx, m_ctx.lctx(), new_e, *this);
     m_ctx.set_env(m_env);
     m_ctx.set_mctx(mctx);
     return r;

--- a/src/frontends/lean/elaborator.h
+++ b/src/frontends/lean/elaborator.h
@@ -157,6 +157,8 @@ private:
 
     bool has_synth_sorry(expr const & e) { return has_synth_sorry({e}); }
     bool has_synth_sorry(std::initializer_list<expr> && es);
+
+public:
     bool try_report(std::exception const & ex);
     bool try_report(std::exception const & ex, optional<expr> const & ref);
     void report_or_throw(elaborator_exception const & ex);
@@ -165,6 +167,7 @@ private:
     expr recoverable_error(optional<expr> const & expected_type, expr const & ref, elaborator_exception const & ex);
     template <class Fn> expr recover_expr_from_exception(optional<expr> const & expected_type, expr const & ref, Fn &&);
 
+private:
     expr ensure_type(expr const & e, expr const & ref);
     expr ensure_function(expr const & e, expr const & ref);
     optional<expr> ensure_has_type(expr const & e, expr const & e_type, expr const & type, expr const & ref);
@@ -342,6 +345,19 @@ public:
 
     bool has_errors() const { return m_has_errors; }
 };
+
+template <class Fn>
+expr elaborator::recover_expr_from_exception(optional<expr> const & expected_type, expr const & ref, Fn && fn) {
+    try {
+        return fn();
+    } catch (std::exception & ex) {
+        if (!try_report(ex, some_expr(ref))) {
+            throw;
+        } else {
+            return mk_sorry(expected_type, ref);
+        }
+    }
+}
 
 pair<expr, level_param_names> elaborate(environment & env, options const & opts, name const & decl_name,
                                         metavar_context & mctx, local_context const & lctx,

--- a/src/library/equations_compiler/compiler.h
+++ b/src/library/equations_compiler/compiler.h
@@ -8,8 +8,9 @@ Author: Leonardo de Moura
 #include "library/metavar_context.h"
 #include "library/equations_compiler/equations.h"
 namespace lean {
+class elaborator;
 expr compile_equations(environment & env, options const & opts, metavar_context & mctx, local_context const & lctx,
-                       expr const & eqns);
+                       expr const & eqns, elaborator & elab);
 void initialize_compiler();
 void finalize_compiler();
 }

--- a/src/library/equations_compiler/elim_match.h
+++ b/src/library/equations_compiler/elim_match.h
@@ -8,14 +8,17 @@ Author: Leonardo de Moura
 #include "library/type_context.h"
 #include "library/equations_compiler/util.h"
 namespace lean {
+class elaborator;
 struct elim_match_result {
     expr       m_fn;
     list<expr> m_lemmas;
     list<list<expr>> m_counter_examples;
 };
-elim_match_result elim_match(environment & env, options const & opts, metavar_context & mctx, local_context const & lctx, expr const & eqns);
+elim_match_result elim_match(environment & env, options const & opts, metavar_context & mctx,
+                local_context const & lctx, expr const & eqns, elaborator & elab);
 eqn_compiler_result mk_nonrec(environment & env, options const & opts, metavar_context & mctx,
-               local_context const & lctx, expr const & eqns);
+               local_context const & lctx, expr const & eqns,
+               elaborator & elab);
 void initialize_elim_match();
 void finalize_elim_match();
 }

--- a/src/library/equations_compiler/structural_rec.cpp
+++ b/src/library/equations_compiler/structural_rec.cpp
@@ -957,12 +957,12 @@ struct structural_rec_fn {
         }
     }
 
-    optional<eqn_compiler_result> operator()(expr const & eqns) {
+    optional<eqn_compiler_result> operator()(expr const & eqns, elaborator & elab) {
         m_ref    = eqns;
         m_header = get_equations_header(eqns);
         auto new_eqns = elim_recursion(eqns);
         if (!new_eqns) return {};
-        elim_match_result R = elim_match(m_env, m_opts, m_mctx, m_lctx, *new_eqns);
+        elim_match_result R = elim_match(m_env, m_opts, m_mctx, m_lctx, *new_eqns, elab);
         expr fn = mk_function(R.m_fn);
         if (m_header.m_aux_lemmas) {
             lean_assert(!m_header.m_is_meta);
@@ -977,9 +977,9 @@ struct structural_rec_fn {
 };
 
 optional<eqn_compiler_result> try_structural_rec(environment & env, options const & opts, metavar_context & mctx,
-                                  local_context const & lctx, expr const & eqns) {
+                                  local_context const & lctx, expr const & eqns, elaborator & elab) {
     structural_rec_fn F(env, opts, mctx, lctx);
-    if (auto r = F(eqns)) {
+    if (auto r = F(eqns, elab)) {
         env  = F.env();
         mctx = F.mctx();
         return r;

--- a/src/library/equations_compiler/structural_rec.h
+++ b/src/library/equations_compiler/structural_rec.h
@@ -8,6 +8,7 @@ Author: Leonardo de Moura
 #include "library/type_context.h"
 #include "library/equations_compiler/util.h"
 namespace lean {
+class elaborator;
 /** \brief Try to eliminate "recursive calls" in the equations \c eqns by using brec_on's below.
     If successful, elim_match is used to compile pattern matching.
 
@@ -17,7 +18,7 @@ namespace lean {
        construction, where every recursive call is structurally smaller. */
 optional<eqn_compiler_result> try_structural_rec(environment & env, options const & opts,
                                   metavar_context & mctx, local_context const & lctx,
-                                  expr const & eqns);
+                                  expr const & eqns, elaborator & elab);
 
 void initialize_structural_rec();
 void finalize_structural_rec();

--- a/src/library/equations_compiler/unbounded_rec.cpp
+++ b/src/library/equations_compiler/unbounded_rec.cpp
@@ -36,10 +36,10 @@ static expr replace_rec_apps(type_context & ctx, expr const & e) {
 
 eqn_compiler_result unbounded_rec(environment & env, options const & opts,
                    metavar_context & mctx, local_context const & lctx,
-                   expr const & e) {
+                   expr const & e, elaborator & elab) {
     type_context ctx(env, opts, mctx, lctx, transparency_mode::Semireducible);
     expr e1 = replace_rec_apps(ctx, e);
-    auto R = elim_match(env, opts, mctx, lctx, e1);
+    auto R = elim_match(env, opts, mctx, lctx, e1, elab);
 
     list<expr> counter_examples;
     if (R.m_counter_examples) {

--- a/src/library/equations_compiler/unbounded_rec.h
+++ b/src/library/equations_compiler/unbounded_rec.h
@@ -8,11 +8,12 @@ Author: Leonardo de Moura
 #include "library/type_context.h"
 #include "library/equations_compiler/util.h"
 namespace lean {
+class elaborator;
 /** \brief Eliminate "recursive calls" using rec_fn_macro.
 
     This compilation step can only be used to compile meta definitions.
     If we use it on regular definitions, the kernel will reject it. */
 eqn_compiler_result unbounded_rec(environment & env, options const & opts,
                    metavar_context & mctx, local_context const & lctx,
-                   expr const & eqns);
+                   expr const & eqns, elaborator & elab);
 }

--- a/src/library/equations_compiler/wf_rec.h
+++ b/src/library/equations_compiler/wf_rec.h
@@ -8,9 +8,10 @@ Author: Leonardo de Moura
 #include "library/type_context.h"
 #include "library/equations_compiler/util.h"
 namespace lean {
+class elaborator;
 eqn_compiler_result wf_rec(environment & env, options const & opts,
             metavar_context & mctx, local_context const & lctx,
-            expr const & eqns);
+            expr const & eqns, elaborator & elab);
 void initialize_wf_rec();
 void finalize_wf_rec();
 }

--- a/tests/lean/1162.lean.expected.out
+++ b/tests/lean/1162.lean.expected.out
@@ -1,1 +1,3 @@
 1162.lean:10:12: error: equation compiler error, equation #2 has not been used in the compilation, note that the left-hand-side of equation #1 is a variable
+1162.lean:11:12: error: equation compiler error, equation #3 has not been used in the compilation, note that the left-hand-side of equation #1 is a variable
+1162.lean:12:12: error: equation compiler error, equation #4 has not been used in the compilation, note that the left-hand-side of equation #1 is a variable

--- a/tests/lean/elab_error_recovery.lean
+++ b/tests/lean/elab_error_recovery.lean
@@ -9,7 +9,8 @@ def half_baked : ℕ → ℕ
 -- exceptions during tactic evaluation
 | 7  := by do undefined
 -- nested elaboration errors
-| _  := begin exact [] end
+| 10 := begin exact [] end
+-- missing cases
 
 #print half_baked._main
 

--- a/tests/lean/elab_error_recovery.lean.expected.out
+++ b/tests/lean/elab_error_recovery.lean.expected.out
@@ -19,8 +19,7 @@ elab_error_recovery.lean:12:20: error: invalid type ascription, expression has t
 but is expected to have type
   ℕ
 state:
-half_baked : ℕ → ℕ,
-_x : ℕ
+half_baked : ℕ → ℕ
 ⊢ ℕ
 elab_error_recovery.lean:6:8: error: don't know how to synthesize placeholder
 context:
@@ -30,15 +29,18 @@ elab_error_recovery.lean:8:29: error: don't know how to synthesize placeholder
 context:
 half_baked : ℕ → ℕ
 ⊢ ℕ
+elab_error_recovery.lean:1:4: error: non-exhaustive match, the following cases are missing:
+half_baked _
 def half_baked._main : ℕ → ℕ :=
 λ (a : ℕ),
   ite (a = 3) (id_rhs ℕ 2)
     (ite (a = 0) (id_rhs ℕ (1 + ⁇))
        (ite (a = 5) (id_rhs ℕ (⁇ + 4))
-          (ite (a = 42) (id_rhs ℕ (ite (2 ∈ 3) 3 ⁇)) (ite (a = 7) (id_rhs ℕ ⁇) (id_rhs ℕ ⁇)))))
+          (ite (a = 42) (id_rhs ℕ (ite (2 ∈ 3) 3 ⁇))
+             (ite (a = 7) (id_rhs ℕ ⁇) (ite (a = 10) (id_rhs ℕ ⁇) ⁇)))))
 2
 nat.succ (nat.succ (nat.succ (nat.succ ⁇)))
 2
-elab_error_recovery.lean:21:13: error: type expected at
+elab_error_recovery.lean:22:13: error: type expected at
   0
 ∀ (x : ⁇), x = x : Prop


### PR DESCRIPTION
Adds error recovery to the equations compiler:
 * Non-exhaustive matches can now be compiled.
 * Failed proofs of well-foundedness are substituted with sorry.
 * We show all failed well-foundedness conditions, not just the first one.  You can immediately spot the unproven recursive calls by the red squiggles in the editor.
 * Equational lemmas can still be generated (with some exceptions, probably).
 * Missing cases in non-exhaustive matches are always reported.
 * The resulting definitions can be executed by the VM.

The concrete motivation for this change was a function with 20 equations and about twice as many recursive calls.  So adding `have ... := sorry` for the well-foundedness conditions was not really an option.  I'd like to see all failed recursive calls and their well-foundedness conditions upfront, so that I can see the interesting cases and figure out a suitable well-founded relation.  Besides, it's also nice to be able to use `#eval` as a sanity check, and prove correctness while ignoring termination at first.

The main ugliness here is that we keep a reference to the elaborator in the equations compiler.  (This is the easiest way to get the right behavior with backtracking, and we can also reuse helper functions.)  I think this part will change with #1674 anyhow, my plan would be to pass the `elaborator_state` object to the equation compiler then--this might even simplify the functions a bit, since we already pass half the elaborator state as separate arguments (environment, options, and metavariable/local context).