### PR TITLE
chore(.travis.yml): undo Travis update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: cpp
 sudo: true
 cache: apt
 dist: trusty
+group: deprecated-2017Q3
 addons:
   apt:
     sources: &apt_sources


### PR DESCRIPTION
The test_registry test is failing because `python3` seems to have reverted to Python 3.4 in a Travis upgrade. Probably related to https://github.com/travis-ci/travis-ci/issues/8315#issuecomment-327537437.