### PR TITLE
Parameterized user-defined attributes

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -64,6 +64,8 @@ def list.append : list α → list α → list α
 
 * `simp` and `dsimp` can now unfold let-bindings in the local context.  Use `dsimp [x]` or `simp [x]` to unfold the let-binding `x : nat := 3`.
 
+* User-defined attributes can now take parameters parsed by a `lean.parser`. A `[derive]` attribute that can derive typeclasses such as `decidable_eq` and `inhabited` has been implemented on top of this.
+
 *Changes*
 
 * We now have two type classes for converting to string: `has_to_string` and `has_repr`.

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -11,6 +11,7 @@ open nat
 
 /- the type, coercions, and notation -/
 
+@[derive decidable_eq]
 inductive int : Type
 | of_nat : nat → int
 | neg_succ_of_nat : nat → int
@@ -20,9 +21,6 @@ notation `ℤ` := int
 instance : has_coe nat int := ⟨int.of_nat⟩
 
 notation `-[1+ ` n `]` := int.neg_succ_of_nat n
-
-instance : decidable_eq int :=
-by tactic.mk_dec_eq_instance
 
 protected def int.repr : int → string
 | (int.of_nat n)          := repr n

--- a/library/init/meta/attribute.lean
+++ b/library/init/meta/attribute.lean
@@ -45,10 +45,17 @@ meta constant user_attribute.get_cache {α β : Type} (attr : user_attribute α 
 meta def user_attribute.parse_reflect {α β : Type} (attr : user_attribute α β) : lean.parser expr :=
 (λ a, attr.reflect_param a) <$> attr.parser
 
-meta constant user_attribute.get_param_untyped {α β : Type} : user_attribute α β → name → tactic expr
+meta constant user_attribute.get_param_untyped {α β : Type} (attr : user_attribute α β) (decl : name)
+  : tactic expr
+meta constant user_attribute.set_param_untyped {α β : Type} [reflected β] (attr : user_attribute α β) (decl : name)
+  (val : expr) (persistent : bool) (prio : option nat := none) : tactic unit
 
 meta def user_attribute.get_param {α β : Type} [reflected β] (attr : user_attribute α β) (n : name) : tactic β :=
 attr.get_param_untyped n >>= tactic.eval_expr β
+
+meta def user_attribute.set_param {α β : Type} [reflected β] (attr : user_attribute α β) (n : name)
+  (val : β) (persistent : bool) (prio : option nat := none) : tactic unit :=
+attr.set_param_untyped n (attr.reflect_param val) persistent prio
 
 open tactic
 

--- a/library/init/meta/attribute.lean
+++ b/library/init/meta/attribute.lean
@@ -9,9 +9,16 @@ import init.meta.tactic init.meta.rb_map init.meta.has_reflect
 meta constant attribute.get_instances : name → tactic (list name)
 meta constant attribute.fingerprint : name → tactic nat
 
-meta structure user_attribute :=
-(name         : name)
-(descr        : string)
+meta structure user_attribute_cache_cfg (cache_ty : Type) :=
+(mk_cache     : list name → tactic cache_ty)
+(dependencies : list name)
+
+meta def user_attribute.dflt_cache_cfg : tactic unit :=
+tactic.exact `(⟨λ _, pure (), []⟩ : user_attribute_cache_cfg unit)
+
+meta structure user_attribute (cache_ty : Type := unit) :=
+(name          : name)
+(descr         : string)
 /- Optional handler that will be called after the attribute has been applied to a declaration.
    Failing the tactic will fail the entire `attribute/def/...` command, i.e. the attribute will
    not be applied after all.
@@ -20,33 +27,35 @@ meta structure user_attribute :=
 (after_set    : option (Π (decl : _root_.name) (prio : nat) (persistent : bool), command) := none)
 /- Optional handler that will be called before the attribute is removed from a declaration. -/
 (before_unset : option (Π (decl : _root_.name) (persistent : bool), command) := none)
+(cache_cfg     : user_attribute_cache_cfg cache_ty . user_attribute.dflt_cache_cfg)
 
 /- Registers a new user-defined attribute. The argument must be the name of a definition of type
    `user_attribute` or a sub-structure. -/
 meta def attribute.register (decl : name) : command :=
 tactic.set_basic_attribute ``user_attribute decl tt
 
-meta structure caching_user_attribute (α : Type) extends user_attribute :=
-(mk_cache     : list _root_.name → tactic α)
-(dependencies : list _root_.name)
+meta constant user_attribute.get_cache {α β : Type} (attr : user_attribute α β) : tactic α
 
-meta constant caching_user_attribute.get_cache : Π {α : Type}, caching_user_attribute α → tactic α
 
 open tactic
 
 meta def register_attribute := attribute.register
 
+meta def get_attribute_cache_dyn {α : Type} [reflected α] (name : name) : tactic α :=
+let attr : pexpr := expr.const name [] in
+do e ← to_expr ``(user_attribute.get_cache %%attr),
+   t ← eval_expr (tactic α) e,
+   t
+
 meta def mk_name_set_attr (attr_name : name) : command :=
-do let t := `(caching_user_attribute name_set),
+do let t := `(user_attribute name_set),
    let v := `({name     := attr_name,
-                 descr    := "name_set attribute",
+               descr    := "name_set attribute",
+               cache_cfg := {
                  mk_cache := λ ns, return (name_set.of_list ns),
-                 dependencies := [] } : caching_user_attribute name_set),
+                 dependencies := []}} : user_attribute name_set),
    add_meta_definition attr_name [] t v,
    register_attribute attr_name
 
-meta def get_name_set_for_attr (attr_name : name) : tactic name_set :=
-do
-  cnst   ← return (expr.const attr_name []),
-  attr   ← eval_expr (caching_user_attribute name_set) cnst,
-  caching_user_attribute.get_cache attr
+meta def get_name_set_for_attr (name : name) : tactic name_set :=
+get_attribute_cache_dyn name

