### PR TITLE
Allow extending structures in the current context

### DIFF
--- a/src/frontends/lean/util.cpp
+++ b/src/frontends/lean/util.cpp
@@ -164,8 +164,6 @@ bool is_local_ref(expr const & e) {
     if (!is_as_atomic(e))
         return false;
     expr const & imp_arg = get_as_atomic_arg(e);
-    if (!is_app(imp_arg))
-        return false;
     buffer<expr> locals;
     expr const & f = get_app_args(imp_arg, locals);
     return

--- a/tests/lean/run/extend_local_ref.lean
+++ b/tests/lean/run/extend_local_ref.lean
@@ -1,0 +1,17 @@
+section
+universe u
+
+structure a :=
+(a : Type u)
+
+structure b extends a
+end
+
+section
+parameter α : Type
+
+structure c :=
+(a : α)
+
+structure d extends c
+end

--- a/tests/lean/structure_segfault.lean.expected.out
+++ b/tests/lean/structure_segfault.lean.expected.out
@@ -2,4 +2,4 @@ structure_segfault.lean:7:17: error: invalid expression
 structure_segfault.lean:7:25: error: invalid 'structure', expression must be a 'parent' structure
 structure_segfault.lean:11:33: error: unknown identifier 'x'
 structure_segfault.lean:11:28: error: invalid 'structure', expression must be a 'parent' structure
-structure_segfault.lean:13:28: error: invalid 'structure', expression must be a 'parent' structure
+structure_segfault.lean:13:30: error: invalid 'structure', expression must be a 'parent' structure


### PR DESCRIPTION
Reported by @thalesant and @rlewis1988. I only fixed it for the new structure command because that code path never actually has to inspect the parent structure.