### PR TITLE
has_coe_to_sort: Force coercion to actually be to a sort.

### DIFF
--- a/library/init/coe.lean
+++ b/library/init/coe.lean
@@ -45,7 +45,7 @@ class has_coe_to_fun (a : Sort u) : Sort (max u (v+1)) :=
 (F : a → Sort v) (coe : Π x, F x)
 
 class has_coe_to_sort (a : Sort u) : Type (max u (v+1)) :=
-(S : Sort v) (coe : a → S)
+(coe : a → Sort v)
 
 def lift {a : Sort u} {b : Sort v} [has_lift a b] : a → b :=
 @has_lift.lift a b _
@@ -70,7 +70,7 @@ lift_t
 @[reducible] def coe_fn {a : Sort u} [has_coe_to_fun.{u v} a] : Π x : a, has_coe_to_fun.F.{u v} x :=
 has_coe_to_fun.coe
 
-@[reducible] def coe_sort {a : Sort u} [has_coe_to_sort.{u v} a] : a → has_coe_to_sort.S.{u v} a :=
+@[reducible] def coe_sort {a : Sort u} [has_coe_to_sort.{u v} a] : a → Sort v :=
 has_coe_to_sort.coe
 
 /- Notation -/
@@ -133,8 +133,7 @@ instance coe_fn_trans {a : Sort u₁} {b : Sort u₂} [has_coe_t_aux a b] [has_c
   coe := λ x, coe_fn (@has_coe_t_aux.coe a b _ x) }
 
 instance coe_sort_trans {a : Sort u₁} {b : Sort u₂} [has_coe_t_aux a b] [has_coe_to_sort.{u₂ u₃} b] : has_coe_to_sort.{u₁ u₃} a :=
-{ S   := has_coe_to_sort.S.{u₂ u₃} b,
-  coe := λ x, coe_sort (@has_coe_t_aux.coe a b _ x) }
+{ coe := λ x, coe_sort (@has_coe_t_aux.coe a b _ x) }
 
 /- Every coercion is also a lift -/
 
@@ -147,7 +146,7 @@ instance coe_bool_to_Prop : has_coe bool Prop :=
 ⟨λ y, y = tt⟩
 
 instance coe_sort_bool : has_coe_to_sort bool :=
-⟨Prop, λ y, y = tt⟩
+⟨λ y, y = tt⟩
 
 instance coe_decidable_eq (x : bool) : decidable (coe x) :=
 show decidable (x = tt), from bool.decidable_eq x tt

--- a/tests/lean/coe6.lean
+++ b/tests/lean/coe6.lean
@@ -4,7 +4,7 @@ structure Group :=
 
 attribute [instance]
 definition Group_to_Type : has_coe_to_sort Group :=
-{ S := Type u, coe := λ g, g^.carrier }
+{ coe := λ g, g^.carrier }
 
 constant g : Group.{1}
 set_option pp.binder_types true

--- a/tests/lean/run/coe_to_sort.lean
+++ b/tests/lean/run/coe_to_sort.lean
@@ -4,7 +4,7 @@ structure pointed :=
 (carrier : Type u) (point : carrier)
 
 instance: has_coe_to_sort pointed :=
-⟨_, pointed.carrier⟩
+⟨pointed.carrier⟩
 
 example (p : pointed) := list p -- coercion works in argument position
 example (p : pointed) : p := p.point

--- a/tests/lean/run/coe_to_sort_abstract.lean
+++ b/tests/lean/run/coe_to_sort_abstract.lean
@@ -1,0 +1,1 @@
+def coe_to_sort_abstract (s) [s_coe_to_sort : has_coe_to_sort s] : s → Type := λ x, x

--- a/tests/lean/run/coe_univ_bug.lean
+++ b/tests/lean/run/coe_univ_bug.lean
@@ -9,7 +9,7 @@ v + 1
 universe variable u
 
 instance pred2subtype {A : Type u} : has_coe_to_sort (A → Prop) :=
-⟨Type u, (λ p : A → Prop, subtype p)⟩
+⟨(λ p : A → Prop, subtype p)⟩
 
 instance coesubtype {A : Type u} {p : A → Prop} : has_coe (@coe_sort _ pred2subtype p) A :=
 ⟨λ s, subtype.val s⟩

--- a/tests/lean/run/pred_to_subtype_coercion.lean
+++ b/tests/lean/run/pred_to_subtype_coercion.lean
@@ -2,7 +2,7 @@ universe variables u
 
 attribute [instance]
 definition pred2subtype {A : Type u} : has_coe_to_sort (A → Prop) :=
-⟨Type u, λ p : A → Prop, subtype p⟩
+⟨λ p : A → Prop, subtype p⟩
 
 definition below (n : nat) : nat → Prop :=
 λ i, i < n


### PR DESCRIPTION
The 'S' field was not only superfluous, it also allowed nonsense
definitions like:

```lean
example : has_coe_to_sort ℕ := ⟨ℕ, id⟩
```

With this change, having a [has_coe_to_sort s] in the context actually
allows for coercing s to a type without needing to know any concrete
details about s.