### PR TITLE
fix(frontends/dependencies): ignore `.olean` files when listing depen…

### DIFF
--- a/src/frontends/lean/dependencies.cpp
+++ b/src/frontends/lean/dependencies.cpp
@@ -33,7 +33,7 @@ bool display_deps(search_path const & path, environment const & env, std::ostrea
     auto display_dep = [&](optional<unsigned> const & k, name const & f) {
         import_args = true;
         try {
-            std::string m_name = find_file(path, base, k, name_to_file(f), {".lean", ".hlean", ".olean", ".lua"});
+            std::string m_name = find_file(path, base, k, name_to_file(f), {".lean"});
             int last_idx = m_name.find_last_of(".");
             std::string rawname = m_name.substr(0, last_idx);
             std::string ext = m_name.substr(last_idx);


### PR DESCRIPTION
The `--deps` flag failed when a `.olean` file existed next to its source `.lean` file. This fix makes Lean consider only `.lean` files when looking for dependences.

# Pull Request Description

Ensure you have read the contribution guide before filling in a description of the
pull request, regardless of whether it is complete or a work in progress.
All Pull Requests should include test case(s) which demonstrates the intended
behavior of a feature, or a regression test demonstrating that the fix resolves
the issue.
