### PR TITLE
fix(interactive): fix focus tactic.

### DIFF
--- a/library/init/meta/interactive.lean
+++ b/library/init/meta/interactive.lean
@@ -640,7 +640,7 @@ tactic.any_goals
 `focus { t }` temporarily hides all goals other than the first, applies `t`, and then restores the other goals. It fails if there are no goals.
 -/
 meta def focus (tac : itactic) : tactic unit :=
-tactic.focus [tac]
+tactic.focus1 tac
 
 private meta def assume_core (n : name) (ty : pexpr) :=
 do t ← target,

--- a/tests/lean/interactive/focus.lean.expected.out
+++ b/tests/lean/interactive/focus.lean.expected.out
@@ -1,5 +1,4 @@
-{"msgs":[{"caption":"","file_name":"f","pos_col":2,"pos_line":4,"severity":"error","text":"focus tactic failed, insufficient number of tactics\nstate:\na b c : ℕ,\na_1 : a = b,\na_2 : b = 0\n⊢ b = a"}],"response":"all_messages"}
 {"message":"file invalidated","response":"ok","seq_num":0}
 {"record":{"doc":"`focus { t }` temporarily hides all goals other than the first, applies `t`, and then restores the other goals. It fails if there are no goals.","source":,"state":"a b c : ℕ,\na_1 : a = b,\na_2 : b = 0\n⊢ a = 0","tactic_param_idx":0,"tactic_params":["{ tactic }"],"text":"focus","type":"tactic.interactive.itactic → tactic unit"},"response":"ok","seq_num":5}
 {"record":{"doc":"`focus { t }` temporarily hides all goals other than the first, applies `t`, and then restores the other goals. It fails if there are no goals.","source":,"state":"b c : ℕ,\na_2 : b = 0\n⊢ b = 0","tactic_param_idx":0,"tactic_params":["{ tactic }"],"text":"focus","type":"tactic.interactive.itactic → tactic unit"},"response":"ok","seq_num":7}
-{"response":"ok","seq_num":9}
+{"record":{"state":"b c : ℕ,\na_2 : b = 0\n⊢ b = 0\n\na b c : ℕ,\na_1 : a = b,\na_2 : b = 0\n⊢ b = a"},"response":"ok","seq_num":9}

--- a/tests/lean/run/focus.lean
+++ b/tests/lean/run/focus.lean
@@ -1,0 +1,12 @@
+open nat
+example (n m : ℕ) : n + m = m + n :=
+begin
+  induction m with m IHm,
+  focus { induction n with n IHn,
+    focus { reflexivity },
+    focus { exact congr_arg succ IHn }},
+  focus { apply eq.trans (congr_arg succ IHm),
+    clear IHm, induction n with n IHn,
+    focus { reflexivity },
+    focus { exact congr_arg succ IHn }}
+end


### PR DESCRIPTION
Previously it would fail if there was more than one goal.

Notes: 
* <s>I haven't run the test suite. Could you add the instructions for doing that to [CONTRIBUTING.md](https://github.com/leanprover/lean/blob/master/.github/CONTRIBUTING.md)?</s>
* <s>The test https://github.com/leanprover/lean/blob/master/tests/lean/interactive/focus.lean failed before this commit. Is the test suite executed correctly? It succeeds after this commit (though I haven't checked if it produces the right output, see first note).</s> (I see that in the `expected.out` file it is supposed to raise an error)