--- a/library/init/meta/coinductive_predicates.lean
+++ b/library/init/meta/coinductive_predicates.lean
@@ -112,7 +112,7 @@ section
 universe u
 
 @[user_attribute]
-meta def monotonicity := { user_attribute . name := `monotonicity, descr := "Monotonicity rules for predicates" }
+meta def monotonicity : user_attribute := { name := `monotonicity, descr := "Monotonicity rules for predicates" }
 
 lemma monotonicity.pi {α : Sort u} {p q : α → Prop} (h : ∀a, implies (p a) (q a)) :
   implies (Πa, p a) (Πa, q a) :=

--- a/library/init/meta/default.lean
+++ b/library/init/meta/default.lean
@@ -10,7 +10,7 @@ import init.meta.tactic init.meta.contradiction_tactic init.meta.constructor_tac
 import init.meta.injection_tactic init.meta.relation_tactics init.meta.fun_info
 import init.meta.congr_lemma init.meta.match_tactic init.meta.ac_tactics
 import init.meta.backward init.meta.rewrite_tactic
-import init.meta.mk_dec_eq_instance init.meta.mk_inhabited_instance
+import init.meta.derive
 import init.meta.simp_tactic init.meta.set_get_option_tactics
 import init.meta.interactive init.meta.converter init.meta.vm
 import init.meta.comp_value_tactics init.meta.smt

--- a/library/init/meta/derive.lean
+++ b/library/init/meta/derive.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2017 Microsoft Corporation. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Sebastian Ullrich
+
+Attribute that can automatically derive typeclass instances.
+-/
+prelude
+import init.meta.attribute
+import init.meta.interactive_base
+import init.meta.mk_dec_eq_instance
+import init.meta.mk_has_sizeof_instance
+import init.meta.mk_inhabited_instance
+
+open lean
+open interactive.types
+open tactic
+
+/-- A handler that may or may not be able to implement the typeclass `cls` for `decl`.
+    It should return `tt` if it was able to derive `cls` and `ff` if it does not know
+    how to derive `cls`, in which case lower-priority handlers will be tried next. -/
+meta def derive_handler := Π (cls : pexpr) (decl : name), tactic bool
+
+@[user_attribute]
+meta def derive_handler_attr : user_attribute :=
+{ name := `derive_handler, descr := "register a definition of type `derive_handler` for use in the [derive] attribute" }
+
+private meta def try_handlers (p : pexpr) (n : name) : list derive_handler → tactic unit
+| []      := fail format!"failed to find a derive handler for '{p}'"
+| (h::hs) :=
+do success ← h p n,
+   when (¬success) $
+     try_handlers hs
+
+@[user_attribute] meta def derive_attr : user_attribute unit (list pexpr) :=
+{ name := `derive, descr := "automatically derive typeclass instances",
+  parser := pexpr_list_or_texpr,
+  after_set := some (λ n _ _,
+  do ps ← derive_attr.get_param n,
+     handlers ← attribute.get_instances `derive_handler,
+     handlers ← handlers.mmap (λ n, eval_expr derive_handler (expr.const n [])),
+     ps.mmap' (λ p, try_handlers p n handlers)) }
+
+meta def instance_derive_handler (cls : name) (tac : tactic unit) : derive_handler :=
+λ p n,
+if p.is_constant_of cls then
+do decl ← get_decl n,
+   -- TODO: parameters, parameter instances, universes
+   ty ← mk_app cls [expr.const n []],
+   (_, val) ← tactic.solve_aux ty tac,
+   val ← instantiate_mvars val,
+   add_decl (declaration.defn (n ++ cls) [] ty val reducibility_hints.abbrev tt),
+   set_basic_attribute `instance (n ++ cls) tt,
+   pure true
+else pure false
+
+@[derive_handler] meta def decidable_eq_derive_handler :=
+instance_derive_handler ``decidable_eq mk_dec_eq_instance
+
+@[derive_handler] meta def has_sizeof_derive_handler :=
+instance_derive_handler ``has_sizeof mk_has_sizeof_instance
+
+@[derive_handler] meta def inhabited_derive_handler :=
+instance_derive_handler ``inhabited mk_inhabited_instance

--- a/library/init/meta/expr.lean
+++ b/library/init/meta/expr.lean
@@ -265,7 +265,7 @@ meta def is_aux_decl : expr → bool
 | (local_const _ _ binder_info.aux_decl _) := tt
 | _                                        := ff
 
-meta def is_constant_of : expr → name → bool
+meta def is_constant_of : expr elab → name → bool
 | (const n₁ ls) n₂ := n₁ = n₂
 | e             n  := ff
 

--- a/library/init/meta/mk_inhabited_instance.lean
+++ b/library/init/meta/mk_inhabited_instance.lean
@@ -3,7 +3,7 @@ Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 
-Helper tactic for showing that a type has decidable equality.
+Helper tactic for showing that a type is inhabited.
 -/
 prelude
 import init.meta.interactive_base

--- a/library/init/meta/simp_tactic.lean
+++ b/library/init/meta/simp_tactic.lean
@@ -335,20 +335,18 @@ meta def to_simp_lemmas : simp_lemmas → list name → tactic simp_lemmas
 | S (n::ns) := do S' ← S.add_simp n, to_simp_lemmas S' ns
 
 meta def mk_simp_attr (attr_name : name) : command :=
-do let t := `(caching_user_attribute simp_lemmas),
+do let t := `(user_attribute simp_lemmas),
    let v := `({name     := attr_name,
-                 descr    := "simplifier attribute",
+               descr    := "simplifier attribute",
+               cache_cfg := {
                  mk_cache := λ ns, do {tactic.to_simp_lemmas simp_lemmas.mk ns},
-                 dependencies := [`reducibility] } : caching_user_attribute simp_lemmas),
+                 dependencies := [`reducibility]}} : user_attribute simp_lemmas),
    add_decl (declaration.defn attr_name [] t v reducibility_hints.abbrev ff),
    attribute.register attr_name
 
 meta def get_user_simp_lemmas (attr_name : name) : tactic simp_lemmas :=
 if attr_name = `default then simp_lemmas.mk_default
-else do
-  cnst   ← return (expr.const attr_name []),
-  attr   ← eval_expr (caching_user_attribute simp_lemmas) cnst,
-  caching_user_attribute.get_cache attr
+else get_attribute_cache_dyn attr_name
 
 meta def join_user_simp_lemmas_core : simp_lemmas → list name → tactic simp_lemmas
 | S []             := return S

--- a/library/init/meta/smt/ematch.lean
+++ b/library/init/meta/smt/ematch.lean
@@ -79,7 +79,7 @@ meta def to_hinst_lemmas_core (m : transparency) : bool → list name → hinst_
   end
 
 meta def mk_hinst_lemma_attr_core (attr_name : name) (as_simp : bool) : command :=
-do let t := `(caching_user_attribute hinst_lemmas),
+do let t := `(user_attribute hinst_lemmas),
    let v := `({name     := attr_name,
                descr    := "hinst_lemma attribute",
                after_set := some $ λ n _ _,
@@ -87,8 +87,9 @@ do let t := `(caching_user_attribute hinst_lemmas),
                  fail format!"invalid ematch lemma '{n}'",
                -- allow unsetting
                before_unset := some $ λ _ _, skip,
-               mk_cache := λ ns, to_hinst_lemmas_core reducible as_simp ns hinst_lemmas.mk,
-               dependencies := [`reducibility] } : caching_user_attribute hinst_lemmas),
+               cache_cfg := {
+                 mk_cache := λ ns, to_hinst_lemmas_core reducible as_simp ns hinst_lemmas.mk,
+                 dependencies := [`reducibility]}} : user_attribute hinst_lemmas),
    add_decl (declaration.defn attr_name [] t v reducibility_hints.abbrev ff),
    attribute.register attr_name
 
