### PR TITLE
feat(util): add math alphanum symbol Latin letter blocks

### DIFF
--- a/doc/changes.md
+++ b/doc/changes.md
@@ -105,6 +105,10 @@ master branch (aka work in progress branch)
 
 * Add interactive `subst_vars` tactic.
 
+* Allow the Script, Double-struck, and Fractur symbols from
+  Mathematical Alphanumeric Symbols: https://unicode.org/charts/PDF/U1D400.pdf
+  to be used as variables Example: `variables 𝓞 : Prop`.
+
 *Changes*
 
 * Replace `inout` modifier in type class declarations with `out_param` modifier.

--- a/src/util/name.cpp
+++ b/src/util/name.cpp
@@ -30,7 +30,8 @@ bool is_letter_like_unicode(unsigned u) {
             (0x391  <= u && u <= 0x3A9 && u != 0x3A0 && u != 0x3A3) || // Upper greek, but Pi and Sigma
             (0x3ca  <= u && u <= 0x3fb) ||               // Coptic letters
             (0x1f00 <= u && u <= 0x1ffe) ||              // Polytonic Greek Extended Character Set
-            (0x2100 <= u && u <= 0x214f);                // Letter like block
+            (0x2100 <= u && u <= 0x214f) ||              // Letter like block
+            (0x1d49c <= u && u <= 0x1d59f);              // Latin letters, Script, Double-struck, Fractur
 }
 bool is_sub_script_alnum_unicode(unsigned u) {
     return

--- a/tests/lean/run/letters.lean
+++ b/tests/lean/run/letters.lean
@@ -1,0 +1,2 @@
+variables 𝓞 : Prop
+#check 𝓞


### PR DESCRIPTION
Add the latin letter blocks from,
https://unicode.org/charts/PDF/U1D400.pdf
to is_letter_like() so they may be bound to variables.
-- 
Not sure if this would be desired, or the correct way to go about this.
If not, by all means close.

I was trying to match the notation of some variables used in a textbook,
But was unable to figure out a way to use unicode symbols using the `notation` command as variable names.
trying to figure out how alpha was handled for variable names, lead to the attached patch.