### PR TITLE
fix(init/meta/interactive_base): declare |- notation

### DIFF
--- a/library/init/meta/interactive_base.lean
+++ b/library/init/meta/interactive_base.lean
@@ -59,6 +59,9 @@ meta def brackets (l r : string) (p : parser α) := tk l *> p <* tk r
 
 meta def list_of (p : parser α) := brackets "[" "]" $ sep_by (skip_info (tk ",")) p
 
+precedence `⊢` : 0
+precedence `|-` : 0
+
 /-- A 'tactic expression', which uses right-binding power 2 so that it is terminated by
     '<|>' (rbp 2), ';' (rbp 1), and ',' (rbp 0). It should be used for any (potentially)
     trailing expression parameters. -/

--- a/tests/lean/run/simp_options.lean
+++ b/tests/lean/run/simp_options.lean
@@ -48,3 +48,10 @@ by simp [fab] at h; assumption
 
 example (h : p (f a)) : p (f b) :=
 by simp only [fab] at h; assumption
+
+example (h₁ : p (f a)) (h₂ : p (f a)) : p (f a) :=
+begin
+  simp only [fab] at h₁ ⊢,
+  tactic.fail_if_success `[exact h₂],
+  exact h₁
+end


### PR DESCRIPTION
This fixes a bug in 26548c9 preventing it from actually being used. It declares the `|-` and `⊢` tokens so that `tk` will work with them. A test case has been added to test `simp at ⊢` notation.

This is a resubmission of one part of #1777.