@@ -98,7 +99,7 @@ meta def mk_hinst_lemma_attrs_core (as_simp : bool) : list name → command
   (mk_hinst_lemma_attr_core n as_simp >> mk_hinst_lemma_attrs_core ns)
   <|>
   (do type ← infer_type (expr.const n []),
-      let expected := `(caching_user_attribute hinst_lemmas),
+      let expected := `(user_attribute),
       (is_def_eq type expected
        <|> fail format!"failed to create hinst_lemma attribute '{n}', declaration already exists and has different type."),
       mk_hinst_lemma_attrs_core ns)
@@ -111,7 +112,7 @@ meta def merge_hinst_lemma_attrs (m : transparency) (as_simp : bool) : list name
   merge_hinst_lemma_attrs attrs new_hs
 
 /--
-Create a new "cached" attribute (attr_name : caching_user_attribute hinst_lemmas).
+Create a new "cached" attribute (attr_name : user_attribute hinst_lemmas).
 It also creates "cached" attributes for each attr_names and simp_attr_names if they have not been defined
 yet. Moreover, the hinst_lemmas for attr_name will be the union of the lemmas tagged with
     attr_name, attrs_name, and simp_attr_names.
@@ -120,7 +121,7 @@ For the ones in simp_attr_names, we use the left-hand-side of the conclusion as 
 meta def mk_hinst_lemma_attr_set (attr_name : name) (attr_names : list name) (simp_attr_names : list name) : command :=
 do mk_hinst_lemma_attrs_core ff attr_names,
    mk_hinst_lemma_attrs_core tt simp_attr_names,
