### PR TITLE
fix warnings with VS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -248,7 +248,7 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 elseif (MSVC)
     # All good. Maybe enforce a recent version?
     set(STATIC ON) # FIXME: not working yet
-    set(CMAKE_CXX_FLAGS                "/GL /EHsc /W1 /Zc:implicitNoexcept- -D_SCL_SECURE_NO_WARNINGS ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS                "/GL /EHsc /W2 /Zc:implicitNoexcept- -D_SCL_SECURE_NO_WARNINGS ${CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS_DEBUG          "/Od /Zi ${CMAKE_CXX_FLAGS_DEBUG}")
     set(CMAKE_CXX_FLAGS_MINSIZEREL     "/Os /Zc:inline ${CMAKE_CXX_FLAGS_MINSIZEREL}")
     set(CMAKE_CXX_FLAGS_RELEASE        "/O2 /Oi /Oy /Zc:inline ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -124,7 +124,7 @@ bool pp_using_anonymous_constructor(environment const & env, name const & n) {
 }
 
 void initialize_pp() {
-    g_ellipsis_n_fmt  = new format(highlight(format("\u2026")));
+    g_ellipsis_n_fmt  = new format(highlight(format("\xE2\x80\xA6"))); //\u2026
     g_ellipsis_fmt    = new format(highlight(format("...")));
     g_placeholder_fmt = new format(highlight(format("_")));
     g_lambda_n_fmt    = new format(highlight_keyword(format("\xCE\xBB"))); //\u03BB

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -124,16 +124,16 @@ bool pp_using_anonymous_constructor(environment const & env, name const & n) {
 }
 
 void initialize_pp() {
-    g_ellipsis_n_fmt  = new format(highlight(format("\xE2\x80\xA6"))); //\u2026
+    g_ellipsis_n_fmt  = new format(highlight(format("…")));
     g_ellipsis_fmt    = new format(highlight(format("...")));
     g_placeholder_fmt = new format(highlight(format("_")));
-    g_lambda_n_fmt    = new format(highlight_keyword(format("\xCE\xBB"))); //\u03BB
+    g_lambda_n_fmt    = new format(highlight_keyword(format("λ")));
     g_lambda_fmt      = new format(highlight_keyword(format("fun")));
-    g_forall_n_fmt    = new format(highlight_keyword(format("\xE2\x88\x80"))); //\u2200
+    g_forall_n_fmt    = new format(highlight_keyword(format("∀")));
     g_forall_fmt      = new format(highlight_keyword(format("forall")));
     g_pi_n_fmt        = new format(highlight_keyword(format("Π")));
     g_pi_fmt          = new format(highlight_keyword(format("Pi")));
-    g_arrow_n_fmt     = new format(highlight_keyword(format("\xE2\x86\x92"))); //\u2192
+    g_arrow_n_fmt     = new format(highlight_keyword(format("→")));
     g_arrow_fmt       = new format(highlight_keyword(format("->")));
     g_let_fmt         = new format(highlight_keyword(format("let")));
     g_in_fmt          = new format(highlight_keyword(format("in")));

--- a/src/frontends/lean/pp.cpp
+++ b/src/frontends/lean/pp.cpp
@@ -127,13 +127,13 @@ void initialize_pp() {
     g_ellipsis_n_fmt  = new format(highlight(format("\u2026")));
     g_ellipsis_fmt    = new format(highlight(format("...")));
     g_placeholder_fmt = new format(highlight(format("_")));
-    g_lambda_n_fmt    = new format(highlight_keyword(format("\u03BB")));
+    g_lambda_n_fmt    = new format(highlight_keyword(format("\xCE\xBB"))); //\u03BB
     g_lambda_fmt      = new format(highlight_keyword(format("fun")));
-    g_forall_n_fmt    = new format(highlight_keyword(format("\u2200")));
+    g_forall_n_fmt    = new format(highlight_keyword(format("\xE2\x88\x80"))); //\u2200
     g_forall_fmt      = new format(highlight_keyword(format("forall")));
     g_pi_n_fmt        = new format(highlight_keyword(format("Π")));
     g_pi_fmt          = new format(highlight_keyword(format("Pi")));
-    g_arrow_n_fmt     = new format(highlight_keyword(format("\u2192")));
+    g_arrow_n_fmt     = new format(highlight_keyword(format("\xE2\x86\x92"))); //\u2192
     g_arrow_fmt       = new format(highlight_keyword(format("->")));
     g_let_fmt         = new format(highlight_keyword(format("let")));
     g_in_fmt          = new format(highlight_keyword(format("in")));
@@ -1868,7 +1868,7 @@ std::string sexpr_to_string(sexpr const & s) {
 // check whether a space must be inserted between the strings so that lexing them would
 // produce separate tokens
 std::pair<bool, token_table const *> pretty_fn::needs_space_sep(token_table const * last, std::string const & s1, std::string const & s2) const {
-    if (s1.size() == 0 || (is_id_rest(get_utf8_last_char(s1.data()), s1.data() + s1.size()) && is_id_rest(s2.data(), s2.data() + s2.size())))
+    if (s1.empty() || (is_id_rest(get_utf8_last_char(s1.data()), s1.data() + s1.size()) && is_id_rest(s2.data(), s2.data() + s2.size())))
         return mk_pair(true, nullptr); // would be lexed as a single identifier without space
 
     if (last) {

--- a/src/library/tactic/smt/smt_state.cpp
+++ b/src/library/tactic/smt/smt_state.cpp
@@ -641,7 +641,7 @@ format smt_goal_to_format(smt_goal sg, tactic_state const & ts) {
     expr target                = decl.get_type();
     if (inst_mvars)
         target                 = mctx_tmp.instantiate_mvars(target);
-    format turnstile           = unicode ? format("\u22A2") /* ⊢ */ : format("|-");
+    format turnstile           = unicode ? format("\xE2\x8A\xA2") /* \u22A2 ⊢ */ : format("|-");
     type_context ctx(ts.env(), opts, mctx_tmp, lctx, transparency_mode::All);
     formatter_factory const & fmtf = get_global_ios().get_formatter_factory();
     formatter fmt              = fmtf(ts.env(), opts, ctx);
@@ -677,7 +677,7 @@ format smt_state_to_format_core(vm_obj const & ss, tactic_state const & ts) {
        TODO(Leo): move this code to a different place */
     metavar_context mctx = ts.mctx();
     bool unicode         = get_pp_unicode(ts.get_options());
-    format turnstile     = unicode ? format("\u22A2") /* ⊢ */ : format("|-");
+    format turnstile     = unicode ? format("\xE2\x8A\xA2") /* \u22A2 ⊢ */ : format("|-");
     for (expr const & g : tail(ts.goals())) {
         metavar_decl d = mctx.get_metavar_decl(g);
         type_context ctx(ts.env(), ts.get_options(), mctx, d.get_context(), transparency_mode::Semireducible);

--- a/src/library/tactic/smt/smt_state.cpp
+++ b/src/library/tactic/smt/smt_state.cpp
@@ -641,7 +641,7 @@ format smt_goal_to_format(smt_goal sg, tactic_state const & ts) {
     expr target                = decl.get_type();
     if (inst_mvars)
         target                 = mctx_tmp.instantiate_mvars(target);
-    format turnstile           = unicode ? format("\xE2\x8A\xA2") /* \u22A2 ⊢ */ : format("|-");
+    format turnstile(unicode ? "⊢" : "|-");
     type_context ctx(ts.env(), opts, mctx_tmp, lctx, transparency_mode::All);
     formatter_factory const & fmtf = get_global_ios().get_formatter_factory();
     formatter fmt              = fmtf(ts.env(), opts, ctx);
@@ -677,7 +677,7 @@ format smt_state_to_format_core(vm_obj const & ss, tactic_state const & ts) {
        TODO(Leo): move this code to a different place */
     metavar_context mctx = ts.mctx();
     bool unicode         = get_pp_unicode(ts.get_options());
-    format turnstile     = unicode ? format("\xE2\x8A\xA2") /* \u22A2 ⊢ */ : format("|-");
+    format turnstile(unicode ? "⊢" : "|-");
     for (expr const & g : tail(ts.goals())) {
         metavar_decl d = mctx.get_metavar_decl(g);
         type_context ctx(ts.env(), ts.get_options(), mctx, d.get_context(), transparency_mode::Semireducible);

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -211,7 +211,7 @@ format tactic_state::pp_goal(formatter_factory const & fmtf, expr const & g, boo
     if (target_lhs_only && is_simp_relation(env(), type, rel, lhs, rhs)) {
         r += format("|") + space() + nest(indent, fmt(lhs));
     } else {
-        format turnstile           = unicode ? format("\xE2\x8A\xA2") /* \u22A2 ⊢ */ : format("|-");
+        format turnstile(unicode ? "⊢" : "|-");
         r += turnstile + space() + nest(indent, fmt(type));
     }
     if (get_pp_goal_compact(get_options()))

--- a/src/library/tactic/tactic_state.cpp
+++ b/src/library/tactic/tactic_state.cpp
@@ -211,7 +211,7 @@ format tactic_state::pp_goal(formatter_factory const & fmtf, expr const & g, boo
     if (target_lhs_only && is_simp_relation(env(), type, rel, lhs, rhs)) {
         r += format("|") + space() + nest(indent, fmt(lhs));
     } else {
-        format turnstile           = unicode ? format("\u22A2") /* ⊢ */ : format("|-");
+        format turnstile           = unicode ? format("\xE2\x8A\xA2") /* \u22A2 ⊢ */ : format("|-");
         r += turnstile + space() + nest(indent, fmt(type));
     }
     if (get_pp_goal_compact(get_options()))

--- a/src/tests/frontends/lean/scanner.cpp
+++ b/src/tests/frontends/lean/scanner.cpp
@@ -154,8 +154,9 @@ static void tst2() {
     check("Int -+-> Int", {tk::Identifier, tk::Keyword, tk::Identifier}, env);
     check("x := 10", {tk::Identifier, tk::Keyword, tk::Numeral});
     check("{x}", {tk::Keyword, tk::Identifier, tk::Keyword});
-    check("\u03BB \u2200 \u2192", {tk::Keyword, tk::Keyword, tk::Keyword});
-    check_keyword("\u03BB", "fun");
+    // "\u03BB \u2200 \u2192"
+    check("\xCE\xBB \xE2\x88\x80 \xE2\x86\x92", {tk::Keyword, tk::Keyword, tk::Keyword});
+    check_keyword("\xCE\xBB", "fun");  // \u03BB
     scan("theorem a : Prop axiom b : Int");
     check("theorem a : Prop axiom b : Int", {tk::CommandKeyword, tk::Identifier, tk::Keyword, tk::Identifier,
                 tk::CommandKeyword, tk::Identifier, tk::Keyword, tk::Identifier});
@@ -171,7 +172,7 @@ static void tst3() {
     scan("\"\naaa\"");
     scan_error("foo.* 01");
     scan("10.0.");
-    scan("{ } . forall exists let in \u2200 := _");
+    scan("{ } . forall exists let in \xE2\x88\x80 := _"); // \u2200
 }
 
 static void tst4(unsigned N) {

--- a/src/tests/frontends/lean/scanner.cpp
+++ b/src/tests/frontends/lean/scanner.cpp
@@ -154,9 +154,8 @@ static void tst2() {
     check("Int -+-> Int", {tk::Identifier, tk::Keyword, tk::Identifier}, env);
     check("x := 10", {tk::Identifier, tk::Keyword, tk::Numeral});
     check("{x}", {tk::Keyword, tk::Identifier, tk::Keyword});
-    // "\u03BB \u2200 \u2192"
-    check("\xCE\xBB \xE2\x88\x80 \xE2\x86\x92", {tk::Keyword, tk::Keyword, tk::Keyword});
-    check_keyword("\xCE\xBB", "fun");  // \u03BB
+    check("λ ∀ →", {tk::Keyword, tk::Keyword, tk::Keyword});
+    check_keyword("λ", "fun");
     scan("theorem a : Prop axiom b : Int");
     check("theorem a : Prop axiom b : Int", {tk::CommandKeyword, tk::Identifier, tk::Keyword, tk::Identifier,
                 tk::CommandKeyword, tk::Identifier, tk::Keyword, tk::Identifier});
@@ -172,7 +171,7 @@ static void tst3() {
     scan("\"\naaa\"");
     scan_error("foo.* 01");
     scan("10.0.");
-    scan("{ } . forall exists let in \xE2\x88\x80 := _"); // \u2200
+    scan("{ } . forall exists let in ∀ := _");
 }
 
 static void tst4(unsigned N) {

--- a/src/tests/util/name.cpp
+++ b/src/tests/util/name.cpp
@@ -98,9 +98,9 @@ static void tst5() {
 
 static void tst6() {
     lean_assert(name({"foo", "bla"}).is_safe_ascii());
-    lean_assert(!name({"foo", "b\u2200aaa"}).is_safe_ascii());
-    lean_assert(!name({"\u2200", "boo"}).is_safe_ascii());
-    lean_assert(!name(name(name("baa"), "bla\u2200"), "foo").is_safe_ascii());
+    lean_assert(!name({"foo", "b\xE2\x88\x80" "aaa"}).is_safe_ascii()); //u2200
+    lean_assert(!name({"\xE2\x88\x80", "boo"}).is_safe_ascii());
+    lean_assert(!name(name(name("baa"), "bla\xE2\x88\x80"), "foo").is_safe_ascii());
 }
 
 static void tst7() {

--- a/src/tests/util/name.cpp
+++ b/src/tests/util/name.cpp
@@ -98,9 +98,9 @@ static void tst5() {
 
 static void tst6() {
     lean_assert(name({"foo", "bla"}).is_safe_ascii());
-    lean_assert(!name({"foo", "b\xE2\x88\x80" "aaa"}).is_safe_ascii()); //u2200
-    lean_assert(!name({"\xE2\x88\x80", "boo"}).is_safe_ascii());
-    lean_assert(!name(name(name("baa"), "bla\xE2\x88\x80"), "foo").is_safe_ascii());
+    lean_assert(!name({"foo", "b∀aaa"}).is_safe_ascii());
+    lean_assert(!name({"∀", "boo"}).is_safe_ascii());
+    lean_assert(!name(name(name("baa"), "bla∀"), "foo").is_safe_ascii());
 }
 
 static void tst7() {

--- a/src/tests/util/numerics/float.cpp
+++ b/src/tests/util/numerics/float.cpp
@@ -9,11 +9,11 @@ Author: Soonho Kong
 using namespace lean;
 
 static void abs() {
-    float f1 = -398723.3218937912;
-    float f2 = -9823.3487729;
+    float f1 = -398723.3218937912f;
+    float f2 = -9823.3487729f;
     float f3 = 0.0;
-    float f4 = 398.347389;
-    float f5 = 78398.30912;
+    float f4 = 398.347389f;
+    float f5 = 78398.30912f;
     float_abs(f1);
     float_abs(f2);
     float_abs(f3);
@@ -27,11 +27,11 @@ static void abs() {
 }
 
 static void ceil() {
-    float f1 = -398723.3218937912;
-    float f2 = -9823.3487729;
+    float f1 = -398723.3218937912f;
+    float f2 = -9823.3487729f;
     float f3 = 0.0;
-    float f4 = 398.347389;
-    float f5 = 78398.30912;
+    float f4 = 398.347389f;
+    float f5 = 78398.30912f;
     float_ceil(f1);
     float_ceil(f2);
     float_ceil(f3);

--- a/src/util/numerics/mpq.h
+++ b/src/util/numerics/mpq.h
@@ -71,7 +71,7 @@ public:
     friend int cmp(mpq const & a, mpz const & b);
     friend int cmp(mpq const & a, unsigned b) { return mpq_cmp_ui(a.m_val, b, 1); }
     friend int cmp(mpq const & a, int b) { return mpq_cmp_si(a.m_val, b, 1); }
-    friend int cmp(mpq const & a, double b) { return a.get_double() - b; }
+    friend int cmp(mpq const & a, double b) { return static_cast<int>(a.get_double() - b); }
 
     friend bool operator<(mpq const & a, mpq const & b) { return cmp(a, b) < 0; }
     friend bool operator<(mpq const & a, mpz const & b) { return cmp(a, b) < 0; }

--- a/src/util/serializer.cpp
+++ b/src/util/serializer.cpp
@@ -28,7 +28,7 @@ void serializer_core::write_unsigned(unsigned i) {
     if (i < 255) {
         m_out.put(i & 0xff);
     } else {
-        m_out.put(0xff);
+        m_out.put(char(0xff));
         m_out.put((i >> 24) & 0xff);
         m_out.put((i >> 16) & 0xff);
         m_out.put((i >> 8) & 0xff);

--- a/src/util/serializer.cpp
+++ b/src/util/serializer.cpp
@@ -28,7 +28,7 @@ void serializer_core::write_unsigned(unsigned i) {
     if (i < 255) {
         m_out.put(i & 0xff);
     } else {
-        m_out.put(char(0xff));
+        m_out.put(-1);
         m_out.put((i >> 24) & 0xff);
         m_out.put((i >> 16) & 0xff);
         m_out.put((i >> 8) & 0xff);

--- a/src/util/sexpr/options.cpp
+++ b/src/util/sexpr/options.cpp
@@ -139,9 +139,9 @@ char const * options::get_string(char const * n, char const * default_value) con
     return !is_nil(r) && is_string(r) ? to_string(r).c_str() : default_value;
 }
 
-static char const * g_left_angle_bracket  = "\u27E8";
-static char const * g_right_angle_bracket = "\u27E9";
-static char const * g_arrow               = "\u21a6";
+static char const * g_left_angle_bracket  = "\xE2\x9F\xA8"; // "\u27E8";
+static char const * g_right_angle_bracket = "\xE2\x9F\xA9"; // "\u27E9";
+static char const * g_arrow               = "\xE2\x86\xA6"; // "\u21a6";
 static char const * g_assign              = ":=";
 
 options options::update(name const & n, sexpr const & v) const {

--- a/src/util/sexpr/options.cpp
+++ b/src/util/sexpr/options.cpp
@@ -139,9 +139,9 @@ char const * options::get_string(char const * n, char const * default_value) con
     return !is_nil(r) && is_string(r) ? to_string(r).c_str() : default_value;
 }
 
-static char const * g_left_angle_bracket  = "\xE2\x9F\xA8"; // "\u27E8";
-static char const * g_right_angle_bracket = "\xE2\x9F\xA9"; // "\u27E9";
-static char const * g_arrow               = "\xE2\x86\xA6"; // "\u21a6";
+static char const * g_left_angle_bracket  = "⟨";
+static char const * g_right_angle_bracket = "⟩";
+static char const * g_arrow               = "↦";
 static char const * g_assign              = ":=";
 
 options options::update(name const & n, sexpr const & v) const {


### PR DESCRIPTION
It's now /W2 clean.

We can't use \u with VS because the encoding is dependent on the locale. With the \xXX encoding we ensure it's UTF-8.