### PR TITLE
feat(init/meta/interactive): multiple subst

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -919,8 +919,8 @@ tactic.ac_refl
 meta def cc : tactic unit :=
 tactic.cc
 
-meta def subst (q : parse texpr) : tactic unit :=
-i_to_expr q >>= tactic.subst >> try (tactic.reflexivity reducible)
+meta def subst (l : parse parser.pexpr*) : tactic unit :=
+l.mmap' $ λ q, i_to_expr q >>= tactic.subst >> try (tactic.reflexivity reducible)
 
 meta def clear : parse ident* → tactic unit :=
 tactic.clear_lst

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -919,8 +919,8 @@ tactic.ac_refl
 meta def cc : tactic unit :=
 tactic.cc
 
-meta def subst (l : parse parser.pexpr*) : tactic unit :=
-l.mmap' $ λ q, i_to_expr q >>= tactic.subst >> try (tactic.reflexivity reducible)
+meta def subst (l : parse identa*) : tactic unit :=
+l.mmap' $ λ q, q.get >>= tactic.subst >> try (tactic.reflexivity reducible)
 
 meta def clear : parse ident* → tactic unit :=
 tactic.clear_lst

--- a/tests/lean/run/simulate_on.lean
+++ b/tests/lean/run/simulate_on.lean
@@ -5,3 +5,11 @@ begin
   guard_target b + 0 + 0 = b,
   reflexivity
 end
+
+example (a b c : nat) : a = 0 → b = 1 → c = 0 → b + a + c = b :=
+begin
+  intros h1 h2 h3,
+  subst h1 h3,
+  guard_target b + 0 + 0 = b,
+  reflexivity
+end


### PR DESCRIPTION
This allows `subst a, subst b, subst c` to be written `subst a b c`. In order to support `‹_›` notation without backtracking, a special parser is introduced for mixed identifier / assumption brackets, which can be listed without delimiters, making it possible to use them in other places where hypothesis names are expected (such as `at h1 h2`).

I attempted to use the `parser.pexpr` parser directly, and this almost works, but it breaks code such as `begin subst a end` because `end` is parsed as an expr and fails *after* consuming the token, so the parser cannot continue. The `ident` and `tk` parsers do not consume their input on failure, which is why the `identa` parser still works in this situation. This can be worked around by using a comma as in `begin subst a, end` but this PR instead special cases the `‹_›` notation to maintain backward compatibility.

This is a resubmission of one part of #1777.