### PR TITLE
feat(src/library/tactic): add list_axioms tactic

### DIFF
--- a/library/init/meta/tactic.lean
+++ b/library/init/meta/tactic.lean
@@ -424,6 +424,7 @@ meta constant set_env : environment → tactic unit
 /-- (doc_string env d k) return the doc string for d (if available) -/
 meta constant doc_string : name → tactic string
 meta constant add_doc_string : name → string → tactic unit
+meta constant list_axioms : name → tactic (list name)
 /--
 Create an auxiliary definition with name `c` where `type` and `value` may contain local constants and
 meta-variables. This function collects all dependencies (universe parameters, universe metavariables,

--- a/src/library/tactic/CMakeLists.txt
+++ b/src/library/tactic/CMakeLists.txt
@@ -9,4 +9,4 @@ add_library(tactic OBJECT occurrences.cpp kabstract.cpp tactic_state.cpp
   simp_result.cpp user_attribute.cpp eval.cpp
   simp_lemmas.cpp eqn_lemmas.cpp dsimplify.cpp simplify.cpp
   vm_monitor.cpp destruct_tactic.cpp norm_num_tactic.cpp hole_command.cpp
-  elaborator_exception.cpp algebraic_normalizer.cpp tactic_evaluator.cpp)
+  elaborator_exception.cpp algebraic_normalizer.cpp tactic_evaluator.cpp list_axioms_tactic.cpp)

--- a/src/library/tactic/init_module.cpp
+++ b/src/library/tactic/init_module.cpp
@@ -36,6 +36,7 @@ Author: Leonardo de Moura
 #include "library/tactic/destruct_tactic.h"
 #include "library/tactic/algebraic_normalizer.h"
 #include "library/tactic/hole_command.h"
+#include "library/tactic/list_axioms_tactic.h"
 #include "library/tactic/backward/init_module.h"
 #include "library/tactic/smt/init_module.h"
 
@@ -74,10 +75,12 @@ void initialize_tactic_module() {
     initialize_destruct_tactic();
     initialize_algebraic_normalizer();
     initialize_hole_command();
+    initialize_list_axioms_tactic();
     initialize_smt_module();
 }
 void finalize_tactic_module() {
     finalize_smt_module();
+    finalize_list_axioms_tactic();
     finalize_hole_command();
     finalize_algebraic_normalizer();
     finalize_destruct_tactic();

--- a/src/library/tactic/list_axioms_tactic.cpp
+++ b/src/library/tactic/list_axioms_tactic.cpp
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2017 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Robert Y. Lewis
+*/
+#include "kernel/for_each_fn.h"
+#include "library/util.h"
+#include "library/vm/vm_name.h"
+#include "library/vm/vm_list.h"
+#include "library/tactic/tactic_state.h"
+#include "library/tactic/list_axioms_tactic.h"
+#include "library/sorry.h"
+
+namespace lean {
+
+void list_axioms_deps::visit(name const & n) {
+    if (m_visited.contains(n))
+        return;
+    m_visited.insert(n);
+    declaration const & d = m_env.get(n);
+    if (!d.is_definition() && !m_env.is_builtin(n)) {
+        m_use_axioms = true;
+        m_axioms.insert(d.get_name());
+    }
+    visit(d.get_type());
+    if (d.is_definition())
+        visit(d.get_value());
+}
+
+void list_axioms_deps::visit(expr const & e) {
+    for_each(e, [&](expr const & e, unsigned) {
+        if (is_sorry(e) && !m_used_sorry) {
+            m_used_sorry = true;
+        }
+        if (is_constant(e))
+            visit(const_name(e));
+        return true;
+    });
+}
+
+buffer<name> list_axioms_deps::axiom_list() {
+    buffer<name> b = buffer<name>();
+    m_axioms.to_buffer(b);
+    return b;
+}
+
+vm_obj tactic_list_axioms(vm_obj const & n, vm_obj const & s0) {
+    tactic_state const & s = tactic::to_state(s0);
+    environment const & env = s.env();
+    name nm = to_name(n);
+    try {
+        buffer<name> const & axiom_names = list_axioms_deps(env)(nm);
+        return tactic::mk_success(to_obj(axiom_names), s);
+    } catch (exception e) {
+        return tactic::mk_exception(e, s);
+    }
+}
+    
+void initialize_list_axioms_tactic() {
+    DECLARE_VM_BUILTIN(name({"tactic", "list_axioms"}), tactic_list_axioms);
+}
+
+void finalize_list_axioms_tactic() {
+}
+
+}

--- a/src/library/tactic/list_axioms_tactic.h
+++ b/src/library/tactic/list_axioms_tactic.h
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2017 Robert Y. Lewis. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+Author: Robert Y. Lewis
+*/
+
+#pragma once
+#include "util/name_set.h"
+
+namespace lean {
+
+struct list_axioms_deps {
+    environment     m_env;
+    name_set        m_visited;
+    name_set        m_axioms;
+    bool            m_use_axioms;
+    bool            m_used_sorry;
+    list_axioms_deps(environment const & env):
+        m_env(env), m_use_axioms(false), m_used_sorry(false) {}
+
+    void visit(name const & n);
+    void visit(expr const & e);
+    buffer<name> axiom_list();
+    buffer<name> operator()(name const & n) {
+        visit(n);
+        return axiom_list();
+   }
+};
+
+void initialize_list_axioms_tactic();
+void finalize_list_axioms_tactic();
+
+}

--- a/tests/lean/list_axioms_tactic.lean
+++ b/tests/lean/list_axioms_tactic.lean
@@ -1,0 +1,15 @@
+open tactic
+
+constant α : Type
+constant a : α
+axiom f : ∀ b : α, a = b
+theorem g (b : α) : b = a := eq.symm (f b)
+
+run_cmd list_axioms `g >>= trace
+#print axioms g
+
+run_cmd list_axioms `nat.add_comm >>= trace
+#print axioms nat.add_comm
+
+run_cmd list_axioms `fake_name
+#print axioms fake_name


### PR DESCRIPTION
This copies and slightly modifies the code used for `#print axioms` to add a tactic `list_axioms : name -> tactic (list name)`. 

Two questions. One, the code for this and for `#print axioms` can be combined pretty easily, but I wasn't sure where it should live. I'm happy to make that change if someone suggests a place. Two, `sorry` won't appear in the list of axioms, since it isn't a name. We could change the type to `name -> tactic (list name x bool)`, but that's slightly less convenient to use. Thoughts? Should we add both variants?