### PR TITLE
fix(library/tactic/simp_lemmas): avoid rewrite failure with more robust code

### DIFF
--- a/src/library/tactic/simp_lemmas.cpp
+++ b/src/library/tactic/simp_lemmas.cpp
@@ -1227,7 +1227,7 @@ static bool instantiate_emetas(type_context & ctx, list<expr> const & _emetas, l
     lean_assert(emetas.size() == instances.size());
     for (unsigned i = 0; i < emetas.size(); ++i) {
         expr m = emetas[i];
-        unsigned mvar_idx = emetas.size() - 1 - i;
+        unsigned mvar_idx = to_meta_idx(m);
         expr m_type = ctx.instantiate_mvars(ctx.infer(m));
         // TODO(Leo, Daniel): do we need the following assertion?
         // lean_assert(!has_expr_metavar(m_type));
@@ -1416,9 +1416,10 @@ public:
     }
 };
 
-static bool instantiate_emetas(tmp_type_context & tmp_ctx, vm_obj const & prove_fn, unsigned num_emeta, list<expr> const & emetas, list<bool> const & instances, tactic_state const & s) {
+static bool instantiate_emetas(tmp_type_context & tmp_ctx, vm_obj const & prove_fn, list <expr> const & emetas,
+                               list<bool> const & instances, tactic_state const & s) {
     simp_aux_prover prover(prove_fn, s);
-    return instantiate_emetas_fn<simp_aux_prover>(prover)(tmp_ctx, num_emeta, emetas, instances);
+    return instantiate_emetas_fn<simp_aux_prover>(prover)(tmp_ctx, emetas, instances);
 }
 
 
@@ -1430,7 +1431,7 @@ static simp_result simp_lemma_rewrite_core(type_context & ctx, simp_lemma const 
         return simp_result(e);
     }
 
-    if (!instantiate_emetas(tmp_ctx, prove_fn, sl.get_num_emeta(), sl.get_emetas(), sl.get_instances(), s)) {
+    if (!instantiate_emetas(tmp_ctx, prove_fn, sl.get_emetas(), sl.get_instances(), s)) {
         lean_trace("simp_lemmas", tout() << "fail to instantiate emetas: " << sl.get_id() << "\n";);
         return simp_result(e);
     }

--- a/src/library/tactic/simp_util.h
+++ b/src/library/tactic/simp_util.h
@@ -39,12 +39,10 @@ public:
     instantiate_emetas_fn(Prover & prover):
         m_prover(prover) {}
 
-    bool operator()(tmp_type_context & tmp_ctx, unsigned num_emeta,
-                    list<expr> const & emetas, list<bool> const & instances) {
+    bool operator()(tmp_type_context & tmp_ctx, list<expr> const & emetas, list<bool> const & instances) {
         bool failed = false;
-        unsigned i  = num_emeta;
         for_each2(emetas, instances, [&](expr const & mvar, bool const & is_instance) {
-                i--;
+                unsigned mvar_idx = to_meta_idx(mvar);
                 if (failed) return;
                 expr mvar_type = tmp_ctx.instantiate_mvars(tmp_ctx.infer(mvar));
                 if (has_idx_metavar(mvar_type)) {
@@ -52,7 +50,7 @@ public:
                     return;
                 }
 
-                if (tmp_ctx.is_eassigned(i)) return;
+                if (tmp_ctx.is_eassigned(mvar_idx)) return;
 
                 if (is_instance) {
                     if (auto v = tmp_ctx.ctx().mk_class_instance(mvar_type)) {
@@ -70,7 +68,7 @@ public:
                     }
                 }
 
-                if (tmp_ctx.is_eassigned(i)) return;
+                if (tmp_ctx.is_eassigned(mvar_idx)) return;
 
                 if (optional<expr> pf = try_auto_param(tmp_ctx, mvar_type)) {
                     lean_verify(tmp_ctx.is_def_eq(mvar, *pf));

--- a/src/library/tactic/simplify.cpp
+++ b/src/library/tactic/simplify.cpp
@@ -132,10 +132,10 @@ public:
     }
 };
 
-bool simplify_core_fn::instantiate_emetas(tmp_type_context & tmp_ctx, unsigned num_emeta,
-                                          list<expr> const & emetas, list<bool> const & instances) {
+bool simplify_core_fn::instantiate_emetas(tmp_type_context & tmp_ctx, list <expr> const & emetas,
+                                          list<bool> const & instances) {
     simp_prover prover(*this);
-    return instantiate_emetas_fn<simp_prover>(prover)(tmp_ctx, num_emeta, emetas, instances);
+    return instantiate_emetas_fn<simp_prover>(prover)(tmp_ctx, emetas, instances);
 }
 
 simp_result simplify_core_fn::lift_from_eq(simp_result const & r_eq) {
@@ -309,7 +309,7 @@ simp_result simplify_core_fn::try_user_congr(expr const & e, simp_lemma const & 
     if (!simplified)
         return simp_result(e);
 
-    if (!instantiate_emetas(tmp_ctx, cl.get_num_emeta(), cl.get_emetas(), cl.get_instances()))
+    if (!instantiate_emetas(tmp_ctx, cl.get_emetas(), cl.get_instances()))
         return simp_result(e);
 
     for (unsigned i = 0; i < cl.get_num_umeta(); i++) {
@@ -534,7 +534,7 @@ simp_result simplify_core_fn::rewrite_core(expr const & e, simp_lemma const & sl
         return simp_result(e);
     }
 
-    if (!instantiate_emetas(tmp_ctx, sl.get_num_emeta(), sl.get_emetas(), sl.get_instances())) {
+    if (!instantiate_emetas(tmp_ctx, sl.get_emetas(), sl.get_instances())) {
         lean_simp_trace_d(m_ctx, name({"simplify", "failure"}),
                           lean_trace_init_bool(name({"simplify", "failure"}), get_pp_implicit_name(), true);
                           tout() << "fail to instantiate emetas: '" << sl.get_id() << "' at\n"

--- a/src/library/tactic/simplify.h
+++ b/src/library/tactic/simplify.h
@@ -95,8 +95,8 @@ protected:
     bool should_defeq_canonize() const {
         return m_cfg.m_canonize_instances || m_cfg.m_canonize_proofs;
     }
-    bool instantiate_emetas(tmp_type_context & tmp_tctx, unsigned num_emeta,
-                            list<expr> const & emetas, list<bool> const & instances);
+    bool instantiate_emetas(tmp_type_context & tmp_tctx, list <expr> const & emetas,
+                                list<bool> const & instances);
     simp_result lift_from_eq(simp_result const & r_eq);
     simp_lemmas add_to_slss(simp_lemmas const & slss, buffer<expr> const & ls);
     expr remove_unnecessary_casts(expr const & e);

--- a/tests/lean/run/bug_refl_lemma.lean
+++ b/tests/lean/run/bug_refl_lemma.lean
@@ -1,0 +1,4 @@
+def f := @id
+@[simp] lemma foo {α : Type} [inhabited α] : f = @id α := rfl
+
+example : f = @id ℕ := by simp


### PR DESCRIPTION
The old code assumed `emetas` to be descendingly ordered by tmp idx, which is
not true for rfl lemmas.