### PR TITLE
fix(vm/get_cwd): add test for get_cwd

### DIFF
--- a/src/library/vm/vm_io.cpp
+++ b/src/library/vm/vm_io.cpp
@@ -457,7 +457,7 @@ static vm_obj io_get_cwd(vm_obj const &) {
     char buffer[PATH_MAX];
     auto cwd = getcwd(buffer, sizeof(buffer));
     if (cwd) {
-        return mk_io_result(mk_vm_some(to_obj(std::string(cwd))));
+        return mk_io_result(to_obj(std::string(cwd)));
     } else {
         return mk_io_failure("get_cwd failed");
     }

--- a/tests/lean/run/1010.lean
+++ b/tests/lean/run/1010.lean
@@ -1,0 +1,5 @@
+import system.io
+
+#eval io.env.get_cwd >>= io.print
+
+section end


### PR DESCRIPTION
`get_cwd` used to crash every time. Fixed.