### PR TITLE
feat(init/meta/injection_tactic): injection also does subst

### DIFF
--- a/library/init/meta/injection_tactic.lean
+++ b/library/init/meta/injection_tactic.lean
@@ -25,8 +25,9 @@ private meta def injection_intro : expr → list name → tactic (list expr × l
 | e  ns           := return ([], ns)
 
 -- Tries to decompose the given expression by constructor injectivity.
--- Returns the list of new hypotheses, and the remaining names from the given list.
-meta def injection_with (h : expr) (ns : list name) : tactic (list expr × list name) :=
+-- Returns the list of new hypotheses, and the remaining names from the given list,
+-- or none if the goal was closed.
+meta def injection_with (h : expr) (ns : list name) : tactic (option (list expr × list name)) :=
 do
   ht ← infer_type h,
   (lhs0, rhs0) ← match_eq ht,
@@ -46,30 +47,35 @@ do
       pr_type ← infer_type pr,
       pr_type ← whnf pr_type,
       eapply pr,
-      injection_intro (binding_domain pr_type) ns
+      try (clear h),
+      some <$> injection_intro (binding_domain pr_type) ns
     else fail "injection tactic failed, argument must be an equality proof where lhs and rhs are of the form (c ...), where c is a constructor"
-  else do
+  else
+  let Il := name.get_prefix n_fl,
+      Ir := name.get_prefix n_fr in
+  if Il = Ir then do
     tgt ← target,
-    let I_name := name.get_prefix n_fl,
-    pr ← mk_app (I_name <.> "no_confusion") [tgt, lhs, rhs, h],
+    pr ← mk_app (Il <.> "no_confusion") [tgt, lhs, rhs, h],
     exact pr,
-    return ([], ns)
+    return none
+  else if lhs.is_local_constant || rhs.is_local_constant then
+    subst h >> return (some ([], ns))
+  else
+    fail "injection tactic failed, argument must be an equality proof where lhs and rhs are of the form (c ...), where c is a constructor"
 
 meta def injection (h : expr) : tactic (list expr) :=
-do (t, _) ← injection_with h [], return t
+do o ← injection_with h [],
+   return $ option.rec [] prod.fst o
 
-private meta def injections_with_inner : nat → list expr → list name → tactic unit
+meta def injections_with : nat → list expr → list name → tactic unit
 | 0     lc        ns := fail "recursion depth exceeded"
 | (n+1) []        ns := skip
 | (n+1) (h :: lc) ns :=
   do o ← try_core (injection_with h ns), match o with
-  | none          := injections_with_inner (n+1) lc ns
-  | some ([], _)  := skip -- This means that the contradiction part was triggered and the goal is done
-  | some (t, ns') := injections_with_inner n (t ++ lc) ns'
+  | none                  := injections_with (n+1) lc ns
+  | some none             := skip
+  | some (some ([], ns')) := injections_with (n+1) lc ns'
+  | some (some (t, ns'))  := injections_with n (t ++ lc) ns'
   end
-
-meta def injections_with (ns : list name) : tactic unit :=
-do lc ← local_context,
-   injections_with_inner 5 lc ns
 
 end tactic

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -684,7 +684,9 @@ meta def injection (q : parse texpr) (hs : parse with_ident_list) : tactic unit 
 do e ← i_to_expr q, tactic.injection_with e hs, try assumption
 
 meta def injections (hs : parse with_ident_list) : tactic unit :=
-do tactic.injections_with hs, try assumption
+do lc ← local_context,
+   tactic.injections_with 5 lc hs,
+   try assumption
 
 end interactive
 

--- a/tests/lean/run/interactive1.lean
+++ b/tests/lean/run/interactive1.lean
@@ -26,7 +26,7 @@ open nat
 example (b c : nat) : succ b = succ c → b + 2 = c + 2 :=
 begin
   intro h,
-  injection h with h', clear h,
+  injection h with h',
   trace_state,
   subst h'
 end


### PR DESCRIPTION
Now it should be about as smart as the internal injection tactic used for discharging index equalities in `cases`.

This is a resubmission of one part of #1777.