### PR TITLE
merge ginduction -> induction

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -3,9 +3,13 @@ master branch (aka work in progress branch)
 
 *Features*
 
-- Implemented [RFC #1820](https://github.com/leanprover/lean/issues/1820)
+* Implemented [RFC #1820](https://github.com/leanprover/lean/issues/1820)
 
 *Changes*
+
+* `by_cases t with h` is now `by_cases h : t`.
+
+* `ginduction t with h h1 h2` is now `induction h : t with h1 h2`.
 
 *API name changes*
 

--- a/library/init/algebra/functions.lean
+++ b/library/init/algebra/functions.lean
@@ -24,7 +24,9 @@ solve1 $ intros
 >> try `[apply le_of_not_le, assumption]
 
 meta def tactic.interactive.min_tac (a b : interactive.parse lean.parser.pexpr) : tactic unit :=
-`[by_cases (%%a ≤ %%b), repeat {min_tac_step}]
+interactive.by_cases (none, ``(%%a ≤ %%b)); min_tac_step
+-- TODO(Mario): why doesn't this work?
+--`[by_cases (%%a ≤ %%b), repeat {min_tac_step}]
 
 lemma min_le_left (a b : α) : min a b ≤ a :=
 by min_tac a b

--- a/library/init/data/bool/lemmas.lean
+++ b/library/init/data/bool/lemmas.lean
@@ -120,7 +120,7 @@ theorem of_to_bool_ff {p : Prop} [decidable p] : to_bool p = ff → ¬p := (to_b
 
 theorem to_bool_congr {p q : Prop} [decidable p] [decidable q] (h : p ↔ q) : to_bool p = to_bool q :=
 begin
-  ginduction to_bool q with h',
+  induction h' : to_bool q,
   exact to_bool_ff (mt h.1 $ of_to_bool_ff h'),
   exact to_bool_true (h.2 $ of_to_bool_true h') 
 end

--- a/library/init/data/list/lemmas.lean
+++ b/library/init/data/list/lemmas.lean
@@ -192,7 +192,7 @@ theorem length_remove_nth : ∀ (l : list α) (i : ℕ), i < length l → length
 
 @[simp] lemma partition_eq_filter_filter (p : α → Prop) [decidable_pred p] : ∀ (l : list α), partition p l = (filter p l, filter (not ∘ p) l)
 | []     := rfl
-| (a::l) := by { by_cases p a with pa; simp [partition, filter, pa, partition_eq_filter_filter l],
+| (a::l) := by { by_cases pa : p a; simp [partition, filter, pa, partition_eq_filter_filter l],
                  rw [if_neg (not_not_intro pa)], rw [if_pos pa] }
 
 /- sublists -/
@@ -223,7 +223,7 @@ lemma length_le_of_sublist : ∀ {l₁ l₂ : list α}, l₁ <+ l₂ → length 
 @[simp] theorem filter_append {p : α → Prop} [h : decidable_pred p] :
   ∀ (l₁ l₂ : list α), filter p (l₁++l₂) = filter p l₁ ++ filter p l₂
 | []      l₂ := rfl
-| (a::l₁) l₂ := by by_cases p a with pa; simp [pa, filter_append]
+| (a::l₁) l₂ := by by_cases pa : p a; simp [pa, filter_append]
 
 @[simp] theorem filter_sublist {p : α → Prop} [h : decidable_pred p] : Π (l : list α), filter p l <+ l
 | []     := sublist.slnil

--- a/library/init/data/list/qsort.lean
+++ b/library/init/data/list/qsort.lean
@@ -14,7 +14,7 @@ def qsort.F {α} (lt : α → α → bool) : Π (x : list α),
   (Π (y : list α), length y < length x → list α) → list α
 | []     IH := []
 | (h::t) IH := begin
-    ginduction partition (λ x, lt h x = tt) t with e large small,
+    induction e : partition (λ x, lt h x = tt) t with large small,
     have : length small < length (h::t) ∧ length large < length (h::t),
     { rw partition_eq_filter_filter at e,
       injection e,
@@ -38,7 +38,7 @@ by rw [qsort, well_founded.fix_eq, qsort.F]
   qsort lt small ++ h :: qsort lt large :=
 begin
   rw [qsort, well_founded.fix_eq, qsort.F],
-  ginduction partition (λ x, lt h x = tt) t with e large small,
+  induction e : partition (λ x, lt h x = tt) t with large small,
   simp [e], rw [e]
 end
 

--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -208,7 +208,7 @@ lemma binary_rec_eq {C : nat → Sort u} {z : C 0} {f : ∀ b n, C n → C (bit 
   binary_rec z f (bit b n) = f b n (binary_rec z f n) :=
 begin
   rw [binary_rec],
-  by_cases (bit b n = 0) with h',
+  by_cases h' : bit b n = 0,
   {simp [dif_pos h'],
    generalize : binary_rec._main._pack._proof_1 (bit b n) h' = e,
    revert e,

--- a/library/init/data/nat/bitwise.lean
+++ b/library/init/data/nat/bitwise.lean
@@ -233,7 +233,7 @@ lemma bitwise_bit_aux {f : bool → bool → bool} (h : f ff ff = ff) :
 begin
   apply funext, intro n,
   apply bit_cases_on n, intros b n, rw [binary_rec_eq],
-  { cases b; try {rw h}; ginduction f ff tt with fft; simp [cond]; refl },
+  { cases b; try {rw h}; induction fft : f ff tt; simp [cond]; refl },
   { rw [h, show cond (f ff tt) 0 0 = 0, by cases f ff tt; refl,
            show cond (f tt ff) (bit ff 0) 0 = 0, by cases f tt ff; refl]; refl }
 end
@@ -256,7 +256,7 @@ by rw bitwise_zero_left; cases f ff tt; refl
 begin
   unfold bitwise,
   rw [binary_rec_eq, binary_rec_eq],
-  { ginduction f tt ff with ftf; dsimp [cond],
+  { induction ftf : f tt ff; dsimp [cond],
     rw [show f a ff = ff, by cases a; assumption],
     apply @congr_arg _ _ _ 0 (bit ff), tactic.swap,
     rw [show f a ff = a, by cases a; assumption],

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -896,7 +896,7 @@ theorem succ_inj {n m : ℕ} (H : succ n = succ m) : n = m :=
 nat.succ.inj_arrow H id
 
 theorem discriminate {B : Sort u} {n : ℕ} (H1: n = 0 → B) (H2 : ∀m, n = succ m → B) : B :=
-by ginduction n with h; [exact H1 h, exact H2 _ h]
+by cases h : n; [exact H1 h, exact H2 _ h]
 
 theorem one_succ_zero : 1 = succ 0 := rfl
 

--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -1045,15 +1045,15 @@ do t ← target, guard_expr_eq t p
 meta def guard_hyp (n : parse ident) (p : parse $ tk ":=" *> texpr) : tactic unit :=
 do h ← get_local n >>= infer_type, guard_expr_eq h p
 
-meta def by_cases (q : parse texpr) (n : parse (tk "with" *> ident)?): tactic unit :=
-do p ← tactic.to_expr_strict q,
-   tactic.by_cases p (n.get_or_else `h)
+meta def by_cases : parse cases_arg_p → tactic unit
+| (n, q) := do
+  p ← tactic.to_expr_strict q,
+  tactic.by_cases p (n.get_or_else `h)
 
 meta def by_contradiction (n : parse ident?) : tactic unit :=
 tactic.by_contradiction n >> return ()
 
-meta def by_contra (n : parse ident?) : tactic unit :=
-tactic.by_contradiction n >> return ()
+meta def by_contra := by_contradiction
 
 /-- Type check the given expression, and trace its type. -/
 meta def type_check (p : parse texpr) : tactic unit :=

--- a/library/init/meta/smt/interactive.lean
+++ b/library/init/meta/smt/interactive.lean
@@ -229,7 +229,8 @@ smt_tactic.repeat t
 meta def all_goals (t : itactic) : smt_tactic unit :=
 smt_tactic.all_goals t
 
-meta def induction (p : parse texpr) (rec_name : parse using_ident) (ids : parse with_ident_list)
+meta def induction (p : parse tactic.interactive.cases_arg_p)
+  (rec_name : parse using_ident) (ids : parse with_ident_list)
   (revert : parse $ (tk "generalizing" *> ident*)?) : smt_tactic unit :=
 slift (tactic.interactive.induction p rec_name ids revert)
 


### PR DESCRIPTION
and also `by_cases h : p` in place of `by_cases p with h`. These changes are meant to improve consistency between cases, by_cases, and induction, and reduce the number of tactic names to remember.