### PR TITLE
fix(algebra/group): remove inherited [simp] from add_comm

### DIFF
--- a/library/data/stream.lean
+++ b/library/data/stream.lean
@@ -42,7 +42,7 @@ theorem head_cons (a : α) (s : stream α) : head (a :: s) = a := rfl
 theorem tail_cons (a : α) (s : stream α) : tail (a :: s) = s := rfl
 
 theorem tail_drop (n : nat) (s : stream α) : tail (drop n s) = drop n (tail s) :=
-funext (λ i, begin unfold tail drop, simp  end)
+funext (λ i, begin unfold tail drop, simp [add_right_comm] end)
 
 theorem nth_drop (n m : nat) (s : stream α) : nth n (drop m s) = nth (n+m) s := rfl
 

--- a/library/init/algebra/group.lean
+++ b/library/init/algebra/group.lean
@@ -223,6 +223,8 @@ ls.foldl (λ t ⟨src, tgt⟩, do
   else t)
 skip
 
+local attribute [-simp] mul_comm mul_assoc mul_left_comm
+
 run_cmd transport_multiplicative_to_additive
   [/- map operations -/
    (`has_mul.mul, `has_add.add), (`has_one.one, `has_zero.zero), (`has_inv.inv, `has_neg.neg),

--- a/library/init/algebra/norm_num.lean
+++ b/library/init/algebra/norm_num.lean
@@ -15,7 +15,7 @@ def add1 [has_add α] [has_one α] (a : α) : α :=
 a + 1
 
 local attribute [reducible] bit0 bit1 add1
-local attribute [simp] right_distrib left_distrib
+local attribute [simp] right_distrib left_distrib add_comm add_left_comm
 
 private meta def u : tactic unit :=
 `[unfold bit0 bit1 add1]

--- a/library/init/algebra/ordered_field.lean
+++ b/library/init/algebra/ordered_field.lean
@@ -345,7 +345,7 @@ begin
     calc
       a + a > b + a             : add_lt_add_right h _
         ... = b + a + b - b     : by rw add_sub_cancel
-        ... = b + b + a - b     : by simp
+        ... = b + b + a - b     : by rw add_right_comm
         ... = (b + b) + (a - b) : by rw add_sub,
    have h3 : (a + a) / 2 > ((b + b) + (a - b)) / 2,
      exact div_lt_div_of_lt_of_pos h2 two_pos,

--- a/library/init/data/int/basic.lean
+++ b/library/init/data/int/basic.lean
@@ -9,6 +9,8 @@ prelude
 import init.data.nat.lemmas init.data.nat.gcd init.meta.transfer init.data.list
 open nat
 
+local attribute [simp] add_assoc add_comm add_left_comm mul_assoc mul_comm mul_left_comm
+
 /- the type, coercions, and notation -/
 
 @[derive decidable_eq]
@@ -392,8 +394,6 @@ protected meta def transfer_core : tactic unit := do
 protected meta def transfer (distrib := tt) : tactic unit :=
 if distrib then `[int.transfer_core, simp [add_mul, mul_add]]
 else `[int.transfer_core, simp]
-
-local attribute [simp] mul_assoc mul_comm mul_left_comm
 
 instance : comm_ring int :=
 { add            := int.add,

--- a/library/init/data/int/comp_lemmas.lean
+++ b/library/init/data/int/comp_lemmas.lean
@@ -64,7 +64,7 @@ le_of_lt
 /- 3. nat_abs auxiliary lemmas -/
 
 lemma neg_succ_of_nat_lt_zero (n : ℕ) : neg_succ_of_nat n < 0 :=
-@lt.intro _ _ n (by simp [neg_succ_of_nat_coe, int.coe_nat_succ, int.coe_nat_add, int.coe_nat_one])
+@lt.intro _ _ n (by simp [neg_succ_of_nat_coe, int.coe_nat_succ, int.coe_nat_add, int.coe_nat_one, add_assoc])
 
 lemma of_nat_ge_zero (n : ℕ) : of_nat n ≥ 0 :=
 @le.intro _ _ n (by rw [zero_add, int.coe_nat_eq])

--- a/library/init/data/int/order.lean
+++ b/library/init/data/int/order.lean
@@ -39,7 +39,7 @@ lemma le.intro_sub {a b : ℤ} {n : ℕ} (h : b - a = n) : a ≤ b :=
 show nonneg (b - a), by rw h; trivial
 
 lemma le.intro {a b : ℤ} {n : ℕ} (h : a + n = b) : a ≤ b :=
-le.intro_sub (by rw [← h]; simp)
+le.intro_sub (by rw [← h]; simp [add_comm])
 
 lemma le.dest_sub {a b : ℤ} (h : a ≤ b) : ∃ n : ℕ, b - a = n := nonneg.elim h
 
@@ -82,7 +82,8 @@ let ⟨n, (h : ↑(1+n) = a)⟩ := le.dest h in
 ⟨n, by rw add_comm at h; exact h.symm⟩
 
 lemma lt_add_succ (a : ℤ) (n : ℕ) : a < a + ↑(nat.succ n) :=
-le.intro (show a + 1 + n = a + nat.succ n, begin simp [int.coe_nat_eq], reflexivity end)
+le.intro (show a + 1 + n = a + nat.succ n,
+  begin simp [int.coe_nat_eq, add_comm, add_left_comm], refl end)
 
 lemma lt.intro {a b : ℤ} {n : ℕ} (h : a + nat.succ n = b) : a < b :=
 h ▸ lt_add_succ a n

--- a/library/init/data/list/lemmas.lean
+++ b/library/init/data/list/lemmas.lean
@@ -33,7 +33,7 @@ lemma length_cons (a : α) (l : list α) : length (a :: l) = length l + 1 :=
 rfl
 
 @[simp] lemma length_append (s t : list α) : length (s ++ t) = length s + length t :=
-by induction s; simp [*]
+by induction s; simp [*, add_right_comm]
 
 @[simp] lemma length_repeat (a : α) (n : ℕ) : length (repeat a n) = n :=
 by induction n; simp [*]; refl

--- a/library/init/data/nat/lemmas.lean
+++ b/library/init/data/nat/lemmas.lean
@@ -776,7 +776,7 @@ begin
     { apply nat.sub_lt _ h.left,
       apply lt_of_lt_of_le h.left h.right },
     rw [div_def, mod_def, if_pos h, if_pos h],
-    simp [left_distrib, IH _ h'],
+    simp [left_distrib, add_comm, add_left_comm, IH _ h'],
     rw [← nat.add_sub_assoc h.right, nat.add_sub_cancel_left] },
   -- ¬ (0 < k ∧ k ≤ m)
   { rw [div_def, mod_def, if_neg h', if_neg h'], simp },
@@ -850,7 +850,7 @@ begin
     { simp [succ_mul, not_succ_le_zero],
       apply not_le_of_gt,
       apply lt_of_lt_of_le h,
-      apply le_add_right } },
+      apply le_add_left } },
   -- step: k ≤ y
   { rw [div_eq_sub_div Hk h],
     cases x with x,
@@ -915,7 +915,7 @@ theorem sub_induction {P : ℕ → ℕ → Sort u} (H1 : ∀m, P 0 m)
 theorem succ_add_eq_succ_add (n m : ℕ) : succ n + m = n + succ m :=
 by simp [succ_add, add_succ]
 
-theorem one_add (n : ℕ) : 1 + n = succ n := by simp
+theorem one_add (n : ℕ) : 1 + n = succ n := by simp [add_comm]
 
 protected theorem add_right_comm : ∀ (n m k : ℕ), n + m + k = n + k + m :=
 right_comm nat.add nat.add_comm nat.add_assoc
@@ -1012,7 +1012,7 @@ by rw [nat.mul_sub_left_distrib, right_distrib, right_distrib, mul_comm b a, add
        nat.add_sub_add_left]
 
 theorem succ_mul_succ_eq (a b : nat) : succ a * succ b = a*b + a + b + 1 :=
-begin rw [← add_one, ← add_one], simp [right_distrib, left_distrib] end
+begin rw [← add_one, ← add_one], simp [add_comm, add_left_comm, right_distrib, left_distrib] end
 
 theorem succ_sub {m n : ℕ} (h : m ≥ n) : succ m - n = succ (m - n) :=
 exists.elim (nat.le.dest h)
@@ -1145,7 +1145,7 @@ begin
     have h₄ : x - n * k ≥ n,
     { apply @nat.le_of_add_le_add_right (n*k),
       rw [nat.sub_add_cancel h₂],
-      simp [mul_succ] at h₁, simp [h₁] },
+      simp [mul_succ, add_comm] at h₁, simp [h₁] },
     rw [mul_succ, ← nat.sub_sub, ← mod_eq_sub_mod h₄, k_ih h₂] }
 end
 
@@ -1374,7 +1374,7 @@ begin
       simp [pow_succ] at h₁,
       simp [h₁] },
     rw [mod_eq_of_lt h₁, mod_eq_of_lt h₂],
-    simp [mod_add_div] },
+    simp [mod_add_div, add_comm] },
   -- step: p ≥ b^succ w
   { -- Generate condiition for induction principal
     have h₂ : p - b^succ w < p,

--- a/library/init/meta/well_founded_tactics.lean
+++ b/library/init/meta/well_founded_tactics.lean
@@ -14,7 +14,7 @@ by {apply nat.add_lt_add_left, assumption}
 
 /- TODO(Leo): move this lemma, or delete it after we add algebraic normalizer. -/
 lemma nat.zero_lt_one_add (a : nat) : 0 < 1 + a :=
-suffices 0 < a + 1, by {simp, assumption},
+suffices 0 < a + 1, by {simp [add_comm], assumption},
 nat.zero_lt_succ _
 
 /- TODO(Leo): move this lemma, or delete it after we add algebraic normalizer. -/


### PR DESCRIPTION
It looks like this is a bug in the implementation of `transport_multiplicative_to_additive` - at the time of the call, `mul_comm` has `[simp]` enabled locally, but when it gets copied to `add_comm` it becomes permanent.

A test:
 `#print add_comm`
```
@[no_rsimp, priority 100, simp, priority 100]
theorem add_comm : ∀ {α : Type u} [_inst_1 : add_comm_semigroup α] (a b : α), a + b = b + a :=
λ {α : Type u} [_inst_1 : add_comm_semigroup α], add_comm_semigroup.add_comm
```
I hope I'm not off base with this change, which is intended to finish the job of b7322e2. But be aware it has some fallout for dependent projects.