-   let t  := `(caching_user_attribute hinst_lemmas),
+   let t  := `(user_attribute hinst_lemmas),
    let v  := `({name     := attr_name,
                 descr    := "hinst_lemma attribute set",
                 after_set := some $ λ n _ _,
@@ -128,19 +129,17 @@ do mk_hinst_lemma_attrs_core ff attr_names,
                   fail format!"invalid ematch lemma '{n}'",
                 -- allow unsetting
                 before_unset := some $ λ _ _, skip,
-                mk_cache := λ ns, do {
-                   hs₁ ← to_hinst_lemmas_core reducible ff ns hinst_lemmas.mk,
-                   hs₂ ← merge_hinst_lemma_attrs reducible ff attr_names hs₁,
-                   merge_hinst_lemma_attrs reducible tt simp_attr_names hs₂},
-                dependencies := [`reducibility] ++ attr_names ++ simp_attr_names } : caching_user_attribute hinst_lemmas),
+                cache_cfg := {
+                  mk_cache := λ ns, do {
+                    hs₁ ← to_hinst_lemmas_core reducible ff ns hinst_lemmas.mk,
+                    hs₂ ← merge_hinst_lemma_attrs reducible ff attr_names hs₁,
+                    merge_hinst_lemma_attrs reducible tt simp_attr_names hs₂},
+                  dependencies := [`reducibility] ++ attr_names ++ simp_attr_names}} : user_attribute hinst_lemmas),
    add_decl (declaration.defn attr_name [] t v reducibility_hints.abbrev ff),
    attribute.register attr_name
 
 meta def get_hinst_lemmas_for_attr (attr_name : name) : tactic hinst_lemmas :=
-do
-  cnst   ← return (expr.const attr_name []),
-  attr   ← eval_expr (caching_user_attribute hinst_lemmas) cnst,
-  caching_user_attribute.get_cache attr
+get_attribute_cache_dyn attr_name
 
 structure ematch_config :=
 (max_instances  : nat := 10000)

--- a/library/init/meta/smt/rsimp.lean
+++ b/library/init/meta/smt/rsimp.lean
@@ -29,9 +29,10 @@ private meta def to_hinst_lemmas (m : transparency) (ex : name_set) : list name 
     We say `ex_attr_name` is the "exception set". It is useful for excluding lemmas in `simp_attr_name`
     which are not good or redundant for ematching. -/
 meta def mk_hinst_lemma_attr_from_simp_attr (attr_decl_name attr_name : name) (simp_attr_name : name) (ex_attr_name : name) : command :=
-do let t := `(caching_user_attribute hinst_lemmas),
+do let t := `(user_attribute hinst_lemmas),
    let v := `({name     := attr_name,
-                 descr    := sformat!"hinst_lemma attribute derived from '{simp_attr_name}'",
+               descr    := sformat!"hinst_lemma attribute derived from '{simp_attr_name}'",
+               cache_cfg := {
                  mk_cache := λ ns,
                  let aux := simp_attr_name in
                  let ex_attr := ex_attr_name in
@@ -41,7 +42,7 @@ do let t := `(caching_user_attribute hinst_lemmas),
                    ex   ← get_name_set_for_attr ex_attr,
                    to_hinst_lemmas reducible ex ss hs
                  },
-                 dependencies := [`reducibility, simp_attr_name]} : caching_user_attribute hinst_lemmas),
+                 dependencies := [`reducibility, simp_attr_name]}} : user_attribute hinst_lemmas),
    add_decl (declaration.defn attr_decl_name [] t v reducibility_hints.abbrev ff),
    attribute.register attr_decl_name
 

--- a/library/init/meta/vm.lean
+++ b/library/init/meta/vm.lean
@@ -5,18 +5,16 @@ Authors: Leonardo de Moura
 -/
 prelude
 import init.meta.tactic init.data.option_t
-import init.meta.mk_dec_eq_instance
+import init.meta.derive
 
 meta constant vm_obj : Type
 
+@[derive decidable_eq]
 inductive vm_obj_kind
 | simple | constructor | closure | native_closure | mpz
 | name | level | expr | declaration
 | environment | tactic_state | format
 | options | other
-
-instance vm_obj_kind_dec_eq : decidable_eq vm_obj_kind :=
-by tactic.mk_dec_eq_instance
 
 namespace vm_obj
 meta constant kind            : vm_obj → vm_obj_kind

--- a/library/tools/debugger/cli.lean
+++ b/library/tools/debugger/cli.lean
@@ -9,11 +9,9 @@ import tools.debugger.util
 
 namespace debugger
 
+@[derive decidable_eq]
 inductive mode
 | init | step | run | done
-
-instance : decidable_eq mode :=
-by tactic.mk_dec_eq_instance
 
 structure state :=
 (md         : mode)

--- a/src/emacs/lean-dev.el
+++ b/src/emacs/lean-dev.el
@@ -11,6 +11,6 @@
   (interactive)
   (message (shell-command-to-string (format "yes | ./test_single.sh \"%s\" \"%s\" yes"
                                             (lean-get-executable "lean")
-                                            (buffer-name)))))
+                                            (buffer-file-name)))))
 
 (provide 'lean-dev)

--- a/src/frontends/lean/decl_attributes.cpp
+++ b/src/frontends/lean/decl_attributes.cpp
@@ -134,8 +134,10 @@ environment decl_attributes::apply(environment env, io_state const & ios, name c
 bool decl_attributes::ok_for_inductive_type() const {
     for (entry const & e : m_entries) {
         name const & n = e.m_attr->get_name();
-        if ((n != "class" && !is_class_symbol_tracking_attribute(n)) || e.deleted())
-            return false;
+        if (is_system_attribute(n)) {
+            if ((n != "class" && !is_class_symbol_tracking_attribute(n)) || e.deleted())
+                return false;
+        }
     }
     return true;
 }

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2996,7 +2996,7 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
                         report_or_throw(elaborator_exception(e, sstream() << "invalid structure value {...}, field '"
                                                                 << S_fname << "' is implicit and must not be provided"));
                     }
-                    c_arg = mk_metavar(d, ref);
+                    c_arg = binding_info(c_type).is_inst_implicit() ? mk_instance(d, ref) : mk_metavar(d, ref);
                 }
             }
             c_args.push_back(c_arg);

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2920,7 +2920,7 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
             expr c_arg;
             expr d = binding_domain(c_type);
             if (i < nparams) {
-                if (is_explicit(binding_info(c_type))) {
+                if (is_explicit(binding_info(c_type)) && !expected_type) {
                     report_or_throw(elaborator_exception(e, sstream() << "invalid structure value {...}, structure parameter '" <<
                                                             binding_name(c_type)
                                                             << "' is explicit in the structure constructor '" <<

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -3196,6 +3196,7 @@ expr elaborator::visit_expr_quote(expr const & e, optional<expr> const & expecte
         } else {
             new_s = visit(s, none_expr());
         }
+        synthesize(); // try to instantiate all metavars in `new_s`, otherwise reflection will fail
         expr cls = mk_app(m_ctx, get_reflected_name(), new_s);
         return mk_instance(cls, e);
     }

--- a/src/library/attribute_manager.h
+++ b/src/library/attribute_manager.h
@@ -126,7 +126,7 @@ public:
     typed_attribute(name const & id, char const * descr, after_set_proc after_set = {}, before_unset_proc before_unset = {}) :
             attribute(id, descr, after_set, before_unset) {}
 
-    virtual attr_data_ptr parse_data(abstract_parser & p) const final override {
+    virtual attr_data_ptr parse_data(abstract_parser & p) const override {
         auto data = new Data;
         data->parse(p);
         return attr_data_ptr(data);

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -366,6 +366,7 @@ name const * g_unit_cases_on = nullptr;
 name const * g_unit_star = nullptr;
 name const * g_unsafe_monad_from_pure_bind = nullptr;
 name const * g_user_attribute = nullptr;
+name const * g_user_attribute_parse_reflect = nullptr;
 name const * g_vm_monitor = nullptr;
 name const * g_partial_order = nullptr;
 name const * g_well_founded_fix = nullptr;
@@ -742,6 +743,7 @@ void initialize_constants() {
     g_unit_star = new name{"unit", "star"};
     g_unsafe_monad_from_pure_bind = new name{"unsafe_monad_from_pure_bind"};
     g_user_attribute = new name{"user_attribute"};
+    g_user_attribute_parse_reflect = new name{"user_attribute", "parse_reflect"};
     g_vm_monitor = new name{"vm_monitor"};
     g_partial_order = new name{"partial_order"};
     g_well_founded_fix = new name{"well_founded", "fix"};
@@ -1119,6 +1121,7 @@ void finalize_constants() {
     delete g_unit_star;
     delete g_unsafe_monad_from_pure_bind;
     delete g_user_attribute;
+    delete g_user_attribute_parse_reflect;
     delete g_vm_monitor;
     delete g_partial_order;
     delete g_well_founded_fix;
@@ -1495,6 +1498,7 @@ name const & get_unit_cases_on_name() { return *g_unit_cases_on; }
 name const & get_unit_star_name() { return *g_unit_star; }
 name const & get_unsafe_monad_from_pure_bind_name() { return *g_unsafe_monad_from_pure_bind; }
 name const & get_user_attribute_name() { return *g_user_attribute; }
+name const & get_user_attribute_parse_reflect_name() { return *g_user_attribute_parse_reflect; }
 name const & get_vm_monitor_name() { return *g_vm_monitor; }
 name const & get_partial_order_name() { return *g_partial_order; }
 name const & get_well_founded_fix_name() { return *g_well_founded_fix; }

--- a/src/library/constants.cpp
+++ b/src/library/constants.cpp
@@ -27,7 +27,6 @@ name const * g_bool = nullptr;
 name const * g_bool_ff = nullptr;
 name const * g_bool_tt = nullptr;
 name const * g_combinator_K = nullptr;
-name const * g_caching_user_attribute = nullptr;
 name const * g_cast = nullptr;
 name const * g_cast_heq = nullptr;
 name const * g_char = nullptr;
@@ -404,7 +403,6 @@ void initialize_constants() {
     g_bool_ff = new name{"bool", "ff"};
     g_bool_tt = new name{"bool", "tt"};
     g_combinator_K = new name{"combinator", "K"};
-    g_caching_user_attribute = new name{"caching_user_attribute"};
     g_cast = new name{"cast"};
     g_cast_heq = new name{"cast_heq"};
     g_char = new name{"char"};
@@ -782,7 +780,6 @@ void finalize_constants() {
     delete g_bool_ff;
     delete g_bool_tt;
     delete g_combinator_K;
-    delete g_caching_user_attribute;
     delete g_cast;
     delete g_cast_heq;
     delete g_char;
@@ -1159,7 +1156,6 @@ name const & get_bool_name() { return *g_bool; }
 name const & get_bool_ff_name() { return *g_bool_ff; }
 name const & get_bool_tt_name() { return *g_bool_tt; }
 name const & get_combinator_K_name() { return *g_combinator_K; }
-name const & get_caching_user_attribute_name() { return *g_caching_user_attribute; }
 name const & get_cast_name() { return *g_cast; }
 name const & get_cast_heq_name() { return *g_cast_heq; }
 name const & get_char_name() { return *g_char; }

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -368,6 +368,7 @@ name const & get_unit_cases_on_name();
 name const & get_unit_star_name();
 name const & get_unsafe_monad_from_pure_bind_name();
 name const & get_user_attribute_name();
+name const & get_user_attribute_parse_reflect_name();
 name const & get_vm_monitor_name();
 name const & get_partial_order_name();
 name const & get_well_founded_fix_name();

--- a/src/library/constants.h
+++ b/src/library/constants.h
@@ -29,7 +29,6 @@ name const & get_bool_name();
 name const & get_bool_ff_name();
 name const & get_bool_tt_name();
 name const & get_combinator_K_name();
-name const & get_caching_user_attribute_name();
 name const & get_cast_name();
 name const & get_cast_heq_name();
 name const & get_char_name();

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -22,7 +22,6 @@ bool
 bool.ff
 bool.tt
 combinator.K
-caching_user_attribute
 cast
 cast_heq
 char

--- a/src/library/constants.txt
+++ b/src/library/constants.txt
@@ -361,6 +361,7 @@ unit.cases_on
 unit.star
 unsafe_monad_from_pure_bind
 user_attribute
+user_attribute.parse_reflect
 vm_monitor
 partial_order
 well_founded.fix

--- a/src/library/tactic/smt/smt_state.cpp
+++ b/src/library/tactic/smt/smt_state.cpp
@@ -423,10 +423,9 @@ vm_obj mk_smt_state(tactic_state s, smt_config const & cfg) {
 
 static hinst_lemmas get_hinst_lemmas(name const & attr_name, tactic_state const & s) {
     auto & S      = get_vm_state();
-    vm_obj attr   = S.get_constant(attr_name);
-    vm_obj r      = caching_user_attribute_get_cache(mk_vm_unit(), attr, to_obj(s));
+    vm_obj r      = user_attribute_get_cache(S, s, attr_name);
     if (tactic::is_result_exception(r))
-        throw exception(sstream() << "failed to initialize sm_state, failed to retrieve attribute '" << attr_name << "'");
+        throw exception(sstream() << "failed to initialize smt_state, failed to retrieve attribute '" << attr_name << "'");
     vm_obj lemmas = tactic::get_result_value(r);
     if (!is_hinst_lemmas(lemmas))
         throw exception(sstream() << "failed to initialize smt_state, attribute '" << attr_name << "' is not a hinst_lemmas");
@@ -436,9 +435,9 @@ static hinst_lemmas get_hinst_lemmas(name const & attr_name, tactic_state const 
 static simp_lemmas get_simp_lemmas(name const & attr_name, tactic_state const & s) {
     auto & S      = get_vm_state();
     vm_obj attr   = S.get_constant(attr_name);
-    vm_obj r      = caching_user_attribute_get_cache(mk_vm_unit(), attr, to_obj(s));
+    vm_obj r      = user_attribute_get_cache(S, s, attr_name);
     if (tactic::is_result_exception(r))
-        throw exception(sstream() << "failed to initialize sm_state, failed to retrieve attribute '" << attr_name << "'");
+        throw exception(sstream() << "failed to initialize smt_state, failed to retrieve attribute '" << attr_name << "'");
     vm_obj lemmas = tactic::get_result_value(r);
     if (!is_simp_lemmas(lemmas))
         throw exception(sstream() << "failed to initialize smt_state, attribute '" << attr_name << "' is not a simp_lemmas");

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -93,6 +93,30 @@ vm_obj user_attribute_get_param_untyped(vm_obj const &, vm_obj const &, vm_obj c
     LEAN_TACTIC_CATCH(s);
 }
 
+vm_obj user_attribute_set_param_untyped(expr const & beta, name const & attr_n, name const & n, expr const & val,
+                                        bool persistent, unsigned prio, tactic_state const & s) {
+    type_context ctx(s.env(), s.get_options());
+    if (!ctx.is_def_eq(beta, ctx.infer(val))) {
+        return tactic::mk_exception(sstream() << "set_param_untyped failed, '" << val << "' is not of type '" << beta << "'", s);
+    }
+    LEAN_TACTIC_TRY;
+        attribute const & attr = get_attribute(s.env(), attr_n);
+        if (user_attribute const * user_attr = dynamic_cast<user_attribute const *>(&attr)) {
+            environment new_env = user_attr->set(s.env(), get_global_ios(), n, prio, user_attribute_data(val), persistent);
+            return tactic::mk_success(set_env(s, new_env));
+        } else {
+            return tactic::mk_exception(sstream() << "set_param_untyped failed, '" << attr_n << "' is not a user attribute", s);
+        }
+    LEAN_TACTIC_CATCH(s);
+}
+
+vm_obj user_attribute_set_param_untyped(unsigned DEBUG_CODE(num), vm_obj const * args) {
+    lean_assert(num == 9);
+    unsigned prio = is_none(args[7]) ? LEAN_DEFAULT_PRIORITY : to_unsigned(get_some_value(args[7]));
+    return user_attribute_set_param_untyped(to_expr(args[2]), to_name(cfield(args[3], 0)), to_name(args[4]),
+                                            to_expr(args[5]), to_bool(args[6]), prio, tactic::to_state(args[8]));
+}
+
 static environment add_user_attr(environment const & env, name const & d) {
     auto const & ty = env.get(d).get_type();
     if (!is_app_of(ty, get_user_attribute_name(), 2))
@@ -326,6 +350,8 @@ void initialize_user_attribute() {
     DECLARE_VM_BUILTIN(name({"attribute", "fingerprint"}),              attribute_fingerprint);
     DECLARE_VM_BUILTIN(name({"user_attribute", "get_cache"}),           user_attribute_get_cache_core);
     DECLARE_VM_BUILTIN(name({"user_attribute", "get_param_untyped"}),   user_attribute_get_param_untyped);
+    declare_vm_builtin(name({"user_attribute", "set_param_untyped"}), "user_attribute_set_param_untyped",
+                       9, user_attribute_set_param_untyped);
     DECLARE_VM_BUILTIN(name({"tactic",    "set_basic_attribute"}),      set_basic_attribute);
     DECLARE_VM_BUILTIN(name({"tactic",    "unset_attribute"}),          unset_attribute);
     DECLARE_VM_BUILTIN(name({"tactic",    "has_attribute"}),            has_attribute);

--- a/src/library/tactic/user_attribute.cpp
+++ b/src/library/tactic/user_attribute.cpp
@@ -44,29 +44,25 @@ static environment update(environment const & env, user_attr_ext const & ext) {
 
 static environment add_user_attr(environment const & env, name const & d) {
     auto const & ty = env.get(d).get_type();
-    if (!is_constant(ty, get_user_attribute_name()) && !is_constant(get_app_fn(ty), get_caching_user_attribute_name()))
-        throw exception("invalid [user_attribute], must be applied to definition of type user_attribute");
+    if (!is_app_of(ty, get_user_attribute_name(), 2))
+        throw exception("invalid [user_attribute] usage, must be applied to definition of type `user_attribute`");
 
     vm_state vm(env, options());
-    vm_obj o = vm.invoke(d, {});
-    if (is_constant(get_app_fn(ty), get_caching_user_attribute_name()))
-        o = cfield(o, 0);
-    name const & n = to_name(cfield(o, 0));
-    if (n.is_anonymous())
+    vm_obj o = vm.get_constant(d);
+    name const & attr_name = to_name(cfield(o, 0));
+    if (attr_name.is_anonymous())
         throw exception(sstream() << "invalid user_attribute, anonymous attribute names are not allowed");
-    if (is_attribute(env, n))
-        throw exception(sstream() << "an attribute named [" << n << "] has already been registered");
+    if (is_attribute(env, attr_name))
+        throw exception(sstream() << "an attribute named [" << attr_name << "] has already been registered");
     std::string descr = to_string(cfield(o, 1));
     after_set_proc after_set;
     if (!is_none(cfield(o, 2))) {
         after_set = [=](environment const & env, io_state const & ios, name const & n, unsigned prio, bool persistent) {
             vm_state vm(env, ios.get_options());
             scope_vm_state scope(vm);
-            vm_obj o = vm.invoke(d, {});
-            if (is_constant(get_app_fn(ty), get_caching_user_attribute_name()))
-                o = cfield(o, 0);
+            vm_obj o = vm.get_constant(d);
             tactic_state s = mk_tactic_state_for(env, options(), {}, local_context(), mk_true());
-            auto vm_r = vm.invoke(get_some_value(cfield(o, 2)), to_obj(n), to_obj(prio), mk_vm_bool(persistent), to_obj(s));
+            auto vm_r = vm.invoke(get_some_value(cfield(o, 2)), to_obj(n), mk_vm_nat(prio), mk_vm_bool(persistent), to_obj(s));
             tactic::report_exception(vm, vm_r);
             return tactic::to_state(tactic::get_result_state(vm_r)).env();
         };
@@ -76,9 +72,7 @@ static environment add_user_attr(environment const & env, name const & d) {
         before_unset = [=](environment const & env, io_state const & ios, name const & n, bool persistent) {
             vm_state vm(env, ios.get_options());
             scope_vm_state scope(vm);
-            vm_obj o = vm.invoke(d, {});
-            if (is_constant(get_app_fn(ty), get_caching_user_attribute_name()))
-                o = cfield(o, 0);
+            vm_obj o = vm.get_constant(d);
             tactic_state s = mk_tactic_state_for(env, options(), {}, local_context(), mk_true());
             auto vm_r = vm.invoke(get_some_value(cfield(o, 3)), to_obj(n), mk_vm_bool(persistent), to_obj(s));
             tactic::report_exception(vm, vm_r);
@@ -87,7 +81,7 @@ static environment add_user_attr(environment const & env, name const & d) {
     }
 
     user_attr_ext ext = get_extension(env);
-    ext.m_attrs.insert(n, attribute_ptr(new basic_attribute(n, descr.c_str(), after_set, before_unset)));
+    ext.m_attrs.insert(attr_name, attribute_ptr(new basic_attribute(attr_name, descr.c_str(), after_set, before_unset)));
     return update(env, ext);
 }
 
@@ -166,11 +160,12 @@ static bool check_dep_fingerprints(environment const & env, list<name> const & d
     }
 }
 
-vm_obj caching_user_attribute_get_cache(vm_obj const &, vm_obj const & vm_attr, vm_obj const & vm_s) {
+vm_obj user_attribute_get_cache_core(vm_obj const &, vm_obj const &, vm_obj const & vm_attr, vm_obj const & vm_s) {
     tactic_state const & s       = tactic::to_state(vm_s);
-    name const & n               = to_name(cfield(cfield(vm_attr, 0), 0));
-    vm_obj const & cache_handler = cfield(vm_attr, 1);
-    list<name> const & deps      = to_list_name(cfield(vm_attr, 2));
+    name const & n               = to_name(cfield(vm_attr, 0));
+    vm_obj const & cache_cfg     = cfield(vm_attr, 4);
+    vm_obj const & cache_handler = cfield(cache_cfg, 0);
+    list<name> const & deps      = to_list_name(cfield(cache_cfg, 1));
     LEAN_TACTIC_TRY;
     environment const & env = s.env();
     attribute const & attr  = get_attribute(env, n);
@@ -220,6 +215,11 @@ vm_obj caching_user_attribute_get_cache(vm_obj const &, vm_obj const & vm_attr, 
         return result;
     }
     LEAN_TACTIC_CATCH(s);
+}
+
+vm_obj user_attribute_get_cache(vm_state & S, tactic_state const & s, name const & attr_name) {
+    vm_obj attr   = S.get_constant(attr_name);
+    return user_attribute_get_cache_core(mk_vm_unit(), mk_vm_unit(), attr, to_obj(s));
 }
 
 vm_obj set_basic_attribute(vm_obj const & vm_attr_n, vm_obj const & vm_n, vm_obj const & p, vm_obj const & vm_prio, vm_obj const & vm_s) {
@@ -273,7 +273,7 @@ vm_obj has_attribute(vm_obj const & vm_attr_n, vm_obj const & vm_n, vm_obj const
 void initialize_user_attribute() {
     DECLARE_VM_BUILTIN(name({"attribute", "get_instances"}),            attribute_get_instances);
     DECLARE_VM_BUILTIN(name({"attribute", "fingerprint"}),              attribute_fingerprint);
-    DECLARE_VM_BUILTIN(name({"caching_user_attribute", "get_cache"}),   caching_user_attribute_get_cache);
+    DECLARE_VM_BUILTIN(name({"user_attribute", "get_cache"}),           user_attribute_get_cache_core);
     DECLARE_VM_BUILTIN(name({"tactic",    "set_basic_attribute"}),      set_basic_attribute);
     DECLARE_VM_BUILTIN(name({"tactic",    "unset_attribute"}),          unset_attribute);
     DECLARE_VM_BUILTIN(name({"tactic",    "has_attribute"}),            has_attribute);

--- a/src/library/tactic/user_attribute.h
+++ b/src/library/tactic/user_attribute.h
@@ -6,9 +6,10 @@ Author: Sebastian Ullrich
 */
 #pragma once
 #include "library/vm/vm.h"
+#include "library/tactic/tactic_state.h"
 
 namespace lean {
-vm_obj caching_user_attribute_get_cache(vm_obj const &, vm_obj const & vm_attr, vm_obj const & vm_s);
+vm_obj user_attribute_get_cache(vm_state & S, tactic_state const & s, name const & attr_name);
 void initialize_user_attribute();
 void finalize_user_attribute();
 }

--- a/tests/lean/caching_user_attribute.lean
+++ b/tests/lean/caching_user_attribute.lean
@@ -1,21 +1,25 @@
 @[user_attribute]
-meta def foo_attr : caching_user_attribute string :=
+meta def foo_attr : user_attribute string :=
 { name     := `foo, descr := "bar",
-  mk_cache := λ ns, return $ string.join (list.map (λ n, to_string n ++ "\n") ns),
-  dependencies := [] }
+  cache_cfg := {
+    mk_cache := λ ns, return $ string.join (list.map (λ n, to_string n ++ "\n") ns),
+    dependencies := []} }
 
 attribute [foo] eq.refl eq.mp
 
 set_option trace.user_attributes_cache true
 
 run_cmd do
-  s : string ← caching_user_attribute.get_cache foo_attr,
+  s : string ← foo_attr.get_cache,
   tactic.trace s,
-  s : string ← caching_user_attribute.get_cache foo_attr,
-  tactic.trace s,
-  tactic.set_basic_attribute `foo ``eq.mpr,
-  s : string ← caching_user_attribute.get_cache foo_attr,
+  s : string ← foo_attr.get_cache,
+  tactic.trace s
+
+attribute [foo] eq.mpr
+
+run_cmd do
+  s : string ← foo_attr.get_cache,
   tactic.trace s,
   tactic.set_basic_attribute `reducible ``eq.mp, -- should not affect [foo] cache
-  s : string ← caching_user_attribute.get_cache foo_attr,
+  s : string ← foo_attr.get_cache,
   tactic.trace s

--- a/tests/lean/caching_user_attribute.lean
+++ b/tests/lean/caching_user_attribute.lean
@@ -13,11 +13,8 @@ run_cmd do
   s : string ← foo_attr.get_cache,
   tactic.trace s,
   s : string ← foo_attr.get_cache,
-  tactic.trace s
-
-attribute [foo] eq.mpr
-
-run_cmd do
+  tactic.trace s,
+  foo_attr.set_param `eq.mpr () tt,
   s : string ← foo_attr.get_cache,
   tactic.trace s,
   tactic.set_basic_attribute `reducible ``eq.mp, -- should not affect [foo] cache

--- a/tests/lean/derive.lean
+++ b/tests/lean/derive.lean
@@ -1,0 +1,8 @@
+@[derive [decidable_eq, inhabited, has_sizeof]]
+inductive foo
+| bar : ℕ → foo
+| baz : foo
+
+#check foo.decidable_eq
+#check foo.inhabited
+#check foo.has_sizeof

--- a/tests/lean/derive.lean.expected.out
+++ b/tests/lean/derive.lean.expected.out
@@ -1,0 +1,3 @@
+foo.decidable_eq : decidable_eq foo
+foo.inhabited : inhabited foo
+foo.has_sizeof : has_sizeof foo

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -366,6 +366,7 @@ run_cmd script_check_id `unit.cases_on
 run_cmd script_check_id `unit.star
 run_cmd script_check_id `unsafe_monad_from_pure_bind
 run_cmd script_check_id `user_attribute
+run_cmd script_check_id `user_attribute.parse_reflect
 run_cmd script_check_id `vm_monitor
 run_cmd script_check_id `partial_order
 run_cmd script_check_id `well_founded.fix

--- a/tests/lean/run/check_constants.lean
+++ b/tests/lean/run/check_constants.lean
@@ -27,7 +27,6 @@ run_cmd script_check_id `bool
 run_cmd script_check_id `bool.ff
 run_cmd script_check_id `bool.tt
 run_cmd script_check_id `combinator.K
-run_cmd script_check_id `caching_user_attribute
 run_cmd script_check_id `cast
 run_cmd script_check_id `cast_heq
 run_cmd script_check_id `char

--- a/tests/lean/run/eval_attr_cache.lean
+++ b/tests/lean/run/eval_attr_cache.lean
@@ -1,17 +1,18 @@
 open tactic
 @[user_attribute]
-meta def my_attr : caching_user_attribute (name → bool) :=
+meta def my_attr : user_attribute (name → bool) :=
 { name         := "my_attr",
   descr        := "my attr",
-  mk_cache     := λ ls, do {
-   let c := `(λ n : name, (name.cases_on n ff (λ _ _, to_bool (n ∈ ls)) (λ _ _, ff) : bool)),
-   eval_expr (name → bool) c
-  },
-  dependencies := []
+  cache_cfg := {
+    mk_cache   := λ ls, do {
+      let c := `(λ n : name, (name.cases_on n ff (λ _ _, to_bool (n ∈ ls)) (λ _ _, ff) : bool)),
+      eval_expr (name → bool) c
+    },
+    dependencies := []}
 }
 
 meta def my_tac : tactic unit :=
