### PR TITLE
Allow field notation for recursive calls

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -52,6 +52,14 @@ master branch (aka work in progress branch)
 
 * Add `user_attribute.after_set/before_unset` handlers that can be used for validation as well as side-effecting attributes.
 
+* Field notation can now be used to make recursive calls.
+
+```
+def list.append : list α → list α → list α
+| []       l := l
+| (h :: s) t := h :: s.append t
+```
+
 *Changes*
 
 * We now have two type classes for converting to string: `has_to_string` and `has_repr`.

--- a/library/init/meta/rb_map.lean
+++ b/library/init/meta/rb_map.lean
@@ -142,22 +142,22 @@ private meta def format_key {key} [has_to_format key] (k : key) (first : bool) :
 
 namespace rb_set
 meta def insert {key} (s : rb_set key) (k : key) : rb_set key :=
-s.insert k ()
+rb_map.insert s k ()
 
 meta def erase {key} (s : rb_set key) (k : key) : rb_set key :=
-s.erase k
+rb_map.erase s k
 
 meta def contains {key} (s : rb_set key) (k : key) : bool :=
-s.contains k
+rb_map.contains s k
 
 meta def size {key} (s : rb_set key) : nat :=
-s.size
+rb_map.size s
 
 meta def empty {key : Type} (s : rb_set key) : bool :=
-s.empty
+rb_map.empty s
 
 meta def fold {key α : Type} (s : rb_set key) (a : α) (fn : key → α → α) : α :=
-s.fold a (λ k _ a, fn k a)
+rb_map.fold s a (λ k _ a, fn k a)
 
 meta def mfold {key α :Type} {m : Type → Type} [monad m] (s : rb_set key) (a : α) (fn : key → α → m α) : m α :=
 s.fold (return a) (λ k act, act >>= fn k)

--- a/src/frontends/lean/elaborator.h
+++ b/src/frontends/lean/elaborator.h
@@ -244,10 +244,11 @@ private:
         name m_S_name; // structure name of field expression type
         name m_base_S_name; // structure name of field
         name m_fname;
+        optional<local_decl> m_ldecl; // projection is a local constant: recursive call
 
-        field_resolution(name const & full_fname):
-                m_S_name(full_fname.get_prefix()), m_base_S_name(full_fname.get_prefix()), m_fname(full_fname.get_string())
-        {}
+        field_resolution(name const & full_fname, optional<local_decl> ldecl = {}):
+                m_S_name(full_fname.get_prefix()), m_base_S_name(full_fname.get_prefix()),
+                m_fname(full_fname.get_string()), m_ldecl(ldecl) {}
         field_resolution(const name & S_name, const name & base_S_name, const name & fname):
                 m_S_name(S_name), m_base_S_name(base_S_name), m_fname(fname) {}
 

--- a/tests/lean/proj_notation.lean
+++ b/tests/lean/proj_notation.lean
@@ -37,3 +37,9 @@ structure car :=
 #check p.1
 #check p.2
 #check λ c : car, c.1.2
+
+namespace nat
+  def myadd : nat → nat → nat
+  | 0 m := m
+  | (n+1) m := n.myadd m + 1
+end nat


### PR DESCRIPTION
Not a high-priority feature, but I kept writing code that failed because of this inconsistency.