### PR TITLE
fix(init/meta/tactic): skip solved goals in seq_focus and seq

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -547,7 +547,7 @@ tactic.skip
 meta def solve1 : itactic → tactic unit :=
 tactic.solve1
 
-meta def abstract (id : parse ident? ) (tac : itactic) : tactic unit :=
+meta def abstract (id : parse ident?) (tac : itactic) : tactic unit :=
 tactic.abstract tac id
 
 meta def all_goals : itactic → tactic unit :=

--- a/tests/lean/andthen_focus_error_message.lean.expected.out
+++ b/tests/lean/andthen_focus_error_message.lean.expected.out
@@ -8,11 +8,9 @@ a b c : ℕ
 ⊢ b = b
 andthen_focus_error_message.lean:16:14: error: focus tactic failed, insufficient number of tactics
 state:
-no goals
-andthen_focus_error_message.lean:22:14: error: focus tactic failed, insufficient number of tactics
-state:
 a : ℕ
 ⊢ a = a
-
+andthen_focus_error_message.lean:22:14: error: focus tactic failed, insufficient number of tactics
+state:
 a : ℕ
 ⊢ a = a

--- a/tests/lean/interactive/focus.lean.expected.out
+++ b/tests/lean/interactive/focus.lean.expected.out
@@ -1,4 +1,4 @@
-{"msgs":[{"caption":"","file_name":"f","pos_col":2,"pos_line":4,"severity":"error","text":"focus tactic failed, insufficient number of tactics\nstate:\nb c : ℕ,\na_2 : b = 0\n⊢ b = 0"}],"response":"all_messages"}
+{"msgs":[{"caption":"","file_name":"f","pos_col":2,"pos_line":4,"severity":"error","text":"focus tactic failed, insufficient number of tactics\nstate:\na b c : ℕ,\na_1 : a = b,\na_2 : b = 0\n⊢ b = a"}],"response":"all_messages"}
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"record":{"source":,"state":"a b c : ℕ,\na_1 : a = b,\na_2 : b = 0\n⊢ a = 0","tactic_param_idx":0,"tactic_params":["{ tactic }"],"text":"focus","type":"tactic.interactive.itactic → tactic unit"},"response":"ok","seq_num":5}
 {"record":{"source":,"state":"b c : ℕ,\na_2 : b = 0\n⊢ b = 0","tactic_param_idx":0,"tactic_params":["{ tactic }"],"text":"focus","type":"tactic.interactive.itactic → tactic unit"},"response":"ok","seq_num":7}

--- a/tests/lean/run/dependent_seq.lean
+++ b/tests/lean/run/dependent_seq.lean
@@ -1,0 +1,8 @@
+
+theorem test (n : nat) (h : n = n) : true := trivial
+
+example (h : 3 = 3) : true :=
+by apply test; assumption
+
+example (h : 3 = 3) : true :=
+by apply test; [assumption]


### PR DESCRIPTION
and all/any_goals. This occurs when solving the first subgoal generated by `tac1; tac2` closes the second goal as well, before the second `tac2` invocation is run. Reported by @jldodds on gitter.