### PR TITLE
feat(frontends/lean): change structure update notation

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -25,6 +25,12 @@ master branch (aka work in progress branch)
   The new instance is more efficient than the one in mathlib because it doesn't
   convert the array into a list.
 
+- Add alternative syntax `{..., ..s}` for the structure update `{s with ...}`.
+  Multiple fallback sources can be given: `{..., ..s, ..t}` will fall back to
+  searching a field in `s`, then in `t`. The last component can also be `..`,
+  which will replace any missing fields with a placeholder.
+  The old notation will be removed in the future.
+
 *Changes*
 
 - `string` is now a list of unicode scalar values. Moreover, in the VM,

--- a/library/init/meta/pexpr.lean
+++ b/library/init/meta/pexpr.lean
@@ -22,12 +22,11 @@ meta constant pexpr.is_choice_macro : pexpr → bool
 /-- Information about unelaborated structure instance expressions. -/
 meta structure structure_instance_info :=
 (struct       : option name := none)
-(source       : option pexpr := none)
 (field_names  : list name)
 (field_values : list pexpr)
+(sources      : list pexpr := [])
 
-/-- Create a structure instance expression.
-    Note: If both `struct` and `source` are specified, the former will be ignored. -/
+/-- Create a structure instance expression. -/
 meta constant pexpr.mk_structure_instance : structure_instance_info → pexpr
 meta constant pexpr.get_structure_instance_info : pexpr → option structure_instance_info
 

--- a/src/frontends/lean/elaborator.cpp
+++ b/src/frontends/lean/elaborator.cpp
@@ -2891,10 +2891,6 @@ public:
 };
 
 expr elaborator::visit_structure_instance(expr const & e, optional<expr> const & _expected_type) {
-    name S_name;
-    optional<expr> src;
-    buffer<name> fnames;
-    buffer<expr> fvalues;
     optional<expr> expected_type;
     if (_expected_type) {
         synthesize_type_class_instances();
@@ -2903,27 +2899,32 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
             expected_type = none_expr();
     }
     bool use_subobjects = !m_opts.get_bool("old_structure_cmd", false);
-    get_structure_instance_info(e, S_name, src, fnames, fvalues);
+    auto info = get_structure_instance_info(e);
+    name & S_name = info.m_struct_name;
+    buffer<name> & fnames = info.m_field_names;
+    buffer<expr> & fvalues = info.m_field_values;
+    bool catchall = info.m_catchall;
+
     if (!S_name.is_anonymous() && !is_structure(env(), S_name))
         throw elaborator_exception(e, sstream() << "invalid structure instance, '" <<
                                    S_name << "' is not the name of a structure type");
     lean_assert(fnames.size() == fvalues.size());
-    name src_S_name;
-    if (src) {
-        src = visit(*src, none_expr());
+    struct source { expr m_e; name m_S_name; };
+    buffer<source> sources;
+    for (expr src : info.m_sources) {
+        src = visit(src, none_expr());
         synthesize_type_class_instances();
-        expr type  = instantiate_mvars(whnf(infer_type(*src)));
+        expr type  = instantiate_mvars(whnf(infer_type(src)));
         expr src_S = get_app_fn(type);
         if (!is_constant(src_S) || !is_structure(m_env, const_name(src_S))) {
             auto pp_fn = mk_pp_ctx();
             report_or_throw(elaborator_exception(e,
-                                       format("invalid structure update { src with ...}, source is not a structure") +
-                                       pp_indent(pp_fn, *src) +
+                                       format("invalid structure notation source, not a structure") +
+                                       pp_indent(pp_fn, src) +
                                        line() + format("which has type") +
                                        pp_indent(pp_fn, type)));
-            src = none_expr();
         } else {
-            src_S_name          = const_name(src_S);
+            sources.push_back(source {copy_tag(src, mk_as_is(src)), const_name(src_S)});
         }
     }
     if (S_name.is_anonymous()) {
@@ -2937,8 +2938,8 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
                                                   "but it is not a structure") + pp_indent(pp_fn, *expected_type));
             }
             S_name = const_name(S);
