### PR TITLE
fix(lean/bin/leanpkg*): handle spaces in paths

### DIFF
--- a/bin/leanpkg
+++ b/bin/leanpkg
@@ -14,12 +14,12 @@ else
     READLINK=readlink
 fi
 
-leandir=$(dirname $($READLINK -f $0))/..
-leandir=$($READLINK -f $leandir)
+leandir=$(dirname "$($READLINK -f "$0")")/..
+leandir=$($READLINK -f "$leandir")
 
 librarydir="$leandir/lib/lean"
 test -d "$librarydir" || librarydir="$leandir"
 
 LEAN_PATH=$librarydir/library:$librarydir/leanpkg \
   PATH=$leandir/bin:$PATH \
-  exec lean --run $librarydir/leanpkg/leanpkg/main.lean "$@"
+  exec lean --run "$librarydir/leanpkg/leanpkg/main.lean" "$@"

--- a/bin/leanpkg.bat
+++ b/bin/leanpkg.bat
@@ -2,8 +2,8 @@
 
 SET LEANDIR=%~dp0%../
 SET LIBDIR=%LEANDIR%\lib\lean
-IF NOT EXIST %LIBDIR% SET LIBDIR=%LEANDIR%
+IF NOT EXIST "%LIBDIR%" SET LIBDIR=%LEANDIR%
 SET LEAN_PATH=%LIBDIR%\library;%LIBDIR%\leanpkg
 SET PATH=%LEANDIR%\bin;%PATH%
 
-lean --run %LIBDIR%\leanpkg\leanpkg\main.lean %*
+lean --run "%LIBDIR%\leanpkg\leanpkg\main.lean" %*


### PR DESCRIPTION
Fixes #1973. I've tested it locally and this appears to be enough to solve the problem.

I'm unsure if this falls within the scope of the "must include tests" contributing guideline, but I suppose we could make AppVeyor intentionally put Lean into a directory with spaces?