### PR TITLE
feat(leanpkg): add git branch tracking for dependencies

### DIFF
--- a/leanpkg/leanpkg/resolve.lean
+++ b/leanpkg/leanpkg/resolve.lean
@@ -59,11 +59,12 @@ match dep.src with
   let depdir := resolve_dir dir relpath,
   io.put_str_ln $ dep.name ++ ": using local path " ++ depdir,
   modify $ λ assg, assg.insert dep.name depdir
-| (source.git url rev) := do
+| (source.git url rev branch) := do
   let depdir := "_target/deps/" ++ dep.name,
   already_there ← dir_exists depdir,
   if already_there then do {
-    io.put_str_ln $ dep.name ++ ": trying to update " ++ depdir ++ " to revision " ++ rev,
+    io.put_str $ dep.name ++ ": trying to update " ++ depdir ++ " to revision " ++ rev,
+    io.put_str_ln $ match branch with | none := "" | some branch := "@" ++ branch end,
     hash ← git_parse_origin_revision depdir rev,
     rev_ex ← git_revision_exists depdir hash,
     when (¬rev_ex) $


### PR DESCRIPTION
Add branch tracking for git dependencies. There is no functional change to currently existing `leanpkg.toml` manifests. In a git dependency an optional `branch="..."` (along with the required `git=...` and `rev=...`) is now permitted, which will cause subsequent invocations of `leanpkg upgrade` to track that branch, as opposed to a default determined by the Lean version.

We opt to store the branch name inside an `option string`, instead of just picking a default the first time `leanpkg.toml` is read with it missing, since then when `leanpkg.toml` is re-written unexpected `branch = "..."` entries will not appear (as was the case with the old behaviour).