-        } else if (src) {
-            S_name = src_S_name;
+        } else if (sources.size() == 1 && !catchall) {
+            S_name = sources[0].m_S_name;
         } else {
             throw elaborator_exception(e, "invalid structure value {...}, expected type is not known"
                                        "(solution: use qualified structure instance { struct_id . ... }");
@@ -2948,7 +2949,6 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
         throw elaborator_exception(e, "invalid structure instance, type is a private structure");
     buffer<bool> used;
     used.resize(fnames.size(), false);
-    if (src) src = copy_tag(*src, mk_as_is(*src));
 
     // field -> elaborated value
     name_map<expr> field2value;
@@ -2976,6 +2976,7 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
             expr c_arg;
             expr d = binding_domain(c_type);
             if (i < nparams) {
+                /* struct type parameter */
                 if (is_explicit(binding_info(c_type)) && !expected_type) {
                     report_or_throw(elaborator_exception(e, sstream() << "invalid structure value {...}, structure parameter '" <<
                                                             binding_name(c_type)
@@ -2984,6 +2985,7 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
                 }
                 c_arg = mk_metavar(d, ref);
             } else {
+                /* struct field */
                 name S_fname = deinternalize_field_name(binding_name(c_type));
                 if (is_explicit(binding_info(c_type))) {
                     unsigned j = 0;
@@ -2998,36 +3000,35 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
                         }
                     }
                     if (j == fnames.size()) {
-                        if (src && !is_subobject_field(m_env, nested_S_name, S_fname)) {
-                            optional<name> opt_base_S_name = find_field(m_env, src_S_name, S_fname);
-                            if (!opt_base_S_name) {
-                                report_or_throw(elaborator_exception(ref,
-                                                           sstream() << "invalid structure update { src with ... }, field '"
-                                                                     << S_fname << "'"
-                                                                     << " was not provided, nor was it found in the source of type '"
-                                                                     << src_S_name << "'."));
-                                c_arg = mk_sorry(some_expr(d), ref);
-                            } else {
-                                name base_S_name = *opt_base_S_name;
-                                expr base_src = *mk_base_projections(m_env, src_S_name, base_S_name, *src);
-                                expr f = mk_proj_app(m_env, base_S_name, S_fname, base_src);
-                                c_arg = visit(f, none_expr());
+                        if (!is_subobject_field(m_env, nested_S_name, S_fname)) {
+                            for (source const & src : sources) {
+                                if (optional<name> opt_base_S_name = find_field(m_env, src.m_S_name, S_fname)) {
+                                    /* field from source */
+                                    name base_S_name = *opt_base_S_name;
+                                    expr base_src = *mk_base_projections(m_env, src.m_S_name, base_S_name, src.m_e);
+                                    expr f = mk_proj_app(m_env, base_S_name, S_fname, base_src);
+                                    c_arg = visit(f, none_expr());
+                                    expr c_arg_type = infer_type(c_arg);
+                                    if (!is_def_eq(c_arg_type, d)) {
+                                        format msg =
+                                                format("type mismatch at field '") + format(S_fname) +
+                                                format("' from source '") + pp(src.m_e) + format("'");
+                                        msg += pp_indent(mk_pp_ctx(), c_arg);
+                                        msg += line() + pp_type_mismatch(c_arg_type, d);
+                                        report_or_throw(elaborator_exception(ref, msg));
+                                        c_arg = mk_sorry(some_expr(d), ref);
+                                    }
+                                    field2value.insert(S_fname, c_arg);
+                                    break;
+                                }
                             }
-                            expr c_arg_type = infer_type(c_arg);
-                            if (!is_def_eq(c_arg_type, d)) {
-                                format msg =
-                                        format("type mismatch at field '") + format(S_fname) + format("' from source");
-                                msg += pp_indent(mk_pp_ctx(), c_arg);
-                                msg += line() + pp_type_mismatch(c_arg_type, d);
-                                report_or_throw(elaborator_exception(ref, msg));
-                                c_arg = mk_sorry(some_expr(d), ref);
-                            }
-                            field2value.insert(S_fname, c_arg);
-                        } else {
+                        }
+                        if (!field2value.contains(S_fname)) { // "field from source" failed
                             optional<name> p;
                             // note: S_name instead of nested_S_name
                             if (has_default_value(m_env, S_name, S_fname) || is_auto_param(d) ||
                                 (p = is_subobject_field(m_env, nested_S_name, S_fname))) {
+                                /* default/auto/subobject field: postpone */
                                 c_arg = mk_metavar(d, ref);
                                 field2mvar.insert(S_fname, c_arg);
                                 mvar2field.insert(mlocal_name(c_arg), S_fname);
@@ -3040,6 +3041,10 @@ expr elaborator::visit_structure_instance(expr const & e, optional<expr> const &
                                     }
                                     field2value.insert(S_fname, nested.first);
                                 }
+                            } else if (catchall) {
+                                /* catchall: insert placeholder */
+                                c_arg = mk_metavar(none_expr(), ref);
+                                field2value.insert(S_fname, c_arg);
                             } else {
                                 report_or_throw(elaborator_exception(e, sstream() << "invalid structure value { ... }, field '" <<
                                                                         S_fname << "' was not provided"));

--- a/src/frontends/lean/parser.cpp
+++ b/src/frontends/lean/parser.cpp
@@ -2367,23 +2367,16 @@ void parser::parse_imports(unsigned & fingerprint, std::vector<module_name> & im
             try {
                 unsigned h = 0;
                 while (true) {
-                    if (curr_is_token(get_period_tk())) {
+                    if (curr_is_token(get_period_tk()) || curr_is_token(get_dotdot_tk()) ||
+                        curr_is_token(get_ellipsis_tk())) {
+                        unsigned d = get_token_info().token().size();
                         if (!k_init) {
-                            k = 0;
+                            k = d - 1;
                             k_init = true;
+                            h = d - 1;
                         } else {
-                            k = k + 1;
-                            h++;
-                        }
-                        next();
-                    } else if (curr_is_token(get_ellipsis_tk())) {
-                        if (!k_init) {
-                            k = 2;
-                            k_init = true;
-                            h = 2;
-                        } else {
-                            k = k + 3;
-                            h += 3;
+                            k = d;
+                            h = d;
                         }
                         next();
                     } else {

--- a/src/frontends/lean/structure_instance.cpp
+++ b/src/frontends/lean/structure_instance.cpp
@@ -9,6 +9,7 @@ Author: Leonardo de Moura
 #include "library/kernel_serializer.h"
 #include "frontends/lean/parser.h"
 #include "frontends/lean/tokens.h"
+#include "frontends/lean/structure_instance.h"
 
 namespace lean {
 static name * g_structure_instance_name          = nullptr;
@@ -23,71 +24,68 @@ static std::string * g_structure_instance_opcode = nullptr;
   Example: Given
      structure point (A B : Type) := (x : A) (y : B)
   the structure instance
-     { point, x := 10, y := 20 }
+     { point . x := 10, y := 20 }
   is compiled into
      point.mk 10 20
 */
 class structure_instance_macro_cell : public macro_definition_cell {
     name       m_struct;
+    bool       m_catchall;
     list<name> m_fields;
 public:
-    structure_instance_macro_cell(name const & s, list<name> const & fs):
-        m_struct(s), m_fields(fs) {}
+    structure_instance_macro_cell(name const & s, bool ca, list<name> const & fs):
+        m_struct(s), m_catchall(ca), m_fields(fs) {}
     virtual name get_name() const override { return *g_structure_instance_name; }
     virtual expr check_type(expr const &, abstract_type_context &, bool) const override { throw_se_ex(); }
     virtual optional<expr> expand(expr const &, abstract_type_context &) const override { throw_se_ex(); }
     virtual void write(serializer & s) const override {
-        s << *g_structure_instance_opcode << m_struct;
+        s << *g_structure_instance_opcode << m_struct << m_catchall;
         write_list(s, m_fields);
     }
     name const & get_struct() const { return m_struct; }
+    bool get_catchall() const { return m_catchall; }
     list<name> const & get_field_names() const { return m_fields; }
     virtual bool operator==(macro_definition_cell const & other) const override {
         if (auto other_ptr = dynamic_cast<structure_instance_macro_cell const *>(&other)) {
-            return m_struct == other_ptr->m_struct && m_fields == other_ptr->m_fields;
+            return m_struct == other_ptr->m_struct && m_catchall == other_ptr->m_catchall && m_fields == other_ptr->m_fields;
         } else {
             return false;
         }
     }
 };
 
-static expr mk_structure_instance_core(name const & s, list<name> const & fs, unsigned num, expr const * args) {
-    lean_assert(num == length(fs) || num == length(fs) + 1);
-    macro_definition def(new structure_instance_macro_cell(s, fs));
+static expr mk_structure_instance_core(name const & s, bool ca, list<name> const & fs, unsigned num, expr const * args) {
+    lean_assert(num >= length(fs));
+    macro_definition def(new structure_instance_macro_cell(s, ca, fs));
     return mk_macro(def, num, args);
 }
 
-expr mk_structure_instance(name const & s, buffer<name> const & fns, buffer<expr> const & fvs) {
+expr mk_structure_instance(name const & s, buffer<name> const & fns, buffer<expr> const & fvs,
+                           buffer<expr> const & sources, bool catchall) {
     lean_assert(fns.size() == fvs.size());
-    return mk_structure_instance_core(s, to_list(fns), fvs.size(), fvs.data());
-}
-
-expr mk_structure_instance(expr const & src, buffer<name> const & fns, buffer<expr> const & fvs) {
     buffer<expr> aux;
     aux.append(fvs);
-    aux.push_back(src);
-    return mk_structure_instance_core(name(), to_list(fns), aux.size(), aux.data());
+    aux.append(sources);
+    return mk_structure_instance_core(s, catchall, to_list(fns), aux.size(), aux.data());
 }
 
 bool is_structure_instance(expr const & e) {
     return is_macro(e) && macro_def(e).get_name() == *g_structure_instance_name;
 }
 
-void get_structure_instance_info(expr const & e,
-                                 name & struct_name,
-                                 optional<expr> & source,
-                                 buffer<name> & field_names,
-                                 buffer<expr> & field_values) {
+structure_instance_info get_structure_instance_info(expr const & e) {
     lean_assert(is_structure_instance(e));
-    struct_name = static_cast<structure_instance_macro_cell const*>(macro_def(e).raw())->get_struct();
-    list<name> const & fns = static_cast<structure_instance_macro_cell const*>(macro_def(e).raw())->get_field_names();
-    to_buffer(fns, field_names);
-    unsigned num_fields = field_names.size();
-    lean_assert(macro_num_args(e) == num_fields || macro_num_args(e) == num_fields+1);
-    if (num_fields < macro_num_args(e))
-        source = macro_arg(e, num_fields);
+    structure_instance_info info;
+    auto m = static_cast<structure_instance_macro_cell const*>(macro_def(e).raw());
+    info.m_struct_name = m->get_struct();
+    to_buffer(m->get_field_names(), info.m_field_names);
+    unsigned num_fields = info.m_field_names.size();
     for (unsigned i = 0; i < num_fields; i++)
-        field_values.push_back(macro_arg(e, i));
+        info.m_field_values.push_back(macro_arg(e, i));
+    for (unsigned i = num_fields; i < macro_num_args(e); i++)
+        info.m_sources.push_back(macro_arg(e, i));
+    info.m_catchall = m->get_catchall();
+    return info;
 }
 
 void initialize_structure_instance() {
@@ -97,12 +95,13 @@ void initialize_structure_instance() {
                                 [](deserializer & d, unsigned num, expr const * args) {
                                     list<name> fns;
                                     name s;
-                                    d >> s;
+                                    bool ca;
+                                    d >> s >> ca;
                                     fns = read_list<name>(d);
                                     unsigned len = length(fns);
-                                    if (num != len + 1 && num != len)
+                                    if (num < len)
                                         throw corrupted_stream_exception();
-                                    return mk_structure_instance_core(s, fns, num, args);
+                                    return mk_structure_instance_core(s, ca, fns, num, args);
                                 });
 }
 

--- a/src/frontends/lean/structure_instance.h
+++ b/src/frontends/lean/structure_instance.h
@@ -7,11 +7,17 @@ Author: Leonardo de Moura
 #pragma once
 #include "frontends/lean/parse_table.h"
 namespace lean {
-expr mk_structure_instance(name const & s, buffer<name> const & fns, buffer<expr> const & fvs);
-expr mk_structure_instance(expr const & src, buffer<name> const & fns, buffer<expr> const & fvs);
+expr mk_structure_instance(name const & s = {}, buffer<name> const & fns = {}, buffer<expr> const & fvs = {},
+                           buffer<expr> const & sources = {}, bool catchall = false);
 bool is_structure_instance(expr const & e);
-void get_structure_instance_info(expr const & e, name & struct_name, optional<expr> & source,
-                                 buffer<name> & field_names, buffer<expr> & field_values);
+struct structure_instance_info {
+    name m_struct_name; // empty if omitted
+    buffer<name> m_field_names;
+    buffer<expr> m_field_values;
+    buffer<expr> m_sources;
+    bool m_catchall; // "..." syntax: fill in placeholders for remaining fields
+};
+structure_instance_info get_structure_instance_info(expr const & e);
 void initialize_structure_instance();
 void finalize_structure_instance();
 }

--- a/src/frontends/lean/token_table.cpp
+++ b/src/frontends/lean/token_table.cpp
@@ -91,7 +91,7 @@ void init_token_table(token_table & t) {
          {"Type", g_max_prec}, {"Type*", g_max_prec}, {"Sort", g_max_prec}, {"Sort*", g_max_prec},
          {"(:", g_max_prec}, {":)", 0}, {".(", g_max_prec}, {"._", g_max_prec},
          {"⟨", g_max_prec}, {"⟩", 0}, {"^", 0},
-         {"//", 0}, {"|", 0}, {"with", 0}, {"without", 0}, {"...", 0}, {",", 0},
+         {"//", 0}, {"|", 0}, {"with", 0}, {"without", 0}, {"..", 0}, {"...", 0}, {",", 0},
          {".", 0}, {":", 0}, {"!", 0}, {"calc", 0}, {":=", 0}, {"--", 0}, {"#", g_max_prec},
          {"/-", 0}, {"/--", 0}, {"/-!", 0}, {"begin", g_max_prec}, {"using", 0},
          {"@@", g_max_prec}, {"@", g_max_prec},

--- a/src/frontends/lean/tokens.cpp
+++ b/src/frontends/lean/tokens.cpp
@@ -54,6 +54,7 @@ static name const * g_assume_tk = nullptr;
 static name const * g_suppose_tk = nullptr;
 static name const * g_fun_tk = nullptr;
 static name const * g_match_tk = nullptr;
+static name const * g_dotdot_tk = nullptr;
 static name const * g_ellipsis_tk = nullptr;
 static name const * g_raw_tk = nullptr;
 static name const * g_true_tk = nullptr;
@@ -179,6 +180,7 @@ void initialize_tokens() {
     g_suppose_tk = new name{"suppose"};
     g_fun_tk = new name{"fun"};
     g_match_tk = new name{"match"};
+    g_dotdot_tk = new name{".."};
     g_ellipsis_tk = new name{"..."};
     g_raw_tk = new name{"raw"};
     g_true_tk = new name{"true"};
@@ -305,6 +307,7 @@ void finalize_tokens() {
     delete g_suppose_tk;
     delete g_fun_tk;
     delete g_match_tk;
+    delete g_dotdot_tk;
     delete g_ellipsis_tk;
     delete g_raw_tk;
     delete g_true_tk;
@@ -430,6 +433,7 @@ name const & get_assume_tk() { return *g_assume_tk; }
 name const & get_suppose_tk() { return *g_suppose_tk; }
 name const & get_fun_tk() { return *g_fun_tk; }
 name const & get_match_tk() { return *g_match_tk; }
+name const & get_dotdot_tk() { return *g_dotdot_tk; }
 name const & get_ellipsis_tk() { return *g_ellipsis_tk; }
 name const & get_raw_tk() { return *g_raw_tk; }
 name const & get_true_tk() { return *g_true_tk; }

--- a/src/frontends/lean/tokens.h
+++ b/src/frontends/lean/tokens.h
@@ -56,6 +56,7 @@ name const & get_assume_tk();
 name const & get_suppose_tk();
 name const & get_fun_tk();
 name const & get_match_tk();
+name const & get_dotdot_tk();
 name const & get_ellipsis_tk();
 name const & get_raw_tk();
 name const & get_true_tk();

--- a/src/frontends/lean/tokens.txt
+++ b/src/frontends/lean/tokens.txt
@@ -49,6 +49,7 @@ assume       assume
 suppose      suppose
 fun          fun
 match        match
+dotdot       ..
 ellipsis     ...
 raw          raw
 true         true

--- a/src/library/vm/vm_pexpr.cpp
+++ b/src/library/vm/vm_pexpr.cpp
@@ -43,40 +43,29 @@ vm_obj pexpr_is_choice_macro(vm_obj const & e) {
 
 vm_obj pexpr_mk_structure_instance(vm_obj const & info) {
     name struct_name;
+    buffer<name> field_names;
+    buffer<expr> field_values;
+    buffer<expr> sources;
     if (!is_none(cfield(info, 0))) {
         struct_name = to_name(get_some_value(cfield(info, 0)));
     }
-    optional<expr> source;
-    if (!is_none(cfield(info, 1))) {
-        source = to_expr(get_some_value(cfield(info, 1)));
-    }
-    buffer<name> field_names;
-    to_buffer_name(cfield(info, 2), field_names);
-    buffer<expr> field_values;
-    to_buffer_expr(cfield(info, 3), field_values);
-
-    if (source) {
-        return to_obj(mk_structure_instance(*source, field_names, field_values));
-    } else {
-        return to_obj(mk_structure_instance(struct_name, field_names, field_values));
-    }
+    to_buffer_name(cfield(info, 1), field_names);
+    to_buffer_expr(cfield(info, 2), field_values);
+    to_buffer_expr(cfield(info, 3), sources);
+    return to_obj(mk_structure_instance(struct_name, field_names, field_values, sources));
 }
 
 vm_obj pexpr_get_structure_instance_info(vm_obj const & e) {
     if (!is_structure_instance(to_expr(e))) {
         return mk_vm_none();
     }
-    name struct_name;
-    optional<expr> source;
-    buffer<name> field_names;
-    buffer<expr> field_values;
-
-    get_structure_instance_info(to_expr(e), struct_name, source, field_names, field_values);
+    auto info = get_structure_instance_info(to_expr(e));
     optional<name> opt_struct_name;
-    if (struct_name) {
-        opt_struct_name = struct_name;
+    if (info.m_struct_name) {
+        opt_struct_name = info.m_struct_name;
     }
-    return mk_vm_some(mk_vm_constructor(0, to_obj(opt_struct_name), to_obj(source), to_obj(field_names), to_obj(field_values)));
+    return mk_vm_some(mk_vm_constructor(0, to_obj(opt_struct_name), to_obj(info.m_field_names),
+                                        to_obj(info.m_field_values), to_obj(info.m_sources)));
 }
 
 void initialize_vm_pexpr() {

--- a/tests/lean/structure_instance_bug2.lean.expected.out
+++ b/tests/lean/structure_instance_bug2.lean.expected.out
@@ -1,4 +1,4 @@
 structure_instance_bug2.lean:4:0: error: invalid structure instance, 'default_smt_pre_config' is not the name of a structure type
-structure_instance_bug2.lean:13:0: error: invalid structure update { src with ... }, field 'fst' was not provided, nor was it found in the source of type 'st'.
-structure_instance_bug2.lean:13:0: error: invalid structure update { src with ... }, field 'snd' was not provided, nor was it found in the source of type 'st'.
+structure_instance_bug2.lean:13:0: error: invalid structure value { ... }, field 'fst' was not provided
+structure_instance_bug2.lean:13:0: error: invalid structure value { ... }, field 'snd' was not provided
 structure_instance_bug2.lean:13:0: error: invalid structure value { ... }, 'i' is not a field of structure 'prod'

--- a/tests/lean/structure_instance_info.lean
+++ b/tests/lean/structure_instance_info.lean
@@ -2,7 +2,7 @@ open tactic
 
 run_cmd
 do let e := pexpr.mk_structure_instance { struct := some "prod", field_names := ["fst", "snd"], field_values := [``(1), ``(2)] },
-   let f := pexpr.mk_structure_instance { source := some e, field_names := ["snd"], field_values := [``(1)] },
+   let f := pexpr.mk_structure_instance { field_names := ["snd"], field_values := [``(1)], sources := [e] },
    to_expr e >>= trace,
    to_expr f >>= trace,
    trace $ e.get_structure_instance_info >>= structure_instance_info.struct,


### PR DESCRIPTION
`{s with ...}` is now `{..., ..s}`, which more clearly expresses that the
result type is not necessarily equal to the type of `s` (in absence of an
expected type and a structure name, we still default to the type of `s`).

Multiple fallback sources can be given: `{..., ..s, ..t}` will fall back to
searching a field in `s`, then in `t`. The last component can also be `..`,
which will replace any missing fields with a placeholder.

The old notation will be removed in the future.