### PR TITLE
feat(init/logic): false.elim eliminates to Sort

### DIFF
--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -41,8 +41,8 @@ assume hna : ¬a, absurd ha hna
 
 /- false -/
 
-lemma false.elim {c : Prop} (h : false) : c :=
-false.rec c h
+@[inline] def false.elim {C : Sort u} (h : false) : C :=
+false.rec C h
 
 /- eq -/
 


### PR DESCRIPTION
Now false.elim is almost the same as false.rec, except that it is non-dependent and is not elaborated as an eliminator like false.rec. The `@[inline]` attribute may be superfluous, since the definition is very short.

This is a resubmission of one part of #1777.