### PR TITLE
feat(init/logic): mark `id` as reducible

### DIFF
--- a/library/init/logic.lean
+++ b/library/init/logic.lean
@@ -8,7 +8,7 @@ import init.core
 
 universes u v w
 
-@[inline] def id {α : Sort u} (a : α) : α := a
+@[inline, reducible] def id {α : Sort u} (a : α) : α := a
 
 def flip {α : Sort u} {β : Sort v} {φ : Sort w} (f : α → β → φ) : β → α → φ :=
 λ b a, f a b

--- a/tests/lean/interactive/info.lean
+++ b/tests/lean/interactive/info.lean
@@ -15,5 +15,5 @@ example := [tt]
 example := [tt]++[]
              --^ "command": "info"
 
-#print id
+#print f
      --^ "command": "info"

--- a/tests/lean/interactive/info.lean.expected.out
+++ b/tests/lean/interactive/info.lean.expected.out
@@ -1,4 +1,4 @@
-{"msgs":[{"caption":"print result","end_pos_col":26,"end_pos_line":19,"file_name":"f","pos_col":0,"pos_line":18,"severity":"information","text":"@[inline]\ndef id : Π {α : Sort u}, α → α :=\nλ {α : Sort u} (a : α), a"}],"response":"all_messages"}
+{"msgs":[{"caption":"print result","end_pos_col":26,"end_pos_line":19,"file_name":"f","pos_col":0,"pos_line":18,"severity":"information","text":"@[reducible]\ndef f : bool :=\ntt"}],"response":"all_messages"}
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"record":{"source":},"response":"ok","seq_num":2}
 {"record":{"doc":"reducible"},"response":"ok","seq_num":5}
@@ -6,4 +6,4 @@
 {"record":{"doc":"(trace) enable/disable tracing for the given module and submodules"},"response":"ok","seq_num":10}
 {"record":{"full-id":"list.cons","source":,"type":"Π {T : Type}, T → list T → list T"},"response":"ok","seq_num":13}
 {"record":{"full-id":"has_append.append","source":,"type":"Π {α : Type} [c : has_append α], α → α → α"},"response":"ok","seq_num":16}
-{"record":{"full-id":"id","source":,"type":"Π {α : Sort u}, α → α"},"response":"ok","seq_num":19}
+{"record":{"full-id":"f","source":,"type":"bool"},"response":"ok","seq_num":19}


### PR DESCRIPTION
As noted by @skaslev, it would be nice if `simp` could match expressions like `(λ x, x) <$> x` with `id_map`. I used the same fix in https://github.com/Kha/system_f_sub/blob/master/system_f_sub.lean#L6 and I assume there's no reason not to do so globally.