-do f ← caching_user_attribute.get_cache my_attr,
+do f ← my_attr.get_cache,
    trace (f `foo),
    return ()
 

--- a/tests/lean/slow_error.lean
+++ b/tests/lean/slow_error.lean
@@ -1,4 +1,4 @@
-variable a : caching_user_attribute string
+variable a : user_attribute string
 variable b : string
 
 #check a = b

--- a/tests/lean/slow_error.lean.expected.out
+++ b/tests/lean/slow_error.lean.expected.out
@@ -5,4 +5,4 @@ term
 has type
   string
 but is expected to have type
-  caching_user_attribute string
+  (user_attribute string)

--- a/tests/lean/user_attribute.lean
+++ b/tests/lean/user_attribute.lean
@@ -33,3 +33,13 @@ section
   @[user_attribute]
   meta def baz_attr : user_attribute := { name := `baz, descr := x }
 end
+
+-- parameterized attributes
+
+@[user_attribute] meta def pattr : user_attribute unit name :=
+{ name := `pattr, descr := "pattr", parser := lean.parser.ident }
+
+@[pattr poing]
+def foo := 1
+
+run_cmd pattr.get_param `foo >>= tactic.trace

--- a/tests/lean/user_attribute.lean.expected.out
+++ b/tests/lean/user_attribute.lean.expected.out
@@ -9,9 +9,10 @@ constructor eq.refl : ∀ {α : Sort u} (a : α), a = a
 [eq.refl]
 user_attribute.lean:23:5: error: an attribute named [reducible] has already been registered
 user_attribute.lean:23:5: warning: declaration 'duplicate' uses sorry
-user_attribute.lean:28:5: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:28:5: error: invalid [user_attribute] usage, must be applied to definition of type `user_attribute`
 user_attribute.lean:28:9: error: don't know how to synthesize placeholder
 context:
 ⊢ Sort ?
-user_attribute.lean:34:7: error: invalid [user_attribute], must be applied to definition of type user_attribute
+user_attribute.lean:34:7: error: invalid [user_attribute] usage, must be applied to definition of type `user_attribute`
 user_attribute.lean:34:7: warning: declaration 'baz_attr' uses sorry
+poing


### PR DESCRIPTION
Add a parameter parser to `user_attribute`, store the parsed result in reflected form and provide a typed API to retrieve it. Implement a `[derive]` attribute on top of that.

/cc @rlewis1988, https://github.com/formalabstracts/formalabstracts/pull/49