### PR TITLE
feat(emacs): highlight flycheck and eldoc output

### DIFF
--- a/src/emacs/lean-flycheck.el
+++ b/src/emacs/lean-flycheck.el
@@ -57,7 +57,7 @@
                            ("warning" 'warning)
                            ("information" 'info)
                            (_ 'info))
-                         text
+                         (lean-highlight-string text)
                          :filename file_name
                          :checker checker :buffer buffer))
 

--- a/src/emacs/lean-info.el
+++ b/src/emacs/lean-info.el
@@ -56,6 +56,14 @@
    ;; current window of current buffer is selected (i.e., in focus)
    (eq (current-buffer) (window-buffer))))
 
+(defun lean-highlight-string (str)
+  "Returns 'str' highlighted in lean-info-mode"
+  (lean-ensure-info-buffer " Lean tmp buffer")
+  (lean-with-info-output-to-buffer (get-buffer " Lean tmp buffer")
+    (princ str)
+    (font-lock-fontify-buffer)
+    (buffer-string)))
+
 (defun lean-get-info-record-at-point (cont)
   "Get info-record at the current point"
   (with-demoted-errors "lean get info: %s"

--- a/src/emacs/lean-type.el
+++ b/src/emacs/lean-type.el
@@ -55,7 +55,7 @@
                         (propertize expr 'face 'font-lock-variable-name-face)
                         type))))
       (when type
-        (setq type-str type))
+        (setq type-str (lean-highlight-string type)))
       (when tactic_params
         (setq tactic_params (-map-indexed (lambda (i param)
                                             (if (eq i tactic_param_idx)


### PR DESCRIPTION
![highlighted eldoc output](https://user-images.githubusercontent.com/109126/30549311-bd719e72-9c94-11e7-9f59-9e88659df8e5.png)

Thanks to @cpitclaudel who taught me the secret of how to fontify individual strings at ICFP.