### PR TITLE
chore(.travis.yml): gpg key for new rvm maintainer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,7 @@ before_install:
       brew install gmp &&
       # workaround for https://github.com/travis-ci/travis-ci/issues/6307
       command curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+      command curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
       rvm get head || true
     fi
 


### PR DESCRIPTION
[OS X builds are currently failing on Travis](https://travis-ci.org/leanprover/lean/jobs/477775262#L1091), the underlying issue seems to be that [rvm has a new maintainer with a new gpg key](https://github.com/rvm/rvm/issues/4520).

# Pull Request Description

Ensure you have read the contribution guide before filling in a description of the
pull request, regardless of whether it is complete or a work in progress.
All Pull Requests should include test case(s) which demonstrates the intended
behavior of a feature, or a regression test demonstrating that the fix resolves
the issue.
