### PR TITLE
fix MSVC build

### DIFF
--- a/src/api/exception.h
+++ b/src/api/exception.h
@@ -11,7 +11,6 @@ Author: Leonardo de Moura
 #include "api/lean_macros.h"
 #include "api/lean_bool.h"
 #include "api/lean_exception.h"
-#include "api/exception.h"
 
 namespace lean {
 inline throwable * to_exception(lean_exception e) { return reinterpret_cast<throwable *>(e); }

--- a/src/library/io_state.cpp
+++ b/src/library/io_state.cpp
@@ -81,13 +81,11 @@ scope_global_ios::~scope_global_ios() {
     g_ios = m_old_ios;
 }
 
-MK_THREAD_LOCAL_GET_DEF(std::string, get_what_str);
-
 char const * formatted_exception::what() const noexcept {
     options const & opts = get_global_ios().get_options();
     std::ostringstream out;
     out << mk_pair(m_fmt, opts);
-    std::string & r = get_what_str();
+    std::string & r = get_tls_str_buffer();
     r = out.str();
     return r.c_str();
 }

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -17,9 +17,8 @@ throwable::throwable(sstream const & strm):m_msg(strm.str()) {}
 throwable::~throwable() noexcept {}
 char const * throwable::what() const noexcept { return m_msg.c_str(); }
 
-MK_THREAD_LOCAL_GET_DEF(std::string, get_g_buffer);
 char const * stack_space_exception::what() const noexcept {
-    std::string & buffer = get_g_buffer();
+    std::string & buffer = get_tls_str_buffer();
     std::ostringstream s;
     s << "deep recursion was detected at '" << m_component_name << "' (potential solution: increase stack space in your system)";
     buffer = s.str();
@@ -27,7 +26,7 @@ char const * stack_space_exception::what() const noexcept {
 }
 
 char const * memory_exception::what() const noexcept {
-    std::string & buffer = get_g_buffer();
+    std::string & buffer = get_tls_str_buffer();
     std::ostringstream s;
     s << "excessive memory consumption detected at '" << m_component_name << "' (potential solution: increase memory consumption threshold)";
     buffer = s.str();

--- a/src/util/parser_exception.cpp
+++ b/src/util/parser_exception.cpp
@@ -8,12 +8,11 @@
 #include "util/parser_exception.h"
 
 namespace lean {
-MK_THREAD_LOCAL_GET_DEF(std::string, get_g_buffer);
 char const * parser_exception::what() const noexcept {
   try {
-    std::string & buffer = get_g_buffer();
+    std::string & buffer = get_tls_str_buffer();
     std::ostringstream s;
-    s << m_fname << ":" << m_pos.first << ":" << m_pos.second << ": error: " << m_msg;
+    s << m_fname << ':' << m_pos.first << ':' << m_pos.second << ": error: " << m_msg;
     buffer = s.str();
     return buffer.c_str();
   } catch (std::exception & ex) {

--- a/src/util/thread.cpp
+++ b/src/util/thread.cpp
@@ -22,6 +22,13 @@ Author: Leonardo de Moura
 
 namespace lean {
 
+MK_THREAD_LOCAL_GET_DEF(std::string, get_buffer_str);
+
+std::string& get_tls_str_buffer() {
+    return get_buffer_str();
+}
+
+
 using runnable = std::function<void()>;
 
 static void thread_main(void * p) {

--- a/src/util/thread.h
+++ b/src/util/thread.h
@@ -8,6 +8,7 @@ Author: Leonardo de Moura
 #include <iostream>
 #include <chrono>
 #include <functional>
+#include <string>
 
 #ifndef LEAN_STACK_BUFFER_SPACE
 #define LEAN_STACK_BUFFER_SPACE 128*1024  // 128 Kb
@@ -15,6 +16,9 @@ Author: Leonardo de Moura
 
 namespace lean {
 namespace chrono = std::chrono;
+
+/// obtain a thread-specific string buffer
+std::string& get_tls_str_buffer();
 };
 
 #if defined(LEAN_MULTI_THREAD)


### PR DESCRIPTION
Visual Studio has a limitation on the size of thread-local storage.
This change compresses 3 thread-local strings into 1 by sharing those temporary buffers.