### PR TITLE
fix(init/data/option/instances): Use option.* instead of option_*

### DIFF
--- a/library/init/data/option/instances.lean
+++ b/library/init/data/option/instances.lean
@@ -9,23 +9,23 @@ import init.meta.tactic
 
 universes u v
 
-@[inline] def option_bind {α : Type u} {β : Type v} : option α → (α → option β) → option β
+@[inline] def option.bind {α : Type u} {β : Type v} : option α → (α → option β) → option β
 | none     b := none
 | (some a) b := b a
 
-def option_map {α β} (f : α → β) (o : option α) : option β :=
-option_bind o (some ∘ f)
+def option.map {α β} (f : α → β) (o : option α) : option β :=
+option.bind o (some ∘ f)
 
-@[simp] theorem option.map_id {α} : (option_map id : option α → option α) = id :=
+@[simp] theorem option.map_id {α} : (option.map id : option α → option α) = id :=
 funext (λo, match o with | none := rfl | some x := rfl end)
 
 instance : monad option :=
-{pure := @some, bind := @option_bind, map := @option_map,
+{pure := @some, bind := @option.bind, map := @option.map,
  id_map := λ α x, option.rec rfl (λ x, rfl) x,
  pure_bind := λ α β x f, rfl,
  bind_assoc := λ α β γ x f g, option.rec rfl (λ x, rfl) x}
 
-def option_orelse {α : Type u} : option α → option α → option α
+def option.orelse {α : Type u} : option α → option α → option α
 | (some a) o         := some a
 | none     (some a)  := some a
 | none     none      := none
@@ -33,7 +33,7 @@ def option_orelse {α : Type u} : option α → option α → option α
 instance : alternative option :=
 { option.monad with
   failure := @none,
-  orelse  := @option_orelse }
+  orelse  := @option.orelse }
 
 lemma option.eq_of_eq_some {α : Type u} : Π {x y : option α}, (∀z, x = some z ↔ y = some z) → x = y
 | none     none     h := rfl


### PR DESCRIPTION
This enables use of projection notation. Note that the notations are not always available here since they require one universe instead of two.