### PR TITLE
fix(library/init):removed unused import

### DIFF
--- a/library/init/default.lean
+++ b/library/init/default.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Leonardo de Moura
 -/
 prelude
-import init.core init.logic init.category init.data.basic init.version
+import init.core init.logic init.category init.data.basic
 import init.propext init.cc_lemmas init.funext init.category.combinators init.function init.classical
 import init.util init.coe init.wf init.meta init.meta.well_founded_tactics init.algebra init.data
 


### PR DESCRIPTION
the low level export of the library is not working with the import of the init.version, that was added to .gitignore since release 3.4.0
Closes #1964

